### PR TITLE
Cleaning System.Data.Common.Tests up

### DIFF
--- a/src/System.Data.Common/tests/System/Data/Common/DataAdapterTest.cs
+++ b/src/System.Data.Common/tests/System/Data/Common/DataAdapterTest.cs
@@ -96,8 +96,8 @@ namespace System.Data.Tests.Common
             // The LoadOption enumeration value, 666, is invalid
             Assert.Null(ex.InnerException);
             Assert.NotNull(ex.Message);
-            Assert.Contains(ex.Message, "LoadOption");
-            Assert.Contains(ex.Message, "666");
+            Assert.Contains("LoadOption", ex.Message);
+            Assert.Contains("666", ex.Message);
             Assert.NotNull(ex.ParamName);
             Assert.Equal("LoadOption", ex.ParamName);
         }
@@ -122,8 +122,8 @@ namespace System.Data.Tests.Common
             // The MissingMappingAction enumeration value, 666, is invalid
             Assert.Null(ex.InnerException);
             Assert.NotNull(ex.Message);
-            Assert.Contains(ex.Message, "MissingMappingAction");
-            Assert.Contains(ex.Message, "666");
+            Assert.Contains("MissingMappingAction", ex.Message);
+            Assert.Contains("666", ex.Message);
             Assert.NotNull(ex.ParamName);
             Assert.Equal("MissingMappingAction", ex.ParamName);
 
@@ -149,8 +149,8 @@ namespace System.Data.Tests.Common
             // The MissingSchemaAction enumeration value, 666, is invalid
             Assert.Null(ex.InnerException);
             Assert.NotNull(ex.Message);
-            Assert.Contains(ex.Message, "MissingSchemaAction");
-            Assert.Contains(ex.Message, "666");
+            Assert.Contains("MissingSchemaAction", ex.Message);
+            Assert.Contains("666", ex.Message);
             Assert.NotNull(ex.ParamName);
             Assert.Equal("MissingSchemaAction", ex.ParamName);
         }

--- a/src/System.Data.Common/tests/System/Data/Common/DataAdapterTest.cs
+++ b/src/System.Data.Common/tests/System/Data/Common/DataAdapterTest.cs
@@ -69,18 +69,11 @@ namespace System.Data.Tests.Common
         {
             DataAdapter da = new MyAdapter();
             DataSet ds = new DataSet();
-            try
-            {
-                da.Fill(ds);
-                Assert.False(true);
-            }
-            catch (NotSupportedException ex)
-            {
-                // Specified method is not supported
-                Assert.Equal(typeof(NotSupportedException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-            }
+            NotSupportedException ex = Assert.Throws<NotSupportedException>(() => da.Fill(ds));
+            // Specified method is not supported
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+
         }
 
         [Fact]
@@ -99,22 +92,14 @@ namespace System.Data.Tests.Common
         public void FillLoadOption_Invalid()
         {
             DataAdapter da = new MyAdapter();
-            try
-            {
-                da.FillLoadOption = (LoadOption)666;
-                Assert.False(true);
-            }
-            catch (ArgumentOutOfRangeException ex)
-            {
-                // The LoadOption enumeration value, 666, is invalid
-                Assert.Equal(typeof(ArgumentOutOfRangeException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.IndexOf("LoadOption") != -1);
-                Assert.True(ex.Message.IndexOf("666") != -1);
-                Assert.NotNull(ex.ParamName);
-                Assert.Equal("LoadOption", ex.ParamName);
-            }
+            ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(() => da.FillLoadOption = (LoadOption)666);
+            // The LoadOption enumeration value, 666, is invalid
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+            Assert.Contains(ex.Message, "LoadOption");
+            Assert.Contains(ex.Message, "666");
+            Assert.NotNull(ex.ParamName);
+            Assert.Equal("LoadOption", ex.ParamName);
         }
 
         [Fact]
@@ -133,22 +118,15 @@ namespace System.Data.Tests.Common
         public void MissingMappingAction_Invalid()
         {
             DataAdapter da = new MyAdapter();
-            try
-            {
-                da.MissingMappingAction = (MissingMappingAction)666;
-                Assert.False(true);
-            }
-            catch (ArgumentOutOfRangeException ex)
-            {
-                // The MissingMappingAction enumeration value, 666, is invalid
-                Assert.Equal(typeof(ArgumentOutOfRangeException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.IndexOf("MissingMappingAction") != -1);
-                Assert.True(ex.Message.IndexOf("666") != -1);
-                Assert.NotNull(ex.ParamName);
-                Assert.Equal("MissingMappingAction", ex.ParamName);
-            }
+            ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(() => da.MissingMappingAction = (MissingMappingAction)666);
+            // The MissingMappingAction enumeration value, 666, is invalid
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+            Assert.Contains(ex.Message, "MissingMappingAction");
+            Assert.Contains(ex.Message, "666");
+            Assert.NotNull(ex.ParamName);
+            Assert.Equal("MissingMappingAction", ex.ParamName);
+
         }
 
         [Fact]
@@ -167,22 +145,14 @@ namespace System.Data.Tests.Common
         public void MissingSchemaAction_Invalid()
         {
             DataAdapter da = new MyAdapter();
-            try
-            {
-                da.MissingSchemaAction = (MissingSchemaAction)666;
-                Assert.False(true);
-            }
-            catch (ArgumentOutOfRangeException ex)
-            {
-                // The MissingSchemaAction enumeration value, 666, is invalid
-                Assert.Equal(typeof(ArgumentOutOfRangeException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.IndexOf("MissingSchemaAction") != -1);
-                Assert.True(ex.Message.IndexOf("666") != -1);
-                Assert.NotNull(ex.ParamName);
-                Assert.Equal("MissingSchemaAction", ex.ParamName);
-            }
+            ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(() => da.MissingSchemaAction = (MissingSchemaAction)666);
+            // The MissingSchemaAction enumeration value, 666, is invalid
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+            Assert.Contains(ex.Message, "MissingSchemaAction");
+            Assert.Contains(ex.Message, "666");
+            Assert.NotNull(ex.ParamName);
+            Assert.Equal("MissingSchemaAction", ex.ParamName);
         }
 
         [Fact]

--- a/src/System.Data.Common/tests/System/Data/Common/DataAdapterTest.cs
+++ b/src/System.Data.Common/tests/System/Data/Common/DataAdapterTest.cs
@@ -73,7 +73,6 @@ namespace System.Data.Tests.Common
             // Specified method is not supported
             Assert.Null(ex.InnerException);
             Assert.NotNull(ex.Message);
-
         }
 
         [Fact]
@@ -126,7 +125,6 @@ namespace System.Data.Tests.Common
             Assert.Contains("666", ex.Message);
             Assert.NotNull(ex.ParamName);
             Assert.Equal("MissingMappingAction", ex.ParamName);
-
         }
 
         [Fact]

--- a/src/System.Data.Common/tests/System/Data/Common/DataColumnMappingCollectionTest.cs
+++ b/src/System.Data.Common/tests/System/Data/Common/DataColumnMappingCollectionTest.cs
@@ -164,7 +164,6 @@ namespace System.Data.Tests.Common
                 eq = _columnMapCollection[i].Equals(colcops[i]);
                 Assert.True(eq);
             }
-            colcops = null;
             colcops = new DataColumnMapping[7];
             _columnMapCollection.CopyTo(colcops, 2);
             for (int i = 0; i < 5; i++)
@@ -176,42 +175,6 @@ namespace System.Data.Tests.Common
             Assert.False(eq);
             eq = _columnMapCollection[0].Equals(colcops[1]);
             Assert.False(eq);
-        }
-
-        [Fact]
-        public void Equals()
-        {
-            //            DataColumnMappingCollection collect2=new DataColumnMappingCollection();
-            _columnMapCollection.AddRange(_cols);
-            //            collect2.AddRange(cols);
-            DataColumnMappingCollection copy1;
-            copy1 = _columnMapCollection;
-
-            //            Assert.Equal (false, columnMapCollection.Equals(collect2));
-            Assert.True(_columnMapCollection.Equals(copy1));
-            //            Assert.Equal (false, collect2.Equals(columnMapCollection));
-            Assert.True(copy1.Equals(_columnMapCollection));
-            //            Assert.Equal (false, collect2.Equals(copy1));
-            Assert.True(copy1.Equals(_columnMapCollection));
-            Assert.True(_columnMapCollection.Equals(_columnMapCollection));
-            //            Assert.Equal (true, collect2.Equals(collect2));
-            Assert.True(copy1.Equals(copy1));
-
-            //            Assert.Equal (false, Object.Equals(collect2, columnMapCollection));
-            Assert.True(object.Equals(copy1, _columnMapCollection));
-            //            Assert.Equal (false, Object.Equals(columnMapCollection, collect2));
-            Assert.True(object.Equals(_columnMapCollection, copy1));
-            //            Assert.Equal (false, Object.Equals(copy1, collect2));
-            Assert.True(object.Equals(_columnMapCollection, copy1));
-            Assert.True(object.Equals(_columnMapCollection, _columnMapCollection));
-            //            Assert.Equal (true, Object.Equals(collect2, collect2));
-            Assert.True(object.Equals(copy1, copy1));
-            //            Assert.Equal (false, Object.Equals(columnMapCollection, collect2));
-            Assert.True(object.Equals(_columnMapCollection, copy1));
-            //            Assert.Equal (false, Object.Equals(collect2, columnMapCollection));
-            Assert.True(object.Equals(copy1, _columnMapCollection));
-            //            Assert.Equal (false, Object.Equals(collect2, copy1));
-            Assert.True(object.Equals(copy1, _columnMapCollection));
         }
 
         [Fact]

--- a/src/System.Data.Common/tests/System/Data/Common/DataTableMappingCollectionTest.cs
+++ b/src/System.Data.Common/tests/System/Data/Common/DataTableMappingCollectionTest.cs
@@ -160,42 +160,6 @@ namespace System.Data.Tests.Common
         }
 
         [Fact]
-        public void Equals()
-        {
-            //            DataTableMappingCollection collect2=new DataTableMappingCollection();
-            _tableMapCollection.AddRange(_tabs);
-            //            collect2.AddRange(tabs);
-            DataTableMappingCollection copy1;
-            copy1 = _tableMapCollection;
-
-            //            Assert.False(tableMapCollection.Equals(collect2));
-            Assert.True(_tableMapCollection.Equals(copy1));
-            //            Assert.False(collect2.Equals(tableMapCollection));
-            Assert.True(copy1.Equals(_tableMapCollection));
-            //            Assert.False(collect2.Equals(copy1));
-            Assert.True(copy1.Equals(_tableMapCollection));
-            Assert.True(_tableMapCollection.Equals(_tableMapCollection));
-            //            Assert.True(collect2.Equals(collect2));
-            Assert.True(copy1.Equals(copy1));
-
-            //            Assert.False(Object.Equals(collect2, tableMapCollection));
-            Assert.True(object.Equals(copy1, _tableMapCollection));
-            //            Assert.False(Object.Equals(tableMapCollection, collect2));
-            Assert.True(object.Equals(_tableMapCollection, copy1));
-            //            Assert.False(Object.Equals(copy1, collect2));
-            Assert.True(object.Equals(_tableMapCollection, copy1));
-            Assert.True(object.Equals(_tableMapCollection, _tableMapCollection));
-            //            Assert.True(Object.Equals(collect2, collect2));
-            Assert.True(object.Equals(copy1, copy1));
-            //            Assert.False(Object.Equals(tableMapCollection, collect2));
-            Assert.True(object.Equals(_tableMapCollection, copy1));
-            //            Assert.False(Object.Equals(collect2, tableMapCollection));
-            Assert.True(object.Equals(copy1, _tableMapCollection));
-            //            Assert.False(Object.Equals(collect2, copy1));
-            Assert.True(object.Equals(copy1, _tableMapCollection));
-        }
-
-        [Fact]
         public void GetByDataSetTable()
         {
             _tableMapCollection.AddRange(_tabs);

--- a/src/System.Data.Common/tests/System/Data/Common/DbCommandBuilderTest.cs
+++ b/src/System.Data.Common/tests/System/Data/Common/DbCommandBuilderTest.cs
@@ -45,21 +45,15 @@ namespace System.Data.Tests.Common
         {
             MyCommandBuilder cb = new MyCommandBuilder();
             cb.CatalogLocation = CatalogLocation.End;
-            try
-            {
-                cb.CatalogLocation = (CatalogLocation)666;
-                Assert.False(true);
-            }
-            catch (ArgumentOutOfRangeException ex)
-            {
-                // The CatalogLocation enumeration value, 666, is invalid
-                Assert.Equal(typeof(ArgumentOutOfRangeException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.IndexOf("CatalogLocation") != -1);
-                Assert.True(ex.Message.IndexOf("666") != -1);
-                Assert.Equal("CatalogLocation", ex.ParamName);
-            }
+
+            ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(() => cb.CatalogLocation = (CatalogLocation)666);
+            // The CatalogLocation enumeration value, 666, is invalid
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+            Assert.Contains(ex.Message, "CatalogLocation");
+            Assert.Contains(ex.Message, "666");
+            Assert.Equal("CatalogLocation", ex.ParamName);
+
             Assert.Equal(CatalogLocation.End, cb.CatalogLocation);
         }
 
@@ -94,21 +88,14 @@ namespace System.Data.Tests.Common
         {
             MyCommandBuilder cb = new MyCommandBuilder();
             cb.ConflictOption = ConflictOption.CompareRowVersion;
-            try
-            {
-                cb.ConflictOption = (ConflictOption)666;
-                Assert.False(true);
-            }
-            catch (ArgumentOutOfRangeException ex)
-            {
-                // The ConflictOption enumeration value, 666, is invalid
-                Assert.Equal(typeof(ArgumentOutOfRangeException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.IndexOf("ConflictOption") != -1);
-                Assert.True(ex.Message.IndexOf("666") != -1);
-                Assert.Equal("ConflictOption", ex.ParamName);
-            }
+            ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(() => cb.ConflictOption = (ConflictOption)666);
+            // The ConflictOption enumeration value, 666, is invalid
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+            Assert.Contains(ex.Message, "ConflictOption");
+            Assert.Contains(ex.Message, "666");
+            Assert.Equal("ConflictOption", ex.ParamName);
+
             Assert.Equal(ConflictOption.CompareRowVersion, cb.ConflictOption);
         }
 
@@ -116,29 +103,14 @@ namespace System.Data.Tests.Common
         public void QuoteIdentifier()
         {
             MyCommandBuilder cb = new MyCommandBuilder();
-            try
-            {
-                cb.QuoteIdentifier(null);
-                Assert.False(true);
-            }
-            catch (NotSupportedException ex)
-            {
-                Assert.Equal(typeof(NotSupportedException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.Equal((new NotSupportedException()).Message, ex.Message);
-            }
 
-            try
-            {
-                cb.QuoteIdentifier("mono");
-                Assert.False(true);
-            }
-            catch (NotSupportedException ex)
-            {
-                Assert.Equal(typeof(NotSupportedException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.Equal((new NotSupportedException()).Message, ex.Message);
-            }
+            NotSupportedException ex = Assert.Throws<NotSupportedException>(() => cb.QuoteIdentifier(null));
+            Assert.Null(ex.InnerException);
+            Assert.Equal((new NotSupportedException()).Message, ex.Message);
+
+            NotSupportedException ex2 = Assert.Throws<NotSupportedException>(() => cb.QuoteIdentifier("mono"));
+            Assert.Null(ex.InnerException);
+            Assert.Equal((new NotSupportedException()).Message, ex.Message);
         }
 
         [Fact]

--- a/src/System.Data.Common/tests/System/Data/Common/DbCommandBuilderTest.cs
+++ b/src/System.Data.Common/tests/System/Data/Common/DbCommandBuilderTest.cs
@@ -50,8 +50,8 @@ namespace System.Data.Tests.Common
             // The CatalogLocation enumeration value, 666, is invalid
             Assert.Null(ex.InnerException);
             Assert.NotNull(ex.Message);
-            Assert.Contains(ex.Message, "CatalogLocation");
-            Assert.Contains(ex.Message, "666");
+            Assert.Contains("CatalogLocation", ex.Message);
+            Assert.Contains("666", ex.Message);
             Assert.Equal("CatalogLocation", ex.ParamName);
 
             Assert.Equal(CatalogLocation.End, cb.CatalogLocation);
@@ -92,8 +92,8 @@ namespace System.Data.Tests.Common
             // The ConflictOption enumeration value, 666, is invalid
             Assert.Null(ex.InnerException);
             Assert.NotNull(ex.Message);
-            Assert.Contains(ex.Message, "ConflictOption");
-            Assert.Contains(ex.Message, "666");
+            Assert.Contains("ConflictOption", ex.Message);
+            Assert.Contains("666", ex.Message);
             Assert.Equal("ConflictOption", ex.ParamName);
 
             Assert.Equal(ConflictOption.CompareRowVersion, cb.ConflictOption);

--- a/src/System.Data.Common/tests/System/Data/Common/DbConnectionStringBuilderTest.cs
+++ b/src/System.Data.Common/tests/System/Data/Common/DbConnectionStringBuilderTest.cs
@@ -86,40 +86,25 @@ namespace System.Data.Tests.Common
             for (int i = 0; i < invalid_keywords.Length; i++)
             {
                 string keyword = invalid_keywords[i];
-                try
-                {
-                    _builder.Add(keyword, "abc");
-                    Assert.False(true);
-                }
-                catch (ArgumentException ex)
-                {
-                    // Invalid keyword, contain one or more of 'no characters',
-                    // 'control characters', 'leading or trailing whitespace'
-                    // or 'leading semicolons'
-                    Assert.Equal(typeof(ArgumentException), ex.GetType());
-                    Assert.Null(ex.InnerException);
-                    Assert.NotNull(ex.Message);
-                    Assert.Contains(keyword, ex.Message);
-                    Assert.Equal(keyword, ex.ParamName);
-                }
+
+                ArgumentException ex = Assert.Throws<ArgumentException>(() => _builder.Add(keyword, "abc"));
+                // Invalid keyword, contain one or more of 'no characters',
+                // 'control characters', 'leading or trailing whitespace'
+                // or 'leading semicolons'
+                Assert.Null(ex.InnerException);
+                Assert.NotNull(ex.Message);
+                Assert.Contains(keyword, ex.Message);
+                Assert.Equal(keyword, ex.ParamName);
             }
         }
 
         [Fact]
         public void Add_Keyword_Null()
         {
-            try
-            {
-                _builder.Add(null, "abc");
-                Assert.False(true);
-            }
-            catch (ArgumentNullException ex)
-            {
-                Assert.Equal(typeof(ArgumentNullException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.Equal("keyword", ex.ParamName);
-            }
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => _builder.Add(null, "abc"));
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+            Assert.Equal("keyword", ex.ParamName);
         }
 
         [Fact]
@@ -289,113 +274,61 @@ namespace System.Data.Tests.Common
             for (int i = 0; i < invalid_keywords.Length; i++)
             {
                 string keyword = invalid_keywords[i];
-                try
-                {
-                    _builder[keyword] = "abc";
-                    Assert.False(true);
-                }
-                catch (ArgumentException ex)
-                {
-                    // Invalid keyword, contain one or more of 'no characters',
-                    // 'control characters', 'leading or trailing whitespace'
-                    // or 'leading semicolons'
-                    Assert.Equal(typeof(ArgumentException), ex.GetType());
-                    Assert.Null(ex.InnerException);
-                    Assert.NotNull(ex.Message);
-                    Assert.Contains(keyword, ex.Message);
-                    Assert.Equal(keyword, ex.ParamName);
-                }
+                ArgumentException ex = Assert.Throws<ArgumentException>(() => _builder[keyword] = "abc");
+                // Invalid keyword, contain one or more of 'no characters',
+                // 'control characters', 'leading or trailing whitespace'
+                // or 'leading semicolons'
+                Assert.Null(ex.InnerException);
+                Assert.NotNull(ex.Message);
+                Assert.Contains(keyword, ex.Message);
+                Assert.Equal(keyword, ex.ParamName);
 
                 _builder[keyword] = null;
                 Assert.False(_builder.ContainsKey(keyword));
 
-                try
-                {
-                    object value = _builder[keyword];
-                    Assert.False(true);
-                }
-                catch (ArgumentException ex)
-                {
-                    // Keyword not supported: '...'
-                    Assert.Equal(typeof(ArgumentException), ex.GetType());
-                    Assert.Null(ex.InnerException);
-                    Assert.NotNull(ex.Message);
-
-                    // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
-                    // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
-                    // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
-                    Assert.Matches(@"[\p{Pi}\p{Po}]" + Regex.Escape(keyword) + @"[\p{Pf}\p{Po}]", ex.Message);
-
-                    Assert.Null(ex.ParamName);
-                }
+                ArgumentException ex2 = Assert.Throws<ArgumentException>(() => _builder[keyword]);
+                // Keyword not supported: '...'
+                Assert.Null(ex2.InnerException);
+                Assert.NotNull(ex2.Message);
+                // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
+                // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
+                // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
+                Assert.Matches(@"[\p{Pi}\p{Po}]" + Regex.Escape(keyword) + @"[\p{Pf}\p{Po}]", ex2.Message);
+                Assert.Null(ex2.ParamName);
             }
         }
 
         [Fact]
         public void Indexer_Keyword_NotSupported()
         {
-            try
-            {
-                object value = _builder["abc"];
-                Assert.False(true);
-            }
-            catch (ArgumentException ex)
-            {
-                // Keyword not supported: 'abc'
-                Assert.Equal(typeof(ArgumentException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-
-                // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
-                // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
-                // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
-                Assert.Matches(@"[\p{Pi}\p{Po}]" + "abc" + @"[\p{Pf}\p{Po}]", ex.Message);
-
-                Assert.Null(ex.ParamName);
-            }
+            ArgumentException ex = Assert.Throws<ArgumentException>(() => _builder["abc"]);
+            // Keyword not supported: 'abc'
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+            // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
+            // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
+            // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
+            Assert.Matches(@"[\p{Pi}\p{Po}]" + "abc" + @"[\p{Pf}\p{Po}]", ex.Message);
+            Assert.Null(ex.ParamName);
         }
 
         [Fact]
         public void Indexer_Keyword_Null()
         {
-            try
-            {
-                _builder[null] = "abc";
-                Assert.False(true);
-            }
-            catch (ArgumentNullException ex)
-            {
-                Assert.Equal(typeof(ArgumentNullException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.Equal("keyword", ex.ParamName);
-            }
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => _builder[null] = "abc");
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+            Assert.Equal("keyword", ex.ParamName);
 
-            try
-            {
-                _builder[null] = null;
-                Assert.False(true);
-            }
-            catch (ArgumentNullException ex)
-            {
-                Assert.Equal(typeof(ArgumentNullException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.Equal("keyword", ex.ParamName);
-            }
+            ArgumentNullException ex2 = Assert.Throws<ArgumentNullException>(() => _builder[null] = null);
+            Assert.Null(ex2.InnerException);
+            Assert.NotNull(ex2.Message);
+            Assert.Equal("keyword", ex2.ParamName);
 
-            try
-            {
-                object value = _builder[null];
-                Assert.False(true);
-            }
-            catch (ArgumentNullException ex)
-            {
-                Assert.Equal(typeof(ArgumentNullException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.Equal("keyword", ex.ParamName);
-            }
+            ArgumentNullException ex3 = Assert.Throws<ArgumentNullException>(() => _builder[null]);
+            Assert.Null(ex3.InnerException);
+            Assert.NotNull(ex3.Message);
+            Assert.Equal("keyword", ex3.ParamName);
         }
 
         [Fact]
@@ -403,25 +336,17 @@ namespace System.Data.Tests.Common
         {
             _builder["DriverID"] = null;
             Assert.Equal(string.Empty, _builder.ConnectionString);
-            try
-            {
-                object value = _builder["DriverID"];
-                Assert.False(true);
-            }
-            catch (ArgumentException ex)
-            {
-                // Keyword not supported: 'DriverID'
-                Assert.Equal(typeof(ArgumentException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
 
-                // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
-                // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
-                // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
-                Assert.Matches(@"[\p{Pi}\p{Po}]" + "DriverID" + @"[\p{Pf}\p{Po}]", ex.Message);
+            ArgumentException ex = Assert.Throws<ArgumentException>(() => _builder["DriverID"]);
+            // Keyword not supported: 'DriverID'
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+            // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
+            // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
+            // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
+            Assert.Matches(@"[\p{Pi}\p{Po}]" + "DriverID" + @"[\p{Pf}\p{Po}]", ex.Message);
+            Assert.Null(ex.ParamName);
 
-                Assert.Null(ex.ParamName);
-            }
             Assert.False(_builder.ContainsKey("DriverID"));
             Assert.Equal(string.Empty, _builder.ConnectionString);
 
@@ -513,18 +438,10 @@ namespace System.Data.Tests.Common
         [Fact]
         public void Remove_Keyword_Null()
         {
-            try
-            {
-                _builder.Remove(null);
-                Assert.False(true);
-            }
-            catch (ArgumentNullException ex)
-            {
-                Assert.Equal(typeof(ArgumentNullException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.Equal("keyword", ex.ParamName);
-            }
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => _builder.Remove(null));
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+            Assert.Equal("keyword", ex.ParamName);
         }
 
         [Fact]
@@ -582,18 +499,10 @@ namespace System.Data.Tests.Common
         public void ContainsKey_Keyword_Null()
         {
             _builder["SourceType"] = "DBC";
-            try
-            {
-                _builder.ContainsKey(null);
-                Assert.False(true);
-            }
-            catch (ArgumentNullException ex)
-            {
-                Assert.Equal(typeof(ArgumentNullException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.Equal("keyword", ex.ParamName);
-            }
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => _builder.ContainsKey(null));
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+            Assert.Equal("keyword", ex.ParamName);
         }
 
         [Fact]
@@ -730,60 +639,34 @@ namespace System.Data.Tests.Common
         [Fact] // AppendKeyValuePair (StringBuilder, String, String)
         public void AppendKeyValuePair1_Builder_Null()
         {
-            try
-            {
-                DbConnectionStringBuilder.AppendKeyValuePair(
-                    null, "Server",
-                    "localhost");
-                Assert.False(true);
-            }
-            catch (ArgumentNullException ex)
-            {
-                Assert.Equal(typeof(ArgumentNullException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.Equal("builder", ex.ParamName);
-            }
+            ArgumentNullException ex =
+                Assert.Throws<ArgumentNullException>(() => DbConnectionStringBuilder.AppendKeyValuePair(null, "Server", "localhost"));
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+            Assert.Equal("builder", ex.ParamName);
         }
 
         [Fact] // AppendKeyValuePair (StringBuilder, String, String)
         public void AppendKeyValuePair1_Keyword_Empty()
         {
             StringBuilder sb = new StringBuilder();
-            try
-            {
-                DbConnectionStringBuilder.AppendKeyValuePair(
-                    sb, string.Empty, "localhost");
-                Assert.False(true);
-            }
-            catch (ArgumentException ex)
-            {
-                // Expecting non-empty string for 'keyName'
-                // parameter
-                Assert.Equal(typeof(ArgumentException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.Null(ex.ParamName);
-            }
+            ArgumentException ex =
+                Assert.Throws<ArgumentException>(() => DbConnectionStringBuilder.AppendKeyValuePair(sb, string.Empty, "localhost"));
+            // Expecting non-empty string for 'keyName' parameter
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+            Assert.Null(ex.ParamName);
         }
 
         [Fact] // AppendKeyValuePair (StringBuilder, String, String)
         public void AppendKeyValuePair1_Keyword_Null()
         {
             StringBuilder sb = new StringBuilder();
-            try
-            {
-                DbConnectionStringBuilder.AppendKeyValuePair(
-                    sb, null, "localhost");
-                Assert.False(true);
-            }
-            catch (ArgumentNullException ex)
-            {
-                Assert.Equal(typeof(ArgumentNullException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.Equal("keyName", ex.ParamName);
-            }
+            ArgumentNullException ex =
+                Assert.Throws<ArgumentNullException>(() => DbConnectionStringBuilder.AppendKeyValuePair(sb, null, "localhost"));
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+            Assert.Null(ex.ParamName);
         }
 
         [Fact] // AppendKeyValuePair (StringBuilder, String, String, Boolean)
@@ -1619,105 +1502,54 @@ namespace System.Data.Tests.Common
         [Fact] // AppendKeyValuePair (StringBuilder, String, String, Boolean)
         public void AppendKeyValuePair2_Builder_Null()
         {
-            try
-            {
-                DbConnectionStringBuilder.AppendKeyValuePair(
-                    null, "Server",
-                    "localhost", true);
-                Assert.False(true);
-            }
-            catch (ArgumentNullException ex)
-            {
-                Assert.Equal(typeof(ArgumentNullException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.Equal("builder", ex.ParamName);
-            }
+            ArgumentNullException ex1 =
+                Assert.Throws<ArgumentNullException>(() => DbConnectionStringBuilder.AppendKeyValuePair(null, "Server", "localhost", true));
+            Assert.Null(ex1.InnerException);
+            Assert.NotNull(ex1.Message);
+            Assert.Equal("builder", ex1.ParamName);
 
-            try
-            {
-                DbConnectionStringBuilder.AppendKeyValuePair(
-                    null, "Server",
-                    "localhost", false);
-                Assert.False(true);
-            }
-            catch (ArgumentNullException ex)
-            {
-                Assert.Equal(typeof(ArgumentNullException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.Equal("builder", ex.ParamName);
-            }
+            ArgumentNullException ex2 =
+                Assert.Throws<ArgumentNullException>(() => DbConnectionStringBuilder.AppendKeyValuePair(null, "Server", "localhost", false));
+            Assert.Null(ex2.InnerException);
+            Assert.NotNull(ex2.Message);
+            Assert.Equal("builder", ex2.ParamName);
         }
 
         [Fact] // AppendKeyValuePair (StringBuilder, String, String, Boolean)
         public void AppendKeyValuePair2_Keyword_Empty()
         {
             StringBuilder sb = new StringBuilder();
-            try
-            {
-                DbConnectionStringBuilder.AppendKeyValuePair(
-                    sb, string.Empty, "localhost", true);
-                Assert.False(true);
-            }
-            catch (ArgumentException ex)
-            {
-                // Expecting non-empty string for 'keyName'
-                // parameter
-                Assert.Equal(typeof(ArgumentException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.Null(ex.ParamName);
-            }
 
-            try
-            {
-                DbConnectionStringBuilder.AppendKeyValuePair(
-                    sb, string.Empty, "localhost", false);
-                Assert.False(true);
-            }
-            catch (ArgumentException ex)
-            {
-                // Expecting non-empty string for 'keyName'
-                // parameter
-                Assert.Equal(typeof(ArgumentException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.Null(ex.ParamName);
-            }
+            ArgumentException ex1 =
+                Assert.Throws<ArgumentException>(() => DbConnectionStringBuilder.AppendKeyValuePair(null, string.Empty, "localhost", true));
+            // Expecting non-empty string for 'keyName' parameter
+            Assert.Null(ex1.InnerException);
+            Assert.NotNull(ex1.Message);
+            Assert.Null(ex1.ParamName);
+
+            ArgumentException ex2 =
+                Assert.Throws<ArgumentException>(() => DbConnectionStringBuilder.AppendKeyValuePair(null, string.Empty, "localhost", false));
+            // Expecting non-empty string for 'keyName' parameter
+            Assert.Null(ex2.InnerException);
+            Assert.NotNull(ex2.Message);
+            Assert.Null(ex2.ParamName);
         }
 
         [Fact] // AppendKeyValuePair (StringBuilder, String, String, Boolean)
         public void AppendKeyValuePair2_Keyword_Null()
         {
             StringBuilder sb = new StringBuilder();
-            try
-            {
-                DbConnectionStringBuilder.AppendKeyValuePair(
-                    sb, null, "localhost", true);
-                Assert.False(true);
-            }
-            catch (ArgumentNullException ex)
-            {
-                Assert.Equal(typeof(ArgumentNullException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.Equal("keyName", ex.ParamName);
-            }
+            ArgumentNullException ex1 =
+                Assert.Throws<ArgumentNullException>(() => DbConnectionStringBuilder.AppendKeyValuePair(null, null, "localhost", true));
+            Assert.Null(ex1.InnerException);
+            Assert.NotNull(ex1.Message);
+            Assert.Equal("keyName", ex1.ParamName);
 
-            try
-            {
-                DbConnectionStringBuilder.AppendKeyValuePair(
-                    sb, null, "localhost", false);
-                Assert.False(true);
-            }
-            catch (ArgumentNullException ex)
-            {
-                Assert.Equal(typeof(ArgumentNullException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.Equal("keyName", ex.ParamName);
-            }
+            ArgumentNullException ex2 =
+                Assert.Throws<ArgumentNullException>(() => DbConnectionStringBuilder.AppendKeyValuePair(null, null, "localhost", false));
+            Assert.Null(ex2.InnerException);
+            Assert.NotNull(ex2.Message);
+            Assert.Equal("keyName", ex2.ParamName);
         }
 
         [Fact]
@@ -1840,19 +1672,11 @@ namespace System.Data.Tests.Common
         [Fact]
         public void TryGetValue_Keyword_Null()
         {
-            object value = null;
-            try
-            {
-                _builder.TryGetValue(null, out value);
-                Assert.False(true);
-            }
-            catch (ArgumentNullException ex)
-            {
-                Assert.Equal(typeof(ArgumentNullException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.Equal("keyword", ex.ParamName);
-            }
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => _builder.TryGetValue(null, out object value));
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+            Assert.Equal("keyword", ex.ParamName);
+
         }
 
         [Fact]
@@ -2426,21 +2250,13 @@ namespace System.Data.Tests.Common
                 if (found)
                     continue;
 
-                try
-                {
-                    sb.ConnectionString = test1[0];
-                    Assert.False(true);
-                }
-                catch (ArgumentException ex)
-                {
-                    // Format of the initialization string does
-                    // not conform to specification starting
-                    // at index 0
-                    Assert.Equal(typeof(ArgumentException), ex.GetType());
-                    Assert.Null(ex.InnerException);
-                    Assert.NotNull(ex.Message);
-                    Assert.Null(ex.ParamName);
-                }
+                ArgumentException ex = Assert.Throws<ArgumentException>(() => sb.ConnectionString = test1[0]);
+                // Format of the initialization string does
+                // not conform to specification starting
+                // at index 0
+                Assert.Null(ex.InnerException);
+                Assert.NotNull(ex.Message);
+                Assert.Null(ex.ParamName);
             }
 
             // check uniqueness of tests
@@ -2450,8 +2266,7 @@ namespace System.Data.Tests.Common
                 {
                     if (i == j)
                         continue;
-                    if (tests1[i] == tests1[j])
-                        Assert.False(true);
+                    Assert.Equal(tests1[i], tests1[j]);
                 }
             }
 
@@ -2462,8 +2277,7 @@ namespace System.Data.Tests.Common
                 {
                     if (i == j)
                         continue;
-                    if (tests2[i] == tests2[j])
-                        Assert.False(true);
+                    Assert.Equal(tests2[i], tests2[j]);
                 }
             }
         }

--- a/src/System.Data.Common/tests/System/Data/Common/DbConnectionStringBuilderTest.cs
+++ b/src/System.Data.Common/tests/System/Data/Common/DbConnectionStringBuilderTest.cs
@@ -666,7 +666,7 @@ namespace System.Data.Tests.Common
                 Assert.Throws<ArgumentNullException>(() => DbConnectionStringBuilder.AppendKeyValuePair(sb, null, "localhost"));
             Assert.Null(ex.InnerException);
             Assert.NotNull(ex.Message);
-            Assert.Null(ex.ParamName);
+            Assert.Equal("keyName", ex.ParamName);
         }
 
         [Fact] // AppendKeyValuePair (StringBuilder, String, String, Boolean)
@@ -1521,14 +1521,14 @@ namespace System.Data.Tests.Common
             StringBuilder sb = new StringBuilder();
 
             ArgumentException ex1 =
-                Assert.Throws<ArgumentException>(() => DbConnectionStringBuilder.AppendKeyValuePair(null, string.Empty, "localhost", true));
+                Assert.Throws<ArgumentException>(() => DbConnectionStringBuilder.AppendKeyValuePair(sb, string.Empty, "localhost", true));
             // Expecting non-empty string for 'keyName' parameter
             Assert.Null(ex1.InnerException);
             Assert.NotNull(ex1.Message);
             Assert.Null(ex1.ParamName);
 
             ArgumentException ex2 =
-                Assert.Throws<ArgumentException>(() => DbConnectionStringBuilder.AppendKeyValuePair(null, string.Empty, "localhost", false));
+                Assert.Throws<ArgumentException>(() => DbConnectionStringBuilder.AppendKeyValuePair(sb, string.Empty, "localhost", false));
             // Expecting non-empty string for 'keyName' parameter
             Assert.Null(ex2.InnerException);
             Assert.NotNull(ex2.Message);
@@ -1540,13 +1540,13 @@ namespace System.Data.Tests.Common
         {
             StringBuilder sb = new StringBuilder();
             ArgumentNullException ex1 =
-                Assert.Throws<ArgumentNullException>(() => DbConnectionStringBuilder.AppendKeyValuePair(null, null, "localhost", true));
+                Assert.Throws<ArgumentNullException>(() => DbConnectionStringBuilder.AppendKeyValuePair(sb, null, "localhost", true));
             Assert.Null(ex1.InnerException);
             Assert.NotNull(ex1.Message);
             Assert.Equal("keyName", ex1.ParamName);
 
             ArgumentNullException ex2 =
-                Assert.Throws<ArgumentNullException>(() => DbConnectionStringBuilder.AppendKeyValuePair(null, null, "localhost", false));
+                Assert.Throws<ArgumentNullException>(() => DbConnectionStringBuilder.AppendKeyValuePair(sb, null, "localhost", false));
             Assert.Null(ex2.InnerException);
             Assert.NotNull(ex2.Message);
             Assert.Equal("keyName", ex2.ParamName);
@@ -2266,7 +2266,7 @@ namespace System.Data.Tests.Common
                 {
                     if (i == j)
                         continue;
-                    Assert.Equal(tests1[i], tests1[j]);
+                    Assert.NotEqual(tests1[i], tests1[j]);
                 }
             }
 
@@ -2277,7 +2277,7 @@ namespace System.Data.Tests.Common
                 {
                     if (i == j)
                         continue;
-                    Assert.Equal(tests2[i], tests2[j]);
+                    Assert.NotEqual(tests2[i], tests2[j]);
                 }
             }
         }

--- a/src/System.Data.Common/tests/System/Data/Common/DbDataAdapterTest.cs
+++ b/src/System.Data.Common/tests/System/Data/Common/DbDataAdapterTest.cs
@@ -33,32 +33,19 @@ namespace System.Data.Tests.Common
         public void UpdateBatchSize()
         {
             MyAdapter da = new MyAdapter();
-            try
-            {
-                da.UpdateBatchSize = 0;
-                Assert.False(true);
-            }
-            catch (NotSupportedException ex)
-            {
-                // Specified method is not supported
-                Assert.Equal(typeof(NotSupportedException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-            }
+
+            NotSupportedException ex1 = Assert.Throws<NotSupportedException>(() => da.UpdateBatchSize = 0);
+            // Specified method is not supported
+            Assert.Null(ex1.InnerException);
+            Assert.NotNull(ex1.Message);
+
             Assert.Equal(1, da.UpdateBatchSize);
 
-            try
-            {
-                da.UpdateBatchSize = int.MaxValue;
-                Assert.False(true);
-            }
-            catch (NotSupportedException ex)
-            {
-                // Specified method is not supported
-                Assert.Equal(typeof(NotSupportedException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-            }
+            NotSupportedException ex2 = Assert.Throws<NotSupportedException>(() => da.UpdateBatchSize = 0);
+            // Specified method is not supported
+            Assert.Null(ex2.InnerException);
+            Assert.NotNull(ex2.Message);
+
             Assert.Equal(1, da.UpdateBatchSize);
 
             da.UpdateBatchSize = 1;
@@ -69,79 +56,49 @@ namespace System.Data.Tests.Common
         public void UpdateBatchSize_Negative()
         {
             MyAdapter da = new MyAdapter();
-            try
-            {
-                da.UpdateBatchSize = -1;
-                Assert.False(true);
-            }
-            catch (NotSupportedException ex)
-            {
-                // Specified method is not supported
-                Assert.Equal(typeof(NotSupportedException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-            }
+
+            NotSupportedException ex = Assert.Throws<NotSupportedException>(() => da.UpdateBatchSize = -1);
+            // Specified method is not supported
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
         }
 
         [Fact]
         public void ClearBatch()
         {
             MyAdapter da = new MyAdapter();
-            try
-            {
-                da.ClearBatch();
-                Assert.False(true);
-            }
-            catch (NotSupportedException ex)
-            {
-                Assert.Equal(typeof(NotSupportedException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-            }
+
+            NotSupportedException ex = Assert.Throws<NotSupportedException>(() => da.ClearBatch());
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
         }
 
         [Fact]
         public void ExecuteBatch()
         {
             MyAdapter da = new MyAdapter();
-            try
-            {
-                da.ExecuteBatch();
-                Assert.False(true);
-            }
-            catch (NotSupportedException ex)
-            {
-                Assert.Equal(typeof(NotSupportedException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-            }
+
+            NotSupportedException ex = Assert.Throws<NotSupportedException>(() => da.ExecuteBatch());
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
         }
 
         [Fact]
         public void GetBatchedParameter()
         {
             MyAdapter da = new MyAdapter();
-            try
-            {
-                da.GetBatchedParameter(1, 1);
-                Assert.False(true);
-            }
-            catch (NotSupportedException ex)
-            {
-                Assert.Equal(typeof(NotSupportedException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-            }
+
+            NotSupportedException ex = Assert.Throws<NotSupportedException>(() => da.GetBatchedParameter(1, 1));
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
         }
 
         [Fact]
         public void GetBatchedRecordsAffected()
         {
             MyAdapter da = new MyAdapter();
-            int recordsAffected = 0;
-            Exception error = null;
 
-            Assert.True(da.GetBatchedRecordsAffected(int.MinValue, out recordsAffected, out error));
+            Assert.True(da.GetBatchedRecordsAffected(int.MinValue, out int recordsAffected, out Exception error));
             Assert.Equal(1, recordsAffected);
             Assert.Null(error);
         }
@@ -150,34 +107,20 @@ namespace System.Data.Tests.Common
         public void InitializeBatching()
         {
             MyAdapter da = new MyAdapter();
-            try
-            {
-                da.InitializeBatching();
-                Assert.False(true);
-            }
-            catch (NotSupportedException ex)
-            {
-                Assert.Equal(typeof(NotSupportedException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-            }
+
+            NotSupportedException ex = Assert.Throws<NotSupportedException>(() => da.InitializeBatching());
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
         }
 
         [Fact]
         public void TerminateBatching()
         {
             MyAdapter da = new MyAdapter();
-            try
-            {
-                da.TerminateBatching();
-                Assert.False(true);
-            }
-            catch (NotSupportedException ex)
-            {
-                Assert.Equal(typeof(NotSupportedException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-            }
+
+            NotSupportedException ex = Assert.Throws<NotSupportedException>(() => da.TerminateBatching());
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
         }
 
         private class MyAdapter : DbDataAdapter

--- a/src/System.Data.Common/tests/System/Data/Common/DbDataReaderMock.cs
+++ b/src/System.Data.Common/tests/System/Data/Common/DbDataReaderMock.cs
@@ -41,12 +41,7 @@ namespace System.Data.Tests.Common
 
         public DbDataReaderMock(DataTable testData)
         {
-            if (testData == null)
-            {
-                throw new ArgumentNullException(nameof(testData));
-            }
-
-            _testDataTable = testData;
+            _testDataTable = testData ?? throw new ArgumentNullException(nameof(testData));
         }
 
         public override void Close()

--- a/src/System.Data.Common/tests/System/Data/Common/DbTransactionTest.cs
+++ b/src/System.Data.Common/tests/System/Data/Common/DbTransactionTest.cs
@@ -53,47 +53,30 @@ namespace System.Data.Tests.Common
                 get { return IsolationLevel.RepeatableRead; }
             }
 
-            public bool IsCommitted
-            {
-                get { return _isCommitted; }
-            }
+            public bool IsCommitted { get; private set; }
 
-            public bool IsRolledback
-            {
-                get { return _isRolledback; }
-            }
+            public bool IsRolledback { get; private set; }
 
-            public bool IsDisposed
-            {
-                get { return _isDisposed; }
-            }
+            public bool IsDisposed { get; private set; }
 
-            public bool Disposing
-            {
-                get { return _disposing; }
-            }
+            public bool Disposing { get; private set; }
 
             public override void Commit()
             {
-                _isCommitted = true;
+                IsCommitted = true;
             }
 
             public override void Rollback()
             {
-                _isRolledback = true;
+                IsRolledback = true;
             }
 
             protected override void Dispose(bool disposing)
             {
-                _isDisposed = true;
-                _disposing = disposing;
+                IsDisposed = true;
+                Disposing = disposing;
                 base.Dispose(disposing);
             }
-
-            private bool _isCommitted;
-            private bool _isRolledback;
-            private bool _isDisposed;
-            private bool _disposing;
         }
     }
 }

--- a/src/System.Data.Common/tests/System/Data/ConstraintCollectionTest.cs
+++ b/src/System.Data.Common/tests/System/Data/ConstraintCollectionTest.cs
@@ -228,7 +228,7 @@ namespace System.Data.Tests
             {
                 Assert.Null(constraints[2].Table);
             }
-            catch (NullReferenceException) { }
+            catch (NullReferenceException) { } 
 
             table.EndInit();
         }

--- a/src/System.Data.Common/tests/System/Data/ConstraintCollectionTest.cs
+++ b/src/System.Data.Common/tests/System/Data/ConstraintCollectionTest.cs
@@ -222,6 +222,7 @@ namespace System.Data.Tests
             table.BeginInit();
             table.Constraints.AddRange(constraints);
 
+            //TODO: what's up with this NRE swallow? does not seem to throw.
             //Check the table property of UniqueConstraint Object
             try
             {
@@ -235,17 +236,10 @@ namespace System.Data.Tests
         [Fact]
         public void Clear()
         {
-            //try
-            //{
             _table.Constraints.Clear(); //Clear all constraints
             Assert.Equal(0, _table.Constraints.Count);
             _table2.Constraints.Clear();
             Assert.Equal(0, _table2.Constraints.Count);
-            //}
-            //catch (Exception e)
-            //{
-            //    Console.WriteLine(e);
-            //}
         }
 
         [Fact]

--- a/src/System.Data.Common/tests/System/Data/ConstraintCollectionTest.cs
+++ b/src/System.Data.Common/tests/System/Data/ConstraintCollectionTest.cs
@@ -222,13 +222,8 @@ namespace System.Data.Tests
             table.BeginInit();
             table.Constraints.AddRange(constraints);
 
-            //TODO: what's up with this NRE swallow? does not seem to throw.
             //Check the table property of UniqueConstraint Object
-            try
-            {
-                Assert.Null(constraints[2].Table);
-            }
-            catch (NullReferenceException) { } 
+            Assert.Null(constraints[2].Table);
 
             table.EndInit();
         }

--- a/src/System.Data.Common/tests/System/Data/ConstraintExceptionTest.cs
+++ b/src/System.Data.Common/tests/System/Data/ConstraintExceptionTest.cs
@@ -103,12 +103,14 @@ namespace System.Data.Tests
         [Fact]
         public void Ctor_ArgumentsRoundtrip()
         {
+            const int COR_E_DataConstraint = unchecked((int)0x8013192a);
+
             var innerException = new Exception("inner exception");
 
             var e = new ConstraintException("test", innerException);
             Assert.Equal("test", e.Message);
             Assert.Same(innerException, e.InnerException);
-            Assert.Equal(-2146232022, e.HResult);
+            Assert.Equal(COR_E_DataConstraint, e.HResult);
         }
     }
 }

--- a/src/System.Data.Common/tests/System/Data/ConstraintTest.cs
+++ b/src/System.Data.Common/tests/System/Data/ConstraintTest.cs
@@ -59,38 +59,14 @@ namespace System.Data.Tests
         [Fact]
         public void SetConstraintNameNullOrEmptyExceptions()
         {
-            bool exceptionCaught = false;
-            string name = null;
-
             _table.Constraints.Add(_constraint1);
 
-            for (int i = 0; i <= 1; i++)
-            {
-                exceptionCaught = false;
-                if (0 == i)
-                    name = null;
-                if (1 == i)
-                    name = string.Empty;
-
-                try
-                {
-                    //Next line should throw ArgumentException
-                    //Because ConstraintName can't be set to null
-                    //or empty while the constraint is part of the
-                    //collection
-                    _constraint1.ConstraintName = name;
-                }
-                catch (ArgumentException)
-                {
-                    exceptionCaught = true;
-                }
-                catch
-                {
-                    Assert.False(true);
-                }
-
-                Assert.True(exceptionCaught);
-            }
+            // Next line should throw ArgumentException
+            // Because ConstraintName can't be set to null
+            // or empty while the constraint is part of the
+            // collection
+            Assert.Throws<ArgumentException>(() => _constraint1.ConstraintName = null);
+            Assert.Throws<ArgumentException>(() => _constraint1.ConstraintName = string.Empty);
         }
 
         [Fact]
@@ -118,8 +94,7 @@ namespace System.Data.Tests
         [Fact]
         public void GetExtendedProperties()
         {
-            PropertyCollection col = _constraint1.ExtendedProperties as
-                PropertyCollection;
+            PropertyCollection col = _constraint1.ExtendedProperties;
 
             Assert.NotNull(col);
         }

--- a/src/System.Data.Common/tests/System/Data/DBConcurrencyExceptionTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DBConcurrencyExceptionTest.cs
@@ -55,7 +55,7 @@ namespace System.Data.Tests
             dbce = new DBConcurrencyException(null);
             Assert.Null(dbce.InnerException);
             Assert.NotNull(dbce.Message);
-            Assert.True(dbce.Message.IndexOf(typeof(DBConcurrencyException).FullName) != -1);
+            Assert.Contains(dbce.Message, typeof(DBConcurrencyException).FullName);
             Assert.Null(dbce.Row);
 
             Assert.Equal(0, dbce.RowCount);
@@ -82,7 +82,7 @@ namespace System.Data.Tests
 
             dbce = new DBConcurrencyException(null, inner);
             Assert.Same(inner, dbce.InnerException);
-            Assert.True(dbce.Message.IndexOf(typeof(DBConcurrencyException).FullName) != -1);
+            Assert.Contains(dbce.Message, typeof(DBConcurrencyException).FullName);
             Assert.Null(dbce.Row);
             Assert.Equal(0, dbce.RowCount);
 
@@ -100,7 +100,7 @@ namespace System.Data.Tests
 
             dbce = new DBConcurrencyException(null, null);
             Assert.Null(dbce.InnerException);
-            Assert.True(dbce.Message.IndexOf(typeof(DBConcurrencyException).FullName) != -1);
+            Assert.Contains(dbce.Message, typeof(DBConcurrencyException).FullName);
             Assert.Null(dbce.Row);
             Assert.Equal(0, dbce.RowCount);
         }
@@ -126,7 +126,7 @@ namespace System.Data.Tests
             rows = new DataRow[] { rowB, rowA, null };
             dbce = new DBConcurrencyException(null, inner, rows);
             Assert.Same(inner, dbce.InnerException);
-            Assert.True(dbce.Message.IndexOf(typeof(DBConcurrencyException).FullName) != -1);
+            Assert.Contains(dbce.Message, typeof(DBConcurrencyException).FullName);
             Assert.Same(rowB, dbce.Row);
             Assert.Equal(3, dbce.RowCount);
 
@@ -154,7 +154,7 @@ namespace System.Data.Tests
             rows = null;
             dbce = new DBConcurrencyException(null, null, rows);
             Assert.Null(dbce.InnerException);
-            Assert.True(dbce.Message.IndexOf(typeof(DBConcurrencyException).FullName) != -1);
+            Assert.Contains(dbce.Message, typeof(DBConcurrencyException).FullName);
             Assert.Null(dbce.Row);
             Assert.Equal(0, dbce.RowCount);
         }

--- a/src/System.Data.Common/tests/System/Data/DBConcurrencyExceptionTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DBConcurrencyExceptionTest.cs
@@ -55,7 +55,7 @@ namespace System.Data.Tests
             dbce = new DBConcurrencyException(null);
             Assert.Null(dbce.InnerException);
             Assert.NotNull(dbce.Message);
-            Assert.Contains(dbce.Message, typeof(DBConcurrencyException).FullName);
+            Assert.Contains(typeof(DBConcurrencyException).FullName, dbce.Message);
             Assert.Null(dbce.Row);
 
             Assert.Equal(0, dbce.RowCount);
@@ -82,7 +82,7 @@ namespace System.Data.Tests
 
             dbce = new DBConcurrencyException(null, inner);
             Assert.Same(inner, dbce.InnerException);
-            Assert.Contains(dbce.Message, typeof(DBConcurrencyException).FullName);
+            Assert.Contains(typeof(DBConcurrencyException).FullName, dbce.Message);
             Assert.Null(dbce.Row);
             Assert.Equal(0, dbce.RowCount);
 
@@ -100,7 +100,7 @@ namespace System.Data.Tests
 
             dbce = new DBConcurrencyException(null, null);
             Assert.Null(dbce.InnerException);
-            Assert.Contains(dbce.Message, typeof(DBConcurrencyException).FullName);
+            Assert.Contains(typeof(DBConcurrencyException).FullName, dbce.Message);
             Assert.Null(dbce.Row);
             Assert.Equal(0, dbce.RowCount);
         }
@@ -126,7 +126,7 @@ namespace System.Data.Tests
             rows = new DataRow[] { rowB, rowA, null };
             dbce = new DBConcurrencyException(null, inner, rows);
             Assert.Same(inner, dbce.InnerException);
-            Assert.Contains(dbce.Message, typeof(DBConcurrencyException).FullName);
+            Assert.Contains(typeof(DBConcurrencyException).FullName, dbce.Message);
             Assert.Same(rowB, dbce.Row);
             Assert.Equal(3, dbce.RowCount);
 
@@ -154,7 +154,7 @@ namespace System.Data.Tests
             rows = null;
             dbce = new DBConcurrencyException(null, null, rows);
             Assert.Null(dbce.InnerException);
-            Assert.Contains(dbce.Message, typeof(DBConcurrencyException).FullName);
+            Assert.Contains(typeof(DBConcurrencyException).FullName, dbce.Message);
             Assert.Null(dbce.Row);
             Assert.Equal(0, dbce.RowCount);
         }

--- a/src/System.Data.Common/tests/System/Data/DataColumnCollectionTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataColumnCollectionTest.cs
@@ -219,7 +219,8 @@ namespace System.Data.Tests
             DataTable table2 = new DataTable("test_table2");
             DataColumnCollection cols = table.Columns;
             DataColumn c = null;
-            Assert.Throws<ArgumentException>(() => cols.Add(c));
+
+            Assert.Throws<ArgumentNullException>(() => cols.Add(c));
 
             c = new DataColumn("test");
             cols.Add(c);
@@ -273,7 +274,9 @@ namespace System.Data.Tests
             //    // Assert.True(e is InvalidExpressionException);
             //    // Assert.Equal("Expression 'substring ('fdsafewq', 2)' is invalid.", e.Message);
             //}
-            Assert.Throws<InvalidExpressionException>(() => cols.Add("test2", typeof(string), "substring ('fdsafewq', 2)"));
+            //TODO: EvaluateException : Invalid number of arguments: function substring().
+            // Should we look for the exact exception? could this be a regression? the commented code above seems to say something else.
+            Assert.ThrowsAny<InvalidExpressionException>(() => cols.Add("test2", typeof(string), "substring ('fdsafewq', 2)"));
         }
 
         [Fact]
@@ -492,10 +495,6 @@ namespace System.Data.Tests
 
             Assert.False(cols.Equals(cols2));
             Assert.False(cols2.Equals(cols));
-            Assert.False(object.Equals(cols, cols2));
-            Assert.True(cols.Equals(cols));
-            Assert.True(cols2.Equals(cols2));
-            Assert.True(object.Equals(cols2, cols2));
         }
 
         [Fact]
@@ -600,7 +599,7 @@ namespace System.Data.Tests
             //     // Never premise English.
             //     //Assert.Equal ("Cannot find column 10.", e.Message);
             // }
-            Assert.Throws<ArgumentException>(() => cols.RemoveAt(10));
+            Assert.Throws<IndexOutOfRangeException>(() => cols.RemoveAt(10));
         }
 
         [Fact]
@@ -614,18 +613,6 @@ namespace System.Data.Tests
 
             ds.Relations.Add("rel1", ds.Tables[0].Columns[0], ds.Tables[1].Columns[0]);
             AssertExtensions.Throws<ArgumentException>(null, () => ds.Tables[0].Columns.RemoveAt(0));
-        }
-
-        [Fact]
-        public void ToStringTest()
-        {
-            DataTable table = new DataTable("test_table");
-            DataColumnCollection cols = table.Columns;
-
-            cols.Add("test");
-            cols.Add("test2");
-            cols.Add("test3");
-            Assert.Equal("System.Data.DataColumnCollection", cols.ToString());
         }
 
         [Fact]

--- a/src/System.Data.Common/tests/System/Data/DataColumnCollectionTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataColumnCollectionTest.cs
@@ -225,57 +225,18 @@ namespace System.Data.Tests
             c = new DataColumn("test");
             cols.Add(c);
 
-            //TODO: what to do with the exception messages? are they disabled because of localisation issues?
-            // try
-            // {
-            //     Cols.Add(C);
-            //     Assert.False(true);
-            // }
-            // catch (ArgumentException e)
-            // {
-            //     // Assert.Equal(typeof (ArgumentException), e.GetType ());
-            //     // Assert.Equal("Column 'test' already belongs to this or another DataTable.", e.Message);
-            // }
+            // Column 'test' already belongs to this or another DataTable.
             Assert.Throws<ArgumentException>(() => cols.Add(c));
 
-            // try
-            // {
-            //     Table2.Columns.Add(C);
-            //     Assert.False(true);
-            // }
-            // catch (ArgumentException e)
-            // {
-            //     // Assert.Equal(typeof (ArgumentException), e.GetType ());
-            //     // Assert.Equal("Column 'test' already belongs to this or another DataTable.", e.Message);
-            // }
+            // Column 'test' already belongs to this or another DataTable.
             Assert.Throws<ArgumentException>(() => table2.Columns.Add(c));
 
             DataColumn c2 = new DataColumn("test");
 
-            //try
-            //{
-            //    cols.Add(c2);
-            //    Assert.False(true);
-            //}
-            //catch (DuplicateNameException e)
-            //{
-            //    // Assert.Equal(typeof (DuplicateNameException), e.GetType ());
-            //    // Assert.Equal("A DataColumn named 'test' already belongs to this DataTable.", e.Message);
-            //}
+            // A DataColumn named 'test' already belongs to this DataTable.
             Assert.Throws<DuplicateNameException>(() => cols.Add(c2));
 
-            //try
-            //{
-            //    cols.Add("test2", typeof(string), "substring ('fdsafewq', 2)");
-            //    Assert.False(true);
-            //}
-            //catch (InvalidExpressionException e)
-            //{
-            //    // Assert.True(e is InvalidExpressionException);
-            //    // Assert.Equal("Expression 'substring ('fdsafewq', 2)' is invalid.", e.Message);
-            //}
-            //TODO: EvaluateException : Invalid number of arguments: function substring().
-            // Should we look for the exact exception? could this be a regression? the commented code above seems to say something else.
+            // EvaluateException : Invalid number of arguments: function substring().
             Assert.ThrowsAny<InvalidExpressionException>(() => cols.Add("test2", typeof(string), "substring ('fdsafewq', 2)"));
         }
 
@@ -407,20 +368,9 @@ namespace System.Data.Tests
             cols2.Add();
             cols2.Add();
 
-            DataRelation Rel = new DataRelation("Rel", cols[0], cols2[0]);
-            set.Relations.Add(Rel);
-            // TODO: do we check the messages?
-            // try
-            // {
-            //     Cols.Clear();
-            //     Assert.False(true);
-            // }
-            // catch (Exception e)
-            // {
-            //     Assert.Equal(typeof(ArgumentException), e.GetType());
-            //     // Never premise English.
-            //     //Assert.Equal ("Cannot remove this column, because it is part of the parent key for relationship Rel.", e.Message);
-            // }
+            DataRelation rel = new DataRelation("Rel", cols[0], cols2[0]);
+            set.Relations.Add(rel);
+            // Cannot remove this column, because it is part of the parent key for relationship Rel.
             Assert.Throws<ArgumentException>(() => cols.Clear());
         }
 
@@ -536,18 +486,7 @@ namespace System.Data.Tests
             cols.Remove("TEST3");
             Assert.Equal(2, cols.Count);
 
-            // TODO: what to do with the exception messages?
-            // try
-            // {
-            //     Cols.Remove("_test_");
-            //     Assert.False(true);
-            // }
-            // catch (Exception e)
-            // {
-            //     Assert.Equal(typeof(ArgumentException), e.GetType());
-            //     // Never premise English.
-            //     //Assert.Equal ("Column '_test_' does not belong to table test_table.", e.Message);
-            // }
+            // Column '_test_' does not belong to table test_table.
             Assert.Throws<ArgumentException>(() => cols.Remove("_test_"));
 
             cols.Add();
@@ -561,17 +500,7 @@ namespace System.Data.Tests
             Assert.Equal(4, cols.Count);
             Assert.Equal("Column1", cols[0].ColumnName);
 
-            // try
-            // {
-            //     cols.Remove(new DataColumn("Column10"));
-            //     Assert.False(true);
-            // }
-            // catch (Exception e)
-            // {
-            //     Assert.Equal(typeof(ArgumentException), e.GetType());
-            //     // Never premise English.
-            //     //Assert.Equal ("Cannot remove a column that doesn't belong to this table.", e.Message);
-            // }
+            // Cannot remove a column that doesn't belong to this table.
             Assert.Throws<ArgumentException>(() => cols.Remove(new DataColumn("Column10")));
 
             cols.Add();
@@ -588,17 +517,7 @@ namespace System.Data.Tests
             Assert.Equal("Column4", cols[0].ColumnName);
             Assert.Equal("Column5", cols[1].ColumnName);
 
-            // try
-            // {
-            //     cols.RemoveAt(10);
-            //     Assert.False(true);
-            // }
-            // catch (Exception e)
-            // {
-            //     Assert.Equal(typeof(IndexOutOfRangeException), e.GetType());
-            //     // Never premise English.
-            //     //Assert.Equal ("Cannot find column 10.", e.Message);
-            // }
+            // Cannot find column 10.
             Assert.Throws<IndexOutOfRangeException>(() => cols.RemoveAt(10));
         }
 

--- a/src/System.Data.Common/tests/System/Data/DataColumnCollectionTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataColumnCollectionTest.cs
@@ -215,213 +215,210 @@ namespace System.Data.Tests
         [Fact]
         public void AddExceptions()
         {
-            DataTable Table = new DataTable("test_table");
-            DataTable Table2 = new DataTable("test_table2");
-            DataColumnCollection Cols = Table.Columns;
-            DataColumn C = null;
+            DataTable table = new DataTable("test_table");
+            DataTable table2 = new DataTable("test_table2");
+            DataColumnCollection cols = table.Columns;
+            DataColumn c = null;
+            Assert.Throws<ArgumentException>(() => cols.Add(c));
 
-            try
-            {
-                Cols.Add(C);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(ArgumentNullException), e.GetType());
-            }
+            c = new DataColumn("test");
+            cols.Add(c);
 
-            C = new DataColumn("test");
-            Cols.Add(C);
+            //TODO: what to do with the exception messages? are they disabled because of localisation issues?
+            // try
+            // {
+            //     Cols.Add(C);
+            //     Assert.False(true);
+            // }
+            // catch (ArgumentException e)
+            // {
+            //     // Assert.Equal(typeof (ArgumentException), e.GetType ());
+            //     // Assert.Equal("Column 'test' already belongs to this or another DataTable.", e.Message);
+            // }
+            Assert.Throws<ArgumentException>(() => cols.Add(c));
 
-            try
-            {
-                Cols.Add(C);
-                Assert.False(true);
-            }
-            catch (ArgumentException e)
-            {
-                //                Assert.Equal (typeof (ArgumentException), e.GetType ());
-                //                Assert.Equal ("Column 'test' already belongs to this or another DataTable.", e.Message);
-            }
+            // try
+            // {
+            //     Table2.Columns.Add(C);
+            //     Assert.False(true);
+            // }
+            // catch (ArgumentException e)
+            // {
+            //     // Assert.Equal(typeof (ArgumentException), e.GetType ());
+            //     // Assert.Equal("Column 'test' already belongs to this or another DataTable.", e.Message);
+            // }
+            Assert.Throws<ArgumentException>(() => table2.Columns.Add(c));
 
-            try
-            {
-                Table2.Columns.Add(C);
-                Assert.False(true);
-            }
-            catch (ArgumentException e)
-            {
-                //                Assert.Equal (typeof (ArgumentException), e.GetType ());
-                //                Assert.Equal ("Column 'test' already belongs to this or another DataTable.", e.Message);
-            }
+            DataColumn c2 = new DataColumn("test");
 
-            DataColumn C2 = new DataColumn("test");
+            //try
+            //{
+            //    cols.Add(c2);
+            //    Assert.False(true);
+            //}
+            //catch (DuplicateNameException e)
+            //{
+            //    // Assert.Equal(typeof (DuplicateNameException), e.GetType ());
+            //    // Assert.Equal("A DataColumn named 'test' already belongs to this DataTable.", e.Message);
+            //}
+            Assert.Throws<DuplicateNameException>(() => cols.Add(c2));
 
-            try
-            {
-                Cols.Add(C2);
-                Assert.False(true);
-            }
-            catch (DuplicateNameException e)
-            {
-                //                Assert.Equal (typeof (DuplicateNameException), e.GetType ());
-                //                Assert.Equal ("A DataColumn named 'test' already belongs to this DataTable.", e.Message);
-            }
-
-            try
-            {
-                Cols.Add("test2", typeof(string), "substring ('fdsafewq', 2)");
-                Assert.False(true);
-            }
-            catch (InvalidExpressionException e)
-            {
-                //                Assert.True (e is InvalidExpressionException);
-                //                Assert.Equal ("Expression 'substring ('fdsafewq', 2)' is invalid.", e.Message);
-            }
+            //try
+            //{
+            //    cols.Add("test2", typeof(string), "substring ('fdsafewq', 2)");
+            //    Assert.False(true);
+            //}
+            //catch (InvalidExpressionException e)
+            //{
+            //    // Assert.True(e is InvalidExpressionException);
+            //    // Assert.Equal("Expression 'substring ('fdsafewq', 2)' is invalid.", e.Message);
+            //}
+            Assert.Throws<InvalidExpressionException>(() => cols.Add("test2", typeof(string), "substring ('fdsafewq', 2)"));
         }
 
         [Fact]
         public void AddRange()
         {
-            DataTable Table = new DataTable("test_table");
-            DataTable Table2 = new DataTable("test_table2");
-            DataColumnCollection Cols = Table.Columns;
-            DataColumn C = null;
-            DataColumn[] ColArray = new DataColumn[2];
+            DataTable table = new DataTable("test_table");
+            DataColumnCollection cols = table.Columns;
+            DataColumn c = null;
+            DataColumn[] colArray = new DataColumn[2];
 
-            C = new DataColumn("test1");
-            ColArray[0] = C;
+            c = new DataColumn("test1");
+            colArray[0] = c;
 
-            C = new DataColumn("test2");
-            C.AllowDBNull = false;
-            C.Caption = "Test_caption";
-            C.DataType = typeof(XmlReader);
-            ColArray[1] = C;
+            c = new DataColumn("test2");
+            c.AllowDBNull = false;
+            c.Caption = "Test_caption";
+            c.DataType = typeof(XmlReader);
+            colArray[1] = c;
 
-            Cols.AddRange(ColArray);
+            cols.AddRange(colArray);
 
-            C = Cols[0];
-            Assert.True(C.AllowDBNull);
-            Assert.False(C.AutoIncrement);
-            Assert.Equal(0L, C.AutoIncrementSeed);
-            Assert.Equal(1L, C.AutoIncrementStep);
-            Assert.Equal("test1", C.Caption);
-            Assert.Equal("Element", C.ColumnMapping.ToString());
-            Assert.Equal("test1", C.ColumnName);
-            Assert.Null(C.Container);
-            Assert.Equal(typeof(string), C.DataType);
-            Assert.Equal(DBNull.Value, C.DefaultValue);
-            Assert.False(C.DesignMode);
-            Assert.Equal("", C.Expression);
-            Assert.Equal(0, C.ExtendedProperties.Count);
-            Assert.Equal(-1, C.MaxLength);
-            Assert.Equal("", C.Namespace);
-            Assert.Equal(0, C.Ordinal);
-            Assert.Equal("", C.Prefix);
-            Assert.False(C.ReadOnly);
-            Assert.Null(C.Site);
-            Assert.Equal("test_table", C.Table.TableName);
-            Assert.Equal("test1", C.ToString());
-            Assert.False(C.Unique);
+            c = cols[0];
+            Assert.True(c.AllowDBNull);
+            Assert.False(c.AutoIncrement);
+            Assert.Equal(0L, c.AutoIncrementSeed);
+            Assert.Equal(1L, c.AutoIncrementStep);
+            Assert.Equal("test1", c.Caption);
+            Assert.Equal("Element", c.ColumnMapping.ToString());
+            Assert.Equal("test1", c.ColumnName);
+            Assert.Null(c.Container);
+            Assert.Equal(typeof(string), c.DataType);
+            Assert.Equal(DBNull.Value, c.DefaultValue);
+            Assert.False(c.DesignMode);
+            Assert.Equal("", c.Expression);
+            Assert.Equal(0, c.ExtendedProperties.Count);
+            Assert.Equal(-1, c.MaxLength);
+            Assert.Equal("", c.Namespace);
+            Assert.Equal(0, c.Ordinal);
+            Assert.Equal("", c.Prefix);
+            Assert.False(c.ReadOnly);
+            Assert.Null(c.Site);
+            Assert.Equal("test_table", c.Table.TableName);
+            Assert.Equal("test1", c.ToString());
+            Assert.False(c.Unique);
 
-            C = Cols[1];
-            Assert.False(C.AllowDBNull);
-            Assert.False(C.AutoIncrement);
-            Assert.Equal(0L, C.AutoIncrementSeed);
-            Assert.Equal(1L, C.AutoIncrementStep);
-            Assert.Equal("Test_caption", C.Caption);
-            Assert.Equal("Element", C.ColumnMapping.ToString());
-            Assert.Equal("test2", C.ColumnName);
-            Assert.Null(C.Container);
-            Assert.Equal(typeof(XmlReader), C.DataType);
-            Assert.Equal(DBNull.Value, C.DefaultValue);
-            Assert.False(C.DesignMode);
-            Assert.Equal("", C.Expression);
-            Assert.Equal(0, C.ExtendedProperties.Count);
-            Assert.Equal(-1, C.MaxLength);
-            Assert.Equal("", C.Namespace);
-            Assert.Equal(1, C.Ordinal);
-            Assert.Equal("", C.Prefix);
-            Assert.False(C.ReadOnly);
-            Assert.Null(C.Site);
-            Assert.Equal("test_table", C.Table.TableName);
-            Assert.Equal("test2", C.ToString());
-            Assert.False(C.Unique);
+            c = cols[1];
+            Assert.False(c.AllowDBNull);
+            Assert.False(c.AutoIncrement);
+            Assert.Equal(0L, c.AutoIncrementSeed);
+            Assert.Equal(1L, c.AutoIncrementStep);
+            Assert.Equal("Test_caption", c.Caption);
+            Assert.Equal("Element", c.ColumnMapping.ToString());
+            Assert.Equal("test2", c.ColumnName);
+            Assert.Null(c.Container);
+            Assert.Equal(typeof(XmlReader), c.DataType);
+            Assert.Equal(DBNull.Value, c.DefaultValue);
+            Assert.False(c.DesignMode);
+            Assert.Equal("", c.Expression);
+            Assert.Equal(0, c.ExtendedProperties.Count);
+            Assert.Equal(-1, c.MaxLength);
+            Assert.Equal("", c.Namespace);
+            Assert.Equal(1, c.Ordinal);
+            Assert.Equal("", c.Prefix);
+            Assert.False(c.ReadOnly);
+            Assert.Null(c.Site);
+            Assert.Equal("test_table", c.Table.TableName);
+            Assert.Equal("test2", c.ToString());
+            Assert.False(c.Unique);
         }
 
         [Fact]
         public void CanRemove()
         {
-            DataTable Table = new DataTable("test_table");
-            DataTable Table2 = new DataTable("test_table_2");
-            DataColumnCollection Cols = Table.Columns;
-            DataColumn C = new DataColumn("test1");
-            Cols.Add();
+            DataTable table = new DataTable("test_table");
+            DataTable table2 = new DataTable("test_table_2");
+            DataColumnCollection cols = table.Columns;
+            DataColumn c = new DataColumn("test1");
+            cols.Add();
 
             // MSDN says that if C doesn't belong to Cols
             // Exception is thrown.
-            Assert.False(Cols.CanRemove(C));
+            Assert.False(cols.CanRemove(c));
 
-            Cols.Add(C);
-            Assert.True(Cols.CanRemove(C));
+            cols.Add(c);
+            Assert.True(cols.CanRemove(c));
 
-            C = new DataColumn();
-            C.Expression = "test1 + 2";
-            Cols.Add(C);
+            c = new DataColumn();
+            c.Expression = "test1 + 2";
+            cols.Add(c);
 
-            C = Cols["test2"];
-            Assert.False(Cols.CanRemove(C));
+            c = cols["test2"];
+            Assert.False(cols.CanRemove(c));
 
-            C = new DataColumn("t");
-            Table2.Columns.Add(C);
-            DataColumnCollection Cols2 = Table2.Columns;
-            Assert.True(Cols2.CanRemove(C));
+            c = new DataColumn("t");
+            table2.Columns.Add(c);
+            DataColumnCollection Cols2 = table2.Columns;
+            Assert.True(Cols2.CanRemove(c));
 
             DataSet Set = new DataSet();
-            Set.Tables.Add(Table);
-            Set.Tables.Add(Table2);
-            DataRelation Rel = new DataRelation("Rel", Table.Columns[0], Table2.Columns[0]);
+            Set.Tables.Add(table);
+            Set.Tables.Add(table2);
+            DataRelation Rel = new DataRelation("Rel", table.Columns[0], table2.Columns[0]);
             Set.Relations.Add(Rel);
 
-            Assert.False(Cols2.CanRemove(C));
-            Assert.False(Cols.CanRemove(null));
+            Assert.False(Cols2.CanRemove(c));
+            Assert.False(cols.CanRemove(null));
         }
 
         [Fact]
         public void Clear()
         {
-            DataTable Table = new DataTable("test_table");
-            DataTable Table2 = new DataTable("test_table2");
-            DataSet Set = new DataSet();
-            Set.Tables.Add(Table);
-            Set.Tables.Add(Table2);
-            DataColumnCollection Cols = Table.Columns;
-            DataColumnCollection Cols2 = Table2.Columns;
+            DataTable table = new DataTable("test_table");
+            DataTable table2 = new DataTable("test_table2");
+            DataSet set = new DataSet();
+            set.Tables.Add(table);
+            set.Tables.Add(table2);
+            DataColumnCollection cols = table.Columns;
+            DataColumnCollection cols2 = table2.Columns;
 
-            Cols.Add();
-            Cols.Add("testi");
+            cols.Add();
+            cols.Add("testi");
 
-            Cols.Clear();
-            Assert.Equal(0, Cols.Count);
+            cols.Clear();
+            Assert.Equal(0, cols.Count);
 
-            Cols.Add();
-            Cols.Add("testi");
-            Cols2.Add();
-            Cols2.Add();
+            cols.Add();
+            cols.Add("testi");
+            cols2.Add();
+            cols2.Add();
 
-            DataRelation Rel = new DataRelation("Rel", Cols[0], Cols2[0]);
-            Set.Relations.Add(Rel);
-            try
-            {
-                Cols.Clear();
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(ArgumentException), e.GetType());
-                // Never premise English.
-                //Assert.Equal ("Cannot remove this column, because it is part of the parent key for relationship Rel.", e.Message);
-            }
+            DataRelation Rel = new DataRelation("Rel", cols[0], cols2[0]);
+            set.Relations.Add(Rel);
+            // TODO: do we check the messages?
+            // try
+            // {
+            //     Cols.Clear();
+            //     Assert.False(true);
+            // }
+            // catch (Exception e)
+            // {
+            //     Assert.Equal(typeof(ArgumentException), e.GetType());
+            //     // Never premise English.
+            //     //Assert.Equal ("Cannot remove this column, because it is part of the parent key for relationship Rel.", e.Message);
+            // }
+            Assert.Throws<ArgumentException>(() => cols.Clear());
         }
 
         [Fact]
@@ -439,35 +436,35 @@ namespace System.Data.Tests
         [Fact]
         public void Contains()
         {
-            DataTable Table = new DataTable("test_table");
-            DataColumnCollection Cols = Table.Columns;
+            DataTable table = new DataTable("test_table");
+            DataColumnCollection cols = table.Columns;
 
-            Cols.Add("test");
-            Cols.Add("tesT2");
+            cols.Add("test");
+            cols.Add("tesT2");
 
-            Assert.True(Cols.Contains("test"));
-            Assert.False(Cols.Contains("_test"));
-            Assert.True(Cols.Contains("TEST"));
-            Table.CaseSensitive = true;
-            Assert.True(Cols.Contains("TEST"));
-            Assert.True(Cols.Contains("test2"));
-            Assert.False(Cols.Contains("_test2"));
-            Assert.True(Cols.Contains("TEST2"));
+            Assert.True(cols.Contains("test"));
+            Assert.False(cols.Contains("_test"));
+            Assert.True(cols.Contains("TEST"));
+            table.CaseSensitive = true;
+            Assert.True(cols.Contains("TEST"));
+            Assert.True(cols.Contains("test2"));
+            Assert.False(cols.Contains("_test2"));
+            Assert.True(cols.Contains("TEST2"));
         }
 
         [Fact]
         public void CopyTo()
         {
-            DataTable Table = new DataTable("test_table");
-            DataColumnCollection Cols = Table.Columns;
+            DataTable table = new DataTable("test_table");
+            DataColumnCollection cols = table.Columns;
 
-            Cols.Add("test");
-            Cols.Add("test2");
-            Cols.Add("test3");
-            Cols.Add("test4");
+            cols.Add("test");
+            cols.Add("test2");
+            cols.Add("test3");
+            cols.Add("test4");
 
             DataColumn[] array = new DataColumn[4];
-            Cols.CopyTo(array, 0);
+            cols.CopyTo(array, 0);
             Assert.Equal(4, array.Length);
             Assert.Equal("test", array[0].ColumnName);
             Assert.Equal("test2", array[1].ColumnName);
@@ -475,7 +472,7 @@ namespace System.Data.Tests
             Assert.Equal("test4", array[3].ColumnName);
 
             array = new DataColumn[6];
-            Cols.CopyTo(array, 2);
+            cols.CopyTo(array, 2);
             Assert.Equal(6, array.Length);
             Assert.Equal("test", array[2].ColumnName);
             Assert.Equal("test2", array[3].ColumnName);
@@ -488,118 +485,122 @@ namespace System.Data.Tests
         [Fact]
         public void Equals()
         {
-            DataTable Table = new DataTable("test_table");
-            DataTable Table2 = new DataTable("test_table");
-            DataColumnCollection Cols = Table.Columns;
-            DataColumnCollection Cols2 = Table2.Columns;
+            DataTable table = new DataTable("test_table");
+            DataTable table2 = new DataTable("test_table");
+            DataColumnCollection cols = table.Columns;
+            DataColumnCollection cols2 = table2.Columns;
 
-            Assert.False(Cols.Equals(Cols2));
-            Assert.False(Cols2.Equals(Cols));
-            Assert.False(object.Equals(Cols, Cols2));
-            Assert.True(Cols.Equals(Cols));
-            Assert.True(Cols2.Equals(Cols2));
-            Assert.True(object.Equals(Cols2, Cols2));
+            Assert.False(cols.Equals(cols2));
+            Assert.False(cols2.Equals(cols));
+            Assert.False(object.Equals(cols, cols2));
+            Assert.True(cols.Equals(cols));
+            Assert.True(cols2.Equals(cols2));
+            Assert.True(object.Equals(cols2, cols2));
         }
 
         [Fact]
         public void IndexOf()
         {
-            DataTable Table = new DataTable("test_table");
-            DataColumnCollection Cols = Table.Columns;
+            DataTable table = new DataTable("test_table");
+            DataColumnCollection cols = table.Columns;
 
-            Cols.Add("test");
-            Cols.Add("test2");
-            Cols.Add("test3");
-            Cols.Add("test4");
+            cols.Add("test");
+            cols.Add("test2");
+            cols.Add("test3");
+            cols.Add("test4");
 
-            Assert.Equal(0, Cols.IndexOf("test"));
-            Assert.Equal(1, Cols.IndexOf("TEST2"));
-            Table.CaseSensitive = true;
-            Assert.Equal(1, Cols.IndexOf("TEST2"));
+            Assert.Equal(0, cols.IndexOf("test"));
+            Assert.Equal(1, cols.IndexOf("TEST2"));
+            table.CaseSensitive = true;
+            Assert.Equal(1, cols.IndexOf("TEST2"));
 
-            Assert.Equal(3, Cols.IndexOf(Cols[3]));
+            Assert.Equal(3, cols.IndexOf(cols[3]));
             DataColumn C = new DataColumn("error");
-            Assert.Equal(-1, Cols.IndexOf(C));
-            Assert.Equal(-1, Cols.IndexOf("_error_"));
+            Assert.Equal(-1, cols.IndexOf(C));
+            Assert.Equal(-1, cols.IndexOf("_error_"));
         }
 
         [Fact]
         public void Remove()
         {
-            DataTable Table = new DataTable("test_table");
-            DataColumnCollection Cols = Table.Columns;
+            DataTable table = new DataTable("test_table");
+            DataColumnCollection cols = table.Columns;
 
-            Cols.Add("test");
-            Cols.Add("test2");
-            Cols.Add("test3");
-            Cols.Add("test4");
+            cols.Add("test");
+            cols.Add("test2");
+            cols.Add("test3");
+            cols.Add("test4");
 
-            Assert.Equal(4, Cols.Count);
-            Cols.Remove("test2");
-            Assert.Equal(3, Cols.Count);
-            Cols.Remove("TEST3");
-            Assert.Equal(2, Cols.Count);
+            Assert.Equal(4, cols.Count);
+            cols.Remove("test2");
+            Assert.Equal(3, cols.Count);
+            cols.Remove("TEST3");
+            Assert.Equal(2, cols.Count);
 
-            try
-            {
-                Cols.Remove("_test_");
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(ArgumentException), e.GetType());
-                // Never premise English.
-                //Assert.Equal ("Column '_test_' does not belong to table test_table.", e.Message);
-            }
+            // TODO: what to do with the exception messages?
+            // try
+            // {
+            //     Cols.Remove("_test_");
+            //     Assert.False(true);
+            // }
+            // catch (Exception e)
+            // {
+            //     Assert.Equal(typeof(ArgumentException), e.GetType());
+            //     // Never premise English.
+            //     //Assert.Equal ("Column '_test_' does not belong to table test_table.", e.Message);
+            // }
+            Assert.Throws<ArgumentException>(() => cols.Remove("_test_"));
 
-            Cols.Add();
-            Cols.Add();
-            Cols.Add();
-            Cols.Add();
+            cols.Add();
+            cols.Add();
+            cols.Add();
+            cols.Add();
 
-            Assert.Equal(6, Cols.Count);
-            Cols.Remove(Cols[0]);
-            Cols.Remove(Cols[0]);
-            Assert.Equal(4, Cols.Count);
-            Assert.Equal("Column1", Cols[0].ColumnName);
+            Assert.Equal(6, cols.Count);
+            cols.Remove(cols[0]);
+            cols.Remove(cols[0]);
+            Assert.Equal(4, cols.Count);
+            Assert.Equal("Column1", cols[0].ColumnName);
 
-            try
-            {
-                Cols.Remove(new DataColumn("Column10"));
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(ArgumentException), e.GetType());
-                // Never premise English.
-                //Assert.Equal ("Cannot remove a column that doesn't belong to this table.", e.Message);
-            }
+            // try
+            // {
+            //     cols.Remove(new DataColumn("Column10"));
+            //     Assert.False(true);
+            // }
+            // catch (Exception e)
+            // {
+            //     Assert.Equal(typeof(ArgumentException), e.GetType());
+            //     // Never premise English.
+            //     //Assert.Equal ("Cannot remove a column that doesn't belong to this table.", e.Message);
+            // }
+            Assert.Throws<ArgumentException>(() => cols.Remove(new DataColumn("Column10")));
 
-            Cols.Add();
-            Cols.Add();
-            Cols.Add();
-            Cols.Add();
+            cols.Add();
+            cols.Add();
+            cols.Add();
+            cols.Add();
 
-            Assert.Equal(8, Cols.Count);
-            Cols.RemoveAt(7);
-            Cols.RemoveAt(1);
-            Cols.RemoveAt(0);
-            Cols.RemoveAt(0);
-            Assert.Equal(4, Cols.Count);
-            Assert.Equal("Column4", Cols[0].ColumnName);
-            Assert.Equal("Column5", Cols[1].ColumnName);
+            Assert.Equal(8, cols.Count);
+            cols.RemoveAt(7);
+            cols.RemoveAt(1);
+            cols.RemoveAt(0);
+            cols.RemoveAt(0);
+            Assert.Equal(4, cols.Count);
+            Assert.Equal("Column4", cols[0].ColumnName);
+            Assert.Equal("Column5", cols[1].ColumnName);
 
-            try
-            {
-                Cols.RemoveAt(10);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(IndexOutOfRangeException), e.GetType());
-                // Never premise English.
-                //Assert.Equal ("Cannot find column 10.", e.Message);
-            }
+            // try
+            // {
+            //     cols.RemoveAt(10);
+            //     Assert.False(true);
+            // }
+            // catch (Exception e)
+            // {
+            //     Assert.Equal(typeof(IndexOutOfRangeException), e.GetType());
+            //     // Never premise English.
+            //     //Assert.Equal ("Cannot find column 10.", e.Message);
+            // }
+            Assert.Throws<ArgumentException>(() => cols.RemoveAt(10));
         }
 
         [Fact]
@@ -618,13 +619,13 @@ namespace System.Data.Tests
         [Fact]
         public void ToStringTest()
         {
-            DataTable Table = new DataTable("test_table");
-            DataColumnCollection Cols = Table.Columns;
+            DataTable table = new DataTable("test_table");
+            DataColumnCollection cols = table.Columns;
 
-            Cols.Add("test");
-            Cols.Add("test2");
-            Cols.Add("test3");
-            Assert.Equal("System.Data.DataColumnCollection", Cols.ToString());
+            cols.Add("test");
+            cols.Add("test2");
+            cols.Add("test3");
+            Assert.Equal("System.Data.DataColumnCollection", cols.ToString());
         }
 
         [Fact]
@@ -634,7 +635,6 @@ namespace System.Data.Tests
             dt.Columns.Add("nom_colonne1", typeof(string));
             dt.Columns.Add("NOM_COLONNE1", typeof(string));
             dt.Columns.Remove("nom_colonne1");
-            int i = dt.Columns.IndexOf("nom_colonne1");
             Assert.Equal(0, dt.Columns.IndexOf("nom_colonne1"));
         }
     }

--- a/src/System.Data.Common/tests/System/Data/DataColumnCollectionTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/DataColumnCollectionTest2.cs
@@ -63,7 +63,7 @@ namespace System.Data.Tests
             Assert.Equal(5, dt.Columns.Count);
 
             //----------------------------- check Add/Remove from begining --------------------
-            dt = initTable();
+            dt = InitTable();
 
             dt.Columns.Remove(dt.Columns[0]);
             dt.Columns.Remove(dt.Columns[0]);
@@ -101,7 +101,7 @@ namespace System.Data.Tests
 
             //----------------------------- check Add/Remove from middle --------------------
 
-            dt = initTable();
+            dt = InitTable();
 
             dt.Columns.Remove(dt.Columns[2]);
             dt.Columns.Remove(dt.Columns[2]);
@@ -138,7 +138,7 @@ namespace System.Data.Tests
 
             //----------------------------- check Add/Remove from end --------------------
 
-            dt = initTable();
+            dt = InitTable();
 
             dt.Columns.Remove(dt.Columns[4]);
             dt.Columns.Remove(dt.Columns[3]);
@@ -174,7 +174,7 @@ namespace System.Data.Tests
             Assert.Equal("Column6", dt.Columns[5].ColumnName);
         }
 
-        private DataTable initTable()
+        private DataTable InitTable()
         {
             DataTable dt = new DataTable();
             for (int i = 0; i < 5; i++)
@@ -370,8 +370,6 @@ namespace System.Data.Tests
             {
                 Assert.Equal(i, dt.Columns.IndexOf(dt.Columns[i].ColumnName));
             }
-
-            DataColumn col = new DataColumn();
 
             Assert.Equal(-1, dt.Columns.IndexOf("temp1"));
 
@@ -645,18 +643,11 @@ namespace System.Data.Tests
         {
             DataTable dt = DataProvider.CreateParentDataTable();
 
-            try
-            {
-                DataColumn column = dt.Columns[6];
-                Assert.False(true);
-            }
-            catch (IndexOutOfRangeException ex)
-            {
-                // Cannot find column 6
-                Assert.Equal(typeof(IndexOutOfRangeException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-            }
+            IndexOutOfRangeException ex =
+                Assert.Throws<IndexOutOfRangeException>(() => dt.Columns[6]);
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+
         }
 
         [Fact] // this [String]
@@ -696,18 +687,11 @@ namespace System.Data.Tests
         {
             DataTable dt = DataProvider.CreateParentDataTable();
 
-            try
-            {
-                DataColumn column = dt.Columns[null];
-                Assert.False(true);
-            }
-            catch (ArgumentNullException ex)
-            {
-                Assert.Equal(typeof(ArgumentNullException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.Equal("name", ex.ParamName);
-            }
+            ArgumentNullException ex =
+                Assert.Throws<ArgumentNullException>(() => dt.Columns[null]);
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+            Assert.Equal("name", ex.ParamName);
         }
 
         [Fact]

--- a/src/System.Data.Common/tests/System/Data/DataColumnCollectionTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/DataColumnCollectionTest2.cs
@@ -624,18 +624,11 @@ namespace System.Data.Tests
         {
             DataTable dt = DataProvider.CreateParentDataTable();
 
-            try
-            {
-                DataColumn column = dt.Columns[-1];
-                Assert.False(true);
-            }
-            catch (IndexOutOfRangeException ex)
-            {
-                // Cannot find column -1
-                Assert.Equal(typeof(IndexOutOfRangeException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-            }
+            IndexOutOfRangeException ex =
+                Assert.Throws<IndexOutOfRangeException>(() => dt.Columns[-1]);
+            // Cannot find column -1
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
         }
 
         [Fact] // this [Int32]

--- a/src/System.Data.Common/tests/System/Data/DataColumnExpressionTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataColumnExpressionTest.cs
@@ -111,21 +111,18 @@ namespace System.Data.Tests
                 foreach (var aggregation in aggregations)
                 {
                     var resultType = type;
-                    //TODO
                     // BUG? sum(Column) is always promoted to SqlInt64
                     if (aggregation.Operator == "sum" && (type == typeof(SqlByte) || type == typeof(SqlInt16) || type == typeof(SqlInt32)))
                         resultType = typeof(SqlInt64);
 
                     if (aggregation.Operator == "count" && (type == typeof(SqlByte) || type == typeof(SqlInt16)))
                         resultType = typeof(SqlInt32);
-                    //TODO
                     // BUG? sum(SqlMoney) yields SqlDecimal, but SqlDecimal can't be converted to SqlMoney
                     if (aggregation.Operator == "sum" && type == typeof(SqlMoney))
                         resultType = typeof(SqlDecimal);
 
                     yield return new object[] { type, aggregation.Operator + "(Child.Data)", ChangeType(aggregation.Result, resultType) };
                 }
-                //TODO
                 // BUG? Var() for SQL types can't convert to System.Double, but StDev can
                 if (type.Namespace == "System.Data.SqlTypes")
                     yield return new object[] { type, "Var(Child.Data)", new SqlDouble(110.0 / 3) };
@@ -192,7 +189,6 @@ namespace System.Data.Tests
 
                 foreach (var equation in arithmeticEquations)
                 {
-                    //TODO
                     // BUG? Dividing two integral SQL types fails, even if the result is integral
                     if (!isIntegral || equation.Expression != "Operand1 / Operand2")
                         yield return new object[] { type, type, type, equation.Expression, operand1, operand2, ChangeType(equation.Result, type) };
@@ -203,7 +199,6 @@ namespace System.Data.Tests
                 foreach (var equation in comparisonEquations)
                 {
                     yield return new object[] { type, type, typeof(SqlBoolean), equation.Expression, operand1, operand2,  new SqlBoolean(equation.Result) };
-                    //TODO
                     // BUG? Result type of comparison of two SQL types (when one operard is Null) is the type itself, not SqlBoolean.
                     yield return new object[] { type, type, type, equation.Expression, operand1, sqlNull, sqlNull };
                 }

--- a/src/System.Data.Common/tests/System/Data/DataColumnExpressionTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataColumnExpressionTest.cs
@@ -111,21 +111,21 @@ namespace System.Data.Tests
                 foreach (var aggregation in aggregations)
                 {
                     var resultType = type;
-
+                    //TODO
                     // BUG? sum(Column) is always promoted to SqlInt64
                     if (aggregation.Operator == "sum" && (type == typeof(SqlByte) || type == typeof(SqlInt16) || type == typeof(SqlInt32)))
                         resultType = typeof(SqlInt64);
 
                     if (aggregation.Operator == "count" && (type == typeof(SqlByte) || type == typeof(SqlInt16)))
                         resultType = typeof(SqlInt32);
-
+                    //TODO
                     // BUG? sum(SqlMoney) yields SqlDecimal, but SqlDecimal can't be converted to SqlMoney
                     if (aggregation.Operator == "sum" && type == typeof(SqlMoney))
                         resultType = typeof(SqlDecimal);
 
                     yield return new object[] { type, aggregation.Operator + "(Child.Data)", ChangeType(aggregation.Result, resultType) };
                 }
-
+                //TODO
                 // BUG? Var() for SQL types can't convert to System.Double, but StDev can
                 if (type.Namespace == "System.Data.SqlTypes")
                     yield return new object[] { type, "Var(Child.Data)", new SqlDouble(110.0 / 3) };
@@ -192,6 +192,7 @@ namespace System.Data.Tests
 
                 foreach (var equation in arithmeticEquations)
                 {
+                    //TODO
                     // BUG? Dividing two integral SQL types fails, even if the result is integral
                     if (!isIntegral || equation.Expression != "Operand1 / Operand2")
                         yield return new object[] { type, type, type, equation.Expression, operand1, operand2, ChangeType(equation.Result, type) };
@@ -202,7 +203,7 @@ namespace System.Data.Tests
                 foreach (var equation in comparisonEquations)
                 {
                     yield return new object[] { type, type, typeof(SqlBoolean), equation.Expression, operand1, operand2,  new SqlBoolean(equation.Result) };
-
+                    //TODO
                     // BUG? Result type of comparison of two SQL types (when one operard is Null) is the type itself, not SqlBoolean.
                     yield return new object[] { type, type, type, equation.Expression, operand1, sqlNull, sqlNull };
                 }

--- a/src/System.Data.Common/tests/System/Data/DataColumnTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataColumnTest.cs
@@ -169,7 +169,7 @@ namespace System.Data.Tests
                 Assert.Throws<InvalidOperationException>(() => col.DateTimeMode = DataSetDateTime.Local);
             Assert.Null(ex.InnerException);
             Assert.NotNull(ex.Message);
-            Assert.Contains("DateTimeNode", ex.Message);
+            Assert.Contains("DateTimeMode", ex.Message);
         }
 
         [Fact]

--- a/src/System.Data.Common/tests/System/Data/DataColumnTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataColumnTest.cs
@@ -183,8 +183,8 @@ namespace System.Data.Tests
                 Assert.Throws<InvalidEnumArgumentException>(() => col.DateTimeMode = (DataSetDateTime)666);
             Assert.Null(ex.InnerException);
             Assert.NotNull(ex.Message);
-            Assert.Contains(ex.Message, "DataSetDateTime");
-            Assert.Contains(ex.Message, "666");
+            Assert.Contains("DataSetDateTime", ex.Message);
+            Assert.Contains("666", ex.Message);
             Assert.Null(ex.ParamName);
         }
 
@@ -222,7 +222,7 @@ namespace System.Data.Tests
             tbl.Columns[0].AutoIncrement = false;
 
             //Set default value to an incompatible datatype
-            Assert.Throws<ArgumentException>(() => tbl.Columns[0].DefaultValue = "hello");
+            Assert.Throws<FormatException>(() => tbl.Columns[0].DefaultValue = "hello");
         }
 
         [Fact]

--- a/src/System.Data.Common/tests/System/Data/DataColumnTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataColumnTest.cs
@@ -63,11 +63,9 @@ namespace System.Data.Tests
         [Fact]
         public void Constructor3_DataType_Null()
         {
-            //TODO: what to do with the message?
             ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => new DataColumn("ColName", null));
             Assert.Null(ex.InnerException);
-            // Never premise English.
-            // Assert.NotNull (ex.Message);
+            Assert.NotNull (ex.Message);
             Assert.NotNull(ex.ParamName);
             Assert.Equal("dataType", ex.ParamName);
         }
@@ -356,51 +354,17 @@ namespace System.Data.Tests
             // Exceptions
             //
 
-            // TODO: which exception is it exactly?
             Assert.ThrowsAny<InvalidExpressionException>(() => c.Expression = "iff (age = 24, 'hurrey', 'boo')");
-            //TODO
             //The following two cases fail on mono. MS.net evaluates the expression
             //immediately upon assignment. We don't do this yet hence we don't throw
             //an exception at this point.
-            //try
-            //{
-            //    C.Expression = "iif (nimi = 24, 'hurrey', 'boo')";
-            //    Assert.False(true);
-            //}
-            //catch (EvaluateException e)
-            //{
-            //    Assert.Equal(typeof(EvaluateException), e.GetType());
-            //    // Never premise English.
-            //    //Assert.Equal ("Cannot find column [nimi].", e.Message);
-            //}
-            // TODO: Exception message?
+            // Cannot find column [nimi].
             Assert.Throws<EvaluateException>(() => c.Expression = "iif (nimi = 24, 'hurrey', 'boo')");
 
-            //try
-            //{
-            //    C.Expression = "iif (name = 24, 'hurrey', 'boo')";
-            //    Assert.False(true);
-            //}
-            //catch (EvaluateException e)
-            //{
-            //    Assert.Equal(typeof(EvaluateException), e.GetType());
-            //    //AssertEquals ("DC41", "Cannot perform '=' operation on System.String and System.Int32.", e.Message);
-            //}
-            //TODO: Exception message?
+            // Cannot perform '=' operation on System.String and System.Int32.
             Assert.Throws<EvaluateException>(() => c.Expression = "iif (name = 24, 'hurrey', 'boo')");
 
-            //try
-            //{
-            //    C.Expression = "convert (age, Boolean)";
-            //    Assert.False(true);
-            //}
-            //catch (EvaluateException e)
-            //{
-            //    Assert.Equal(typeof(EvaluateException), e.GetType());
-            //    // Never premise English.
-            //    //Assert.Equal ("Invalid type name 'Boolean'.", e.Message);
-            //}
-            //TODO: Exception message?
+            // Invalid type name 'Boolean'.
             Assert.Throws<EvaluateException>(() => c.Expression = "convert (age, Boolean)");
         }
 
@@ -854,28 +818,5 @@ namespace System.Data.Tests
                 Expression = test
             };
         }
-        // TODO: what's this?
-#if false
-// Check Windows output for the row [0] value
-        [Fact]
-        public void NullStrings ()
-        {
-            var a = MakeColumn ("nullbar", "null+'bar'");
-            var b = MakeColumn ("barnull", "'bar'+null");
-            var c = MakeColumn ("foobar", "'foo'+'bar'");
-
-                var table = new DataTable();
-
-                table.Columns.Add(a);
-                table.Columns.Add(b);
-                table.Columns.Add(c);
-
-                var row = table.NewRow();
-                table.Rows.Add(row);
-            Assert.Equal (row [0], DBNull.Value);
-            Assert.Equal (row [1], DBNull.Value);
-            Assert.Equal (row [2], "foobar");
-        }
-#endif
     }
 }

--- a/src/System.Data.Common/tests/System/Data/DataColumnTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataColumnTest.cs
@@ -169,8 +169,7 @@ namespace System.Data.Tests
                 Assert.Throws<InvalidOperationException>(() => col.DateTimeMode = DataSetDateTime.Local);
             Assert.Null(ex.InnerException);
             Assert.NotNull(ex.Message);
-            Assert.True(ex.Message.IndexOf("DateTimeMode") != -1);
-            Assert.True(ex.Message.IndexOf("DateTime") != -1);
+            Assert.Contains("DateTimeNode", ex.Message);
         }
 
         [Fact]

--- a/src/System.Data.Common/tests/System/Data/DataColumnTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataColumnTest.cs
@@ -63,20 +63,13 @@ namespace System.Data.Tests
         [Fact]
         public void Constructor3_DataType_Null()
         {
-            try
-            {
-                new DataColumn("ColName", null);
-                Assert.False(true);
-            }
-            catch (ArgumentNullException ex)
-            {
-                Assert.Equal(typeof(ArgumentNullException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                // Never premise English.
-                //                Assert.NotNull (ex.Message);
-                Assert.NotNull(ex.ParamName);
-                Assert.Equal("dataType", ex.ParamName);
-            }
+            //TODO: what to do with the message?
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => new DataColumn("ColName", null));
+            Assert.Null(ex.InnerException);
+            // Never premise English.
+            // Assert.NotNull (ex.Message);
+            Assert.NotNull(ex.ParamName);
+            Assert.Equal("dataType", ex.ParamName);
         }
 
         [Fact]
@@ -87,14 +80,7 @@ namespace System.Data.Tests
             col.AllowDBNull = true;
             _tbl.Rows.Add(_tbl.NewRow());
             _tbl.Rows[0]["NullCheck"] = DBNull.Value;
-            try
-            {
-                col.AllowDBNull = false;
-                Assert.False(true);
-            }
-            catch (DataException)
-            {
-            }
+            Assert.Throws<DataException>(() => col.AllowDBNull = false);
         }
 
         [Fact]
@@ -141,14 +127,7 @@ namespace System.Data.Tests
             col.Expression = "SomeExpression";
 
             //if computed column exception is thrown
-            try
-            {
-                col.AutoIncrement = true;
-                Assert.False(true);
-            }
-            catch (ArgumentException)
-            {
-            }
+            Assert.Throws<ArgumentException>(() => col.AutoIncrement = true);
         }
 
         [Fact]
@@ -183,42 +162,30 @@ namespace System.Data.Tests
         public void DateTime_DataType_Invalid()
         {
             DataColumn col = new DataColumn("birthdate", typeof(int));
-            try
-            {
-                col.DateTimeMode = DataSetDateTime.Local;
-                Assert.False(true);
-            }
-            catch (InvalidOperationException ex)
-            {
-                // The DateTimeMode can be set only on DataColumns
-                // of type DateTime
-                Assert.Equal(typeof(InvalidOperationException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.IndexOf("DateTimeMode") != -1);
-                Assert.True(ex.Message.IndexOf("DateTime") != -1);
-            }
+
+            // The DateTimeMode can be set only on DataColumns
+            // of type DateTime
+            InvalidOperationException ex =
+                Assert.Throws<InvalidOperationException>(() => col.DateTimeMode = DataSetDateTime.Local);
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+            Assert.True(ex.Message.IndexOf("DateTimeMode") != -1);
+            Assert.True(ex.Message.IndexOf("DateTime") != -1);
         }
 
         [Fact]
         public void DateTimeMode_Invalid()
         {
             DataColumn col = new DataColumn("birthdate", typeof(DateTime));
-            try
-            {
-                col.DateTimeMode = (DataSetDateTime)666;
-                Assert.False(true);
-            }
-            catch (InvalidEnumArgumentException ex)
-            {
-                // The DataSetDateTime enumeration value, 666, is invalid
-                Assert.Equal(typeof(InvalidEnumArgumentException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.IndexOf("DataSetDateTime") != -1);
-                Assert.True(ex.Message.IndexOf("666") != -1);
-                Assert.Null(ex.ParamName);
-            }
+
+            // The DataSetDateTime enumeration value, 666, is invalid
+            InvalidEnumArgumentException ex =
+                Assert.Throws<InvalidEnumArgumentException>(() => col.DateTimeMode = (DataSetDateTime)666);
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+            Assert.Contains(ex.Message, "DataSetDateTime");
+            Assert.Contains(ex.Message, "666");
+            Assert.Null(ex.ParamName);
         }
 
         [Fact]
@@ -235,16 +202,8 @@ namespace System.Data.Tests
             _tbl.Columns.Add(col);
 
             //Duplicate name exception
-            try
-            {
-                col2.ColumnName = "abc";
-                _tbl.Columns.Add(col2);
-                Assert.Equal("abc", col2.ColumnName);
-                Assert.False(true);
-            }
-            catch (DuplicateNameException)
-            {
-            }
+            Assert.Throws<DuplicateNameException>(() => { col2.ColumnName = "abc"; _tbl.Columns.Add(col2); });
+
             // Make sure case matters in duplicate checks
             col3.ColumnName = "ABC";
             _tbl.Columns.Add(col3);
@@ -258,26 +217,12 @@ namespace System.Data.Tests
 
             //Set default Value if Autoincrement is true
             tbl.Columns[0].AutoIncrement = true;
-            try
-            {
-                tbl.Columns[0].DefaultValue = 2;
-                Assert.False(true);
-            }
-            catch (ArgumentException)
-            {
-            }
+            Assert.Throws<ArgumentException>(() => tbl.Columns[0].DefaultValue = 2);
 
             tbl.Columns[0].AutoIncrement = false;
 
             //Set default value to an incompatible datatype
-            try
-            {
-                tbl.Columns[0].DefaultValue = "hello";
-                Assert.False(true);
-            }
-            catch (FormatException)
-            {
-            }
+            Assert.Throws<ArgumentException>(() => tbl.Columns[0].DefaultValue = "hello");
         }
 
         [Fact]
@@ -361,280 +306,269 @@ namespace System.Data.Tests
             t.Columns.Add("aaa");
             t.Rows.Add(new object[] { "xxx" });
             DataColumn c = t.Columns.Add("bbb");
-            try
-            {
-                c.Expression = "SUBSTRING(aaa, 6000000000000000, 2)";
-                Assert.False(true);
-            }
-            catch (OverflowException)
-            {
-            }
+            Assert.Throws<OverflowException>(() => c.Expression = "SUBSTRING(aaa, 6000000000000000, 2)");
         }
 
         [Fact]
         public void ExpressionFunctions()
         {
-            DataTable T = new DataTable("test");
-            DataColumn C = new DataColumn("name");
-            T.Columns.Add(C);
-            C = new DataColumn("age");
-            C.DataType = typeof(int);
-            T.Columns.Add(C);
-            C = new DataColumn("id");
-            C.Expression = "substring (name, 1, 3) + len (name) + age";
-            T.Columns.Add(C);
+            DataTable t = new DataTable("test");
+            DataColumn c = new DataColumn("name");
+            t.Columns.Add(c);
+            c = new DataColumn("age");
+            c.DataType = typeof(int);
+            t.Columns.Add(c);
+            c = new DataColumn("id");
+            c.Expression = "substring (name, 1, 3) + len (name) + age";
+            t.Columns.Add(c);
 
-            DataSet Set = new DataSet("TestSet");
-            Set.Tables.Add(T);
+            DataSet set = new DataSet("TestSet");
+            set.Tables.Add(t);
 
-            DataRow Row = null;
+            DataRow row = null;
             for (int i = 0; i < 100; i++)
             {
-                Row = T.NewRow();
-                Row[0] = "human" + i;
-                Row[1] = i;
-                T.Rows.Add(Row);
+                row = t.NewRow();
+                row[0] = "human" + i;
+                row[1] = i;
+                t.Rows.Add(row);
             }
 
-            Row = T.NewRow();
-            Row[0] = "h*an";
-            Row[1] = DBNull.Value;
-            T.Rows.Add(Row);
+            row = t.NewRow();
+            row[0] = "h*an";
+            row[1] = DBNull.Value;
+            t.Rows.Add(row);
 
-            Assert.Equal("hum710", T.Rows[10][2]);
-            Assert.Equal("hum64", T.Rows[4][2]);
-            C = T.Columns[2];
-            C.Expression = "isnull (age, 'succ[[]]ess')";
-            Assert.Equal("succ[[]]ess", T.Rows[100][2]);
+            Assert.Equal("hum710", t.Rows[10][2]);
+            Assert.Equal("hum64", t.Rows[4][2]);
+            c = t.Columns[2];
+            c.Expression = "isnull (age, 'succ[[]]ess')";
+            Assert.Equal("succ[[]]ess", t.Rows[100][2]);
 
-            C.Expression = "iif (age = 24, 'hurrey', 'boo')";
-            Assert.Equal("boo", T.Rows[50][2]);
-            Assert.Equal("hurrey", T.Rows[24][2]);
+            c.Expression = "iif (age = 24, 'hurrey', 'boo')";
+            Assert.Equal("boo", t.Rows[50][2]);
+            Assert.Equal("hurrey", t.Rows[24][2]);
 
-            C.Expression = "convert (age, 'System.Boolean')";
-            Assert.Equal(bool.TrueString, T.Rows[50][2]);
-            Assert.Equal(bool.FalseString, T.Rows[0][2]);
+            c.Expression = "convert (age, 'System.Boolean')";
+            Assert.Equal(bool.TrueString, t.Rows[50][2]);
+            Assert.Equal(bool.FalseString, t.Rows[0][2]);
 
             //
             // Exceptions
             //
 
-            try
-            {
-                // The expression contains undefined function call iff().
-                C.Expression = "iff (age = 24, 'hurrey', 'boo')";
-                Assert.False(true);
-            }
-            catch (EvaluateException)
-            {
-            }
-            catch (SyntaxErrorException)
-            {
-            }
-
+            // TODO: which exception is it exactly?
+            Assert.ThrowsAny<InvalidExpressionException>(() => c.Expression = "iff (age = 24, 'hurrey', 'boo')");
+            //TODO
             //The following two cases fail on mono. MS.net evaluates the expression
             //immediately upon assignment. We don't do this yet hence we don't throw
             //an exception at this point.
-            try
-            {
-                C.Expression = "iif (nimi = 24, 'hurrey', 'boo')";
-                Assert.False(true);
-            }
-            catch (EvaluateException e)
-            {
-                Assert.Equal(typeof(EvaluateException), e.GetType());
-                // Never premise English.
-                //Assert.Equal ("Cannot find column [nimi].", e.Message);
-            }
+            //try
+            //{
+            //    C.Expression = "iif (nimi = 24, 'hurrey', 'boo')";
+            //    Assert.False(true);
+            //}
+            //catch (EvaluateException e)
+            //{
+            //    Assert.Equal(typeof(EvaluateException), e.GetType());
+            //    // Never premise English.
+            //    //Assert.Equal ("Cannot find column [nimi].", e.Message);
+            //}
+            // TODO: Exception message?
+            Assert.Throws<EvaluateException>(() => c.Expression = "iif (nimi = 24, 'hurrey', 'boo')");
 
-            try
-            {
-                C.Expression = "iif (name = 24, 'hurrey', 'boo')";
-                Assert.False(true);
-            }
-            catch (EvaluateException e)
-            {
-                Assert.Equal(typeof(EvaluateException), e.GetType());
-                //AssertEquals ("DC41", "Cannot perform '=' operation on System.String and System.Int32.", e.Message);
-            }
+            //try
+            //{
+            //    C.Expression = "iif (name = 24, 'hurrey', 'boo')";
+            //    Assert.False(true);
+            //}
+            //catch (EvaluateException e)
+            //{
+            //    Assert.Equal(typeof(EvaluateException), e.GetType());
+            //    //AssertEquals ("DC41", "Cannot perform '=' operation on System.String and System.Int32.", e.Message);
+            //}
+            //TODO: Exception message?
+            Assert.Throws<EvaluateException>(() => c.Expression = "iif (name = 24, 'hurrey', 'boo')");
 
-            try
-            {
-                C.Expression = "convert (age, Boolean)";
-                Assert.False(true);
-            }
-            catch (EvaluateException e)
-            {
-                Assert.Equal(typeof(EvaluateException), e.GetType());
-                // Never premise English.
-                //Assert.Equal ("Invalid type name 'Boolean'.", e.Message);
-            }
+            //try
+            //{
+            //    C.Expression = "convert (age, Boolean)";
+            //    Assert.False(true);
+            //}
+            //catch (EvaluateException e)
+            //{
+            //    Assert.Equal(typeof(EvaluateException), e.GetType());
+            //    // Never premise English.
+            //    //Assert.Equal ("Invalid type name 'Boolean'.", e.Message);
+            //}
+            //TODO: Exception message?
+            Assert.Throws<EvaluateException>(() => c.Expression = "convert (age, Boolean)");
         }
 
         [Fact]
         public void ExpressionAggregates()
         {
-            DataTable T = new DataTable("test");
-            DataTable T2 = new DataTable("test2");
+            DataTable t = new DataTable("test");
+            DataTable t2 = new DataTable("test2");
 
-            DataColumn C = new DataColumn("name");
-            T.Columns.Add(C);
-            C = new DataColumn("age");
-            C.DataType = typeof(int);
-            T.Columns.Add(C);
-            C = new DataColumn("childname");
-            T.Columns.Add(C);
+            DataColumn c = new DataColumn("name");
+            t.Columns.Add(c);
+            c = new DataColumn("age");
+            c.DataType = typeof(int);
+            t.Columns.Add(c);
+            c = new DataColumn("childname");
+            t.Columns.Add(c);
 
-            C = new DataColumn("expression");
-            T.Columns.Add(C);
+            c = new DataColumn("expression");
+            t.Columns.Add(c);
 
-            DataSet Set = new DataSet("TestSet");
-            Set.Tables.Add(T);
-            Set.Tables.Add(T2);
+            DataSet set = new DataSet("TestSet");
+            set.Tables.Add(t);
+            set.Tables.Add(t2);
 
-            DataRow Row = null;
+            DataRow row = null;
             for (int i = 0; i < 100; i++)
             {
-                Row = T.NewRow();
-                Row[0] = "human" + i;
-                Row[1] = i;
-                Row[2] = "child" + i;
-                T.Rows.Add(Row);
+                row = t.NewRow();
+                row[0] = "human" + i;
+                row[1] = i;
+                row[2] = "child" + i;
+                t.Rows.Add(row);
             }
 
-            Row = T.NewRow();
-            Row[0] = "h*an";
-            Row[1] = DBNull.Value;
-            T.Rows.Add(Row);
+            row = t.NewRow();
+            row[0] = "h*an";
+            row[1] = DBNull.Value;
+            t.Rows.Add(row);
 
-            C = new DataColumn("name");
-            T2.Columns.Add(C);
-            C = new DataColumn("age");
-            C.DataType = typeof(int);
-            T2.Columns.Add(C);
+            c = new DataColumn("name");
+            t2.Columns.Add(c);
+            c = new DataColumn("age");
+            c.DataType = typeof(int);
+            t2.Columns.Add(c);
 
             for (int i = 0; i < 100; i++)
             {
-                Row = T2.NewRow();
-                Row[0] = "child" + i;
-                Row[1] = i;
-                T2.Rows.Add(Row);
-                Row = T2.NewRow();
-                Row[0] = "child" + i;
-                Row[1] = i - 2;
-                T2.Rows.Add(Row);
+                row = t2.NewRow();
+                row[0] = "child" + i;
+                row[1] = i;
+                t2.Rows.Add(row);
+                row = t2.NewRow();
+                row[0] = "child" + i;
+                row[1] = i - 2;
+                t2.Rows.Add(row);
             }
 
-            DataRelation Rel = new DataRelation("Rel", T.Columns[2], T2.Columns[0]);
-            Set.Relations.Add(Rel);
+            DataRelation rel = new DataRelation("Rel", t.Columns[2], t2.Columns[0]);
+            set.Relations.Add(rel);
 
-            C = T.Columns[3];
-            C.Expression = "Sum (Child.age)";
-            Assert.Equal("-2", T.Rows[0][3]);
-            Assert.Equal("98", T.Rows[50][3]);
+            c = t.Columns[3];
+            c.Expression = "Sum (Child.age)";
+            Assert.Equal("-2", t.Rows[0][3]);
+            Assert.Equal("98", t.Rows[50][3]);
 
-            C.Expression = "Count (Child.age)";
-            Assert.Equal("2", T.Rows[0][3]);
-            Assert.Equal("2", T.Rows[60][3]);
+            c.Expression = "Count (Child.age)";
+            Assert.Equal("2", t.Rows[0][3]);
+            Assert.Equal("2", t.Rows[60][3]);
 
-            C.Expression = "Avg (Child.age)";
-            Assert.Equal("-1", T.Rows[0][3]);
-            Assert.Equal("59", T.Rows[60][3]);
+            c.Expression = "Avg (Child.age)";
+            Assert.Equal("-1", t.Rows[0][3]);
+            Assert.Equal("59", t.Rows[60][3]);
 
-            C.Expression = "Min (Child.age)";
-            Assert.Equal("-2", T.Rows[0][3]);
-            Assert.Equal("58", T.Rows[60][3]);
+            c.Expression = "Min (Child.age)";
+            Assert.Equal("-2", t.Rows[0][3]);
+            Assert.Equal("58", t.Rows[60][3]);
 
-            C.Expression = "Max (Child.age)";
-            Assert.Equal("0", T.Rows[0][3]);
-            Assert.Equal("60", T.Rows[60][3]);
+            c.Expression = "Max (Child.age)";
+            Assert.Equal("0", t.Rows[0][3]);
+            Assert.Equal("60", t.Rows[60][3]);
 
-            C.Expression = "stdev (Child.age)";
-            Assert.Equal((1.4142135623730951).ToString(T.Locale), T.Rows[0][3]);
-            Assert.Equal((1.4142135623730951).ToString(T.Locale), T.Rows[60][3]);
+            c.Expression = "stdev (Child.age)";
+            Assert.Equal((1.4142135623730951).ToString(t.Locale), t.Rows[0][3]);
+            Assert.Equal((1.4142135623730951).ToString(t.Locale), t.Rows[60][3]);
 
-            C.Expression = "var (Child.age)";
-            Assert.Equal("2", T.Rows[0][3]);
-            Assert.Equal("2", T.Rows[60][3]);
+            c.Expression = "var (Child.age)";
+            Assert.Equal("2", t.Rows[0][3]);
+            Assert.Equal("2", t.Rows[60][3]);
         }
 
         [Fact]
         public void ExpressionOperator()
         {
-            DataTable T = new DataTable("test");
-            DataColumn C = new DataColumn("name");
-            T.Columns.Add(C);
-            C = new DataColumn("age");
-            C.DataType = typeof(int);
-            T.Columns.Add(C);
-            C = new DataColumn("id");
-            C.Expression = "substring (name, 1, 3) + len (name) + age";
-            T.Columns.Add(C);
+            DataTable t = new DataTable("test");
+            DataColumn c = new DataColumn("name");
+            t.Columns.Add(c);
+            c = new DataColumn("age");
+            c.DataType = typeof(int);
+            t.Columns.Add(c);
+            c = new DataColumn("id");
+            c.Expression = "substring (name, 1, 3) + len (name) + age";
+            t.Columns.Add(c);
 
-            DataSet Set = new DataSet("TestSet");
-            Set.Tables.Add(T);
+            DataSet set = new DataSet("TestSet");
+            set.Tables.Add(t);
 
-            DataRow Row = null;
+            DataRow row = null;
             for (int i = 0; i < 100; i++)
             {
-                Row = T.NewRow();
-                Row[0] = "human" + i;
-                Row[1] = i;
-                T.Rows.Add(Row);
+                row = t.NewRow();
+                row[0] = "human" + i;
+                row[1] = i;
+                t.Rows.Add(row);
             }
 
-            Row = T.NewRow();
-            Row[0] = "h*an";
-            Row[1] = DBNull.Value;
-            T.Rows.Add(Row);
+            row = t.NewRow();
+            row[0] = "h*an";
+            row[1] = DBNull.Value;
+            t.Rows.Add(row);
 
-            C = T.Columns[2];
-            C.Expression = "age + 4";
-            Assert.Equal("68", T.Rows[64][2]);
+            c = t.Columns[2];
+            c.Expression = "age + 4";
+            Assert.Equal("68", t.Rows[64][2]);
 
-            C.Expression = "age - 4";
-            Assert.Equal("60", T.Rows[64][2]);
+            c.Expression = "age - 4";
+            Assert.Equal("60", t.Rows[64][2]);
 
-            C.Expression = "age * 4";
-            Assert.Equal("256", T.Rows[64][2]);
+            c.Expression = "age * 4";
+            Assert.Equal("256", t.Rows[64][2]);
 
-            C.Expression = "age / 4";
-            Assert.Equal("16", T.Rows[64][2]);
+            c.Expression = "age / 4";
+            Assert.Equal("16", t.Rows[64][2]);
 
-            C.Expression = "age % 5";
-            Assert.Equal("4", T.Rows[64][2]);
+            c.Expression = "age % 5";
+            Assert.Equal("4", t.Rows[64][2]);
 
-            C.Expression = "age in (5, 10, 15, 20, 25)";
-            Assert.Equal("False", T.Rows[64][2]);
-            Assert.Equal("True", T.Rows[25][2]);
+            c.Expression = "age in (5, 10, 15, 20, 25)";
+            Assert.Equal("False", t.Rows[64][2]);
+            Assert.Equal("True", t.Rows[25][2]);
 
-            C.Expression = "name like 'human1%'";
-            Assert.Equal("True", T.Rows[1][2]);
-            Assert.Equal("False", T.Rows[25][2]);
+            c.Expression = "name like 'human1%'";
+            Assert.Equal("True", t.Rows[1][2]);
+            Assert.Equal("False", t.Rows[25][2]);
 
-            C.Expression = "age < 4";
-            Assert.Equal("False", T.Rows[4][2]);
-            Assert.Equal("True", T.Rows[3][2]);
+            c.Expression = "age < 4";
+            Assert.Equal("False", t.Rows[4][2]);
+            Assert.Equal("True", t.Rows[3][2]);
 
-            C.Expression = "age <= 4";
-            Assert.Equal("True", T.Rows[4][2]);
-            Assert.Equal("False", T.Rows[5][2]);
+            c.Expression = "age <= 4";
+            Assert.Equal("True", t.Rows[4][2]);
+            Assert.Equal("False", t.Rows[5][2]);
 
-            C.Expression = "age > 4";
-            Assert.Equal("False", T.Rows[4][2]);
-            Assert.Equal("True", T.Rows[5][2]);
+            c.Expression = "age > 4";
+            Assert.Equal("False", t.Rows[4][2]);
+            Assert.Equal("True", t.Rows[5][2]);
 
-            C.Expression = "age >= 4";
-            Assert.Equal("True", T.Rows[4][2]);
-            Assert.Equal("False", T.Rows[1][2]);
+            c.Expression = "age >= 4";
+            Assert.Equal("True", t.Rows[4][2]);
+            Assert.Equal("False", t.Rows[1][2]);
 
-            C.Expression = "age = 4";
-            Assert.Equal("True", T.Rows[4][2]);
-            Assert.Equal("False", T.Rows[1][2]);
+            c.Expression = "age = 4";
+            Assert.Equal("True", t.Rows[4][2]);
+            Assert.Equal("False", t.Rows[1][2]);
 
-            C.Expression = "age <> 4";
-            Assert.Equal("False", T.Rows[4][2]);
-            Assert.Equal("True", T.Rows[1][2]);
+            c.Expression = "age <> 4";
+            Assert.Equal("False", t.Rows[4][2]);
+            Assert.Equal("True", t.Rows[1][2]);
         }
 
         [Fact]
@@ -645,14 +579,7 @@ namespace System.Data.Tests
             ds.Tables.Add("MyType");
             ds.Tables["MyType"].Columns.Add(new DataColumn("Desc",
                 typeof(string), "", MappingType.SimpleContent));
-            try
-            {
-                ds.Tables["MyType"].Columns["Desc"].MaxLength = 32;
-                Assert.False(true);
-            }
-            catch (ArgumentException)
-            {
-            }
+            Assert.Throws<ArgumentException>(() => ds.Tables["MyType"].Columns["Desc"].MaxLength = 32);
         }
 
         [Fact]
@@ -787,7 +714,6 @@ namespace System.Data.Tests
         [Fact]
         public void Aggregation_TestForSyntaxErrors()
         {
-            string error = "Aggregation functions cannot be called on Singular(Parent) Columns";
             DataSet ds = new DataSet();
             DataTable table1 = new DataTable();
             DataTable table2 = new DataTable();
@@ -807,74 +733,25 @@ namespace System.Data.Tests
             ds.Relations.Add(rel1);
             ds.Relations.Add(rel2);
 
-            error = "Aggregation Functions cannot be called on Columns Returning Single Row (Parent Column)";
-            try
-            {
-                table2.Columns.Add("result", typeof(int), "count(parent.test)");
-                Assert.False(true);
-            }
-            catch (SyntaxErrorException)
-            {
-            }
+            // Aggregation Functions cannot be called on Columns Returning Single Row (Parent Column)
+            Assert.Throws<SyntaxErrorException>(() => table2.Columns.Add("result", typeof(int), "count(parent.test)"));
 
-            error = "Numerical or Functions cannot be called on Columns Returning Multiple Rows (Child Column)";
-            // Check arithematic operator
-            try
-            {
-                table2.Columns.Add("result", typeof(int), "10*(child.test)");
-                Assert.False(true);
-            }
-            catch (SyntaxErrorException)
-            {
-            }
+            // Numerical or Functions cannot be called on Columns Returning Multiple Rows (Child Column);
+            // Check arithmetic operator
+            Assert.Throws<SyntaxErrorException>(() => table2.Columns.Add("result", typeof(int), "10*(child.test)"));
 
             // Check rel operator
-            try
-            {
-                table2.Columns.Add("result", typeof(int), "(child.test) > 10");
-                Assert.False(true);
-            }
-            catch (SyntaxErrorException)
-            {
-            }
+            Assert.Throws<SyntaxErrorException>(() => table2.Columns.Add("result", typeof(int), "(child.test) > 10"));
 
-            // Check predicates
-            try
-            {
-                table2.Columns.Add("result", typeof(int), "(child.test) IN (1,2,3)");
-                Assert.False(true);
-            }
-            catch (SyntaxErrorException)
-            {
-            }
+            // Check predicates 
+            Assert.Throws<SyntaxErrorException>(() => table2.Columns.Add("result", typeof(int), "(child.test) IN (1,2,3)"));
 
-            try
-            {
-                table2.Columns.Add("result", typeof(int), "(child.test) LIKE 1");
-                Assert.False(true);
-            }
-            catch (SyntaxErrorException)
-            {
-            }
+            Assert.Throws<SyntaxErrorException>(() => table2.Columns.Add("result", typeof(int), "(child.test) LIKE 1"));
 
-            try
-            {
-                table2.Columns.Add("result", typeof(int), "(child.test) IS null");
-                Assert.False(true);
-            }
-            catch (SyntaxErrorException)
-            {
-            }
+            Assert.Throws<SyntaxErrorException>(() => table2.Columns.Add("result", typeof(int), "(child.test) IS null"));
 
             // Check Calc Functions
-            try
-            {
-                table2.Columns.Add("result", typeof(int), "isnull(child.test,10)");
-                Assert.False(true);
-            }
-            catch (SyntaxErrorException)
-            {
-            }
+            Assert.Throws<SyntaxErrorException>(() => table2.Columns.Add("result", typeof(int), "isnull(child.test,10)"));
         }
 
         [Fact]
@@ -904,48 +781,34 @@ namespace System.Data.Tests
         [Fact]
         public void B565616_NonIConvertibleTypeTest()
         {
-            try
-            {
-                DataTable dt = new DataTable();
-                Guid id = Guid.NewGuid();
-                dt.Columns.Add("ID", typeof(string));
-                DataRow row = dt.NewRow();
-                row["ID"] = id;
-                Assert.Equal(id.ToString(), row["ID"]);
-            }
-            catch (InvalidCastException ex)
-            {
-                Assert.False(true);
-            }
+            DataTable dt = new DataTable();
+            Guid id = Guid.NewGuid();
+            dt.Columns.Add("ID", typeof(string));
+            DataRow row = dt.NewRow();
+            row["ID"] = id;
+            Assert.Equal(id.ToString(), row["ID"]);
         }
 
         [Fact]
         public void B623451_SetOrdinalTest()
         {
-            try
-            {
-                DataTable t = new DataTable();
-                t.Columns.Add("one");
-                t.Columns.Add("two");
-                t.Columns.Add("three");
-                Assert.Equal("one", t.Columns[0].ColumnName);
-                Assert.Equal("two", t.Columns[1].ColumnName);
-                Assert.Equal("three", t.Columns[2].ColumnName);
+            DataTable t = new DataTable();
+            t.Columns.Add("one");
+            t.Columns.Add("two");
+            t.Columns.Add("three");
+            Assert.Equal("one", t.Columns[0].ColumnName);
+            Assert.Equal("two", t.Columns[1].ColumnName);
+            Assert.Equal("three", t.Columns[2].ColumnName);
 
-                t.Columns["three"].SetOrdinal(0);
-                Assert.Equal("three", t.Columns[0].ColumnName);
-                Assert.Equal("one", t.Columns[1].ColumnName);
-                Assert.Equal("two", t.Columns[2].ColumnName);
+            t.Columns["three"].SetOrdinal(0);
+            Assert.Equal("three", t.Columns[0].ColumnName);
+            Assert.Equal("one", t.Columns[1].ColumnName);
+            Assert.Equal("two", t.Columns[2].ColumnName);
 
-                t.Columns["three"].SetOrdinal(1);
-                Assert.Equal("one", t.Columns[0].ColumnName);
-                Assert.Equal("three", t.Columns[1].ColumnName);
-                Assert.Equal("two", t.Columns[2].ColumnName);
-            }
-            catch (ArgumentOutOfRangeException ex)
-            {
-                Assert.False(true);
-            }
+            t.Columns["three"].SetOrdinal(1);
+            Assert.Equal("one", t.Columns[0].ColumnName);
+            Assert.Equal("three", t.Columns[1].ColumnName);
+            Assert.Equal("two", t.Columns[2].ColumnName);
         }
 
         [Fact]
@@ -992,7 +855,7 @@ namespace System.Data.Tests
                 Expression = test
             };
         }
-
+        // TODO: what's this?
 #if false
 // Check Windows output for the row [0] value
         [Fact]

--- a/src/System.Data.Common/tests/System/Data/DataColumnTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/DataColumnTest2.cs
@@ -24,9 +24,6 @@
 //
 
 using System.ComponentModel;
-using System.Globalization;
-
-
 using Xunit;
 
 namespace System.Data.Tests
@@ -236,18 +233,6 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public void TestGetType()
-        {
-            DataColumn dc;
-            Type myType;
-            dc = new DataColumn();
-            myType = dc.GetType();
-
-            // GetType
-            Assert.Equal(typeof(DataColumn), myType);
-        }
-
-        [Fact]
         public void MaxLength()
         {
             DataColumn dc;
@@ -395,14 +380,7 @@ namespace System.Data.Tests
 
             Assert.True(col.Unique);
 
-            try
-            {
-                col.Unique = false;
-                Assert.False(true);
-            }
-            catch (ArgumentException e)
-            {
-            }
+            Assert.Throws<ArgumentException>(() => col.Unique = false);
 
             Assert.True(col.Unique);
         }
@@ -424,9 +402,6 @@ namespace System.Data.Tests
             string sName = "ColName";
             dc = new DataColumn(sName);
 
-            // ctor - object
-            Assert.False(dc == null);
-
             // ctor - ColName
             Assert.Equal(sName, dc.ColumnName);
         }
@@ -445,8 +420,6 @@ namespace System.Data.Tests
             {
                 typTest = Type.GetType(sType);
                 dc = new DataColumn("ColName", typTest);
-                // ctor - object
-                Assert.False(dc == null);
 
                 // ctor - ColName
                 Assert.Equal(typTest, dc.DataType);
@@ -458,9 +431,6 @@ namespace System.Data.Tests
         {
             DataColumn dc;
             dc = new DataColumn("ColName", typeof(string), "Price * 1.18");
-
-            // ctor - object
-            Assert.False(dc == null);
         }
 
         [Fact]
@@ -473,7 +443,6 @@ namespace System.Data.Tests
                 dc = null;
                 dc = new DataColumn("ColName", typeof(string), "Price * 1.18", (MappingType)i);
                 // Ctor #" + i.ToString());
-                Assert.False(dc == null);
             }
         }
 
@@ -755,12 +724,7 @@ namespace System.Data.Tests
         {
             DataColumn col = new DataColumn("col", typeof(int));
             Assert.Equal(DataSetDateTime.UnspecifiedLocal, col.DateTimeMode);
-            try
-            {
-                col.DateTimeMode = DataSetDateTime.Local;
-                Assert.False(true);
-            }
-            catch (InvalidOperationException e) { }
+            Assert.Throws<InvalidOperationException>(() => col.DateTimeMode = DataSetDateTime.Local);
 
             col = new DataColumn("col", typeof(DateTime));
             col.DateTimeMode = DataSetDateTime.Utc;
@@ -773,19 +737,9 @@ namespace System.Data.Tests
         public void DateTimeMode_InvalidValues()
         {
             DataColumn col = new DataColumn("col", typeof(DateTime));
-            try
-            {
-                col.DateTimeMode = (DataSetDateTime)(-1);
-                Assert.False(true);
-            }
-            catch (InvalidEnumArgumentException e) { }
+            Assert.Throws<InvalidEnumArgumentException>(() => col.DateTimeMode = (DataSetDateTime)(-1));
 
-            try
-            {
-                col.DateTimeMode = (DataSetDateTime)5;
-                Assert.False(true);
-            }
-            catch (InvalidEnumArgumentException e) { }
+            Assert.Throws<InvalidEnumArgumentException>(() => col.DateTimeMode = (DataSetDateTime)5);
         }
 
         [Fact]
@@ -800,31 +754,16 @@ namespace System.Data.Tests
             table.Columns[0].DateTimeMode = DataSetDateTime.Unspecified;
             table.Columns[0].DateTimeMode = DataSetDateTime.UnspecifiedLocal;
 
-            try
-            {
-                table.Columns[0].DateTimeMode = DataSetDateTime.Local;
-                Assert.False(true);
-            }
-            catch (InvalidOperationException e) { }
+            Assert.Throws<InvalidOperationException>(() => table.Columns[0].DateTimeMode = DataSetDateTime.Local);
 
-            try
-            {
-                table.Columns[0].DateTimeMode = DataSetDateTime.Utc;
-                Assert.False(true);
-            }
-            catch (InvalidOperationException e) { }
+            Assert.Throws<InvalidOperationException>(() => table.Columns[0].DateTimeMode = DataSetDateTime.Utc);
         }
 
         [Fact]
         public void SetOrdinalTest()
         {
             DataColumn col = new DataColumn("col", typeof(int));
-            try
-            {
-                col.SetOrdinal(2);
-                Assert.False(true);
-            }
-            catch (ArgumentException e) { }
+            Assert.Throws<ArgumentException>(() => col.SetOrdinal(2));
 
             DataTable table = new DataTable();
             DataColumn col1 = table.Columns.Add("col1", typeof(int));
@@ -842,22 +781,12 @@ namespace System.Data.Tests
             Assert.Equal(1, col3.Ordinal);
             Assert.Equal(2, col1.Ordinal);
 
-            try
-            {
-                table.Columns[0].SetOrdinal(-1);
-                Assert.False(true);
-            }
-            catch (ArgumentOutOfRangeException e) { }
+            Assert.Throws<ArgumentOutOfRangeException>(() => table.Columns[0].SetOrdinal(-1));
 
-            try
-            {
-                table.Columns[0].SetOrdinal(4);
-                Assert.False(true);
-            }
-            catch (ArgumentOutOfRangeException e) { }
+            Assert.Throws<ArgumentOutOfRangeException>(() => table.Columns[0].SetOrdinal(4));
         }
         [Fact]
-        public void bug672113_MulpleColConstraint()
+        public void Bug672113_MulpleColConstraint()
         {
             DataTable FirstTable = new DataTable("First Table");
             DataColumn col0 = new DataColumn("empno", typeof(int));

--- a/src/System.Data.Common/tests/System/Data/DataColumnTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/DataColumnTest2.cs
@@ -404,8 +404,7 @@ namespace System.Data.Tests
         {
             DataColumn col = new DataColumn("ColName", typeof(string), "Price * 1.18");
             Assert.Equal("ColName", col.ColumnName);
-            // Assert.IsType fails because the type returned is System.RuntimeType not System.Type it seems.
-            Assert.Equal("System.String", col.DataType.FullName);
+            Assert.Equal(typeof(string), col.DataType);
             Assert.Equal("Price * 1.18", col.Expression);
         }
 

--- a/src/System.Data.Common/tests/System/Data/DataColumnTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/DataColumnTest2.cs
@@ -168,38 +168,22 @@ namespace System.Data.Tests
         {
             DataColumn dc;
             dc = new DataColumn();
-            string[] sTypeArr = { "System.Boolean", "System.Byte", "System.Char", "System.DateTime",
-                "System.Decimal", "System.Double", "System.Int16", "System.Int32",
-                "System.Int64", "System.SByte", "System.Single", "System.String",
-                "System.TimeSpan", "System.UInt16", "System.UInt32", "System.UInt64" };
+            Type[] typeArr = { typeof(bool), typeof(byte), typeof(char), typeof(DateTime),
+                typeof(decimal), typeof(double), typeof(short), typeof(int),
+                typeof(long), typeof(sbyte), typeof(float), typeof(string),
+                typeof(TimeSpan), typeof(ushort), typeof(uint), typeof(ulong) };
 
             //Checking default value (string)
             // GetType - Default
-            Assert.Equal(Type.GetType("System.String"), dc.DataType);
+            Assert.Equal(typeof(string), dc.DataType);
 
-            foreach (string sType in sTypeArr)
+            foreach (Type type in typeArr)
             {
                 //Cheking Set
-                dc.DataType = Type.GetType(sType);
+                dc.DataType = type;
                 // Checking GetType " + sType);
-                Assert.Equal(Type.GetType(sType), dc.DataType);
+                Assert.Equal(type, dc.DataType);
             }
-        }
-
-        [Fact]
-        public void Equals()
-        {
-            DataColumn dc1, dc2;
-            dc1 = new DataColumn();
-            dc2 = new DataColumn();
-            // #1
-            // Equals 1
-            Assert.False(dc1.Equals(dc2));
-
-            dc1 = dc2;
-            // #2
-            // Equals 2
-            Assert.Equal(dc2, dc1);
         }
 
         [Fact]
@@ -210,8 +194,8 @@ namespace System.Data.Tests
             dc = new DataColumn();
 
             pc = dc.ExtendedProperties;
-            // Checking ExtendedProperties default
-            Assert.True(pc != null);
+            // Checking ExtendedProperties default 
+            Assert.NotNull(pc);
 
             // Checking ExtendedProperties count
             Assert.Equal(0, pc.Count);
@@ -386,16 +370,6 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public void ctor()
-        {
-            DataColumn dc;
-            dc = new DataColumn();
-
-            // ctor
-            Assert.False(dc == null);
-        }
-
-        [Fact]
         public void ctor_ByColumnName()
         {
             DataColumn dc;
@@ -411,26 +385,24 @@ namespace System.Data.Tests
         {
             Type typTest;
             DataColumn dc = null;
-            string[] sTypeArr = { "System.Boolean", "System.Byte", "System.Char", "System.DateTime",
-                "System.Decimal", "System.Double", "System.Int16", "System.Int32",
-                "System.Int64", "System.SByte", "System.Single", "System.String",
-                "System.TimeSpan", "System.UInt16", "System.UInt32", "System.UInt64" };
+            Type[] typeArr = { typeof(bool), typeof(byte), typeof(char), typeof(DateTime),
+                typeof(decimal), typeof(double), typeof(short), typeof(int),
+                typeof(long), typeof(sbyte), typeof(float), typeof(string),
+                typeof(TimeSpan), typeof(ushort), typeof(uint), typeof(ulong) };
 
-            foreach (string sType in sTypeArr)
+            foreach (Type type in typeArr)
             {
-                typTest = Type.GetType(sType);
-                dc = new DataColumn("ColName", typTest);
+                dc = new DataColumn("ColName", type);
 
                 // ctor - ColName
-                Assert.Equal(typTest, dc.DataType);
+                Assert.Equal(type, dc.DataType);
             }
         }
 
         [Fact]
         public void ctor_ByColumnNameTypeExpression()
         {
-            DataColumn dc;
-            dc = new DataColumn("ColName", typeof(string), "Price * 1.18");
+            _ = new DataColumn("ColName", typeof(string), "Price * 1.18");
         }
 
         [Fact]
@@ -440,7 +412,6 @@ namespace System.Data.Tests
             //Cheking constructor for each Enum MappingType
             foreach (int i in Enum.GetValues(typeof(MappingType)))
             {
-                dc = null;
                 dc = new DataColumn("ColName", typeof(string), "Price * 1.18", (MappingType)i);
                 // Ctor #" + i.ToString());
             }
@@ -555,7 +526,7 @@ namespace System.Data.Tests
         {
             DataTable dt = DataProvider.CreateParentDataTable();
             //Simple expression --> not aggregate
-            DataColumn dc = new DataColumn("expr", Type.GetType("System.Decimal"));
+            DataColumn dc = new DataColumn("expr", typeof(decimal));
             dt.Columns.Add(dc);
             dt.Columns["expr"].Expression = dt.Columns[0].ColumnName + "*0.52 +" + dt.Columns[0].ColumnName;
 
@@ -589,7 +560,7 @@ namespace System.Data.Tests
         {
             DataTable dt = DataProvider.CreateParentDataTable();
             //Simple expression -->  aggregate
-            DataColumn dc = new DataColumn("expr", Type.GetType("System.Decimal"));
+            DataColumn dc = new DataColumn("expr", typeof(decimal));
             dt.Columns.Add(dc);
             dt.Columns["expr"].Expression = "sum(" + dt.Columns[0].ColumnName + ") + count(" + dt.Columns[0].ColumnName + ")";
             dt.Columns["expr"].Expression += " + avg(" + dt.Columns[0].ColumnName + ") + Min(" + dt.Columns[0].ColumnName + ")";
@@ -633,7 +604,7 @@ namespace System.Data.Tests
 
             //Create the computed columns
 
-            DataColumn dcComputedParent = new DataColumn("computedParent", Type.GetType("System.Double"));
+            DataColumn dcComputedParent = new DataColumn("computedParent", typeof(double));
             parent.Columns.Add(dcComputedParent);
             dcComputedParent.Expression = "sum(child(Relation1)." + child.Columns[1].ColumnName + ")";
 
@@ -654,7 +625,7 @@ namespace System.Data.Tests
                 }
             }
 
-            DataColumn dcComputedChild = new DataColumn("computedChild", Type.GetType("System.Double"));
+            DataColumn dcComputedChild = new DataColumn("computedChild", typeof(double));
             child.Columns.Add(dcComputedChild);
             dcComputedChild.Expression = "Parent." + parent.Columns[0].ColumnName;
 
@@ -672,7 +643,7 @@ namespace System.Data.Tests
         public void Expression_IIF()
         {
             DataTable dt = DataProvider.CreateParentDataTable();
-            DataColumn dcComputedParent = new DataColumn("computedCol", Type.GetType("System.Double"));
+            DataColumn dcComputedParent = new DataColumn("computedCol", typeof(double));
             dcComputedParent.DefaultValue = 25.5;
             dt.Columns.Add(dcComputedParent);
             dcComputedParent.Expression = "IIF(" + dt.Columns[0].ColumnName + ">3" + ",1,2)";

--- a/src/System.Data.Common/tests/System/Data/DataColumnTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/DataColumnTest2.cs
@@ -402,7 +402,11 @@ namespace System.Data.Tests
         [Fact]
         public void ctor_ByColumnNameTypeExpression()
         {
-            _ = new DataColumn("ColName", typeof(string), "Price * 1.18");
+            DataColumn col = new DataColumn("ColName", typeof(string), "Price * 1.18");
+            Assert.Equal("ColName", col.ColumnName);
+            // Assert.IsType fails because the type returned is System.RuntimeType not System.Type it seems.
+            Assert.Equal("System.String", col.DataType.FullName);
+            Assert.Equal("Price * 1.18", col.Expression);
         }
 
         [Fact]

--- a/src/System.Data.Common/tests/System/Data/DataExceptionTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataExceptionTest.cs
@@ -11,22 +11,24 @@ namespace System.Data.Tests
         [Fact]
         public void Ctor_Parameterless_UsesDefaults()
         {
+            const int COR_E_Data = unchecked((int)(0x80131920));
             var e = new CustomDataException();
             Assert.False(string.IsNullOrWhiteSpace(e.Message));
             Assert.Null(e.InnerException);
-            Assert.Equal(-2146232032, e.HResult);
+            Assert.Equal(COR_E_Data, e.HResult);
         }
 
         [Fact]
         public void Ctor_ArgumentsRoundtrip()
         {
             const int COR_E_SYSTEM = unchecked((int)0x80131501);
+            const int COR_E_Data = unchecked((int)(0x80131920));
             var innerException = new Exception("inner exception");
 
             var e = new CustomDataException("test");
             Assert.Equal("test", e.Message);
             Assert.Null(e.InnerException);
-            Assert.Equal(-2146232032, e.HResult);
+            Assert.Equal(COR_E_Data, e.HResult);
 
             e = new CustomDataException("test", innerException);
             Assert.Equal("test", e.Message);

--- a/src/System.Data.Common/tests/System/Data/DataExceptionTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataExceptionTest.cs
@@ -20,6 +20,7 @@ namespace System.Data.Tests
         [Fact]
         public void Ctor_ArgumentsRoundtrip()
         {
+            const int COR_E_SYSTEM = unchecked((int)0x80131501);
             var innerException = new Exception("inner exception");
 
             var e = new CustomDataException("test");
@@ -30,7 +31,7 @@ namespace System.Data.Tests
             e = new CustomDataException("test", innerException);
             Assert.Equal("test", e.Message);
             Assert.Same(innerException, e.InnerException);
-            Assert.Equal(-2146233087, e.HResult);
+            Assert.Equal(COR_E_SYSTEM, e.HResult);
         }
 
         private class CustomDataException : DataException

--- a/src/System.Data.Common/tests/System/Data/DataRelationCollectionTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataRelationCollectionTest.cs
@@ -34,7 +34,6 @@ namespace System.Data.Tests
     {
         private DataSet _dataset;
         private DataTable _tblparent, _tblchild;
-        private DataRelation _relation;
 
         public DataRelationCollectionTest()
         {
@@ -304,22 +303,8 @@ namespace System.Data.Tests
             drcol.Add(dr1);
             drcol.Add(dr2);
 
-            try
-            {
-                drcol.RemoveAt(-1);
-                Assert.False(true);
-            }
-            catch (IndexOutOfRangeException e)
-            {
-            }
-            try
-            {
-                drcol.RemoveAt(101);
-                Assert.False(true);
-            }
-            catch (IndexOutOfRangeException e)
-            {
-            }
+            Assert.Throws<IndexOutOfRangeException>(() => drcol.RemoveAt(-1));
+            Assert.Throws<IndexOutOfRangeException>(() => drcol.RemoveAt(101));
 
             drcol.RemoveAt(1);
             Assert.False(drcol.Contains(dr2.RelationName));

--- a/src/System.Data.Common/tests/System/Data/DataRelationCollectionTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataRelationCollectionTest.cs
@@ -220,14 +220,8 @@ namespace System.Data.Tests
             DataRelationCollection drcol1 = newds.Relations;
             DataRelationCollection drcol2 = _dataset.Relations;
 
-            Assert.True(drcol.Equals(drcol));
-            Assert.True(drcol.Equals(drcol2));
-
-            Assert.False(drcol1.Equals(drcol));
-            Assert.False(drcol.Equals(drcol1));
-
-            Assert.True(object.Equals(drcol, drcol2));
-            Assert.False(object.Equals(drcol, drcol1));
+            Assert.Same(drcol, drcol2);
+            Assert.NotSame(drcol1, drcol);
         }
 
         [Fact]

--- a/src/System.Data.Common/tests/System/Data/DataRelationCollectionTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/DataRelationCollectionTest2.cs
@@ -379,13 +379,6 @@ namespace System.Data.Tests
             });
         }
 
-        //TODO: what
-        [Fact]
-        public void Add_DataColumn5()
-        {
-            DataSet ds = GetDataSet();
-        }
-
         [Fact]
         public void Remove_DataColumn()
         {
@@ -451,7 +444,7 @@ namespace System.Data.Tests
             });
         }
 
-        //TODO: missing Fact?
+        [Fact]
         private void RemoveAt()
         {
             DataSet ds = GetDataSet();

--- a/src/System.Data.Common/tests/System/Data/DataRelationCollectionTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/DataRelationCollectionTest2.cs
@@ -39,7 +39,7 @@ namespace System.Data.Tests
             _changesCounter++;
         }
 
-        private DataSet getDataSet()
+        private DataSet GetDataSet()
         {
             var ds = new DataSet();
             DataTable dt1 = DataProvider.CreateParentDataTable();
@@ -58,7 +58,7 @@ namespace System.Data.Tests
         [Fact]
         public void AddRange()
         {
-            DataSet ds = getDataSet();
+            DataSet ds = GetDataSet();
             DataRelation[] relArray = new DataRelation[2];
 
             relArray[0] = new DataRelation("rel1", ds.Tables[0].Columns["ParentId"], ds.Tables[1].Columns["ParentId"]);
@@ -76,7 +76,7 @@ namespace System.Data.Tests
         [Fact]
         public void Add_ByDataColumns()
         {
-            DataSet ds = getDataSet();
+            DataSet ds = GetDataSet();
             ds.Relations.Add(ds.Tables[0].Columns["ParentId"], ds.Tables[1].Columns["ParentId"]);
 
             Assert.Equal(1, ds.Relations.Count);
@@ -91,7 +91,7 @@ namespace System.Data.Tests
         [Fact]
         public void Add_ByNameDataColumns()
         {
-            DataSet ds = getDataSet();
+            DataSet ds = GetDataSet();
             ds.Relations.Add("rel1", ds.Tables[0].Columns["ParentId"], ds.Tables[1].Columns["ParentId"]);
 
             Assert.Equal(1, ds.Relations.Count);
@@ -110,7 +110,7 @@ namespace System.Data.Tests
         [Fact]
         public void Add_ByNameDataColumnsWithConstraint()
         {
-            DataSet ds = getDataSet();
+            DataSet ds = GetDataSet();
             ds.Relations.Add("rel1", ds.Tables[0].Columns["ParentId"], ds.Tables[1].Columns["ParentId"], true);
 
             Assert.Equal(1, ds.Relations.Count);
@@ -128,7 +128,7 @@ namespace System.Data.Tests
         [Fact]
         public void Add_ByNameDataColumnsWithOutConstraint()
         {
-            DataSet ds = getDataSet();
+            DataSet ds = GetDataSet();
             ds.Relations.Add("rel1", ds.Tables[0].Columns["ParentId"], ds.Tables[1].Columns["ParentId"], false);
 
             Assert.Equal(1, ds.Relations.Count);
@@ -147,7 +147,7 @@ namespace System.Data.Tests
         [Fact]
         public void CanRemove()
         {
-            DataSet ds = getDataSet();
+            DataSet ds = GetDataSet();
             ds.Relations.Add(ds.Tables[0].Columns["ParentId"], ds.Tables[1].Columns["ParentId"]);
             Assert.True(ds.Relations.CanRemove(ds.Relations[0]));
             Assert.True(ds.Tables[0].ChildRelations.CanRemove(ds.Tables[0].ChildRelations[0]));
@@ -157,8 +157,8 @@ namespace System.Data.Tests
         [Fact]
         public void CanRemove_DataRelation()
         {
-            DataSet ds = getDataSet();
-            DataSet ds1 = getDataSet();
+            DataSet ds = GetDataSet();
+            DataSet ds1 = GetDataSet();
 
             DataRelation rel = new DataRelation("rel1",
                 ds.Tables[0].Columns["ParentId"], ds.Tables[1].Columns["ParentId"]);
@@ -169,7 +169,7 @@ namespace System.Data.Tests
         [Fact]
         public void Clear()
         {
-            DataSet ds = getDataSet();
+            DataSet ds = GetDataSet();
 
             ds.Relations.Add(ds.Tables[0].Columns["ParentId"], ds.Tables[1].Columns["ParentId"]);
             ds.Relations.CollectionChanged += new CollectionChangeEventHandler(Relations_CollectionChanged);
@@ -184,7 +184,7 @@ namespace System.Data.Tests
         [Fact]
         public void CollectionChanged()
         {
-            DataSet ds = getDataSet();
+            DataSet ds = GetDataSet();
 
             ds.Relations.CollectionChanged += new CollectionChangeEventHandler(Relations_CollectionChanged);
 
@@ -201,7 +201,7 @@ namespace System.Data.Tests
         [Fact]
         public void Contains()
         {
-            DataSet ds = getDataSet();
+            DataSet ds = GetDataSet();
             ds.Relations.Add("rel1", ds.Tables[0].Columns["ParentId"], ds.Tables[1].Columns["ParentId"]);
 
             Assert.True(ds.Relations.Contains("rel1"));
@@ -212,7 +212,7 @@ namespace System.Data.Tests
         [Fact]
         public void CopyTo()
         {
-            DataSet ds = getDataSet();
+            DataSet ds = GetDataSet();
 
             DataRelation[] dataRelArray = new DataRelation[2];
 
@@ -230,7 +230,7 @@ namespace System.Data.Tests
         [Fact]
         public void Count()
         {
-            DataSet ds = getDataSet();
+            DataSet ds = GetDataSet();
             Assert.Equal(0, ds.Relations.Count);
             ds.Relations.Add("rel1", ds.Tables[0].Columns["ParentId"], ds.Tables[1].Columns["ParentId"]);
             Assert.Equal(1, ds.Relations.Count);
@@ -245,7 +245,7 @@ namespace System.Data.Tests
         [Fact]
         public void GetEnumerator()
         {
-            DataSet ds = getDataSet();
+            DataSet ds = GetDataSet();
             int counter = 0;
             ds.Relations.Add("rel1", ds.Tables[0].Columns["ParentId"], ds.Tables[1].Columns["ParentId"]);
             ds.Relations.Add("rel2", ds.Tables[0].Columns["String1"], ds.Tables[1].Columns["String1"]);
@@ -263,8 +263,8 @@ namespace System.Data.Tests
         [Fact]
         public void IndexOf_ByDataRelation()
         {
-            DataSet ds = getDataSet();
-            DataSet ds1 = getDataSet();
+            DataSet ds = GetDataSet();
+            DataSet ds1 = GetDataSet();
 
             DataRelation rel1 = new DataRelation("rel1", ds.Tables[0].Columns["ParentId"], ds.Tables[1].Columns["ParentId"]);
             DataRelation rel2 = new DataRelation("rel2", ds.Tables[0].Columns["String1"], ds.Tables[1].Columns["String1"]);
@@ -282,8 +282,8 @@ namespace System.Data.Tests
         [Fact]
         public void IndexOf_ByDataRelationName()
         {
-            DataSet ds = getDataSet();
-            DataSet ds1 = getDataSet();
+            DataSet ds = GetDataSet();
+            DataSet ds1 = GetDataSet();
 
             DataRelation rel1 = new DataRelation("rel1", ds.Tables[0].Columns["ParentId"], ds.Tables[1].Columns["ParentId"]);
             DataRelation rel2 = new DataRelation("rel2", ds.Tables[0].Columns["String1"], ds.Tables[1].Columns["String1"]);
@@ -301,7 +301,7 @@ namespace System.Data.Tests
         [Fact]
         public void Item()
         {
-            DataSet ds = getDataSet();
+            DataSet ds = GetDataSet();
             DataRelation rel1 = new DataRelation("rel1", ds.Tables[0].Columns["ParentId"], ds.Tables[1].Columns["ParentId"]);
             DataRelation rel2 = new DataRelation("rel2", ds.Tables[0].Columns["String1"], ds.Tables[1].Columns["String1"]);
 
@@ -379,28 +379,18 @@ namespace System.Data.Tests
             });
         }
 
+        //TODO: what
         [Fact]
         public void Add_DataColumn5()
         {
             DataSet ds = GetDataSet();
         }
 
-        private DataSet GetDataSet()
-        {
-            var ds = new DataSet();
-            DataTable dt1 = DataProvider.CreateParentDataTable();
-            DataTable dt2 = DataProvider.CreateChildDataTable();
-
-            ds.Tables.Add(dt1);
-            ds.Tables.Add(dt2);
-            return ds;
-        }
-
         [Fact]
         public void Remove_DataColumn()
         {
-            DataSet ds = getDataSet();
-            DataSet ds1 = getDataSet();
+            DataSet ds = GetDataSet();
+            DataSet ds1 = GetDataSet();
             DataRelation rel1 = new DataRelation("rel1", ds.Tables[0].Columns["ParentId"], ds.Tables[1].Columns["ParentId"]);
             DataRelation rel2 = new DataRelation("rel2", ds.Tables[0].Columns["String1"], ds.Tables[1].Columns["String1"]);
 
@@ -430,8 +420,8 @@ namespace System.Data.Tests
         [Fact]
         public void Remove_String()
         {
-            DataSet ds = getDataSet();
-            DataSet ds1 = getDataSet();
+            DataSet ds = GetDataSet();
+            DataSet ds1 = GetDataSet();
             DataRelation rel1 = new DataRelation("rel1", ds.Tables[0].Columns["ParentId"], ds.Tables[1].Columns["ParentId"]);
             DataRelation rel2 = new DataRelation("rel2", ds.Tables[0].Columns["String1"], ds.Tables[1].Columns["String1"]);
 
@@ -461,10 +451,11 @@ namespace System.Data.Tests
             });
         }
 
+        //TODO: missing Fact?
         private void RemoveAt()
         {
-            DataSet ds = getDataSet();
-            DataSet ds1 = getDataSet();
+            DataSet ds = GetDataSet();
+            DataSet ds1 = GetDataSet();
             DataRelation rel1 = new DataRelation("rel1", ds.Tables[0].Columns["ParentId"], ds.Tables[1].Columns["ParentId"]);
             DataRelation rel2 = new DataRelation("rel2", ds.Tables[0].Columns["String1"], ds.Tables[1].Columns["String1"]);
 

--- a/src/System.Data.Common/tests/System/Data/DataRelationTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataRelationTest.cs
@@ -141,14 +141,13 @@ namespace System.Data.Tests
         [Fact]
         public void DataSetRelations()
         {
-            DataRelation relation;
             Assert.Equal(0, _set.Relations.Count);
             Assert.Equal(0, _mom.ParentRelations.Count);
             Assert.Equal(0, _mom.ChildRelations.Count);
             Assert.Equal(0, _child.ParentRelations.Count);
             Assert.Equal(0, _child.ChildRelations.Count);
 
-            relation = new DataRelation("Rel", _mom.Columns[1], _child.Columns[0]);
+            DataRelation relation = new DataRelation("Rel", _mom.Columns[1], _child.Columns[0]);
             _set.Relations.Add(relation);
 
             Assert.Equal(1, _set.Relations.Count);
@@ -184,13 +183,12 @@ namespace System.Data.Tests
         {
             DataRelation relation = new DataRelation("Rel", _mom.Columns[1], _child.Columns[0]);
             _set.Relations.Add(relation);
-            DataRelation test = null;
             Assert.Equal(1, _mom.ChildRelations.Count);
             Assert.Equal(0, _child.ChildRelations.Count);
             Assert.Equal(0, _mom.ParentRelations.Count);
             Assert.Equal(1, _child.ParentRelations.Count);
 
-            test = _child.ParentRelations[0];
+            DataRelation test = _child.ParentRelations[0];
             Assert.Equal("Rel", test.ToString());
             Assert.Equal("Rel", test.RelationName);
             Assert.Equal("Mom", test.ParentTable.TableName);

--- a/src/System.Data.Common/tests/System/Data/DataRelationTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataRelationTest.cs
@@ -59,65 +59,57 @@ namespace System.Data.Tests
         [Fact]
         public void Foreign()
         {
-            DataRelation Relation = new DataRelation("Rel", _mom.Columns[1], _child.Columns[0]);
-            _set.Relations.Add(Relation);
+            DataRelation relation = new DataRelation("Rel", _mom.Columns[1], _child.Columns[0]);
+            _set.Relations.Add(relation);
 
-            DataRow Row = _mom.NewRow();
-            Row[0] = "Teresa";
-            Row[1] = "Jack";
-            _mom.Rows.Add(Row);
+            DataRow row = _mom.NewRow();
+            row[0] = "Teresa";
+            row[1] = "Jack";
+            _mom.Rows.Add(row);
 
-            Row = _mom.NewRow();
-            Row[0] = "Teresa";
-            Row[1] = "Dick";
-            _mom.Rows.Add(Row);
+            row = _mom.NewRow();
+            row[0] = "Teresa";
+            row[1] = "Dick";
+            _mom.Rows.Add(row);
 
-            Row = _mom.NewRow();
-            Row[0] = "Mary";
-            Row[1] = "Harry";
+            row = _mom.NewRow();
+            row[0] = "Mary";
+            row[1] = "Harry";
 
-            Row = _child.NewRow();
-            Row[0] = "Jack";
-            Row[1] = 16;
-            _child.Rows.Add(Row);
+            row = _child.NewRow();
+            row[0] = "Jack";
+            row[1] = 16;
+            _child.Rows.Add(row);
 
-            Row = _child.NewRow();
-            Row[0] = "Dick";
-            Row[1] = 56;
-            _child.Rows.Add(Row);
+            row = _child.NewRow();
+            row[0] = "Dick";
+            row[1] = 56;
+            _child.Rows.Add(row);
 
             Assert.Equal(2, _child.Rows.Count);
 
-            Row = _mom.Rows[0];
-            Row.Delete();
+            row = _mom.Rows[0];
+            row.Delete();
 
             Assert.Equal(1, _child.Rows.Count);
 
-            Row = _mom.NewRow();
-            Row[0] = "Teresa";
-            Row[1] = "Dick";
+            row = _mom.NewRow();
+            row[0] = "Teresa";
+            row[1] = "Dick";
 
-            try
-            {
-                _mom.Rows.Add(Row);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.IsType<ConstraintException>(e);
-            }
+            Assert.Throws<ConstraintException>(() => _mom.Rows.Add(row));
 
-            Row = _mom.NewRow();
-            Row[0] = "Teresa";
-            Row[1] = "Mich";
-            _mom.Rows.Add(Row);
+            row = _mom.NewRow();
+            row[0] = "Teresa";
+            row[1] = "Mich";
+            _mom.Rows.Add(row);
             Assert.Equal(1, _child.Rows.Count);
 
-            Row = _child.NewRow();
-            Row[0] = "Jack";
-            Row[1] = 16;
+            row = _child.NewRow();
+            row[0] = "Jack";
+            row[1] = 16;
 
-            Assert.Throws<InvalidConstraintException>(() => _child.Rows.Add(Row));
+            Assert.Throws<InvalidConstraintException>(() => _child.Rows.Add(row));
         }
 
         [Fact]
@@ -126,7 +118,7 @@ namespace System.Data.Tests
             Assert.Throws<InvalidConstraintException>(() =>
            {
                // Parent Columns and Child Columns don't have type-matching columns.
-               DataRelation Relation = new DataRelation("Rel", _mom.Columns[1], _child.Columns[1], true);
+               DataRelation relation = new DataRelation("Rel", _mom.Columns[1], _child.Columns[1], true);
            });
         }
 
@@ -149,15 +141,15 @@ namespace System.Data.Tests
         [Fact]
         public void DataSetRelations()
         {
-            DataRelation Relation;
+            DataRelation relation;
             Assert.Equal(0, _set.Relations.Count);
             Assert.Equal(0, _mom.ParentRelations.Count);
             Assert.Equal(0, _mom.ChildRelations.Count);
             Assert.Equal(0, _child.ParentRelations.Count);
             Assert.Equal(0, _child.ChildRelations.Count);
 
-            Relation = new DataRelation("Rel", _mom.Columns[1], _child.Columns[0]);
-            _set.Relations.Add(Relation);
+            relation = new DataRelation("Rel", _mom.Columns[1], _child.Columns[0]);
+            _set.Relations.Add(relation);
 
             Assert.Equal(1, _set.Relations.Count);
             Assert.Equal(0, _mom.ParentRelations.Count);
@@ -165,11 +157,11 @@ namespace System.Data.Tests
             Assert.Equal(1, _child.ParentRelations.Count);
             Assert.Equal(0, _child.ChildRelations.Count);
 
-            Relation = _set.Relations[0];
-            Assert.Equal(1, Relation.ParentColumns.Length);
-            Assert.Equal(1, Relation.ChildColumns.Length);
-            Assert.Equal("Rel", Relation.ChildKeyConstraint.ConstraintName);
-            Assert.Equal("Constraint1", Relation.ParentKeyConstraint.ConstraintName);
+            relation = _set.Relations[0];
+            Assert.Equal(1, relation.ParentColumns.Length);
+            Assert.Equal(1, relation.ChildColumns.Length);
+            Assert.Equal("Rel", relation.ChildKeyConstraint.ConstraintName);
+            Assert.Equal("Constraint1", relation.ParentKeyConstraint.ConstraintName);
         }
 
         [Fact]
@@ -190,123 +182,123 @@ namespace System.Data.Tests
         [Fact]
         public void Creation()
         {
-            DataRelation Relation = new DataRelation("Rel", _mom.Columns[1], _child.Columns[0]);
-            _set.Relations.Add(Relation);
-            DataRelation Test = null;
+            DataRelation relation = new DataRelation("Rel", _mom.Columns[1], _child.Columns[0]);
+            _set.Relations.Add(relation);
+            DataRelation test = null;
             Assert.Equal(1, _mom.ChildRelations.Count);
             Assert.Equal(0, _child.ChildRelations.Count);
             Assert.Equal(0, _mom.ParentRelations.Count);
             Assert.Equal(1, _child.ParentRelations.Count);
 
-            Test = _child.ParentRelations[0];
-            Assert.Equal("Rel", Test.ToString());
-            Assert.Equal("Rel", Test.RelationName);
-            Assert.Equal("Mom", Test.ParentTable.TableName);
-            Assert.Equal(1, Test.ParentKeyConstraint.Columns.Length);
-            Assert.False(Test.ParentKeyConstraint.IsPrimaryKey);
-            Assert.Equal(1, Test.ParentColumns.Length);
-            Assert.False(Test.Nested);
-            Assert.Equal(0, Test.ExtendedProperties.Count);
-            Assert.Equal("Child", Test.ChildTable.TableName);
-            Assert.Equal("Rel", Test.ChildKeyConstraint.ConstraintName);
-            Assert.Equal(1, Test.ChildColumns.Length);
+            test = _child.ParentRelations[0];
+            Assert.Equal("Rel", test.ToString());
+            Assert.Equal("Rel", test.RelationName);
+            Assert.Equal("Mom", test.ParentTable.TableName);
+            Assert.Equal(1, test.ParentKeyConstraint.Columns.Length);
+            Assert.False(test.ParentKeyConstraint.IsPrimaryKey);
+            Assert.Equal(1, test.ParentColumns.Length);
+            Assert.False(test.Nested);
+            Assert.Equal(0, test.ExtendedProperties.Count);
+            Assert.Equal("Child", test.ChildTable.TableName);
+            Assert.Equal("Rel", test.ChildKeyConstraint.ConstraintName);
+            Assert.Equal(1, test.ChildColumns.Length);
         }
 
         [Fact]
         public void Creation2()
         {
-            DataSet Set = new DataSet();
-            DataTable Mom2 = new DataTable("Mom");
-            DataTable Child2 = new DataTable("Child");
-            DataTable Hubby = new DataTable("Hubby");
-            Set.Tables.Add(Mom2);
-            Set.Tables.Add(Child2);
-            Set.Tables.Add(Hubby);
+            DataSet set = new DataSet();
+            DataTable mom2 = new DataTable("Mom");
+            DataTable child2 = new DataTable("Child");
+            DataTable hubby = new DataTable("Hubby");
+            set.Tables.Add(mom2);
+            set.Tables.Add(child2);
+            set.Tables.Add(hubby);
 
-            DataColumn Col = new DataColumn("Name");
-            DataColumn Col2 = new DataColumn("ChildName");
-            DataColumn Col3 = new DataColumn("hubby");
-            Mom2.Columns.Add(Col);
-            Mom2.Columns.Add(Col2);
-            Mom2.Columns.Add(Col3);
+            DataColumn col = new DataColumn("Name");
+            DataColumn col2 = new DataColumn("ChildName");
+            DataColumn col3 = new DataColumn("hubby");
+            mom2.Columns.Add(col);
+            mom2.Columns.Add(col2);
+            mom2.Columns.Add(col3);
 
-            DataColumn Col4 = new DataColumn("Name");
-            DataColumn Col5 = new DataColumn("Age");
-            DataColumn Col6 = new DataColumn("father");
-            Child2.Columns.Add(Col4);
-            Child2.Columns.Add(Col5);
-            Child2.Columns.Add(Col6);
+            DataColumn col4 = new DataColumn("Name");
+            DataColumn col5 = new DataColumn("Age");
+            DataColumn col6 = new DataColumn("father");
+            child2.Columns.Add(col4);
+            child2.Columns.Add(col5);
+            child2.Columns.Add(col6);
 
 
-            DataColumn Col7 = new DataColumn("Name");
-            DataColumn Col8 = new DataColumn("Age");
-            Hubby.Columns.Add(Col7);
-            Hubby.Columns.Add(Col8);
+            DataColumn col7 = new DataColumn("Name");
+            DataColumn col8 = new DataColumn("Age");
+            hubby.Columns.Add(col7);
+            hubby.Columns.Add(col8);
 
             DataColumn[] Parents = new DataColumn[2];
-            Parents[0] = Col2;
-            Parents[1] = Col3;
-            DataColumn[] Childs = new DataColumn[2];
-            Childs[0] = Col4;
-            Childs[1] = Col7;
+            Parents[0] = col2;
+            Parents[1] = col3;
+            DataColumn[] childs = new DataColumn[2];
+            childs[0] = col4;
+            childs[1] = col7;
 
-            Assert.Throws<InvalidConstraintException>(() => new DataRelation("Rel", Parents, Childs));
+            Assert.Throws<InvalidConstraintException>(() => new DataRelation("Rel", Parents, childs));
 
-            Childs[1] = Col6;
+            childs[1] = col6;
 
-            Set.Relations.Add(new DataRelation("Rel", Parents, Childs));
+            set.Relations.Add(new DataRelation("Rel", Parents, childs));
 
-            Assert.Equal(1, Mom2.ChildRelations.Count);
-            Assert.Equal(0, Child2.ChildRelations.Count);
-            Assert.Equal(0, Mom2.ParentRelations.Count);
-            Assert.Equal(1, Child2.ParentRelations.Count);
+            Assert.Equal(1, mom2.ChildRelations.Count);
+            Assert.Equal(0, child2.ChildRelations.Count);
+            Assert.Equal(0, mom2.ParentRelations.Count);
+            Assert.Equal(1, child2.ParentRelations.Count);
 
-            DataRelation Test = Child2.ParentRelations[0];
-            Assert.Equal("Rel", Test.ToString());
-            Assert.Equal("Rel", Test.RelationName);
-            Assert.Equal("Mom", Test.ParentTable.TableName);
-            Assert.Equal(2, Test.ParentKeyConstraint.Columns.Length);
-            Assert.False(Test.ParentKeyConstraint.IsPrimaryKey);
-            Assert.Equal(2, Test.ParentColumns.Length);
-            Assert.False(Test.Nested);
-            Assert.Equal(0, Test.ExtendedProperties.Count);
-            Assert.Equal("Child", Test.ChildTable.TableName);
-            Assert.Equal("Rel", Test.ChildKeyConstraint.ConstraintName);
-            Assert.Equal(2, Test.ChildColumns.Length);
-            Assert.Equal(1, Mom2.Constraints.Count);
-            Assert.Equal("Constraint1", Mom2.Constraints[0].ToString());
-            Assert.Equal(1, Child2.Constraints.Count);
-            Assert.Equal(0, Hubby.Constraints.Count);
+            DataRelation test = child2.ParentRelations[0];
+            Assert.Equal("Rel", test.ToString());
+            Assert.Equal("Rel", test.RelationName);
+            Assert.Equal("Mom", test.ParentTable.TableName);
+            Assert.Equal(2, test.ParentKeyConstraint.Columns.Length);
+            Assert.False(test.ParentKeyConstraint.IsPrimaryKey);
+            Assert.Equal(2, test.ParentColumns.Length);
+            Assert.False(test.Nested);
+            Assert.Equal(0, test.ExtendedProperties.Count);
+            Assert.Equal("Child", test.ChildTable.TableName);
+            Assert.Equal("Rel", test.ChildKeyConstraint.ConstraintName);
+            Assert.Equal(2, test.ChildColumns.Length);
+            Assert.Equal(1, mom2.Constraints.Count);
+            Assert.Equal("Constraint1", mom2.Constraints[0].ToString());
+            Assert.Equal(1, child2.Constraints.Count);
+            Assert.Equal(0, hubby.Constraints.Count);
         }
 
         [Fact]
         public void Creation3()
         {
-            DataRelation Relation = new DataRelation("Rel", _mom.Columns[1], _child.Columns[0], false);
-            _set.Relations.Add(Relation);
-            DataRelation Test = null;
+            DataRelation relation = new DataRelation("Rel", _mom.Columns[1], _child.Columns[0], false);
+            _set.Relations.Add(relation);
+            DataRelation test = null;
 
             Assert.Equal(1, _mom.ChildRelations.Count);
             Assert.Equal(0, _child.ChildRelations.Count);
             Assert.Equal(0, _mom.ParentRelations.Count);
             Assert.Equal(1, _child.ParentRelations.Count);
 
-            Test = _child.ParentRelations[0];
+            test = _child.ParentRelations[0];
 
-            Assert.Equal("Rel", Test.ToString());
-            Assert.Equal("Rel", Test.RelationName);
-            Assert.Equal("Mom", Test.ParentTable.TableName);
+            Assert.Equal("Rel", test.ToString());
+            Assert.Equal("Rel", test.RelationName);
+            Assert.Equal("Mom", test.ParentTable.TableName);
 
-            Assert.Null(Test.ParentKeyConstraint);
-            Assert.Null(Test.ParentKeyConstraint);
+            Assert.Null(test.ParentKeyConstraint);
+            Assert.Null(test.ParentKeyConstraint);
 
-            Assert.Equal(1, Test.ParentColumns.Length);
-            Assert.False(Test.Nested);
-            Assert.Equal(0, Test.ExtendedProperties.Count);
-            Assert.Equal("Child", Test.ChildTable.TableName);
+            Assert.Equal(1, test.ParentColumns.Length);
+            Assert.False(test.Nested);
+            Assert.Equal(0, test.ExtendedProperties.Count);
+            Assert.Equal("Child", test.ChildTable.TableName);
 
-            Assert.Null(Test.ChildKeyConstraint);
-            Assert.Equal(1, Test.ChildColumns.Length);
+            Assert.Null(test.ChildKeyConstraint);
+            Assert.Equal(1, test.ChildColumns.Length);
             Assert.Equal(0, _mom.Constraints.Count);
             Assert.Equal(0, _child.Constraints.Count);
         }
@@ -314,140 +306,140 @@ namespace System.Data.Tests
         [Fact]
         public void Creation4()
         {
-            DataRelation Relation = new DataRelation("Rel", "Mom", "Child",
+            DataRelation relation = new DataRelation("Rel", "Mom", "Child",
                                                       new string[] { "ChildName" },
                                                       new string[] { "Name" }, true);
 
-            Assert.Throws<NullReferenceException>(() => _set.Relations.Add(Relation));
-            Assert.Throws<NullReferenceException>(() => _set.Relations.AddRange(new DataRelation[] { Relation }));
+            Assert.Throws<NullReferenceException>(() => _set.Relations.Add(relation));
+            Assert.Throws<NullReferenceException>(() => _set.Relations.AddRange(new DataRelation[] { relation }));
 
             _set.BeginInit();
-            _set.Relations.AddRange(new DataRelation[] { Relation });
+            _set.Relations.AddRange(new DataRelation[] { relation });
             _set.EndInit();
 
-            DataRelation Test = null;
+            DataRelation test = null;
             Assert.Equal(1, _mom.ChildRelations.Count);
             Assert.Equal(0, _child.ChildRelations.Count);
             Assert.Equal(0, _mom.ParentRelations.Count);
             Assert.Equal(1, _child.ParentRelations.Count);
 
-            Test = _child.ParentRelations[0];
-            Assert.Equal("Rel", Test.ToString());
-            Assert.Equal("Rel", Test.RelationName);
-            Assert.Equal("Mom", Test.ParentTable.TableName);
+            test = _child.ParentRelations[0];
+            Assert.Equal("Rel", test.ToString());
+            Assert.Equal("Rel", test.RelationName);
+            Assert.Equal("Mom", test.ParentTable.TableName);
 
-            Assert.Null(Test.ParentKeyConstraint);
+            Assert.Null(test.ParentKeyConstraint);
 
-            Assert.Equal(1, Test.ParentColumns.Length);
-            Assert.True(Test.Nested);
-            Assert.Equal(0, Test.ExtendedProperties.Count);
-            Assert.Equal("Child", Test.ChildTable.TableName);
-            Assert.Null(Test.ChildKeyConstraint);
-            Assert.Equal(1, Test.ChildColumns.Length);
+            Assert.Equal(1, test.ParentColumns.Length);
+            Assert.True(test.Nested);
+            Assert.Equal(0, test.ExtendedProperties.Count);
+            Assert.Equal("Child", test.ChildTable.TableName);
+            Assert.Null(test.ChildKeyConstraint);
+            Assert.Equal(1, test.ChildColumns.Length);
         }
 
         [Fact]
         public void RelationFromSchema()
         {
-            DataSet Set = new DataSet();
-            Set.ReadXmlSchema(new StringReader(DataProvider.store));
-            DataTable Table = Set.Tables[0];
+            DataSet set = new DataSet();
+            set.ReadXmlSchema(new StringReader(DataProvider.store));
+            DataTable table = set.Tables[0];
 
-            Assert.False(Table.CaseSensitive);
-            Assert.Equal(1, Table.ChildRelations.Count);
-            Assert.Equal(0, Table.ParentRelations.Count);
-            Assert.Equal(1, Table.Constraints.Count);
-            Assert.Equal(1, Table.PrimaryKey.Length);
-            Assert.Equal(0, Table.Rows.Count);
-            Assert.Equal("bookstore", Table.TableName);
-            Assert.Equal(1, Table.Columns.Count);
+            Assert.False(table.CaseSensitive);
+            Assert.Equal(1, table.ChildRelations.Count);
+            Assert.Equal(0, table.ParentRelations.Count);
+            Assert.Equal(1, table.Constraints.Count);
+            Assert.Equal(1, table.PrimaryKey.Length);
+            Assert.Equal(0, table.Rows.Count);
+            Assert.Equal("bookstore", table.TableName);
+            Assert.Equal(1, table.Columns.Count);
 
-            DataRelation Relation = Table.ChildRelations[0];
-            Assert.Equal(1, Relation.ChildColumns.Length);
-            Assert.Equal("bookstore_book", Relation.ChildKeyConstraint.ConstraintName);
-            Assert.Equal(1, Relation.ChildKeyConstraint.Columns.Length);
-            Assert.Equal("book", Relation.ChildTable.TableName);
-            Assert.Equal("NewDataSet", Relation.DataSet.DataSetName);
-            Assert.Equal(0, Relation.ExtendedProperties.Count);
-            Assert.True(Relation.Nested);
-            Assert.Equal(1, Relation.ParentColumns.Length);
-            Assert.Equal("Constraint1", Relation.ParentKeyConstraint.ConstraintName);
-            Assert.Equal("bookstore", Relation.ParentTable.TableName);
-            Assert.Equal("bookstore_book", Relation.RelationName);
+            DataRelation relation = table.ChildRelations[0];
+            Assert.Equal(1, relation.ChildColumns.Length);
+            Assert.Equal("bookstore_book", relation.ChildKeyConstraint.ConstraintName);
+            Assert.Equal(1, relation.ChildKeyConstraint.Columns.Length);
+            Assert.Equal("book", relation.ChildTable.TableName);
+            Assert.Equal("NewDataSet", relation.DataSet.DataSetName);
+            Assert.Equal(0, relation.ExtendedProperties.Count);
+            Assert.True(relation.Nested);
+            Assert.Equal(1, relation.ParentColumns.Length);
+            Assert.Equal("Constraint1", relation.ParentKeyConstraint.ConstraintName);
+            Assert.Equal("bookstore", relation.ParentTable.TableName);
+            Assert.Equal("bookstore_book", relation.RelationName);
 
-            Table = Set.Tables[1];
+            table = set.Tables[1];
 
-            Assert.False(Table.CaseSensitive);
-            Assert.Equal(1, Table.ChildRelations.Count);
-            Assert.Equal(1, Table.ParentRelations.Count);
-            Assert.Equal(2, Table.Constraints.Count);
-            Assert.Equal(1, Table.PrimaryKey.Length);
-            Assert.Equal(0, Table.Rows.Count);
-            Assert.Equal("book", Table.TableName);
-            Assert.Equal(5, Table.Columns.Count);
+            Assert.False(table.CaseSensitive);
+            Assert.Equal(1, table.ChildRelations.Count);
+            Assert.Equal(1, table.ParentRelations.Count);
+            Assert.Equal(2, table.Constraints.Count);
+            Assert.Equal(1, table.PrimaryKey.Length);
+            Assert.Equal(0, table.Rows.Count);
+            Assert.Equal("book", table.TableName);
+            Assert.Equal(5, table.Columns.Count);
 
-            Relation = Table.ChildRelations[0];
-            Assert.Equal(1, Relation.ChildColumns.Length);
-            Assert.Equal("book_author", Relation.ChildKeyConstraint.ConstraintName);
-            Assert.Equal(1, Relation.ChildKeyConstraint.Columns.Length);
-            Assert.Equal("author", Relation.ChildTable.TableName);
-            Assert.Equal("NewDataSet", Relation.DataSet.DataSetName);
-            Assert.Equal(0, Relation.ExtendedProperties.Count);
-            Assert.True(Relation.Nested);
-            Assert.Equal(1, Relation.ParentColumns.Length);
-            Assert.Equal("Constraint1", Relation.ParentKeyConstraint.ConstraintName);
-            Assert.Equal("book", Relation.ParentTable.TableName);
-            Assert.Equal("book_author", Relation.RelationName);
+            relation = table.ChildRelations[0];
+            Assert.Equal(1, relation.ChildColumns.Length);
+            Assert.Equal("book_author", relation.ChildKeyConstraint.ConstraintName);
+            Assert.Equal(1, relation.ChildKeyConstraint.Columns.Length);
+            Assert.Equal("author", relation.ChildTable.TableName);
+            Assert.Equal("NewDataSet", relation.DataSet.DataSetName);
+            Assert.Equal(0, relation.ExtendedProperties.Count);
+            Assert.True(relation.Nested);
+            Assert.Equal(1, relation.ParentColumns.Length);
+            Assert.Equal("Constraint1", relation.ParentKeyConstraint.ConstraintName);
+            Assert.Equal("book", relation.ParentTable.TableName);
+            Assert.Equal("book_author", relation.RelationName);
 
-            Table = Set.Tables[2];
-            Assert.False(Table.CaseSensitive);
-            Assert.Equal(0, Table.ChildRelations.Count);
-            Assert.Equal(1, Table.ParentRelations.Count);
-            Assert.Equal(1, Table.Constraints.Count);
-            Assert.Equal(0, Table.PrimaryKey.Length);
-            Assert.Equal(0, Table.Rows.Count);
-            Assert.Equal("author", Table.TableName);
-            Assert.Equal(3, Table.Columns.Count);
+            table = set.Tables[2];
+            Assert.False(table.CaseSensitive);
+            Assert.Equal(0, table.ChildRelations.Count);
+            Assert.Equal(1, table.ParentRelations.Count);
+            Assert.Equal(1, table.Constraints.Count);
+            Assert.Equal(0, table.PrimaryKey.Length);
+            Assert.Equal(0, table.Rows.Count);
+            Assert.Equal("author", table.TableName);
+            Assert.Equal(3, table.Columns.Count);
         }
 
         [Fact]
         public void ChildRows()
         {
-            DataRelation Relation = new DataRelation("Rel", _mom.Columns[1], _child.Columns[0]);
-            _set.Relations.Add(Relation);
+            DataRelation relation = new DataRelation("Rel", _mom.Columns[1], _child.Columns[0]);
+            _set.Relations.Add(relation);
 
-            DataRow TempRow = _mom.NewRow();
-            TempRow[0] = "teresa";
-            TempRow[1] = "john";
-            _mom.Rows.Add(TempRow);
+            DataRow tempRow = _mom.NewRow();
+            tempRow[0] = "teresa";
+            tempRow[1] = "john";
+            _mom.Rows.Add(tempRow);
 
-            TempRow = _mom.NewRow();
-            TempRow[0] = "teresa";
-            TempRow[1] = "Dick";
-            _mom.Rows.Add(TempRow);
+            tempRow = _mom.NewRow();
+            tempRow[0] = "teresa";
+            tempRow[1] = "Dick";
+            _mom.Rows.Add(tempRow);
 
-            TempRow = _child.NewRow();
-            TempRow[0] = "john";
-            TempRow[1] = "15";
-            _child.Rows.Add(TempRow);
+            tempRow = _child.NewRow();
+            tempRow[0] = "john";
+            tempRow[1] = "15";
+            _child.Rows.Add(tempRow);
 
-            TempRow = _child.NewRow();
-            TempRow[0] = "Dick";
-            TempRow[1] = "10";
-            _child.Rows.Add(TempRow);
+            tempRow = _child.NewRow();
+            tempRow[0] = "Dick";
+            tempRow[1] = "10";
+            _child.Rows.Add(tempRow);
 
-            DataRow Row = _mom.Rows[1];
-            TempRow = Row.GetChildRows("Rel")[0];
-            Assert.Equal("Dick", TempRow[0]);
-            Assert.Equal("10", TempRow[1].ToString());
-            TempRow = TempRow.GetParentRow("Rel");
-            Assert.Equal("teresa", TempRow[0]);
-            Assert.Equal("Dick", TempRow[1]);
+            DataRow row = _mom.Rows[1];
+            tempRow = row.GetChildRows("Rel")[0];
+            Assert.Equal("Dick", tempRow[0]);
+            Assert.Equal("10", tempRow[1].ToString());
+            tempRow = tempRow.GetParentRow("Rel");
+            Assert.Equal("teresa", tempRow[0]);
+            Assert.Equal("Dick", tempRow[1]);
 
-            Row = _child.Rows[0];
-            TempRow = Row.GetParentRows("Rel")[0];
-            Assert.Equal("teresa", TempRow[0]);
-            Assert.Equal("john", TempRow[1]);
+            row = _child.Rows[0];
+            tempRow = row.GetParentRows("Rel")[0];
+            Assert.Equal("teresa", tempRow[0]);
+            Assert.Equal("john", tempRow[1]);
         }
     }
 }

--- a/src/System.Data.Common/tests/System/Data/DataRelationTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/DataRelationTest2.cs
@@ -24,8 +24,6 @@
 //
 
 using Xunit;
-//using System.ComponentModel;
-
 
 namespace System.Data.Tests
 {
@@ -183,7 +181,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public void ctor_ByNameDataColumns()
+        public void Ctor_ByNameDataColumns()
         {
             var ds = new DataSet();
             DataTable dtChild = DataProvider.CreateChildDataTable();
@@ -194,9 +192,6 @@ namespace System.Data.Tests
             DataRelation dRel;
             dRel = new DataRelation("MyRelation", dtParent.Columns[0], dtChild.Columns[0]);
             ds.Relations.Add(dRel);
-
-            // DataRelation - CTor
-            Assert.False(dRel == null);
 
             // DataRelation - parent Constraints
             Assert.Equal(1, dtParent.Constraints.Count);
@@ -247,7 +242,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public void ctor_ByNameDataColumnsCreateConstraints()
+        public void Ctor_ByNameDataColumnsCreateConstraints()
         {
             DataRelation dRel;
             DataTable dtChild = DataProvider.CreateChildDataTable();
@@ -292,9 +287,6 @@ namespace System.Data.Tests
                 dRel = new DataRelation("MyRelation", dtParent.Columns[0], dtChild.Columns[0], createConstraints);
                 ds.Relations.Add(dRel);
 
-                // DataRelation - CTor,createConstraints=
-                Assert.False(dRel == null);
-
                 // DataRelation - parent Constraints,createConstraints=
                 Assert.Equal(i, dtParent.Constraints.Count);
 
@@ -313,7 +305,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public void ctor_ByNameDataColumnsArrays()
+        public void Ctor_ByNameDataColumnsArrays()
         {
             var ds = new DataSet();
             DataTable dtChild = DataProvider.CreateChildDataTable();
@@ -356,9 +348,6 @@ namespace System.Data.Tests
             // DataSet DataRelation count
             Assert.Equal(1, ds.Relations.Count);
 
-            // DataRelation - CTor
-            Assert.False(dRel == null);
-
             // DataRelation - parent Constraints
             Assert.Equal(1, dtParent.Constraints.Count);
 
@@ -376,7 +365,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public void ctor_ByNameDataColumnsArraysCreateConstraints()
+        public void Ctor_ByNameDataColumnsArraysCreateConstraints()
         {
             DataRelation dRel;
             DataTable dtChild = DataProvider.CreateChildDataTable();
@@ -419,9 +408,6 @@ namespace System.Data.Tests
                 dRel = new DataRelation("MyRelation", new DataColumn[] { dtParent.Columns[0] }, new DataColumn[] { dtChild.Columns[0] }, createConstraints);
                 ds.Relations.Add(dRel);
 
-                // DataRelation - CTor,createConstraints=
-                Assert.False(dRel == null);
-
                 // DataRelation - parent Constraints,createConstraints=
                 Assert.Equal(i, dtParent.Constraints.Count);
 
@@ -440,7 +426,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public void extendedProperties()
+        public void ExtendedProperties()
         {
             var ds = new DataSet();
             DataTable dtChild = DataProvider.CreateChildDataTable();
@@ -455,15 +441,15 @@ namespace System.Data.Tests
             PropertyCollection pc;
             pc = dRel.ExtendedProperties;
 
-            // Checking ExtendedProperties default
-            Assert.True(pc != null);
+            // Checking ExtendedProperties default 
+            Assert.NotNull(pc);
 
             // Checking ExtendedProperties count
             Assert.Equal(0, pc.Count);
         }
 
         [Fact]
-        public void nested()
+        public void Nested()
         {
             var ds = new DataSet();
             DataTable dtChild = DataProvider.CreateChildDataTable();
@@ -485,7 +471,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public void relationName()
+        public void RelationName()
         {
             var ds = new DataSet();
             DataTable dtChild = DataProvider.CreateChildDataTable();
@@ -511,7 +497,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public void bug79233()
+        public void Bug79233()
         {
             DataSet ds = new DataSet();
             DataTable dtChild = DataProvider.CreateChildDataTable();
@@ -547,12 +533,7 @@ namespace System.Data.Tests
             ds.Relations.Clear();
             t2.Columns[0].DateTimeMode = DataSetDateTime.Local;
 
-            try
-            {
-                ds.Relations.Add("rel", t1.Columns[0], t2.Columns[0], false);
-                Assert.False(true);
-            }
-            catch (InvalidConstraintException) { }
+            Assert.Throws<InvalidConstraintException>(() => ds.Relations.Add("rel", t1.Columns[0], t2.Columns[0], false));
         }
     }
 }

--- a/src/System.Data.Common/tests/System/Data/DataRowCollectionTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataRowCollectionTest.cs
@@ -118,31 +118,10 @@ namespace System.Data.Tests
             Assert.Equal("second", rows[1][1]);
             Assert.Equal("else", rows[2][1]);
 
-            //TODO: messages?
-            //try
-            //{
-            //    Rows.Add(Row);
-            //    Assert.False(true);
-            //}
-            //catch (Exception e)
-            //{
-            //    Assert.Equal(typeof(ArgumentException), e.GetType());
-            //    // Never premise English.
-            //    //Assert.Equal ("This row already belongs to this table.", e.Message);
-            //}
+            // This row already belongs to this table.
             Assert.Throws<ArgumentException>(() => rows.Add(row));
-            //TODO: messages?
-            //try
-            //{
-            //    Row = null;
-            //    Rows.Add(Row);
-            //    Assert.False(true);
-            //}
-            //catch (Exception e)
-            //{
-            //    Assert.Equal(typeof(ArgumentNullException), e.GetType());
-            //    //Assert.Equal ("'row' argument cannot be null.\r\nParameter name: row", e.Message);
-            //}
+
+            // 'row' argument cannot be null.\r\nParameter name: row
             Assert.Throws<ArgumentNullException>(() => rows.Add((DataRow)null));
 
             DataColumn column = new DataColumn("not_null");
@@ -153,17 +132,8 @@ namespace System.Data.Tests
             cols[0] = "first";
             cols[1] = "second";
             cols[2] = null;
-            //TODO: messages
-            //try
-            //{
-            //    Rows.Add(cols);
-            //    Assert.False(true);
-            //}
-            //catch (Exception e)
-            //{
-            //    Assert.Equal(typeof(NoNullAllowedException), e.GetType());
-            //    //Assert.Equal ("Column 'not_null' does not allow nulls.", e.Message);
-            //}
+
+            // Column 'not_null' does not allow nulls.
             Assert.Throws<NoNullAllowedException>(() => rows.Add(cols));
 
             column = _tbl.Columns[0];
@@ -174,18 +144,7 @@ namespace System.Data.Tests
             cols[1] = "second";
             cols[2] = "blabal";
 
-            //TODO: messages
-            //try
-            //{
-            //    Rows.Add(cols);
-            //    Assert.False(true);
-            //}
-            //catch (Exception e)
-            //{
-            //    Assert.Equal(typeof(ConstraintException), e.GetType());
-            //    // Never premise English.
-            //    //Assert.Equal ("Column 'Column1' is constrained to be unique.  Value 'first' is already present.", e.Message);
-            //}
+            // Column 'Column1' is constrained to be unique.  Value 'first' is already present.
             Assert.Throws<ConstraintException>(() => rows.Add(cols));
 
             column = new DataColumn("integer");
@@ -197,17 +156,6 @@ namespace System.Data.Tests
             obs[1] = "second";
             obs[2] = "blabal";
             obs[3] = "ads";
-            // TODO: discrepancy with the docs?
-            //try
-            //{
-            //    Rows.Add(obs);
-            //    Assert.False(true);
-            //}
-            //catch (ArgumentException e)
-            //{
-            //    // MSDN says this exception is InvalidCastException
-            //    //				Assert.Equal (typeof (ArgumentException), e.GetType ());
-            //}
             Assert.Throws<ArgumentException>(() => rows.Add(obs));
 
             object[] obs1 = new object[5];
@@ -359,18 +307,7 @@ namespace System.Data.Tests
             Assert.Equal(2, _tbl.Rows[2][0]);
             Assert.Equal(3, _tbl.Rows[3][0]);
 
-            //TODO: messages
-            //try
-            //{
-            //    Rows.Contains(1);
-            //    Assert.False(true);
-            //}
-            //catch (Exception e)
-            //{
-            //    Assert.Equal(typeof(MissingPrimaryKeyException), e.GetType());
-            //    // Never premise English.
-            //    //Assert.Equal ("Table doesn't have a primary key.", e.Message);
-            //}
+            // Table doesn't have a primary key.
             Assert.Throws<MissingPrimaryKeyException>(() => rows.Contains(1));
 
             _tbl.PrimaryKey = new DataColumn[] { _tbl.Columns[0] };
@@ -378,18 +315,7 @@ namespace System.Data.Tests
             Assert.True(rows.Contains(2));
             Assert.False(rows.Contains(4));
 
-            //TODO: messages
-            //try
-            //{
-            //    Rows.Contains(new object[] { 64, "test0" });
-            //    Assert.False(true);
-            //}
-            //catch (Exception e)
-            //{
-            //    Assert.Equal(typeof(ArgumentException), e.GetType());
-            //    // Never premise English.
-            //    //Assert.Equal ("Expecting 1 value(s) for the key being indexed, but received 2 value(s).", e.Message);
-            //}
+            // Expecting 1 value(s) for the key being indexed, but received 2 value(s).
             Assert.Throws<ArgumentException>(() => rows.Contains(new object[] { 64, "test0" }));
 
             _tbl.PrimaryKey = new DataColumn[] { _tbl.Columns[0], _tbl.Columns[1] };
@@ -397,18 +323,8 @@ namespace System.Data.Tests
             Assert.False(rows.Contains(new object[] { 0, "test1" }));
             Assert.True(rows.Contains(new object[] { 1, "test1" }));
             Assert.True(rows.Contains(new object[] { 2, "test2" }));
-            //TODO: messages
-            //try
-            //{
-            //    Rows.Contains(new object[] { 2 });
-            //    Assert.False(true);
-            //}
-            //catch (Exception e)
-            //{
-            //    Assert.Equal(typeof(ArgumentException), e.GetType());
-            //    // Never premise English.
-            //    //Assert.Equal ("Expecting 2 value(s) for the key being indexed, but received 1 value(s).", e.Message);
-            //}
+
+            // Expecting 2 value(s) for the key being indexed, but received 1 value(s).
             Assert.Throws<ArgumentException>(() => rows.Contains(new object[] { 2 }));
         }
 
@@ -431,17 +347,7 @@ namespace System.Data.Tests
 
             DataRow[] dr = new DataRow[10];
 
-            //TODO: messages
-            //try
-            //{
-            //    rows.CopyTo(dr, 4);
-            //    Assert.False(true);
-            //}
-            //catch (Exception e)
-            //{
-            //    Assert.Equal(typeof(ArgumentException), e.GetType());
-            //    //Assert.Equal ("Destination array was not long enough.  Check destIndex and length, and the array's lower bounds.", e.Message);
-            //}
+            // Destination array was not long enough.  Check destIndex and length, and the array's lower bounds.
             Assert.Throws<ArgumentException>(() => rows.CopyTo(dr, 4));
 
             dr = new DataRow[11];
@@ -519,18 +425,7 @@ namespace System.Data.Tests
             rows.Add(new object[] { 4, "fourth" });
             rows.Add(new object[] { 5, "fifth" });
 
-            //TODO: messages
-            //try
-            //{
-            //    rows.Find(1);
-            //    Assert.False(true);
-            //}
-            //catch (Exception e)
-            //{
-            //    Assert.Equal(typeof(MissingPrimaryKeyException), e.GetType());
-            //    // Never premise English.
-            //    //Assert.Equal ("Table doesn't have a primary key.", e.Message);
-            //}
+            // Table doesn't have a primary key.
             Assert.Throws<MissingPrimaryKeyException>(() => rows.Find(1));
 
             _tbl.PrimaryKey = new DataColumn[] { _tbl.Columns[0] };
@@ -540,50 +435,21 @@ namespace System.Data.Tests
             Assert.Equal(2L, row[0]);
             row = rows.Find("2");
             Assert.Equal(2L, row[0]);
-            //TODO: messages
-            //try
-            //{
-            //    row = rows.Find("test");
-            //    Assert.False(true);
-            //}
-            //catch (Exception e)
-            //{
-            //    Assert.Equal(typeof(FormatException), e.GetType());
-            //    //Assert.Equal ("Input string was not in a correct format.", e.Message);
-            //}
+
+            // Input string was not in a correct format.
             Assert.Throws<FormatException>(() => rows.Find("test"));
 
             string tes = null;
             row = rows.Find(tes);
             Assert.Null(row);
             _tbl.PrimaryKey = null;
-            //TODO: messages
-            //try
-            //{
-            //    rows.Find(new object[] { 1, "fir" });
-            //    Assert.False(true);
-            //}
-            //catch (Exception e)
-            //{
-            //    Assert.Equal(typeof(MissingPrimaryKeyException), e.GetType());
-            //    // Never premise English.
-            //    //Assert.Equal ("Table doesn't have a primary key.", e.Message);
-            //}
+
+            // Table doesn't have a primary key.
             Assert.Throws<MissingPrimaryKeyException>(() => rows.Find(new object[] { 1, "fir" }));
 
             _tbl.PrimaryKey = new DataColumn[] { _tbl.Columns[0], _tbl.Columns[1] };
-            //TODO: messages
-            //try
-            //{
-            //    rows.Find(1);
-            //    Assert.False(true);
-            //}
-            //catch (Exception e)
-            //{
-            //    Assert.Equal(typeof(ArgumentException), e.GetType());
-            //    // Never premise English.
-            //    //Assert.Equal ("Expecting 2 value(s) for the key being indexed, but received 1 value(s).", e.Message);
-            //}
+
+            // Expecting 2 value(s) for the key being indexed, but received 1 value(s).
             Assert.Throws<ArgumentException>(() => rows.Find(1));
 
             row = rows.Find(new object[] { 1, "fir" });
@@ -640,18 +506,8 @@ namespace System.Data.Tests
             row[0] = "e";
             row[1] = "ee";
             row[2] = "eee";
-            //TODO: messages
-            //try
-            //{
-            //    Rows.InsertAt(Row, -1);
-            //    Assert.False(true);
-            //}
-            //catch (Exception e)
-            //{
-            //    Assert.Equal(typeof(IndexOutOfRangeException), e.GetType());
-            //    // Never premise English.
-            //    //Assert.Equal ("The row insert position -1 is invalid.", e.Message);
-            //}
+
+            // The row insert position -1 is invalid.
             Assert.Throws<IndexOutOfRangeException>(() => rows.InsertAt(row, -1));
 
             rows.InsertAt(row, 0);
@@ -673,18 +529,8 @@ namespace System.Data.Tests
 
             rows.InsertAt(row, 500);
             Assert.Equal("g", rows[6][0]);
-            //TODO: messages
-            //try
-            //{
-            //    rows.InsertAt(row, 6);  //Row already belongs to the table
-            //    Assert.False(true);
-            //}
-            //catch (Exception e)
-            //{
-            //    Assert.Equal(typeof(ArgumentException), e.GetType());
-            //    // Never premise English.
-            //    //Assert.Equal ("This row already belongs to this table.", e.Message);
-            //}
+
+            // This row already belongs to this table.
             Assert.Throws<ArgumentException>(() => rows.InsertAt(row, 6));
 
             DataTable table = new DataTable();
@@ -693,18 +539,8 @@ namespace System.Data.Tests
             row = table.NewRow();
             row["Name"] = "Abc";
             table.Rows.Add(row);
-            //TODO: messages, I'll stop commenting on this
-            //try
-            //{
-            //    rows.InsertAt(row, 6);
-            //    Assert.False(true);
-            //}
-            //catch (Exception e)
-            //{
-            //    Assert.Equal(typeof(ArgumentException), e.GetType());
-            //    // Never premise English.
-            //    //Assert.Equal ("This row already belongs to another table.", e.Message);
-            //}
+
+            // This row already belongs to another table.
             Assert.Throws<ArgumentException>(() => rows.InsertAt(row, 6));
 
             table = new DataTable();
@@ -745,59 +581,19 @@ namespace System.Data.Tests
             Assert.Equal("a", _tbl.Rows[0][0]);
             Assert.Equal("c", _tbl.Rows[1][0]);
             Assert.Equal("d", _tbl.Rows[2][0]);
-            //TODO
-            //try
-            //{
-            //    rows.Remove(null);
-            //    Assert.False(true);
-            //}
-            //catch (Exception e)
-            //{
-            //    Assert.Equal(typeof(IndexOutOfRangeException), e.GetType());
-            //    // Never premise English.
-            //    //Assert.Equal ("The given datarow is not in the current DataRowCollection.", e.Message);
-            //}
+
+            // The given datarow is not in the current DataRowCollection.
             Assert.Throws<IndexOutOfRangeException>(() => rows.Remove(null));
 
             DataRow row = new DataTable().NewRow();
-            //TODO
-            //try
-            //{
-            //    rows.Remove(Row);
-            //    Assert.False(true);
-            //}
-            //catch (Exception e)
-            //{
-            //    Assert.Equal(typeof(IndexOutOfRangeException), e.GetType());
-            //    // Never premise English.
-            //    //Assert.Equal ("The given datarow is not in the current DataRowCollection.", e.Message);
-            //}
+
+            // The given datarow is not in the current DataRowCollection.
             Assert.Throws<IndexOutOfRangeException>(() => rows.Remove(row));
-            //TODO
-            //try
-            //{
-            //    rows.RemoveAt(-1);
-            //    Assert.False(true);
-            //}
-            //catch (Exception e)
-            //{
-            //    Assert.Equal(typeof(IndexOutOfRangeException), e.GetType());
-            //    // Never premise English.
-            //    //Assert.Equal ("There is no row at position -1.", e.Message);
-            //}
+
+            // There is no row at position -1.
             Assert.Throws<IndexOutOfRangeException>(() => rows.RemoveAt(-1));
-            //TODO
-            //try
-            //{
-            //    rows.RemoveAt(64);
-            //    Assert.False(true);
-            //}
-            //catch (Exception e)
-            //{
-            //    Assert.Equal(typeof(IndexOutOfRangeException), e.GetType());
-            //    // Never premise English.
-            //    //Assert.Equal ("There is no row at position 64.", e.Message);
-            //}
+
+            // There is no row at position 64.
             Assert.Throws<IndexOutOfRangeException>(() => rows.RemoveAt(64));
 
             rows.RemoveAt(0);

--- a/src/System.Data.Common/tests/System/Data/DataRowCollectionTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataRowCollectionTest.cs
@@ -186,7 +186,7 @@ namespace System.Data.Tests
             //    // Never premise English.
             //    //Assert.Equal ("Column 'Column1' is constrained to be unique.  Value 'first' is already present.", e.Message);
             //}
-            Assert.Throws<NoNullAllowedException>(() => rows.Add(cols));
+            Assert.Throws<ConstraintException>(() => rows.Add(cols));
 
             column = new DataColumn("integer");
             column.DataType = typeof(short);
@@ -478,9 +478,7 @@ namespace System.Data.Tests
 
             DataRowCollection rows2 = _tbl.Rows;
 
-            Assert.True(rows2.Equals(rows1));
-            Assert.True(rows1.Equals(rows2));
-            Assert.True(rows1.Equals(rows1));
+            Assert.Same(rows2, rows1);
 
             DataTable table = new DataTable();
             table.Columns.Add();
@@ -496,10 +494,8 @@ namespace System.Data.Tests
             rows3.Add(new object[] { "6", "6", "6" });
             rows3.Add(new object[] { "7", "7", "7" });
 
-            Assert.False(rows3.Equals(rows1));
-            Assert.False(rows3.Equals(rows2));
-            Assert.False(rows1.Equals(rows3));
-            Assert.False(rows2.Equals(rows3));
+            Assert.NotSame(rows3, rows2);
+            Assert.NotSame(rows1, rows3);
         }
 
         [Fact]
@@ -888,7 +884,7 @@ namespace System.Data.Tests
             var columns = new DataColumn[] { column };
             dt.PrimaryKey = columns;
 
-            Assert.Throws<IndexOutOfRangeException>(() => dt.Rows.Find(new object[] { null }));
+            Assert.Null(dt.Rows.Find(new object[] { null }));
         }
 
         [Fact]
@@ -901,7 +897,7 @@ namespace System.Data.Tests
             var columns = new DataColumn[] { column };
             dt.PrimaryKey = columns;
 
-            Assert.Throws<IndexOutOfRangeException>(() => dt.Rows.Find((object)null));
+            Assert.Null(dt.Rows.Find((object)null));
         }
     }
 }

--- a/src/System.Data.Common/tests/System/Data/DataRowCollectionTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataRowCollectionTest.cs
@@ -35,12 +35,7 @@ namespace System.Data.Tests
 {
     public class DataRowCollectionTest
     {
-        private DataTable _tbl;
-
-        public DataRowCollectionTest()
-        {
-            _tbl = new DataTable();
-        }
+        private readonly DataTable _tbl = new DataTable();
 
         [Fact]
         public void AutoIncrement()
@@ -98,117 +93,122 @@ namespace System.Data.Tests
         {
             _tbl.Columns.Add();
             _tbl.Columns.Add();
-            DataRow Row = _tbl.NewRow();
-            DataRowCollection Rows = _tbl.Rows;
+            DataRow row = _tbl.NewRow();
+            DataRowCollection rows = _tbl.Rows;
 
-            Rows.Add(Row);
-            Assert.Equal(1, Rows.Count);
-            Assert.False(Rows.IsReadOnly);
-            Assert.False(Rows.IsSynchronized);
-            Assert.Equal("System.Data.DataRowCollection", Rows.ToString());
+            rows.Add(row);
+            Assert.Equal(1, rows.Count);
+            Assert.False(rows.IsReadOnly);
+            Assert.False(rows.IsSynchronized);
+            Assert.Equal("System.Data.DataRowCollection", rows.ToString());
 
-            string[] cols = new string[2];
-            cols[0] = "first";
-            cols[1] = "second";
+            string[] cols = new string[2] { "first", "second" };
 
-            Rows.Add(cols);
+            rows.Add(cols);
             cols[0] = "something";
             cols[1] = "else";
-            Rows.Add(cols);
+            rows.Add(cols);
 
-            Assert.Equal(3, Rows.Count);
-            Assert.Equal("System.Data.DataRow", Rows[0].ToString());
-            Assert.Equal(DBNull.Value, Rows[0][0]);
-            Assert.Equal(DBNull.Value, Rows[0][1]);
-            Assert.Equal("first", Rows[1][0]);
-            Assert.Equal("something", Rows[2][0]);
-            Assert.Equal("second", Rows[1][1]);
-            Assert.Equal("else", Rows[2][1]);
+            Assert.Equal(3, rows.Count);
+            Assert.Equal("System.Data.DataRow", rows[0].ToString());
+            Assert.Equal(DBNull.Value, rows[0][0]);
+            Assert.Equal(DBNull.Value, rows[0][1]);
+            Assert.Equal("first", rows[1][0]);
+            Assert.Equal("something", rows[2][0]);
+            Assert.Equal("second", rows[1][1]);
+            Assert.Equal("else", rows[2][1]);
 
-            try
-            {
-                Rows.Add(Row);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(ArgumentException), e.GetType());
-                // Never premise English.
-                //Assert.Equal ("This row already belongs to this table.", e.Message);
-            }
+            //TODO: messages?
+            //try
+            //{
+            //    Rows.Add(Row);
+            //    Assert.False(true);
+            //}
+            //catch (Exception e)
+            //{
+            //    Assert.Equal(typeof(ArgumentException), e.GetType());
+            //    // Never premise English.
+            //    //Assert.Equal ("This row already belongs to this table.", e.Message);
+            //}
+            Assert.Throws<ArgumentException>(() => rows.Add(row));
+            //TODO: messages?
+            //try
+            //{
+            //    Row = null;
+            //    Rows.Add(Row);
+            //    Assert.False(true);
+            //}
+            //catch (Exception e)
+            //{
+            //    Assert.Equal(typeof(ArgumentNullException), e.GetType());
+            //    //Assert.Equal ("'row' argument cannot be null.\r\nParameter name: row", e.Message);
+            //}
+            Assert.Throws<ArgumentNullException>(() => rows.Add((DataRow)null));
 
-            try
-            {
-                Row = null;
-                Rows.Add(Row);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(ArgumentNullException), e.GetType());
-                //Assert.Equal ("'row' argument cannot be null.\r\nParameter name: row", e.Message);
-            }
-
-            DataColumn Column = new DataColumn("not_null");
-            Column.AllowDBNull = false;
-            _tbl.Columns.Add(Column);
+            DataColumn column = new DataColumn("not_null");
+            column.AllowDBNull = false;
+            _tbl.Columns.Add(column);
 
             cols = new string[3];
             cols[0] = "first";
             cols[1] = "second";
             cols[2] = null;
+            //TODO: messages
+            //try
+            //{
+            //    Rows.Add(cols);
+            //    Assert.False(true);
+            //}
+            //catch (Exception e)
+            //{
+            //    Assert.Equal(typeof(NoNullAllowedException), e.GetType());
+            //    //Assert.Equal ("Column 'not_null' does not allow nulls.", e.Message);
+            //}
+            Assert.Throws<NoNullAllowedException>(() => rows.Add(cols));
 
-            try
-            {
-                Rows.Add(cols);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(NoNullAllowedException), e.GetType());
-                //Assert.Equal ("Column 'not_null' does not allow nulls.", e.Message);
-            }
-
-            Column = _tbl.Columns[0];
-            Column.Unique = true;
+            column = _tbl.Columns[0];
+            column.Unique = true;
 
             cols = new string[3];
             cols[0] = "first";
             cols[1] = "second";
             cols[2] = "blabal";
 
-            try
-            {
-                Rows.Add(cols);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(ConstraintException), e.GetType());
-                // Never premise English.
-                //Assert.Equal ("Column 'Column1' is constrained to be unique.  Value 'first' is already present.", e.Message);
-            }
+            //TODO: messages
+            //try
+            //{
+            //    Rows.Add(cols);
+            //    Assert.False(true);
+            //}
+            //catch (Exception e)
+            //{
+            //    Assert.Equal(typeof(ConstraintException), e.GetType());
+            //    // Never premise English.
+            //    //Assert.Equal ("Column 'Column1' is constrained to be unique.  Value 'first' is already present.", e.Message);
+            //}
+            Assert.Throws<NoNullAllowedException>(() => rows.Add(cols));
 
-            Column = new DataColumn("integer");
-            Column.DataType = typeof(short);
-            _tbl.Columns.Add(Column);
+            column = new DataColumn("integer");
+            column.DataType = typeof(short);
+            _tbl.Columns.Add(column);
 
             object[] obs = new object[4];
             obs[0] = "_first";
             obs[1] = "second";
             obs[2] = "blabal";
             obs[3] = "ads";
-
-            try
-            {
-                Rows.Add(obs);
-                Assert.False(true);
-            }
-            catch (ArgumentException e)
-            {
-                // MSDN says this exception is InvalidCastException
-                //                Assert.Equal (typeof (ArgumentException), e.GetType ());
-            }
+            // TODO: discrepancy with the docs?
+            //try
+            //{
+            //    Rows.Add(obs);
+            //    Assert.False(true);
+            //}
+            //catch (ArgumentException e)
+            //{
+            //    // MSDN says this exception is InvalidCastException
+            //    //				Assert.Equal (typeof (ArgumentException), e.GetType ());
+            //}
+            Assert.Throws<ArgumentException>(() => rows.Add(obs));
 
             object[] obs1 = new object[5];
             obs1[0] = "A";
@@ -216,15 +216,7 @@ namespace System.Data.Tests
             obs1[2] = "C";
             obs1[3] = 38;
             obs1[4] = "Extra";
-            try
-            {
-                Rows.Add(obs1);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(ArgumentException), e.GetType());
-            }
+            Assert.Throws<ArgumentException>(() => rows.Add(obs1));
         }
 
         [Fact]
@@ -264,10 +256,10 @@ namespace System.Data.Tests
         [Fact]
         public void Clear()
         {
-            DataRowCollection Rows = _tbl.Rows;
-            DataTable Table = new DataTable("child");
-            Table.Columns.Add("first", typeof(int));
-            Table.Columns.Add("second", typeof(string));
+            DataRowCollection rows = _tbl.Rows;
+            DataTable table = new DataTable("child");
+            table.Columns.Add("first", typeof(int));
+            table.Columns.Add("second", typeof(string));
 
             _tbl.Columns.Add("first", typeof(int));
             _tbl.Columns.Add("second", typeof(float));
@@ -275,97 +267,90 @@ namespace System.Data.Tests
             string[] cols = new string[2];
             cols[0] = "1";
             cols[1] = "1,1";
-            Rows.Add(cols);
+            rows.Add(cols);
 
             cols[0] = "2";
             cols[1] = "2,1";
-            Rows.Add(cols);
+            rows.Add(cols);
 
             cols[0] = "3";
             cols[1] = "3,1";
-            Rows.Add(cols);
+            rows.Add(cols);
 
-            Assert.Equal(3, Rows.Count);
-            Rows.Clear();
+            Assert.Equal(3, rows.Count);
+            rows.Clear();
 
-            Assert.Equal(0, Rows.Count);
+            Assert.Equal(0, rows.Count);
 
             cols[0] = "1";
             cols[1] = "1,1";
-            Rows.Add(cols);
+            rows.Add(cols);
 
             cols[0] = "2";
             cols[1] = "2,1";
-            Rows.Add(cols);
+            rows.Add(cols);
 
             cols[0] = "3";
             cols[1] = "3,1";
-            Rows.Add(cols);
+            rows.Add(cols);
 
             cols[0] = "1";
             cols[1] = "test";
-            Table.Rows.Add(cols);
+            table.Rows.Add(cols);
 
             cols[0] = "2";
             cols[1] = "test2";
-            Table.Rows.Add(cols);
+            table.Rows.Add(cols);
 
             cols[0] = "3";
             cols[1] = "test3";
-            Table.Rows.Add(cols);
+            table.Rows.Add(cols);
 
             DataSet Set = new DataSet();
             Set.Tables.Add(_tbl);
-            Set.Tables.Add(Table);
-            DataRelation Rel = new DataRelation("REL", _tbl.Columns[0], Table.Columns[0]);
+            Set.Tables.Add(table);
+            DataRelation Rel = new DataRelation("REL", _tbl.Columns[0], table.Columns[0]);
             Set.Relations.Add(Rel);
 
-            try
-            {
-                Rows.Clear();
-                Assert.False(true);
-            }
-            catch (InvalidConstraintException)
-            {
-            }
+            Assert.Throws<InvalidConstraintException>(() => rows.Clear());
 
-            Assert.Equal(3, Table.Rows.Count);
-            Table.Rows.Clear();
-            Assert.Equal(0, Table.Rows.Count);
+            Assert.Equal(3, table.Rows.Count);
+            table.Rows.Clear();
+            Assert.Equal(0, table.Rows.Count);
         }
 
         [Fact]
         public void Contains()
         {
-            DataColumn C = new DataColumn("key");
-            C.Unique = true;
-            C.DataType = typeof(int);
-            C.AutoIncrement = true;
-            C.AutoIncrementSeed = 0;
-            C.AutoIncrementStep = 1;
-            _tbl.Columns.Add(C);
+            DataColumn c = new DataColumn("key");
+            c.Unique = true;
+            c.DataType = typeof(int);
+            c.AutoIncrement = true;
+            c.AutoIncrementSeed = 0;
+            c.AutoIncrementStep = 1;
+            _tbl.Columns.Add(c);
             _tbl.Columns.Add("first", typeof(string));
             _tbl.Columns.Add("second", typeof(decimal));
 
-            DataRowCollection Rows = _tbl.Rows;
+            DataRowCollection rows = _tbl.Rows;
 
-            DataRow Row = _tbl.NewRow();
-            _tbl.Rows.Add(Row);
-            Row = _tbl.NewRow();
-            _tbl.Rows.Add(Row);
-            Row = _tbl.NewRow();
-            _tbl.Rows.Add(Row);
-            Row = _tbl.NewRow();
-            _tbl.Rows.Add(Row);
+            DataRow row = _tbl.NewRow();
+            _tbl.Rows.Add(row);
+            row = _tbl.NewRow();
+            _tbl.Rows.Add(row);
+            row = _tbl.NewRow();
+            _tbl.Rows.Add(row);
+            row = _tbl.NewRow();
+            _tbl.Rows.Add(row);
 
-            Rows[0][1] = "test0";
-            Rows[0][2] = 0;
-            Rows[1][1] = "test1";
-            Rows[1][2] = 1;
-            Rows[2][1] = "test2";
-            Rows[2][2] = 2;
-            Rows[3][1] = "test3";
-            Rows[3][2] = 3;
+            rows[0][1] = "test0";
+            rows[0][2] = 0;
+            rows[1][1] = "test1";
+            rows[1][2] = 1;
+            rows[2][1] = "test2";
+            rows[2][2] = 2;
+            rows[3][1] = "test3";
+            rows[3][2] = 3;
 
             Assert.Equal(3, _tbl.Columns.Count);
             Assert.Equal(4, _tbl.Rows.Count);
@@ -374,52 +359,57 @@ namespace System.Data.Tests
             Assert.Equal(2, _tbl.Rows[2][0]);
             Assert.Equal(3, _tbl.Rows[3][0]);
 
-            try
-            {
-                Rows.Contains(1);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(MissingPrimaryKeyException), e.GetType());
-                // Never premise English.
-                //Assert.Equal ("Table doesn't have a primary key.", e.Message);
-            }
+            //TODO: messages
+            //try
+            //{
+            //    Rows.Contains(1);
+            //    Assert.False(true);
+            //}
+            //catch (Exception e)
+            //{
+            //    Assert.Equal(typeof(MissingPrimaryKeyException), e.GetType());
+            //    // Never premise English.
+            //    //Assert.Equal ("Table doesn't have a primary key.", e.Message);
+            //}
+            Assert.Throws<MissingPrimaryKeyException>(() => rows.Contains(1));
 
             _tbl.PrimaryKey = new DataColumn[] { _tbl.Columns[0] };
-            Assert.True(Rows.Contains(1));
-            Assert.True(Rows.Contains(2));
-            Assert.False(Rows.Contains(4));
+            Assert.True(rows.Contains(1));
+            Assert.True(rows.Contains(2));
+            Assert.False(rows.Contains(4));
 
-            try
-            {
-                Rows.Contains(new object[] { 64, "test0" });
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(ArgumentException), e.GetType());
-                // Never premise English.
-                //Assert.Equal ("Expecting 1 value(s) for the key being indexed, but received 2 value(s).", e.Message);
-            }
+            //TODO: messages
+            //try
+            //{
+            //    Rows.Contains(new object[] { 64, "test0" });
+            //    Assert.False(true);
+            //}
+            //catch (Exception e)
+            //{
+            //    Assert.Equal(typeof(ArgumentException), e.GetType());
+            //    // Never premise English.
+            //    //Assert.Equal ("Expecting 1 value(s) for the key being indexed, but received 2 value(s).", e.Message);
+            //}
+            Assert.Throws<ArgumentException>(() => rows.Contains(new object[] { 64, "test0" }));
 
             _tbl.PrimaryKey = new DataColumn[] { _tbl.Columns[0], _tbl.Columns[1] };
-            Assert.False(Rows.Contains(new object[] { 64, "test0" }));
-            Assert.False(Rows.Contains(new object[] { 0, "test1" }));
-            Assert.True(Rows.Contains(new object[] { 1, "test1" }));
-            Assert.True(Rows.Contains(new object[] { 2, "test2" }));
-
-            try
-            {
-                Rows.Contains(new object[] { 2 });
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(ArgumentException), e.GetType());
-                // Never premise English.
-                //Assert.Equal ("Expecting 2 value(s) for the key being indexed, but received 1 value(s).", e.Message);
-            }
+            Assert.False(rows.Contains(new object[] { 64, "test0" }));
+            Assert.False(rows.Contains(new object[] { 0, "test1" }));
+            Assert.True(rows.Contains(new object[] { 1, "test1" }));
+            Assert.True(rows.Contains(new object[] { 2, "test2" }));
+            //TODO: messages
+            //try
+            //{
+            //    Rows.Contains(new object[] { 2 });
+            //    Assert.False(true);
+            //}
+            //catch (Exception e)
+            //{
+            //    Assert.Equal(typeof(ArgumentException), e.GetType());
+            //    // Never premise English.
+            //    //Assert.Equal ("Expecting 2 value(s) for the key being indexed, but received 1 value(s).", e.Message);
+            //}
+            Assert.Throws<ArgumentException>(() => rows.Contains(new object[] { 2 }));
         }
 
         [Fact]
@@ -429,31 +419,33 @@ namespace System.Data.Tests
             _tbl.Columns.Add();
             _tbl.Columns.Add();
 
-            DataRowCollection Rows = _tbl.Rows;
+            DataRowCollection rows = _tbl.Rows;
 
-            Rows.Add(new object[] { "1", "1", "1" });
-            Rows.Add(new object[] { "2", "2", "2" });
-            Rows.Add(new object[] { "3", "3", "3" });
-            Rows.Add(new object[] { "4", "4", "4" });
-            Rows.Add(new object[] { "5", "5", "5" });
-            Rows.Add(new object[] { "6", "6", "6" });
-            Rows.Add(new object[] { "7", "7", "7" });
+            rows.Add(new object[] { "1", "1", "1" });
+            rows.Add(new object[] { "2", "2", "2" });
+            rows.Add(new object[] { "3", "3", "3" });
+            rows.Add(new object[] { "4", "4", "4" });
+            rows.Add(new object[] { "5", "5", "5" });
+            rows.Add(new object[] { "6", "6", "6" });
+            rows.Add(new object[] { "7", "7", "7" });
 
             DataRow[] dr = new DataRow[10];
 
-            try
-            {
-                Rows.CopyTo(dr, 4);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(ArgumentException), e.GetType());
-                //Assert.Equal ("Destination array was not long enough.  Check destIndex and length, and the array's lower bounds.", e.Message);
-            }
+            //TODO: messages
+            //try
+            //{
+            //    rows.CopyTo(dr, 4);
+            //    Assert.False(true);
+            //}
+            //catch (Exception e)
+            //{
+            //    Assert.Equal(typeof(ArgumentException), e.GetType());
+            //    //Assert.Equal ("Destination array was not long enough.  Check destIndex and length, and the array's lower bounds.", e.Message);
+            //}
+            Assert.Throws<ArgumentException>(() => rows.CopyTo(dr, 4));
 
             dr = new DataRow[11];
-            Rows.CopyTo(dr, 4);
+            rows.CopyTo(dr, 4);
 
             Assert.Null(dr[0]);
             Assert.Null(dr[1]);
@@ -474,128 +466,133 @@ namespace System.Data.Tests
             _tbl.Columns.Add();
             _tbl.Columns.Add();
 
-            DataRowCollection Rows1 = _tbl.Rows;
+            DataRowCollection rows1 = _tbl.Rows;
 
-            Rows1.Add(new object[] { "1", "1", "1" });
-            Rows1.Add(new object[] { "2", "2", "2" });
-            Rows1.Add(new object[] { "3", "3", "3" });
-            Rows1.Add(new object[] { "4", "4", "4" });
-            Rows1.Add(new object[] { "5", "5", "5" });
-            Rows1.Add(new object[] { "6", "6", "6" });
-            Rows1.Add(new object[] { "7", "7", "7" });
+            rows1.Add(new object[] { "1", "1", "1" });
+            rows1.Add(new object[] { "2", "2", "2" });
+            rows1.Add(new object[] { "3", "3", "3" });
+            rows1.Add(new object[] { "4", "4", "4" });
+            rows1.Add(new object[] { "5", "5", "5" });
+            rows1.Add(new object[] { "6", "6", "6" });
+            rows1.Add(new object[] { "7", "7", "7" });
 
-            DataRowCollection Rows2 = _tbl.Rows;
+            DataRowCollection rows2 = _tbl.Rows;
 
-            Assert.True(Rows2.Equals(Rows1));
-            Assert.True(Rows1.Equals(Rows2));
-            Assert.True(Rows1.Equals(Rows1));
+            Assert.True(rows2.Equals(rows1));
+            Assert.True(rows1.Equals(rows2));
+            Assert.True(rows1.Equals(rows1));
 
-            DataTable Table = new DataTable();
-            Table.Columns.Add();
-            Table.Columns.Add();
-            Table.Columns.Add();
-            DataRowCollection Rows3 = Table.Rows;
+            DataTable table = new DataTable();
+            table.Columns.Add();
+            table.Columns.Add();
+            table.Columns.Add();
+            DataRowCollection rows3 = table.Rows;
 
-            Rows3.Add(new object[] { "1", "1", "1" });
-            Rows3.Add(new object[] { "2", "2", "2" });
-            Rows3.Add(new object[] { "3", "3", "3" });
-            Rows3.Add(new object[] { "4", "4", "4" });
-            Rows3.Add(new object[] { "5", "5", "5" });
-            Rows3.Add(new object[] { "6", "6", "6" });
-            Rows3.Add(new object[] { "7", "7", "7" });
+            rows3.Add(new object[] { "1", "1", "1" });
+            rows3.Add(new object[] { "2", "2", "2" });
+            rows3.Add(new object[] { "3", "3", "3" });
+            rows3.Add(new object[] { "4", "4", "4" });
+            rows3.Add(new object[] { "5", "5", "5" });
+            rows3.Add(new object[] { "6", "6", "6" });
+            rows3.Add(new object[] { "7", "7", "7" });
 
-            Assert.False(Rows3.Equals(Rows1));
-            Assert.False(Rows3.Equals(Rows2));
-            Assert.False(Rows1.Equals(Rows3));
-            Assert.False(Rows2.Equals(Rows3));
+            Assert.False(rows3.Equals(rows1));
+            Assert.False(rows3.Equals(rows2));
+            Assert.False(rows1.Equals(rows3));
+            Assert.False(rows2.Equals(rows3));
         }
 
         [Fact]
         public void Find()
         {
-            DataColumn Col = new DataColumn("test_1");
-            Col.AllowDBNull = false;
-            Col.Unique = true;
-            Col.DataType = typeof(long);
-            _tbl.Columns.Add(Col);
+            DataColumn col = new DataColumn("test_1");
+            col.AllowDBNull = false;
+            col.Unique = true;
+            col.DataType = typeof(long);
+            _tbl.Columns.Add(col);
 
-            Col = new DataColumn("test_2");
-            Col.DataType = typeof(string);
-            _tbl.Columns.Add(Col);
+            col = new DataColumn("test_2");
+            col.DataType = typeof(string);
+            _tbl.Columns.Add(col);
 
-            DataRowCollection Rows = _tbl.Rows;
+            DataRowCollection rows = _tbl.Rows;
 
-            Rows.Add(new object[] { 1, "first" });
-            Rows.Add(new object[] { 2, "second" });
-            Rows.Add(new object[] { 3, "third" });
-            Rows.Add(new object[] { 4, "fourth" });
-            Rows.Add(new object[] { 5, "fifth" });
+            rows.Add(new object[] { 1, "first" });
+            rows.Add(new object[] { 2, "second" });
+            rows.Add(new object[] { 3, "third" });
+            rows.Add(new object[] { 4, "fourth" });
+            rows.Add(new object[] { 5, "fifth" });
 
-            try
-            {
-                Rows.Find(1);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(MissingPrimaryKeyException), e.GetType());
-                // Never premise English.
-                //Assert.Equal ("Table doesn't have a primary key.", e.Message);
-            }
+            //TODO: messages
+            //try
+            //{
+            //    rows.Find(1);
+            //    Assert.False(true);
+            //}
+            //catch (Exception e)
+            //{
+            //    Assert.Equal(typeof(MissingPrimaryKeyException), e.GetType());
+            //    // Never premise English.
+            //    //Assert.Equal ("Table doesn't have a primary key.", e.Message);
+            //}
+            Assert.Throws<MissingPrimaryKeyException>(() => rows.Find(1));
 
             _tbl.PrimaryKey = new DataColumn[] { _tbl.Columns[0] };
-            DataRow row = Rows.Find(1);
+            DataRow row = rows.Find(1);
             Assert.Equal(1L, row[0]);
-            row = Rows.Find(2);
+            row = rows.Find(2);
             Assert.Equal(2L, row[0]);
-            row = Rows.Find("2");
+            row = rows.Find("2");
             Assert.Equal(2L, row[0]);
-
-            try
-            {
-                row = Rows.Find("test");
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(FormatException), e.GetType());
-                //Assert.Equal ("Input string was not in a correct format.", e.Message);
-            }
+            //TODO: messages
+            //try
+            //{
+            //    row = rows.Find("test");
+            //    Assert.False(true);
+            //}
+            //catch (Exception e)
+            //{
+            //    Assert.Equal(typeof(FormatException), e.GetType());
+            //    //Assert.Equal ("Input string was not in a correct format.", e.Message);
+            //}
+            Assert.Throws<FormatException>(() => rows.Find("test"));
 
             string tes = null;
-            row = Rows.Find(tes);
+            row = rows.Find(tes);
             Assert.Null(row);
             _tbl.PrimaryKey = null;
-
-            try
-            {
-                Rows.Find(new object[] { 1, "fir" });
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(MissingPrimaryKeyException), e.GetType());
-                // Never premise English.
-                //Assert.Equal ("Table doesn't have a primary key.", e.Message);
-            }
+            //TODO: messages
+            //try
+            //{
+            //    rows.Find(new object[] { 1, "fir" });
+            //    Assert.False(true);
+            //}
+            //catch (Exception e)
+            //{
+            //    Assert.Equal(typeof(MissingPrimaryKeyException), e.GetType());
+            //    // Never premise English.
+            //    //Assert.Equal ("Table doesn't have a primary key.", e.Message);
+            //}
+            Assert.Throws<MissingPrimaryKeyException>(() => rows.Find(new object[] { 1, "fir" }));
 
             _tbl.PrimaryKey = new DataColumn[] { _tbl.Columns[0], _tbl.Columns[1] };
+            //TODO: messages
+            //try
+            //{
+            //    rows.Find(1);
+            //    Assert.False(true);
+            //}
+            //catch (Exception e)
+            //{
+            //    Assert.Equal(typeof(ArgumentException), e.GetType());
+            //    // Never premise English.
+            //    //Assert.Equal ("Expecting 2 value(s) for the key being indexed, but received 1 value(s).", e.Message);
+            //}
+            Assert.Throws<ArgumentException>(() => rows.Find(1));
 
-            try
-            {
-                Rows.Find(1);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(ArgumentException), e.GetType());
-                // Never premise English.
-                //Assert.Equal ("Expecting 2 value(s) for the key being indexed, but received 1 value(s).", e.Message);
-            }
-
-            row = Rows.Find(new object[] { 1, "fir" });
+            row = rows.Find(new object[] { 1, "fir" });
             Assert.Null(row);
-            row = Rows.Find(new object[] { 1, "first" });
+            row = rows.Find(new object[] { 1, "first" });
             Assert.Equal(1L, row[0]);
         }
 
@@ -636,79 +633,83 @@ namespace System.Data.Tests
             _tbl.Columns.Add();
             _tbl.Columns.Add();
             _tbl.Columns.Add();
-            DataRowCollection Rows = _tbl.Rows;
+            DataRowCollection rows = _tbl.Rows;
 
-            Rows.Add(new object[] { "a", "aa", "aaa" });
-            Rows.Add(new object[] { "b", "bb", "bbb" });
-            Rows.Add(new object[] { "c", "cc", "ccc" });
-            Rows.Add(new object[] { "d", "dd", "ddd" });
+            rows.Add(new object[] { "a", "aa", "aaa" });
+            rows.Add(new object[] { "b", "bb", "bbb" });
+            rows.Add(new object[] { "c", "cc", "ccc" });
+            rows.Add(new object[] { "d", "dd", "ddd" });
 
-            DataRow Row = _tbl.NewRow();
-            Row[0] = "e";
-            Row[1] = "ee";
-            Row[2] = "eee";
+            DataRow row = _tbl.NewRow();
+            row[0] = "e";
+            row[1] = "ee";
+            row[2] = "eee";
+            //TODO: messages
+            //try
+            //{
+            //    Rows.InsertAt(Row, -1);
+            //    Assert.False(true);
+            //}
+            //catch (Exception e)
+            //{
+            //    Assert.Equal(typeof(IndexOutOfRangeException), e.GetType());
+            //    // Never premise English.
+            //    //Assert.Equal ("The row insert position -1 is invalid.", e.Message);
+            //}
+            Assert.Throws<IndexOutOfRangeException>(() => rows.InsertAt(row, -1));
 
-            try
-            {
-                Rows.InsertAt(Row, -1);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(IndexOutOfRangeException), e.GetType());
-                // Never premise English.
-                //Assert.Equal ("The row insert position -1 is invalid.", e.Message);
-            }
+            rows.InsertAt(row, 0);
+            Assert.Equal("e", rows[0][0]);
+            Assert.Equal("a", rows[1][0]);
 
-            Rows.InsertAt(Row, 0);
-            Assert.Equal("e", Rows[0][0]);
-            Assert.Equal("a", Rows[1][0]);
+            row = _tbl.NewRow();
+            row[0] = "f";
+            row[1] = "ff";
+            row[2] = "fff";
 
-            Row = _tbl.NewRow();
-            Row[0] = "f";
-            Row[1] = "ff";
-            Row[2] = "fff";
+            rows.InsertAt(row, 5);
+            Assert.Equal("f", rows[5][0]);
 
-            Rows.InsertAt(Row, 5);
-            Assert.Equal("f", Rows[5][0]);
+            row = _tbl.NewRow();
+            row[0] = "g";
+            row[1] = "gg";
+            row[2] = "ggg";
 
-            Row = _tbl.NewRow();
-            Row[0] = "g";
-            Row[1] = "gg";
-            Row[2] = "ggg";
-
-            Rows.InsertAt(Row, 500);
-            Assert.Equal("g", Rows[6][0]);
-
-            try
-            {
-                Rows.InsertAt(Row, 6);  //Row already belongs to the table
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(ArgumentException), e.GetType());
-                // Never premise English.
-                //Assert.Equal ("This row already belongs to this table.", e.Message);
-            }
+            rows.InsertAt(row, 500);
+            Assert.Equal("g", rows[6][0]);
+            //TODO: messages
+            //try
+            //{
+            //    rows.InsertAt(row, 6);  //Row already belongs to the table
+            //    Assert.False(true);
+            //}
+            //catch (Exception e)
+            //{
+            //    Assert.Equal(typeof(ArgumentException), e.GetType());
+            //    // Never premise English.
+            //    //Assert.Equal ("This row already belongs to this table.", e.Message);
+            //}
+            Assert.Throws<ArgumentException>(() => rows.InsertAt(row, 6));
 
             DataTable table = new DataTable();
             DataColumn col = new DataColumn("Name");
             table.Columns.Add(col);
-            Row = table.NewRow();
-            Row["Name"] = "Abc";
-            table.Rows.Add(Row);
-            try
-            {
-                Rows.InsertAt(Row, 6);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(ArgumentException), e.GetType());
-                // Never premise English.
-                //Assert.Equal ("This row already belongs to another table.", e.Message);
-            }
+            row = table.NewRow();
+            row["Name"] = "Abc";
+            table.Rows.Add(row);
+            //TODO: messages, I'll stop commenting on this
+            //try
+            //{
+            //    rows.InsertAt(row, 6);
+            //    Assert.False(true);
+            //}
+            //catch (Exception e)
+            //{
+            //    Assert.Equal(typeof(ArgumentException), e.GetType());
+            //    // Never premise English.
+            //    //Assert.Equal ("This row already belongs to another table.", e.Message);
+            //}
+            Assert.Throws<ArgumentException>(() => rows.InsertAt(row, 6));
 
             table = new DataTable();
             col = new DataColumn("Name");
@@ -717,29 +718,15 @@ namespace System.Data.Tests
             UniqueConstraint uk = new UniqueConstraint(col);
             table.Constraints.Add(uk);
 
-            Row = table.NewRow();
-            Row["Name"] = "aaa";
-            table.Rows.InsertAt(Row, 0);
+            row = table.NewRow();
+            row["Name"] = "aaa";
+            table.Rows.InsertAt(row, 0);
 
-            Row = table.NewRow();
-            Row["Name"] = "aaa";
-            try
-            {
-                table.Rows.InsertAt(Row, 1);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(ConstraintException), e.GetType());
-            }
-            try
-            {
-                table.Rows.InsertAt(null, 1);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(ArgumentNullException), e.GetType());
-            }
+            row = table.NewRow();
+            row["Name"] = "aaa";
+
+            Assert.Throws<ConstraintException>(() => table.Rows.InsertAt(row, 1));
+            Assert.Throws<ArgumentNullException>(() => table.Rows.InsertAt(null, 1));
         }
 
         [Fact]
@@ -748,75 +735,79 @@ namespace System.Data.Tests
             _tbl.Columns.Add();
             _tbl.Columns.Add();
             _tbl.Columns.Add();
-            DataRowCollection Rows = _tbl.Rows;
+            DataRowCollection rows = _tbl.Rows;
 
-            Rows.Add(new object[] { "a", "aa", "aaa" });
-            Rows.Add(new object[] { "b", "bb", "bbb" });
-            Rows.Add(new object[] { "c", "cc", "ccc" });
-            Rows.Add(new object[] { "d", "dd", "ddd" });
+            rows.Add(new object[] { "a", "aa", "aaa" });
+            rows.Add(new object[] { "b", "bb", "bbb" });
+            rows.Add(new object[] { "c", "cc", "ccc" });
+            rows.Add(new object[] { "d", "dd", "ddd" });
 
             Assert.Equal(4, _tbl.Rows.Count);
 
-            Rows.Remove(_tbl.Rows[1]);
+            rows.Remove(_tbl.Rows[1]);
             Assert.Equal(3, _tbl.Rows.Count);
             Assert.Equal("a", _tbl.Rows[0][0]);
             Assert.Equal("c", _tbl.Rows[1][0]);
             Assert.Equal("d", _tbl.Rows[2][0]);
+            //TODO
+            //try
+            //{
+            //    rows.Remove(null);
+            //    Assert.False(true);
+            //}
+            //catch (Exception e)
+            //{
+            //    Assert.Equal(typeof(IndexOutOfRangeException), e.GetType());
+            //    // Never premise English.
+            //    //Assert.Equal ("The given datarow is not in the current DataRowCollection.", e.Message);
+            //}
+            Assert.Throws<IndexOutOfRangeException>(() => rows.Remove(null));
 
-            try
-            {
-                Rows.Remove(null);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(IndexOutOfRangeException), e.GetType());
-                // Never premise English.
-                //Assert.Equal ("The given datarow is not in the current DataRowCollection.", e.Message);
-            }
+            DataRow row = new DataTable().NewRow();
+            //TODO
+            //try
+            //{
+            //    rows.Remove(Row);
+            //    Assert.False(true);
+            //}
+            //catch (Exception e)
+            //{
+            //    Assert.Equal(typeof(IndexOutOfRangeException), e.GetType());
+            //    // Never premise English.
+            //    //Assert.Equal ("The given datarow is not in the current DataRowCollection.", e.Message);
+            //}
+            Assert.Throws<IndexOutOfRangeException>(() => rows.Remove(row));
+            //TODO
+            //try
+            //{
+            //    rows.RemoveAt(-1);
+            //    Assert.False(true);
+            //}
+            //catch (Exception e)
+            //{
+            //    Assert.Equal(typeof(IndexOutOfRangeException), e.GetType());
+            //    // Never premise English.
+            //    //Assert.Equal ("There is no row at position -1.", e.Message);
+            //}
+            Assert.Throws<IndexOutOfRangeException>(() => rows.RemoveAt(-1));
+            //TODO
+            //try
+            //{
+            //    rows.RemoveAt(64);
+            //    Assert.False(true);
+            //}
+            //catch (Exception e)
+            //{
+            //    Assert.Equal(typeof(IndexOutOfRangeException), e.GetType());
+            //    // Never premise English.
+            //    //Assert.Equal ("There is no row at position 64.", e.Message);
+            //}
+            Assert.Throws<IndexOutOfRangeException>(() => rows.RemoveAt(64));
 
-            DataRow Row = new DataTable().NewRow();
-
-            try
-            {
-                Rows.Remove(Row);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(IndexOutOfRangeException), e.GetType());
-                // Never premise English.
-                //Assert.Equal ("The given datarow is not in the current DataRowCollection.", e.Message);
-            }
-
-            try
-            {
-                Rows.RemoveAt(-1);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(IndexOutOfRangeException), e.GetType());
-                // Never premise English.
-                //Assert.Equal ("There is no row at position -1.", e.Message);
-            }
-
-            try
-            {
-                Rows.RemoveAt(64);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(IndexOutOfRangeException), e.GetType());
-                // Never premise English.
-                //Assert.Equal ("There is no row at position 64.", e.Message);
-            }
-
-            Rows.RemoveAt(0);
-            Rows.RemoveAt(1);
-            Assert.Equal(1, Rows.Count);
-            Assert.Equal("c", Rows[0][0]);
+            rows.RemoveAt(0);
+            rows.RemoveAt(1);
+            Assert.Equal(1, rows.Count);
+            Assert.Equal("c", rows[0][0]);
         }
 
         [Fact]
@@ -897,14 +888,7 @@ namespace System.Data.Tests
             var columns = new DataColumn[] { column };
             dt.PrimaryKey = columns;
 
-            try
-            {
-                Assert.Null(dt.Rows.Find(new object[] { null }));
-            }
-            catch (IndexOutOfRangeException)
-            {
-                Assert.False(true);
-            }
+            Assert.Throws<IndexOutOfRangeException>(() => dt.Rows.Find(new object[] { null }));
         }
 
         [Fact]
@@ -917,14 +901,7 @@ namespace System.Data.Tests
             var columns = new DataColumn[] { column };
             dt.PrimaryKey = columns;
 
-            try
-            {
-                Assert.Null(dt.Rows.Find((object)null));
-            }
-            catch (IndexOutOfRangeException)
-            {
-                Assert.False(true);
-            }
+            Assert.Throws<IndexOutOfRangeException>(() => dt.Rows.Find((object)null));
         }
     }
 }

--- a/src/System.Data.Common/tests/System/Data/DataRowCollectionTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/DataRowCollectionTest2.cs
@@ -42,7 +42,7 @@ namespace System.Data.Tests
             int index = 0;
             foreach (DataRow dr in dt.Rows)
             {
-                Assert.Equal(dr, arr[index]);
+                Assert.Same(dr, arr[index]);
                 index++;
             }
         }
@@ -66,7 +66,7 @@ namespace System.Data.Tests
             int index = 0;
             while (myEnumerator.MoveNext())
             {
-                Assert.Equal(dt.Rows[index], (DataRow)myEnumerator.Current);
+                Assert.Same(dt.Rows[index], (DataRow)myEnumerator.Current);
                 index++;
             }
             Assert.Equal(index, dt.Rows.Count);
@@ -432,7 +432,7 @@ namespace System.Data.Tests
 
             foreach (DataRow dr in dt.Rows)
             {
-                Assert.Equal(dr, dt.Rows[index]);
+                Assert.Same(dr, dt.Rows[index]);
                 index++;
             }
         }

--- a/src/System.Data.Common/tests/System/Data/DataRowTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataRowTest.cs
@@ -147,17 +147,8 @@ namespace System.Data.Tests
             // Accept changes
             _table.AcceptChanges();
             Assert.Equal("Name 1", (_table.Rows[0])[1]);
-            //TODO: message
-            //try
-            //{
-            //    object o = rc[2];
-            //    Assert.False(true);
-            //}
-            //catch (Exception e)
-            //{
-            //    // Never premise English.
-            //    //Assert.Equal ("#A08", "There is no row at position 2.");
-            //}
+
+            // There is no row at position 2.
             Assert.Throws<IndexOutOfRangeException>(() => rc[2]);
         }
 

--- a/src/System.Data.Common/tests/System/Data/DataRowTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataRowTest.cs
@@ -180,14 +180,14 @@ namespace System.Data.Tests
             DataRow rowC;
 
             colC = new DataColumn();
-            colC.DataType = Type.GetType("System.Int32");
+            colC.DataType = typeof(int);
             colC.ColumnName = "Id";
             colC.AutoIncrement = true;
             tableC.Columns.Add(colC);
 
 
             colC = new DataColumn();
-            colC.DataType = Type.GetType("System.String");
+            colC.DataType = typeof(string);
             colC.ColumnName = "Name";
             tableC.Columns.Add(colC);
 
@@ -230,13 +230,13 @@ namespace System.Data.Tests
             DataRow rowC;
 
             colC = new DataColumn();
-            colC.DataType = Type.GetType("System.Int32");
+            colC.DataType = typeof(int);
             colC.ColumnName = "Id";
             colC.AutoIncrement = true;
             tableP.Columns.Add(colC);
 
             colC = new DataColumn();
-            colC.DataType = Type.GetType("System.Int32");
+            colC.DataType = typeof(int);
             colC.ColumnName = "Id";
             tableC.Columns.Add(colC);
 
@@ -275,13 +275,13 @@ namespace System.Data.Tests
             DataRow rowC;
 
             colC = new DataColumn();
-            colC.DataType = Type.GetType("System.Int32");
+            colC.DataType = typeof(int);
             colC.ColumnName = "Id";
             colC.AutoIncrement = true;
             tableC.Columns.Add(colC);
 
             colC = new DataColumn();
-            colC.DataType = Type.GetType("System.String");
+            colC.DataType = typeof(string);
             colC.ColumnName = "Name";
             tableC.Columns.Add(colC);
 
@@ -312,13 +312,13 @@ namespace System.Data.Tests
             DataRow rowC;
 
             colC = new DataColumn();
-            colC.DataType = Type.GetType("System.Int32");
+            colC.DataType = typeof(System.Int32);
             colC.ColumnName = "Id";
             colC.AutoIncrement = true;
             tableP.Columns.Add(colC);
 
             colC = new DataColumn();
-            colC.DataType = Type.GetType("System.Int32");
+            colC.DataType = typeof(System.Int32);
             colC.ColumnName = "Id";
             tableC.Columns.Add(colC);
 

--- a/src/System.Data.Common/tests/System/Data/DataRowTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataRowTest.cs
@@ -54,20 +54,20 @@ namespace System.Data.Tests
             DataColumn idColumn = new DataColumn();
 
 
-            idColumn.DataType = Type.GetType("System.Int32");
+            idColumn.DataType = typeof(int);
             idColumn.ColumnName = "Id";
             idColumn.AutoIncrement = true;
             namesTable.Columns.Add(idColumn);
 
 
             DataColumn fNameColumn = new DataColumn();
-            fNameColumn.DataType = Type.GetType("System.String");
+            fNameColumn.DataType = typeof(string);
             fNameColumn.ColumnName = "Fname";
             fNameColumn.DefaultValue = "Fname";
             namesTable.Columns.Add(fNameColumn);
 
             DataColumn lNameColumn = new DataColumn();
-            lNameColumn.DataType = Type.GetType("System.String");
+            lNameColumn.DataType = typeof(string);
             lNameColumn.ColumnName = "LName";
             lNameColumn.DefaultValue = "LName";
             namesTable.Columns.Add(lNameColumn);
@@ -108,7 +108,7 @@ namespace System.Data.Tests
 
                 for (int i = 0; i < colArr.Length; i++)
                 {
-                    Assert.Equal(_table.Columns[1], colArr[i]);
+                    Assert.Same(_table.Columns[1], colArr[i]);
                 }
                 _row.ClearErrors();
             }
@@ -119,7 +119,6 @@ namespace System.Data.Tests
         {
             DataRow newRow;
 
-
             for (int i = 1; i <= 2; i++)
             {
                 newRow = _table.NewRow();
@@ -128,13 +127,10 @@ namespace System.Data.Tests
                 _table.Rows.Add(newRow);
             }
             _table.AcceptChanges();
-
-            int cnt = 1;
             for (int i = 1; i < _table.Rows.Count; i++)
             {
                 DataRow r = _table.Rows[i];
-                Assert.Equal("Name " + cnt, r["fName"]);
-                cnt++;
+                Assert.Equal("Name " + i, r["fName"]);
             }
 
 
@@ -151,16 +147,18 @@ namespace System.Data.Tests
             // Accept changes
             _table.AcceptChanges();
             Assert.Equal("Name 1", (_table.Rows[0])[1]);
-            try
-            {
-                object o = rc[2];
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                // Never premise English.
-                //Assert.Equal ("#A08", "There is no row at position 2.");
-            }
+            //TODO: message
+            //try
+            //{
+            //    object o = rc[2];
+            //    Assert.False(true);
+            //}
+            //catch (Exception e)
+            //{
+            //    // Never premise English.
+            //    //Assert.Equal ("#A08", "There is no row at position 2.");
+            //}
+            Assert.Throws<IndexOutOfRangeException>(() => rc[2]);
         }
 
         [Fact]
@@ -255,19 +253,7 @@ namespace System.Data.Tests
             Assert.Equal(1, rows.Length);
             Assert.Equal(tableP.Rows[0], rows[0]);
 
-            try
-            {
-                rows = _row.GetParentRows(dr);
-            }
-            catch (InvalidConstraintException)
-            {
-                //Test done
-                return;
-            }
-            catch (Exception e)
-            {
-                Assert.False(true);
-            }
+            Assert.Throws<InvalidConstraintException>(() => _row.GetParentRows(dr));
         }
 
         [Fact]
@@ -349,19 +335,7 @@ namespace System.Data.Tests
             Assert.Equal(1, rows.Length);
             Assert.Equal(tableC.Rows[0], rows[0]);
 
-            try
-            {
-                rows = rowC.GetChildRows(dr);
-            }
-            catch (InvalidConstraintException)
-            {
-                //Test done
-                return;
-            }
-            catch (Exception e)
-            {
-                Assert.False(true);
-            }
+            Assert.Throws<InvalidConstraintException>(() => rowC.GetChildRows(dr));
         }
 
         // tests item at row, column in table to be DBNull.Value
@@ -410,14 +384,7 @@ namespace System.Data.Tests
 
             DataRow row = table.NewRow();
 
-            try
-            {
-                row.ItemArray = obj;
-            }
-            catch (Exception e1)
-            {
-                Assert.False(true);
-            }
+            row.ItemArray = obj;
 
             table.Rows.Add(row);
 
@@ -430,14 +397,7 @@ namespace System.Data.Tests
 
             row = table.NewRow();
 
-            try
-            {
-                row.ItemArray = obj;
-            }
-            catch (Exception e2)
-            {
-                Assert.False(true);
-            }
+            row.ItemArray = obj;
 
             table.Rows.Add(row);
 
@@ -450,14 +410,7 @@ namespace System.Data.Tests
 
             row = table.NewRow();
 
-            try
-            {
-                row.ItemArray = obj;
-            }
-            catch (Exception e3)
-            {
-                Assert.False(true);
-            }
+            row.ItemArray = obj;
 
             table.Rows.Add(row);
 
@@ -474,14 +427,7 @@ namespace System.Data.Tests
 
             row = table.NewRow();
 
-            try
-            {
-                row.ItemArray = obj;
-            }
-            catch (Exception e3)
-            {
-                Assert.False(true);
-            }
+            row.ItemArray = obj;
 
             table.Rows.Add(row);
 
@@ -529,14 +475,7 @@ namespace System.Data.Tests
 
             DataRow row = table.NewRow();
 
-            try
-            {
-                row.ItemArray = obj;
-            }
-            catch (Exception e1)
-            {
-                Assert.False(true);
-            }
+            row.ItemArray = obj;
 
             table.Rows.Add(row);
 
@@ -548,14 +487,7 @@ namespace System.Data.Tests
 
             row = table.NewRow();
 
-            try
-            {
-                row.ItemArray = obj;
-            }
-            catch (Exception e2)
-            {
-                Assert.False(true);
-            }
+            row.ItemArray = obj;
 
             table.Rows.Add(row);
 
@@ -568,14 +500,7 @@ namespace System.Data.Tests
 
             row = table.NewRow();
 
-            try
-            {
-                row.ItemArray = obj;
-            }
-            catch (Exception e3)
-            {
-                Assert.False(true);
-            }
+            row.ItemArray = obj;
 
             table.Rows.Add(row);
 
@@ -590,14 +515,7 @@ namespace System.Data.Tests
 
             row = table.NewRow();
 
-            try
-            {
-                row.ItemArray = obj;
-            }
-            catch (Exception e3)
-            {
-                Assert.False(true);
-            }
+            row.ItemArray = obj;
 
             table.Rows.Add(row);
 
@@ -623,7 +541,6 @@ namespace System.Data.Tests
         public void AutoIncrementInItemArray()
         {
             string zero = "zero";
-            string num = "num";
 
             DataTable table = new DataTable();
             table.Columns.Add(new DataColumn(zero, typeof(string)));
@@ -642,14 +559,7 @@ namespace System.Data.Tests
 
             DataRow row = table.NewRow();
 
-            try
-            {
-                row.ItemArray = obj;
-            }
-            catch (Exception e1)
-            {
-                Assert.False(true);
-            }
+            row.ItemArray = obj;
 
             table.Rows.Add(row);
 
@@ -661,14 +571,7 @@ namespace System.Data.Tests
 
             row = table.NewRow();
 
-            try
-            {
-                row.ItemArray = obj;
-            }
-            catch (Exception e2)
-            {
-                Assert.False(true);
-            }
+            row.ItemArray = obj;
 
             table.Rows.Add(row);
 
@@ -680,14 +583,7 @@ namespace System.Data.Tests
 
             row = table.NewRow();
 
-            try
-            {
-                row.ItemArray = obj;
-            }
-            catch (Exception e2)
-            {
-                Assert.False(true);
-            }
+            row.ItemArray = obj;
 
             table.Rows.Add(row);
 
@@ -699,14 +595,7 @@ namespace System.Data.Tests
 
             row = table.NewRow();
 
-            try
-            {
-                row.ItemArray = obj;
-            }
-            catch (Exception e2)
-            {
-                Assert.False(true);
-            }
+            row.ItemArray = obj;
 
             table.Rows.Add(row);
 
@@ -720,14 +609,7 @@ namespace System.Data.Tests
 
             row = table.NewRow();
 
-            try
-            {
-                row.ItemArray = obj;
-            }
-            catch (Exception e3)
-            {
-                Assert.False(true);
-            }
+            row.ItemArray = obj;
 
             table.Rows.Add(row);
 
@@ -739,20 +621,12 @@ namespace System.Data.Tests
 
             row = table.NewRow();
 
-            try
-            {
-                row.ItemArray = obj;
-            }
-            catch (Exception e2)
-            {
-                Assert.False(true);
-            }
+            row.ItemArray = obj;
 
             table.Rows.Add(row);
 
             // -- object array smaller than number of columns -----
             string abc = "abc";
-            string def = "def";
             obj = new object[2];
             obj[0] = abc;
             // results:
@@ -761,14 +635,7 @@ namespace System.Data.Tests
 
             row = table.NewRow();
 
-            try
-            {
-                row.ItemArray = obj;
-            }
-            catch (Exception e3)
-            {
-                Assert.False(true);
-            }
+            row.ItemArray = obj;
 
             table.Rows.Add(row);
 
@@ -825,9 +692,9 @@ namespace System.Data.Tests
             parent.Columns.Add("id", typeof(int));
             DataTable child = ds.Tables.Add("child");
             child.Columns.Add("idref", typeof(int));
-            Constraint uniqueId = null;
-            parent.Constraints.Add(uniqueId = new UniqueConstraint("uniqueId",
-                                  new DataColumn[] { parent.Columns["id"] }, true));
+            Constraint uniqueId = new UniqueConstraint("uniqueId",
+                                  new DataColumn[] { parent.Columns["id"] }, true);
+            parent.Constraints.Add(uniqueId);
             ForeignKeyConstraint fkc = new ForeignKeyConstraint("ParentChildConstraint", new DataColumn[] { parent.Columns["id"] },
                       new DataColumn[] { child.Columns["idref"] });
 
@@ -897,7 +764,7 @@ namespace System.Data.Tests
             var parent2Column1 = parent2.Columns.Add("column1");
             var parent2Column2 = parent2.Columns.Add("column2");
 
-            var relation1 = ds.Relations.Add("parent1-child", parent1Column1, childColumn1);
+            ds.Relations.Add("parent1-child", parent1Column1, childColumn1);
             ds.Relations.Add("parent2-child", parent2Column2, childColumn2);
 
             var childRow1 = child.NewRow();
@@ -969,14 +836,7 @@ namespace System.Data.Tests
             Assert.Equal(DBNull.Value, childRow1[childColumn1]);
             Assert.Equal(DBNull.Value, childRow1[childColumn2]);
 
-            try
-            {
-                childRow1.SetParentRow(parent1Row, relation2);
-                Assert.False(true);
-            }
-            catch (InvalidConstraintException e)
-            {
-            }
+            Assert.Throws<InvalidConstraintException>(() => childRow1.SetParentRow(parent1Row, relation2));
             Assert.Equal(DBNull.Value, childRow1[childColumn1]);
             Assert.Equal(DBNull.Value, childRow1[childColumn2]);
 

--- a/src/System.Data.Common/tests/System/Data/DataRowTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/DataRowTest2.cs
@@ -710,18 +710,6 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public new void GetType()
-        {
-            Type myType;
-            DataTable dt = new DataTable();
-            DataRow dr = dt.NewRow();
-            myType = typeof(DataRow);
-
-            // GetType
-            Assert.Equal(typeof(DataRow), myType);
-        }
-
-        [Fact]
         public void HasErrors()
         {
             DataTable dt = new DataTable("myTable");
@@ -1805,13 +1793,13 @@ namespace System.Data.Tests
             dt.Rows.Add(new object[] { addressA, personA });
             DataRow dr = dt.Rows[0];
 
-            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => dr[dc0, (DataRowVersion)666]);
+            DataException ex = Assert.Throws<DataException>(() => dr[dc0, (DataRowVersion)666]);
             Assert.Null(ex.InnerException);
             Assert.NotNull(ex.Message);
-            Assert.Contains(ex.Message, "Original");
-            Assert.Contains(ex.Message, "Current");
-            Assert.Contains(ex.Message, "Proposed");
-            Assert.DoesNotContain(ex.Message, "Default");
+            Assert.Contains("Original", ex.Message);
+            Assert.Contains("Current", ex.Message);
+            Assert.Contains("Proposed", ex.Message);
+            Assert.DoesNotContain("Default", ex.Message);
         }
 
         [Fact] // Object this [DataColumn, DataRowVersion]
@@ -1833,13 +1821,13 @@ namespace System.Data.Tests
             // There is no Original data to access
             Assert.Null(ex1.InnerException);
             Assert.NotNull(ex1.Message);
-            Assert.Contains(ex1.Message, "Original");
+            Assert.Contains("Original", ex1.Message);
 
             VersionNotFoundException ex2 = Assert.Throws<VersionNotFoundException>(() => dr[dc0, DataRowVersion.Proposed]);
             // There is no Proposed data to access
             Assert.Null(ex2.InnerException);
             Assert.NotNull(ex2.Message);
-            Assert.Contains(ex2.Message, "Proposed");
+            Assert.Contains("Proposed", ex2.Message);
         }
 
         [Fact]
@@ -1947,7 +1935,7 @@ namespace System.Data.Tests
 
             foreach (DataRow row in ds.Tables[0].Rows)
             {
-                Assert.True(row.IsNull("ValueListValueMember"));
+                Assert.False(row.IsNull("ValueListValueMember"));
             }
         }
 
@@ -2630,11 +2618,6 @@ namespace System.Data.Tests
             DataTable table = new DataTable();
 
             DataRow row = table.NewRow();
-            try
-            {
-                row.SetModified();
-            }
-            catch (InvalidOperationException) { }
             Assert.Throws<InvalidOperationException>(() => row.SetModified());
 
             table.Columns.Add("col1", typeof(int));

--- a/src/System.Data.Common/tests/System/Data/DataRowTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/DataRowTest2.cs
@@ -1613,84 +1613,84 @@ namespace System.Data.Tests
             dr = dt.Rows[0];
             Assert.Equal(addressA, dr[dc0, DataRowVersion.Current]);
             Assert.Equal(addressA, dr[dc0, DataRowVersion.Default]);
-            Assert.True(AssertNotFound(dr, dc0, DataRowVersion.Original));
-            Assert.True(AssertNotFound(dr, dc0, DataRowVersion.Proposed));
+            AssertNotFound(dr, dc0, DataRowVersion.Original);
+            AssertNotFound(dr, dc0, DataRowVersion.Proposed);
             Assert.Same(personA, dr[dc1, DataRowVersion.Current]);
             Assert.Same(personA, dr[dc1, DataRowVersion.Default]);
-            Assert.True(AssertNotFound(dr, dc1, DataRowVersion.Original));
-            Assert.True(AssertNotFound(dr, dc1, DataRowVersion.Proposed));
+            AssertNotFound(dr, dc1, DataRowVersion.Original);
+            AssertNotFound(dr, dc1, DataRowVersion.Proposed);
 
             dr = dt.Rows[1];
             Assert.Equal(addressB, dr[dc0, DataRowVersion.Current]);
             Assert.Equal(addressB, dr[dc0, DataRowVersion.Default]);
-            Assert.True(AssertNotFound(dr, dc0, DataRowVersion.Original));
-            Assert.True(AssertNotFound(dr, dc0, DataRowVersion.Proposed));
+            AssertNotFound(dr, dc0, DataRowVersion.Original);
+            AssertNotFound(dr, dc0, DataRowVersion.Proposed);
             Assert.Same(personB, dr[dc1, DataRowVersion.Current]);
             Assert.Same(personB, dr[dc1, DataRowVersion.Default]);
-            Assert.True(AssertNotFound(dr, dc1, DataRowVersion.Original));
-            Assert.True(AssertNotFound(dr, dc1, DataRowVersion.Proposed));
+            AssertNotFound(dr, dc1, DataRowVersion.Original);
+            AssertNotFound(dr, dc1, DataRowVersion.Proposed);
 
             dr = dt.Rows[0];
             dr[dc0] = addressC;
             Assert.Equal(addressC, dr[dc0, DataRowVersion.Current]);
             Assert.Equal(addressC, dr[dc0, DataRowVersion.Default]);
-            Assert.True(AssertNotFound(dr, dc0, DataRowVersion.Original));
-            Assert.True(AssertNotFound(dr, dc0, DataRowVersion.Proposed));
+            AssertNotFound(dr, dc0, DataRowVersion.Original);
+            AssertNotFound(dr, dc0, DataRowVersion.Proposed);
             Assert.Same(personA, dr[dc1, DataRowVersion.Current]);
             Assert.Same(personA, dr[dc1, DataRowVersion.Default]);
-            Assert.True(AssertNotFound(dr, dc1, DataRowVersion.Original));
-            Assert.True(AssertNotFound(dr, dc1, DataRowVersion.Proposed));
+            AssertNotFound(dr, dc1, DataRowVersion.Original);
+            AssertNotFound(dr, dc1, DataRowVersion.Proposed);
 
             dr = dt.Rows[1];
             dr.BeginEdit();
             dr[dc1] = personC;
             Assert.Equal(addressB, dr[dc0, DataRowVersion.Current]);
             Assert.Equal(addressB, dr[dc0, DataRowVersion.Default]);
-            Assert.True(AssertNotFound(dr, dc0, DataRowVersion.Original));
+            AssertNotFound(dr, dc0, DataRowVersion.Original);
             Assert.Equal(addressB, dr[dc0, DataRowVersion.Proposed]);
             Assert.Same(personB, dr[dc1, DataRowVersion.Current]);
             Assert.Same(personC, dr[dc1, DataRowVersion.Default]);
-            Assert.True(AssertNotFound(dr, dc1, DataRowVersion.Original));
+            AssertNotFound(dr, dc1, DataRowVersion.Original);
             Assert.Same(personC, dr[dc1, DataRowVersion.Proposed]);
             dr.EndEdit();
             Assert.Equal(addressB, dr[dc0, DataRowVersion.Current]);
             Assert.Equal(addressB, dr[dc0, DataRowVersion.Default]);
-            Assert.True(AssertNotFound(dr, dc0, DataRowVersion.Original));
-            Assert.True(AssertNotFound(dr, dc0, DataRowVersion.Proposed));
+            AssertNotFound(dr, dc0, DataRowVersion.Original);
+            AssertNotFound(dr, dc0, DataRowVersion.Proposed);
             Assert.Same(personC, dr[dc1, DataRowVersion.Current]);
             Assert.Same(personC, dr[dc1, DataRowVersion.Default]);
-            Assert.True(AssertNotFound(dr, dc1, DataRowVersion.Original));
-            Assert.True(AssertNotFound(dr, dc1, DataRowVersion.Proposed));
+            AssertNotFound(dr, dc1, DataRowVersion.Original);
+            AssertNotFound(dr, dc1, DataRowVersion.Proposed);
             dr.AcceptChanges();
             Assert.Equal(addressB, dr[dc0, DataRowVersion.Current]);
             Assert.Equal(addressB, dr[dc0, DataRowVersion.Default]);
             Assert.Equal(addressB, dr[dc0, DataRowVersion.Original]);
-            Assert.True(AssertNotFound(dr, dc0, DataRowVersion.Proposed));
+            AssertNotFound(dr, dc0, DataRowVersion.Proposed);
             Assert.Same(personC, dr[dc1, DataRowVersion.Current]);
             Assert.Same(personC, dr[dc1, DataRowVersion.Default]);
             Assert.Equal(personC, dr[dc1, DataRowVersion.Original]);
-            Assert.True(AssertNotFound(dr, dc1, DataRowVersion.Proposed));
+            AssertNotFound(dr, dc1, DataRowVersion.Proposed);
 
             dr = dt.Rows[0];
             dr.BeginEdit();
             dr[dc0] = addressA;
             Assert.Equal(addressC, dr[dc0, DataRowVersion.Current]);
             Assert.Equal(addressA, dr[dc0, DataRowVersion.Default]);
-            Assert.True(AssertNotFound(dr, dc0, DataRowVersion.Original));
+            AssertNotFound(dr, dc0, DataRowVersion.Original);
             Assert.Equal(addressA, dr[dc0, DataRowVersion.Proposed]);
             Assert.Same(personA, dr[dc1, DataRowVersion.Current]);
             Assert.Same(personA, dr[dc1, DataRowVersion.Default]);
-            Assert.True(AssertNotFound(dr, dc1, DataRowVersion.Original));
+            AssertNotFound(dr, dc1, DataRowVersion.Original);
             Assert.Same(personA, dr[dc1, DataRowVersion.Proposed]);
             dr.CancelEdit();
             Assert.Equal(addressC, dr[dc0, DataRowVersion.Current]);
             Assert.Equal(addressC, dr[dc0, DataRowVersion.Default]);
-            Assert.True(AssertNotFound(dr, dc0, DataRowVersion.Original));
-            Assert.True(AssertNotFound(dr, dc0, DataRowVersion.Proposed));
+            AssertNotFound(dr, dc0, DataRowVersion.Original);
+            AssertNotFound(dr, dc0, DataRowVersion.Proposed);
             Assert.Same(personA, dr[dc1, DataRowVersion.Current]);
             Assert.Same(personA, dr[dc1, DataRowVersion.Default]);
-            Assert.True(AssertNotFound(dr, dc1, DataRowVersion.Original));
-            Assert.True(AssertNotFound(dr, dc1, DataRowVersion.Proposed));
+            AssertNotFound(dr, dc1, DataRowVersion.Original);
+            AssertNotFound(dr, dc1, DataRowVersion.Proposed);
         }
 
         [Fact]
@@ -2702,17 +2702,9 @@ namespace System.Data.Tests
             public EventArgs Args { get; }
         }
 
-        private static bool AssertNotFound(DataRow rc, DataColumn dc, DataRowVersion version)
+        private static void AssertNotFound(DataRow rc, DataColumn dc, DataRowVersion version)
         {
-            try
-            {
-                _ = rc[dc, version];
-                return false;
-            }
-            catch (VersionNotFoundException)
-            {
-                return true;
-            }
+            Assert.Throws<VersionNotFoundException>(() => rc[dc, version]);
         }
 
         private class Person

--- a/src/System.Data.Common/tests/System/Data/DataRowTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/DataRowTest2.cs
@@ -700,15 +700,6 @@ namespace System.Data.Tests
             */
         }
 
-        //TODO: Unused?
-        private void CheckRowVersion(DataRow dr)
-        {
-            if (dr.HasVersion(DataRowVersion.Current)) Console.WriteLine("Has " + DataRowVersion.Current.ToString());
-            if (dr.HasVersion(DataRowVersion.Default)) Console.WriteLine("Has " + DataRowVersion.Default.ToString());
-            if (dr.HasVersion(DataRowVersion.Original)) Console.WriteLine("Has " + DataRowVersion.Original.ToString());
-            if (dr.HasVersion(DataRowVersion.Proposed)) Console.WriteLine("Has " + DataRowVersion.Proposed.ToString());
-        }
-
         [Fact]
         public void HasErrors()
         {
@@ -2016,15 +2007,16 @@ namespace System.Data.Tests
 
             //  testMore();
         }
-        //TODO: why is this disabled?
-        /*public void testMore()
+
+        [Fact]
+        public void TestMore()
         {
             DataTable dt = DataProvider.CreateParentDataTable();
             dt.Rows[0].BeginEdit();
             dt.Rows[0][0] = 10;
             dt.Rows[0].EndEdit();
             dt.AcceptChanges();
-        }*/
+        }
 
         [Fact]
         public void RejectChanges()
@@ -2184,7 +2176,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public void testMore()
+        public void TestMore2()
         {
             DataSet ds = DataProvider.CreateForeignConstraint();
             DataRow drParent = ds.Tables[0].Rows[0];
@@ -2193,7 +2185,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public void test()
+        public void Test()
         {
             // test SetParentRow
             DataTable parent = DataProvider.CreateParentDataTable();
@@ -2626,33 +2618,11 @@ namespace System.Data.Tests
 
             row = table.Rows.Add(new object[] { 1, 2, 3 });
             Assert.Equal(DataRowState.Added, row.RowState);
-            //TODO: messages
-            //try
-            //{
-            //    row.SetModified();
-            //    Assert.False(true);
-            //}
-            //catch (InvalidOperationException e)
-            //{
-            //    // Never premise English.
-            //    //Assert.Equal (SetAddedModified_ErrMsg, e.Message);
-            //}
             Assert.Throws<InvalidOperationException>(() => row.SetModified());
 
             row.AcceptChanges();
             row[0] = 10;
             Assert.Equal(DataRowState.Modified, row.RowState);
-            //TODO
-            //try
-            //{
-            //    row.SetModified();
-            //    Assert.False(true);
-            //}
-            //catch (InvalidOperationException e)
-            //{
-            //    // Never premise English.
-            //    //Assert.Equal (SetAddedModified_ErrMsg, e.Message);
-            //}
             Assert.Throws<InvalidOperationException>(() => row.SetModified());
 
             row.AcceptChanges();

--- a/src/System.Data.Common/tests/System/Data/DataRowTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/DataRowTest2.cs
@@ -23,11 +23,10 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-using System.Collections;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Text.RegularExpressions;
-
 
 using Xunit;
 
@@ -36,13 +35,7 @@ namespace System.Data.Tests
     public class DataRowTest2
     {
         private bool _rowChanged;
-        private ArrayList _eventsFired;
-
-        public DataRowTest2()
-        {
-            _rowChanged = false;
-            _eventsFired = new ArrayList();
-        }
+        private List<EventInfo> _eventsFired = new List<EventInfo>();
 
         [Fact]
         public void AcceptChanges()
@@ -75,7 +68,7 @@ namespace System.Data.Tests
             myRow.CancelEdit();
 
             // DataRow CancelEdit
-            Assert.True((int)myRow[0] == 1);
+            Assert.Equal(1, (int)myRow[0]);
         }
 
         [Fact]
@@ -707,6 +700,7 @@ namespace System.Data.Tests
             */
         }
 
+        //TODO: Unused?
         private void CheckRowVersion(DataRow dr)
         {
             if (dr.HasVersion(DataRowVersion.Current)) Console.WriteLine("Has " + DataRowVersion.Current.ToString());
@@ -966,42 +960,42 @@ namespace System.Data.Tests
             Assert.Equal(addressC, dr[dc0]);
             Assert.Same(personA, dr[dc1]);
 
-            evt = (EventInfo)_eventsFired[0];
+            evt = _eventsFired[0];
             Assert.Equal("ColumnChanging", evt.Name);
             colChangeArgs = (DataColumnChangeEventArgs)evt.Args;
             Assert.Same(dc0, colChangeArgs.Column);
             Assert.Equal(addressC, colChangeArgs.ProposedValue);
             Assert.Same(dt.Rows[0], colChangeArgs.Row);
 
-            evt = (EventInfo)_eventsFired[1];
+            evt = _eventsFired[1];
             Assert.Equal("ColumnChanged", evt.Name);
             colChangeArgs = (DataColumnChangeEventArgs)evt.Args;
             Assert.Same(dc0, colChangeArgs.Column);
             Assert.Equal(addressC, colChangeArgs.ProposedValue);
             Assert.Same(dt.Rows[0], colChangeArgs.Row);
 
-            evt = (EventInfo)_eventsFired[2];
+            evt = _eventsFired[2];
             Assert.Equal("ColumnChanging", evt.Name);
             colChangeArgs = (DataColumnChangeEventArgs)evt.Args;
             Assert.Same(dc1, colChangeArgs.Column);
             Assert.Equal(personC, colChangeArgs.ProposedValue);
             Assert.Same(dt.Rows[1], colChangeArgs.Row);
 
-            evt = (EventInfo)_eventsFired[3];
+            evt = _eventsFired[3];
             Assert.Equal("ColumnChanged", evt.Name);
             colChangeArgs = (DataColumnChangeEventArgs)evt.Args;
             Assert.Same(dc1, colChangeArgs.Column);
             Assert.Equal(personC, colChangeArgs.ProposedValue);
             Assert.Same(dt.Rows[1], colChangeArgs.Row);
 
-            evt = (EventInfo)_eventsFired[4];
+            evt = _eventsFired[4];
             Assert.Equal("ColumnChanging", evt.Name);
             colChangeArgs = (DataColumnChangeEventArgs)evt.Args;
             Assert.Same(dc0, colChangeArgs.Column);
             Assert.Equal(addressB, colChangeArgs.ProposedValue);
             Assert.Same(dt.Rows[0], colChangeArgs.Row);
 
-            evt = (EventInfo)_eventsFired[5];
+            evt = _eventsFired[5];
             Assert.Equal("ColumnChanged", evt.Name);
             colChangeArgs = (DataColumnChangeEventArgs)evt.Args;
             Assert.Same(dc0, colChangeArgs.Column);
@@ -1037,64 +1031,37 @@ namespace System.Data.Tests
             dtA.Rows.Add(new object[] { addressA, personA });
             DataRow dr = dtA.Rows[0];
 
-            try
-            {
-                object value = dr[dcB1];
-                Assert.False(true);
-            }
-            catch (ArgumentException ex)
-            {
-                // Column 'Col0' does not belong to table TableA
-                Assert.Equal(typeof(ArgumentException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
+            ArgumentException ex1 = Assert.Throws<ArgumentException>(() => dr[dcB1]);
+            // Column 'Col0' does not belong to table TableA
+            Assert.Null(ex1.InnerException);
+            Assert.NotNull(ex1.Message);
+            // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
+            // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
+            // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
+            Assert.Matches(@"[\p{Pi}\p{Po}]" + "Col0" + @"[\p{Pf}\p{Po}]", ex1.Message);
+            Assert.Matches(@"\b" + "TableA" + @"\b", ex1.Message);
 
-                // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
-                // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
-                // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
-                Assert.Matches(@"[\p{Pi}\p{Po}]" + "Col0" + @"[\p{Pf}\p{Po}]", ex.Message);
-                Assert.Matches(@"\b" + "TableA" + @"\b", ex.Message);
-            }
-
-            try
-            {
-                object value = dr[new DataColumn("ZZZ")];
-                Assert.False(true);
-            }
-            catch (ArgumentException ex)
-            {
-                // Column 'Col0' does not belong to table TableA
-                Assert.Equal(typeof(ArgumentException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-
-                // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
-                // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
-                // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
-                Assert.Matches(@"[\p{Pi}\p{Po}]" + "ZZZ" + @"[\p{Pf}\p{Po}]", ex.Message);
-                Assert.Matches(@"\b" + "TableA" + @"\b", ex.Message);
-            }
+            ArgumentException ex2 = Assert.Throws<ArgumentException>(() => dr[new DataColumn("ZZZ")]);
+            // Column 'Col0' does not belong to table TableA
+            Assert.Null(ex2.InnerException);
+            Assert.NotNull(ex2.Message);
+            // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
+            // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
+            // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
+            Assert.Matches(@"[\p{Pi}\p{Po}]" + "ZZZ" + @"[\p{Pf}\p{Po}]", ex2.Message);
+            Assert.Matches(@"\b" + "TableA" + @"\b", ex2.Message);
 
             dtA.Columns.Remove(dcA2);
 
-            try
-            {
-                object value = dr[dcA2];
-                Assert.False(true);
-            }
-            catch (ArgumentException ex)
-            {
-                // Column 'Col0' does not belong to table TableA
-                Assert.Equal(typeof(ArgumentException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-
-                // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
-                // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
-                // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
-                Assert.Matches(@"[\p{Pi}\p{Po}]" + "Col1" + @"[\p{Pf}\p{Po}]", ex.Message);
-                Assert.Matches(@"\b" + "TableA" + @"\b", ex.Message);
-            }
+            ArgumentException ex3 = Assert.Throws<ArgumentException>(() => dr[dcA2]);
+            // Column 'Col0' does not belong to table TableA
+            Assert.Null(ex3.InnerException);
+            Assert.NotNull(ex3.Message);
+            // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
+            // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
+            // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
+            Assert.Matches(@"[\p{Pi}\p{Po}]" + "Col1" + @"[\p{Pf}\p{Po}]", ex3.Message);
+            Assert.Matches(@"\b" + "TableA" + @"\b", ex3.Message);
         }
 
         [Fact] // Object this [DataColumn]
@@ -1118,31 +1085,15 @@ namespace System.Data.Tests
             dt.Rows.Add(new object[] { addressA, personA });
             DataRow dr = dt.Rows[0];
 
-            try
-            {
-                object value = dr[(DataColumn)null];
-                Assert.False(true);
-            }
-            catch (ArgumentNullException ex)
-            {
-                Assert.Equal(typeof(ArgumentNullException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.Equal("column", ex.ParamName);
-            }
+            ArgumentNullException ex1 = Assert.Throws<ArgumentNullException>(() => dr[(DataColumn)null]);
+            Assert.Null(ex1.InnerException);
+            Assert.NotNull(ex1.Message);
+            Assert.Equal("column", ex1.ParamName);
 
-            try
-            {
-                dr[(DataColumn)null] = personB;
-                Assert.False(true);
-            }
-            catch (ArgumentNullException ex)
-            {
-                Assert.Equal(typeof(ArgumentNullException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.Equal("column", ex.ParamName);
-            }
+            ArgumentNullException ex2 = Assert.Throws<ArgumentNullException>(() => dr[(DataColumn)null] = personB);
+            Assert.Null(ex2.InnerException);
+            Assert.NotNull(ex2.Message);
+            Assert.Equal("column", ex2.ParamName);
 
             Assert.Equal(0, _eventsFired.Count);
         }
@@ -1177,25 +1128,17 @@ namespace System.Data.Tests
 
             DataRow dr = dt.Rows[0];
 
-            try
-            {
-                dr[dc0] = null;
-                Assert.False(true);
-            }
-            catch (ArgumentException ex)
-            {
-                // Cannot set Column 'Col0' to be null.
-                // Please use DBNull instead
-                Assert.Equal(typeof(ArgumentException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
+            ArgumentException ex = Assert.Throws<ArgumentException>(() => dr[dc0] = null);
+            // Cannot set Column 'Col0' to be null.
+            // Please use DBNull instead
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+            // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
+            // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
+            // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
+            Assert.Matches(@"[\p{Pi}\p{Po}]" + "Col0" + @"[\p{Pf}\p{Po}]", ex.Message);
+            Assert.Matches(@"\b" + "DBNull" + @"\b", ex.Message);
 
-                // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
-                // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
-                // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
-                Assert.Matches(@"[\p{Pi}\p{Po}]" + "Col0" + @"[\p{Pf}\p{Po}]", ex.Message);
-                Assert.Matches(@"\b" + "DBNull" + @"\b", ex.Message);
-            }
 
             Assert.Equal(1, _eventsFired.Count);
             Assert.Equal(addressA, dr[dc0]);
@@ -1265,14 +1208,14 @@ namespace System.Data.Tests
 
             int index = 0;
 
-            evt = (EventInfo)_eventsFired[index++];
+            evt = _eventsFired[index++];
             Assert.Equal("ColumnChanging", evt.Name);
             colChangeArgs = (DataColumnChangeEventArgs)evt.Args;
             Assert.Same(dc0, colChangeArgs.Column);
             Assert.Null(colChangeArgs.ProposedValue);
             Assert.Same(dt.Rows[0], colChangeArgs.Row);
 
-            evt = (EventInfo)_eventsFired[index++];
+            evt = _eventsFired[index++];
             Assert.Equal("ColumnChanging", evt.Name);
             colChangeArgs = (DataColumnChangeEventArgs)evt.Args;
             Assert.Same(dc1, colChangeArgs.Column);
@@ -1280,77 +1223,77 @@ namespace System.Data.Tests
             Assert.Same(dt.Rows[0], colChangeArgs.Row);
 
 
-            evt = (EventInfo)_eventsFired[index++];
+            evt = _eventsFired[index++];
             Assert.Equal("ColumnChanged", evt.Name);
             colChangeArgs = (DataColumnChangeEventArgs)evt.Args;
             Assert.Same(dc1, colChangeArgs.Column);
             Assert.Null(colChangeArgs.ProposedValue);
             Assert.Same(dt.Rows[0], colChangeArgs.Row);
 
-            evt = (EventInfo)_eventsFired[index++];
+            evt = _eventsFired[index++];
             Assert.Equal("ColumnChanging", evt.Name);
             colChangeArgs = (DataColumnChangeEventArgs)evt.Args;
             Assert.Same(dc0, colChangeArgs.Column);
             Assert.Same(DBNull.Value, colChangeArgs.ProposedValue);
             Assert.Same(dt.Rows[0], colChangeArgs.Row);
 
-            evt = (EventInfo)_eventsFired[index++];
+            evt = _eventsFired[index++];
             Assert.Equal("ColumnChanged", evt.Name);
             colChangeArgs = (DataColumnChangeEventArgs)evt.Args;
             Assert.Same(dc0, colChangeArgs.Column);
             Assert.Same(DBNull.Value, colChangeArgs.ProposedValue);
             Assert.Same(dt.Rows[0], colChangeArgs.Row);
 
-            evt = (EventInfo)_eventsFired[index++];
+            evt = _eventsFired[index++];
             Assert.Equal("ColumnChanging", evt.Name);
             colChangeArgs = (DataColumnChangeEventArgs)evt.Args;
             Assert.Same(dc1, colChangeArgs.Column);
             Assert.Same(personC, colChangeArgs.ProposedValue);
             Assert.Same(dt.Rows[0], colChangeArgs.Row);
 
-            evt = (EventInfo)_eventsFired[index++];
+            evt = _eventsFired[index++];
             Assert.Equal("ColumnChanged", evt.Name);
             colChangeArgs = (DataColumnChangeEventArgs)evt.Args;
             Assert.Same(dc1, colChangeArgs.Column);
             Assert.Same(personC, colChangeArgs.ProposedValue);
             Assert.Same(dt.Rows[0], colChangeArgs.Row);
 
-            evt = (EventInfo)_eventsFired[index++];
+            evt = _eventsFired[index++];
             Assert.Equal("ColumnChanging", evt.Name);
             colChangeArgs = (DataColumnChangeEventArgs)evt.Args;
             Assert.Same(dc1, colChangeArgs.Column);
             Assert.Same(DBNull.Value, colChangeArgs.ProposedValue);
             Assert.Same(dt.Rows[0], colChangeArgs.Row);
 
-            evt = (EventInfo)_eventsFired[index++];
+            evt = _eventsFired[index++];
             Assert.Equal("ColumnChanged", evt.Name);
             colChangeArgs = (DataColumnChangeEventArgs)evt.Args;
             Assert.Same(dc1, colChangeArgs.Column);
             Assert.Same(DBNull.Value, colChangeArgs.ProposedValue);
             Assert.Same(dt.Rows[0], colChangeArgs.Row);
 
-            evt = (EventInfo)_eventsFired[index++];
+            evt = _eventsFired[index++];
             Assert.Equal("ColumnChanging", evt.Name);
             colChangeArgs = (DataColumnChangeEventArgs)evt.Args;
             Assert.Same(dc2, colChangeArgs.Column);
             Assert.Null(colChangeArgs.ProposedValue);
             Assert.Same(dt.Rows[0], colChangeArgs.Row);
 
-            evt = (EventInfo)_eventsFired[index++];
+            evt = _eventsFired[index++];
             Assert.Equal("ColumnChanged", evt.Name);
             colChangeArgs = (DataColumnChangeEventArgs)evt.Args;
             Assert.Same(dc2, colChangeArgs.Column);
             Assert.Null(colChangeArgs.ProposedValue);
             Assert.Same(dt.Rows[0], colChangeArgs.Row);
 
-            evt = (EventInfo)_eventsFired[index++];
+            evt = _eventsFired[index++];
             Assert.Equal("ColumnChanging", evt.Name);
             colChangeArgs = (DataColumnChangeEventArgs)evt.Args;
             Assert.Same(dc2, colChangeArgs.Column);
             Assert.Same(DBNull.Value, colChangeArgs.ProposedValue);
             Assert.Same(dt.Rows[0], colChangeArgs.Row);
 
-            evt = (EventInfo)_eventsFired[index++];
+            evt = _eventsFired[index++];
             Assert.Equal("ColumnChanged", evt.Name);
             colChangeArgs = (DataColumnChangeEventArgs)evt.Args;
             Assert.Same(dc2, colChangeArgs.Column);
@@ -1431,25 +1374,16 @@ namespace System.Data.Tests
 
             DataRow dr = dt.Rows[0];
 
-            try
-            {
-                dr[0] = null;
-                Assert.False(true);
-            }
-            catch (ArgumentException ex)
-            {
-                // Cannot set Column 'Col0' to be null.
-                // Please use DBNull instead
-                Assert.Equal(typeof(ArgumentException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-
-                // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
-                // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
-                // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
-                Assert.Matches(@"[\p{Pi}\p{Po}]" + "Col0" + @"[\p{Pf}\p{Po}]", ex.Message);
-                Assert.Matches(@"\b" + "DBNull" + @"\b", ex.Message);
-            }
+            ArgumentException ex = Assert.Throws<ArgumentException>(() => dr[0] = null);
+            // Cannot set Column 'Col0' to be null.
+            // Please use DBNull instead
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+            // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
+            // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
+            // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
+            Assert.Matches(@"[\p{Pi}\p{Po}]" + "Col0" + @"[\p{Pf}\p{Po}]", ex.Message);
+            Assert.Matches(@"\b" + "DBNull" + @"\b", ex.Message);
 
             Assert.Equal(addressA, dr[0]);
             Assert.False(dr.IsNull(0));
@@ -1559,47 +1493,27 @@ namespace System.Data.Tests
 
             DataRow dr = dt.Rows[0];
 
-            try
-            {
-                object value = dr[string.Empty];
-                Assert.False(true);
-            }
-            catch (ArgumentException ex)
-            {
-                //  Column '' does not belong to table Persons
-                Assert.Equal(typeof(ArgumentException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
+            ArgumentException ex1 = Assert.Throws<ArgumentException>(() => dr[string.Empty]);
+            //  Column '' does not belong to table Persons
+            Assert.Null(ex1.InnerException);
+            Assert.NotNull(ex1.Message);
+            // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
+            // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
+            // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
+            Assert.Matches(@"[\p{Pi}\p{Po}]" + "" + @"[\p{Pf}\p{Po}]", ex1.Message);
+            Assert.Matches(@"\b" + "Persons" + @"\b", ex1.Message);
+            Assert.Null(ex1.ParamName);
 
-                // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
-                // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
-                // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
-                Assert.Matches(@"[\p{Pi}\p{Po}]" + "" + @"[\p{Pf}\p{Po}]", ex.Message);
-                Assert.Matches(@"\b" + "Persons" + @"\b", ex.Message);
-
-                Assert.Null(ex.ParamName);
-            }
-
-            try
-            {
-                dr[string.Empty] = personB;
-                Assert.False(true);
-            }
-            catch (ArgumentException ex)
-            {
-                // Column '' does not belong to table Persons
-                Assert.Equal(typeof(ArgumentException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-
-                // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
-                // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
-                // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
-                Assert.Matches(@"[\p{Pi}\p{Po}]" + "" + @"[\p{Pf}\p{Po}]", ex.Message);
-                Assert.Matches(@"\b" + "Persons" + @"\b", ex.Message);
-
-                Assert.Null(ex.ParamName);
-            }
+            ArgumentException ex2 = Assert.Throws<ArgumentException>(() => dr[string.Empty] = personB);
+            // Column '' does not belong to table Persons
+            Assert.Null(ex2.InnerException);
+            Assert.NotNull(ex2.Message);
+            // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
+            // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
+            // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
+            Assert.Matches(@"[\p{Pi}\p{Po}]" + "" + @"[\p{Pf}\p{Po}]", ex2.Message);
+            Assert.Matches(@"\b" + "Persons" + @"\b", ex2.Message);
+            Assert.Null(ex2.ParamName);
         }
 
         [Fact] // Object this [String]
@@ -1619,31 +1533,15 @@ namespace System.Data.Tests
 
             DataRow dr = dt.Rows[0];
 
-            try
-            {
-                object value = dr[(string)null];
-                Assert.False(true);
-            }
-            catch (ArgumentNullException ex)
-            {
-                Assert.Equal(typeof(ArgumentNullException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.Equal("name", ex.ParamName);
-            }
+            ArgumentNullException ex1 = Assert.Throws<ArgumentNullException>(() => dr[(string)null]);
+            Assert.Null(ex1.InnerException);
+            Assert.NotNull(ex1.Message);
+            Assert.Equal("name", ex1.ParamName);
 
-            try
-            {
-                dr[(string)null] = personB;
-                Assert.False(true);
-            }
-            catch (ArgumentNullException ex)
-            {
-                Assert.Equal(typeof(ArgumentNullException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.Equal("name", ex.ParamName);
-            }
+            ArgumentNullException ex2 = Assert.Throws<ArgumentNullException>(() => dr[(string)null] = personB);
+            Assert.Null(ex2.InnerException);
+            Assert.NotNull(ex2.Message);
+            Assert.Equal("name", ex2.ParamName);
         }
 
         [Fact] // Object this [String]
@@ -1667,25 +1565,16 @@ namespace System.Data.Tests
 
             DataRow dr = dt.Rows[0];
 
-            try
-            {
-                dr["Col0"] = null;
-                Assert.False(true);
-            }
-            catch (ArgumentException ex)
-            {
-                // Cannot set Column 'Col0' to be null.
-                // Please use DBNull instead
-                Assert.Equal(typeof(ArgumentException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-
-                // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
-                // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
-                // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
-                Assert.Matches(@"[\p{Pi}\p{Po}]" + "Col0" + @"[\p{Pf}\p{Po}]", ex.Message);
-                Assert.Matches(@"\b" + "DBNull" + @"\b", ex.Message);
-            }
+            ArgumentException ex = Assert.Throws<ArgumentException>(() => dr["Col0"] = null);
+            // Cannot set Column 'Col0' to be null.
+            // Please use DBNull instead
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+            // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
+            // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
+            // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
+            Assert.Matches(@"[\p{Pi}\p{Po}]" + "Col0" + @"[\p{Pf}\p{Po}]", ex.Message);
+            Assert.Matches(@"\b" + "DBNull" + @"\b", ex.Message);
 
             Assert.Equal(addressA, dr["Col0"]);
             Assert.False(dr.IsNull("Col0"));
@@ -1846,64 +1735,37 @@ namespace System.Data.Tests
             dtA.Rows.Add(new object[] { addressA, personA });
             DataRow dr = dtA.Rows[0];
 
-            try
-            {
-                object value = dr[dcB1, DataRowVersion.Default];
-                Assert.False(true);
-            }
-            catch (ArgumentException ex)
-            {
-                // Column 'Col0' does not belong to table TableA
-                Assert.Equal(typeof(ArgumentException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
+            ArgumentException ex1 = Assert.Throws<ArgumentException>(() => dr[dcB1, DataRowVersion.Default]);
+            // Column 'Col0' does not belong to table TableA
+            Assert.Null(ex1.InnerException);
+            Assert.NotNull(ex1.Message);
+            // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
+            // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
+            // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
+            Assert.Matches(@"[\p{Pi}\p{Po}]" + "Col0" + @"[\p{Pf}\p{Po}]", ex1.Message);
+            Assert.Matches(@"\b" + "TableA" + @"\b", ex1.Message);
 
-                // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
-                // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
-                // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
-                Assert.Matches(@"[\p{Pi}\p{Po}]" + "Col0" + @"[\p{Pf}\p{Po}]", ex.Message);
-                Assert.Matches(@"\b" + "TableA" + @"\b", ex.Message);
-            }
-
-            try
-            {
-                object value = dr[new DataColumn("ZZZ"), DataRowVersion.Default];
-                Assert.False(true);
-            }
-            catch (ArgumentException ex)
-            {
-                // Column 'Col0' does not belong to table TableA
-                Assert.Equal(typeof(ArgumentException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-
-                // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
-                // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
-                // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
-                Assert.Matches(@"[\p{Pi}\p{Po}]" + "ZZZ" + @"[\p{Pf}\p{Po}]", ex.Message);
-                Assert.Matches(@"\b" + "TableA" + @"\b", ex.Message);
-            }
+            ArgumentException ex2 = Assert.Throws<ArgumentException>(() => dr[new DataColumn("ZZZ"), DataRowVersion.Default]);
+            // Column 'Col0' does not belong to table TableA
+            Assert.Null(ex2.InnerException);
+            Assert.NotNull(ex2.Message);
+            // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
+            // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
+            // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
+            Assert.Matches(@"[\p{Pi}\p{Po}]" + "ZZZ" + @"[\p{Pf}\p{Po}]", ex2.Message);
+            Assert.Matches(@"\b" + "TableA" + @"\b", ex2.Message);
 
             dtA.Columns.Remove(dcA2);
 
-            try
-            {
-                object value = dr[dcA2, DataRowVersion.Default];
-                Assert.False(true);
-            }
-            catch (ArgumentException ex)
-            {
-                // Column 'Col0' does not belong to table TableA
-                Assert.Equal(typeof(ArgumentException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-
-                // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
-                // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
-                // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
-                Assert.Matches(@"[\p{Pi}\p{Po}]" + "Col1" + @"[\p{Pf}\p{Po}]", ex.Message);
-                Assert.Matches(@"\b" + "TableA" + @"\b", ex.Message);
-            }
+            ArgumentException ex3 = Assert.Throws<ArgumentException>(() => dr[dcA2, DataRowVersion.Default]);
+            // Column 'Col0' does not belong to table TableA
+            Assert.Null(ex3.InnerException);
+            Assert.NotNull(ex3.Message);
+            // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
+            // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
+            // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
+            Assert.Matches(@"[\p{Pi}\p{Po}]" + "Col1" + @"[\p{Pf}\p{Po}]", ex3.Message);
+            Assert.Matches(@"\b" + "TableA" + @"\b", ex3.Message);
         }
 
         [Fact] // Object this [DataColumn, DataRowVersion]
@@ -1922,18 +1784,10 @@ namespace System.Data.Tests
             dt.Rows.Add(new object[] { addressA, personA });
             DataRow dr = dt.Rows[0];
 
-            try
-            {
-                object value = dr[(DataColumn)null, DataRowVersion.Default];
-                Assert.False(true);
-            }
-            catch (ArgumentNullException ex)
-            {
-                Assert.Equal(typeof(ArgumentNullException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.Equal("column", ex.ParamName);
-            }
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => dr[(DataColumn)null, DataRowVersion.Default]);
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+            Assert.Equal("column", ex.ParamName);
         }
 
         [Fact] // Object this [DataColumn, DataRowVersion]
@@ -1947,27 +1801,17 @@ namespace System.Data.Tests
 
             Person personA = new Person("Miguel");
             Address addressA = new Address("X", 5);
-            Person personB = new Person("Chris");
 
             dt.Rows.Add(new object[] { addressA, personA });
             DataRow dr = dt.Rows[0];
 
-            try
-            {
-                object value = dr[dc0, (DataRowVersion)666];
-                Assert.False(true);
-            }
-            catch (DataException ex)
-            {
-                // Version must be Original, Current, or Proposed
-                Assert.Equal(typeof(DataException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.IndexOf("Original") != -1);
-                Assert.True(ex.Message.IndexOf("Current") != -1);
-                Assert.True(ex.Message.IndexOf("Proposed") != -1);
-                Assert.False(ex.Message.IndexOf("Default") != -1);
-            }
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => dr[dc0, (DataRowVersion)666]);
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+            Assert.Contains(ex.Message, "Original");
+            Assert.Contains(ex.Message, "Current");
+            Assert.Contains(ex.Message, "Proposed");
+            Assert.DoesNotContain(ex.Message, "Default");
         }
 
         [Fact] // Object this [DataColumn, DataRowVersion]
@@ -1981,38 +1825,21 @@ namespace System.Data.Tests
 
             Person personA = new Person("Miguel");
             Address addressA = new Address("X", 5);
-            Person personB = new Person("Chris");
 
             dt.Rows.Add(new object[] { addressA, personA });
             DataRow dr = dt.Rows[0];
 
-            try
-            {
-                object value = dr[dc0, DataRowVersion.Original];
-                Assert.False(true);
-            }
-            catch (VersionNotFoundException ex)
-            {
-                // There is no Original data to access
-                Assert.Equal(typeof(VersionNotFoundException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.IndexOf("Original") != -1);
-            }
+            VersionNotFoundException ex1 = Assert.Throws<VersionNotFoundException>(() => dr[dc0, DataRowVersion.Original]);
+            // There is no Original data to access
+            Assert.Null(ex1.InnerException);
+            Assert.NotNull(ex1.Message);
+            Assert.Contains(ex1.Message, "Original");
 
-            try
-            {
-                object value = dr[dc0, DataRowVersion.Proposed];
-                Assert.False(true);
-            }
-            catch (VersionNotFoundException ex)
-            {
-                // There is no Proposed data to access
-                Assert.Equal(typeof(VersionNotFoundException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.IndexOf("Proposed") != -1);
-            }
+            VersionNotFoundException ex2 = Assert.Throws<VersionNotFoundException>(() => dr[dc0, DataRowVersion.Proposed]);
+            // There is no Proposed data to access
+            Assert.Null(ex2.InnerException);
+            Assert.NotNull(ex2.Message);
+            Assert.Contains(ex2.Message, "Proposed");
         }
 
         [Fact]
@@ -2099,13 +1926,11 @@ namespace System.Data.Tests
             dt.Rows.Add(new object[] { 1234 });
             DataRow dr = dt.Rows[0];
 
-            #region --- assignment  ----
             // IsNull_S 1
             Assert.False(dr.IsNull("Col0"));
 
             // IsNull_S 2
             Assert.True(dr.IsNull("Col1"));
-            #endregion
 
             // IsNull_S 1
             MemoryStream st = new MemoryStream();
@@ -2117,15 +1942,12 @@ namespace System.Data.Tests
             st.Position = 0;
             var ds = new DataSet();
             ds.ReadXml(st);
-            //  Here we add the expression column
+            // Here we add the expression column
             ds.Tables[0].Columns.Add("ValueListValueMember", typeof(object), "EmployeeNo");
 
             foreach (DataRow row in ds.Tables[0].Rows)
             {
-                if (row.IsNull("ValueListValueMember") == true)
-                    Assert.Equal("Failed", "SubTest");
-                else
-                    Assert.Equal("Passed", "Passed");
+                Assert.True(row.IsNull("ValueListValueMember"));
             }
         }
 
@@ -2135,18 +1957,18 @@ namespace System.Data.Tests
             DataTable table = new DataTable();
 
             // add the row, with the value in the column
-            DataColumn staticColumn = table.Columns.Add("static", typeof(string), null); // static
+            table.Columns.Add("static", typeof(string), null); // static
             DataRow row = table.Rows.Add("the value");
             Assert.False(row.IsNull("static"));
             Assert.Equal("the value", row["static"]);
 
             // add the first derived column
-            DataColumn firstColumn = table.Columns.Add("first", typeof(string), "static"); // first -> static
+            table.Columns.Add("first", typeof(string), "static"); // first -> static
             Assert.False(row.IsNull("first"));
             Assert.Equal("the value", row["first"]);
 
             // add the second level of related
-            DataColumn secondColumn = table.Columns.Add("second", typeof(string), "first"); // second -> first -> static
+            table.Columns.Add("second", typeof(string), "first"); // second -> first -> static
             Assert.False(row.IsNull("second"));
             Assert.Equal("the value", row["second"]);
         }
@@ -2157,38 +1979,14 @@ namespace System.Data.Tests
             DataTable table = new DataTable();
 
             // add the row, with the value in the column
-            DataColumn staticColumn = table.Columns.Add("static", typeof(string), null);
+            table.Columns.Add("static", typeof(string), null);
             DataRow row = table.Rows.Add("the value");
 
-            try
-            {
-                row.IsNull((string)null);
-                Assert.False(true);
-            }
-            catch (ArgumentNullException)
-            {
-                // do nothing as null columns aren't allowed
-            }
+            Assert.Throws<ArgumentNullException>(() => row.IsNull((string)null));
 
-            try
-            {
-                row.IsNull("");
-                Assert.False(true);
-            }
-            catch (ArgumentException)
-            {
-                // do nothing as we can't find a col with no name
-            }
+            Assert.Throws<ArgumentException>(() => row.IsNull(""));
 
-            try
-            {
-                row.IsNull(null, DataRowVersion.Default);
-                Assert.False(true);
-            }
-            catch (ArgumentNullException)
-            {
-                // do nothing as null columns aren't allowed
-            }
+            Assert.Throws<ArgumentNullException>(() => row.IsNull(null, DataRowVersion.Default));
         }
 
         [Fact]
@@ -2230,7 +2028,7 @@ namespace System.Data.Tests
 
             //  testMore();
         }
-
+        //TODO: why is this disabled?
         /*public void testMore()
         {
             DataTable dt = DataProvider.CreateParentDataTable();
@@ -2463,24 +2261,12 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public new void ToString()
-        {
-            DataRow dr;
-            DataTable dtParent;
-            dtParent = DataProvider.CreateParentDataTable();
-            dr = dtParent.Rows[0];
-
-            // ToString
-            Assert.StartsWith("system.data.datarow", dr.ToString().ToLower());
-        }
-
-        [Fact]
         public void DataRow_RowError()
         {
             DataTable dt = new DataTable("myTable");
             DataRow dr = dt.NewRow();
 
-            Assert.Equal(dr.RowError, string.Empty);
+            Assert.Equal(string.Empty, dr.RowError);
 
             dr.RowError = "Err";
             Assert.Equal("Err", dr.RowError);
@@ -2490,28 +2276,28 @@ namespace System.Data.Tests
         public void DataRow_RowError2()
         {
             Assert.Throws<ConstraintException>(() =>
-           {
-               DataTable dt1 = DataProvider.CreateUniqueConstraint();
+            {
+                DataTable dt1 = DataProvider.CreateUniqueConstraint();
 
-               dt1.BeginLoadData();
+                dt1.BeginLoadData();
 
-               DataRow dr = dt1.NewRow();
-               dr[0] = 3;
-               dt1.Rows.Add(dr);
-               dt1.EndLoadData();
-           });
+                DataRow dr = dt1.NewRow();
+                dr[0] = 3;
+                dt1.Rows.Add(dr);
+                dt1.EndLoadData();
+            });
         }
 
         [Fact]
         public void DataRow_RowError3()
         {
             Assert.Throws<ConstraintException>(() =>
-           {
-               DataSet ds = DataProvider.CreateForeignConstraint();
-               ds.Tables[0].BeginLoadData();
-               ds.Tables[0].Rows[0][0] = 10;
-               ds.Tables[0].EndLoadData(); //Foreign constraint violation
-           });
+            {
+                DataSet ds = DataProvider.CreateForeignConstraint();
+                ds.Tables[0].BeginLoadData();
+                ds.Tables[0].Rows[0][0] = 10;
+                ds.Tables[0].EndLoadData(); //Foreign constraint violation
+            });
         }
 
         [Fact]
@@ -2527,12 +2313,7 @@ namespace System.Data.Tests
             table.BeginLoadData();
             table.Rows.Add(new object[] { null, 1, 1 });
             table.Rows.Add(new object[] { 1, 1, 1 });
-            try
-            {
-                table.EndLoadData();
-                Assert.False(true);
-            }
-            catch (ConstraintException) { }
+            Assert.Throws<ConstraintException>(() => table.EndLoadData());
             Assert.True(table.HasErrors);
             DataRow[] rows = table.GetErrors();
 
@@ -2765,7 +2546,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public void bug78885()
+        public void Bug78885()
         {
             DataSet ds = new DataSet();
             DataTable t = ds.Tables.Add("table");
@@ -2806,14 +2587,7 @@ namespace System.Data.Tests
             DataTable table = new DataTable();
 
             DataRow row = table.NewRow();
-            try
-            {
-                row.SetAdded();
-                Assert.False(true);
-            }
-            catch (InvalidOperationException e)
-            {
-            }
+            Assert.Throws<InvalidOperationException>(() => row.SetAdded());
 
             table.Columns.Add("col1", typeof(int));
             table.Columns.Add("col2", typeof(int));
@@ -2821,27 +2595,13 @@ namespace System.Data.Tests
 
             row = table.Rows.Add(new object[] { 1, 2, 3 });
             Assert.Equal(DataRowState.Added, row.RowState);
-            try
-            {
-                row.SetAdded();
-                Assert.False(true);
-            }
-            catch (InvalidOperationException e)
-            {
-            }
+            Assert.Throws<InvalidOperationException>(() => row.SetAdded());
             Assert.Equal(DataRowState.Added, row.RowState);
 
             row.AcceptChanges();
             row[0] = 10;
             Assert.Equal(DataRowState.Modified, row.RowState);
-            try
-            {
-                row.SetAdded();
-                Assert.False(true);
-            }
-            catch (InvalidOperationException e)
-            {
-            }
+            Assert.Throws<InvalidOperationException>(() => row.SetAdded());
 
             row.AcceptChanges();
             Assert.Equal(DataRowState.Unchanged, row.RowState);
@@ -2875,6 +2635,7 @@ namespace System.Data.Tests
                 row.SetModified();
             }
             catch (InvalidOperationException) { }
+            Assert.Throws<InvalidOperationException>(() => row.SetModified());
 
             table.Columns.Add("col1", typeof(int));
             table.Columns.Add("col2", typeof(int));
@@ -2882,30 +2643,34 @@ namespace System.Data.Tests
 
             row = table.Rows.Add(new object[] { 1, 2, 3 });
             Assert.Equal(DataRowState.Added, row.RowState);
-            try
-            {
-                row.SetModified();
-                Assert.False(true);
-            }
-            catch (InvalidOperationException e)
-            {
-                // Never premise English.
-                //Assert.Equal (SetAddedModified_ErrMsg, e.Message);
-            }
+            //TODO: messages
+            //try
+            //{
+            //    row.SetModified();
+            //    Assert.False(true);
+            //}
+            //catch (InvalidOperationException e)
+            //{
+            //    // Never premise English.
+            //    //Assert.Equal (SetAddedModified_ErrMsg, e.Message);
+            //}
+            Assert.Throws<InvalidOperationException>(() => row.SetModified());
 
             row.AcceptChanges();
             row[0] = 10;
             Assert.Equal(DataRowState.Modified, row.RowState);
-            try
-            {
-                row.SetModified();
-                Assert.False(true);
-            }
-            catch (InvalidOperationException e)
-            {
-                // Never premise English.
-                //Assert.Equal (SetAddedModified_ErrMsg, e.Message);
-            }
+            //TODO
+            //try
+            //{
+            //    row.SetModified();
+            //    Assert.False(true);
+            //}
+            //catch (InvalidOperationException e)
+            //{
+            //    // Never premise English.
+            //    //Assert.Equal (SetAddedModified_ErrMsg, e.Message);
+            //}
+            Assert.Throws<InvalidOperationException>(() => row.SetModified());
 
             row.AcceptChanges();
             Assert.Equal(DataRowState.Unchanged, row.RowState);
@@ -2975,29 +2740,20 @@ namespace System.Data.Tests
         {
             public EventInfo(string name, EventArgs args)
             {
-                _name = name;
-                _args = args;
+                Name = name;
+                Args = args;
             }
 
-            public string Name
-            {
-                get { return _name; }
-            }
+            public string Name { get; }
 
-            public EventArgs Args
-            {
-                get { return _args; }
-            }
-
-            private readonly string _name;
-            private readonly EventArgs _args;
+            public EventArgs Args { get; }
         }
 
         private static bool AssertNotFound(DataRow rc, DataColumn dc, DataRowVersion version)
         {
             try
             {
-                object value = rc[dc, version];
+                _ = rc[dc, version];
                 return false;
             }
             catch (VersionNotFoundException)

--- a/src/System.Data.Common/tests/System/Data/DataRowViewTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/DataRowViewTest2.cs
@@ -102,7 +102,7 @@ namespace System.Data.Tests
             DataView dvTmp2 = dvParent[3].CreateChildView(drel);
 
             // ChildView != null
-            Assert.True(dvTmp1 != null);
+            Assert.NotNull(dvTmp1);
 
             // Child view table = ChildTable
             Assert.Equal(dtChild, dvTmp1.Table);
@@ -134,7 +134,7 @@ namespace System.Data.Tests
             DataView dvTmp2 = dvParent[3].CreateChildView("ParentChild");
 
             // ChildView != null
-            Assert.True(dvTmp1 != null);
+            Assert.NotNull(dvTmp1);
 
             // Child view table = ChildTable
             Assert.Equal(dtChild, dvTmp1.Table);
@@ -166,12 +166,12 @@ namespace System.Data.Tests
             // check that the DataRowView still has the same DataView
             dv.Table = null;
 
-            Assert.True(drv1.DataView == dv);
+            Assert.Same(drv1.DataView, dv);
 
             //check that the DataRowView has a new DataView
             // check that the DataRowView has a new DataView
             dv = new DataView();
-            Assert.True(drv1.DataView.Equals(dv));
+            Assert.Equal(drv1.DataView, dv);
         }
 
         [Fact]
@@ -181,16 +181,16 @@ namespace System.Data.Tests
             DataView dv = new DataView(dt);
 
             DataRowView drv = dv[0];
-            int TableRowsCount = dt.Rows.Count;
-            int ViewRowCount = dv.Count;
+            int tableRowsCount = dt.Rows.Count;
+            int viewRowCount = dv.Count;
 
             // DataView Count
             drv.Delete();
-            Assert.Equal(dv.Count, ViewRowCount - 1);
+            Assert.Equal(viewRowCount - 1, dv.Count);
 
             //the table count should stay the same until EndEdit is invoked
             // Table Count
-            Assert.Equal(TableRowsCount, dt.Rows.Count);
+            Assert.Equal(tableRowsCount, dt.Rows.Count);
 
             // DataRowState deleted
             Assert.Equal(DataRowState.Deleted, drv.Row.RowState);

--- a/src/System.Data.Common/tests/System/Data/DataRowViewTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/DataRowViewTest2.cs
@@ -25,7 +25,6 @@
 
 using Xunit;
 
-
 namespace System.Data.Tests
 {
     public class DataRowViewTest2

--- a/src/System.Data.Common/tests/System/Data/DataSetAssertion.cs
+++ b/src/System.Data.Common/tests/System/Data/DataSetAssertion.cs
@@ -26,7 +26,6 @@
 
 
 using System.Collections;
-using System.Diagnostics;
 using System.IO;
 using System.Xml;
 using Xunit;

--- a/src/System.Data.Common/tests/System/Data/DataSetReadXmlSchemaTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataSetReadXmlSchemaTest.cs
@@ -26,7 +26,6 @@
 
 
 using System.IO;
-using System.Diagnostics;
 using System.Globalization;
 using System.Xml;
 using Microsoft.DotNet.RemoteExecutor;

--- a/src/System.Data.Common/tests/System/Data/DataSetReadXmlTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataSetReadXmlTest.cs
@@ -33,17 +33,17 @@ namespace System.Data.Tests
 {
     public class DataSetReadXmlTest
     {
-        private const string xml1 = "";
-        private const string xml2 = "<root/>";
-        private const string xml3 = "<root></root>";
-        private const string xml4 = "<root>   </root>";
-        private const string xml5 = "<root>test</root>";
-        private const string xml6 = "<root><test>1</test></root>";
-        private const string xml7 = "<root><test>1</test><test2>a</test2></root>";
-        private const string xml8 = "<dataset><table><col1>foo</col1><col2>bar</col2></table></dataset>";
-        private const string xml29 = @"<PersonalSite><License Name='Sum Wang' Email='sumwang@somewhere.net' Mode='Trial' StartDate='01/01/2004' Serial='aaa' /></PersonalSite>";
+        private const string Xml1 = "";
+        private const string Xml2 = "<root/>";
+        private const string Xml3 = "<root></root>";
+        private const string Xml4 = "<root>   </root>";
+        private const string Xml5 = "<root>test</root>";
+        private const string Xml6 = "<root><test>1</test></root>";
+        private const string Xml7 = "<root><test>1</test><test2>a</test2></root>";
+        private const string Xml8 = "<dataset><table><col1>foo</col1><col2>bar</col2></table></dataset>";
+        private const string Xml29 = @"<PersonalSite><License Name='Sum Wang' Email='sumwang@somewhere.net' Mode='Trial' StartDate='01/01/2004' Serial='aaa' /></PersonalSite>";
 
-        private const string diff1 = @"<diffgr:diffgram xmlns:msdata='urn:schemas-microsoft-com:xml-msdata' xmlns:diffgr='urn:schemas-microsoft-com:xml-diffgram-v1'>
+        private const string Diff1 = @"<diffgr:diffgram xmlns:msdata='urn:schemas-microsoft-com:xml-msdata' xmlns:diffgr='urn:schemas-microsoft-com:xml-diffgram-v1'>
   <NewDataSet>
     <Table1 diffgr:id='Table11' msdata:rowOrder='0' diffgr:hasChanges='inserted'>
       <Column1_1>ppp</Column1_1>
@@ -52,7 +52,7 @@ namespace System.Data.Tests
     </Table1>
   </NewDataSet>
 </diffgr:diffgram>";
-        private const string diff2 = diff1 + xml8;
+        private const string Diff2 = Diff1 + Xml8;
 
         private const string schema1 = @"<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema'>
     <xs:element name='Root'>
@@ -63,7 +63,7 @@ namespace System.Data.Tests
         </xs:complexType>
     </xs:element>
 </xs:schema>";
-        private const string schema2 = schema1 + xml8;
+        private const string Schema2 = Schema1 + Xml8;
 
         [Fact]
         public void ReadSimpleAuto()
@@ -72,52 +72,52 @@ namespace System.Data.Tests
 
             // empty XML
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "EmptyString", xml1,
+            DataSetAssertion.AssertReadXml(ds, "EmptyString", Xml1,
                 XmlReadMode.Auto, XmlReadMode.Auto,
                 "NewDataSet", 0);
 
             // simple element
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "EmptyElement", xml2,
+            DataSetAssertion.AssertReadXml(ds, "EmptyElement", Xml2,
                 XmlReadMode.Auto, XmlReadMode.InferSchema,
                 "root", 0);
 
             // simple element2
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "StartEndTag", xml3,
+            DataSetAssertion.AssertReadXml(ds, "StartEndTag", Xml3,
                 XmlReadMode.Auto, XmlReadMode.InferSchema,
                 "root", 0);
 
             // whitespace in simple element
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "Whitespace", xml4,
+            DataSetAssertion.AssertReadXml(ds, "Whitespace", Xml4,
                 XmlReadMode.Auto, XmlReadMode.InferSchema,
                 "root", 0);
 
             // text in simple element
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SingleText", xml5,
+            DataSetAssertion.AssertReadXml(ds, "SingleText", Xml5,
                 XmlReadMode.Auto, XmlReadMode.InferSchema,
                 "root", 0);
 
             // simple table pattern:
             // root becomes a table and test becomes a column.
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SimpleTable", xml6,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable", Xml6,
                 XmlReadMode.Auto, XmlReadMode.InferSchema,
                 "NewDataSet", 1);
             DataSetAssertion.AssertDataTable("xml6", ds.Tables[0], "root", 1, 1, 0, 0, 0, 0);
 
             // simple table with 2 columns:
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SimpleTable2", xml7,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable2", Xml7,
                 XmlReadMode.Auto, XmlReadMode.InferSchema,
                 "NewDataSet", 1);
             DataSetAssertion.AssertDataTable("xml7", ds.Tables[0], "root", 2, 1, 0, 0, 0, 0);
 
             // simple dataset with 1 table:
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SimpleDataSet", xml8,
+            DataSetAssertion.AssertReadXml(ds, "SimpleDataSet", Xml8,
                 XmlReadMode.Auto, XmlReadMode.InferSchema,
                 "dataset", 1);
             DataSetAssertion.AssertDataTable("xml8", ds.Tables[0], "table", 2, 1, 0, 0, 0, 0);
@@ -130,49 +130,49 @@ namespace System.Data.Tests
 
             // empty XML
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "EmptyString", xml1,
+            DataSetAssertion.AssertReadXml(ds, "EmptyString", Xml1,
                 XmlReadMode.DiffGram, XmlReadMode.DiffGram,
                 "NewDataSet", 0);
 
             // simple element
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "EmptyElement", xml2,
+            DataSetAssertion.AssertReadXml(ds, "EmptyElement", Xml2,
                 XmlReadMode.DiffGram, XmlReadMode.DiffGram,
                 "NewDataSet", 0);
 
             // simple element2
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "StartEndTag", xml3,
+            DataSetAssertion.AssertReadXml(ds, "StartEndTag", Xml3,
                 XmlReadMode.DiffGram, XmlReadMode.DiffGram,
                 "NewDataSet", 0);
 
             // whitespace in simple element
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "Whitespace", xml4,
+            DataSetAssertion.AssertReadXml(ds, "Whitespace", Xml4,
                 XmlReadMode.DiffGram, XmlReadMode.DiffGram,
                 "NewDataSet", 0);
 
             // text in simple element
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SingleText", xml5,
+            DataSetAssertion.AssertReadXml(ds, "SingleText", Xml5,
                 XmlReadMode.DiffGram, XmlReadMode.DiffGram,
                 "NewDataSet", 0);
 
             // simple table pattern:
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SimpleTable", xml6,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable", Xml6,
                 XmlReadMode.DiffGram, XmlReadMode.DiffGram,
                 "NewDataSet", 0);
 
             // simple table with 2 columns:
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SimpleTable2", xml7,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable2", Xml7,
                 XmlReadMode.DiffGram, XmlReadMode.DiffGram,
                 "NewDataSet", 0);
 
             // simple dataset with 1 table:
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SimpleDataSet", xml8,
+            DataSetAssertion.AssertReadXml(ds, "SimpleDataSet", Xml8,
                 XmlReadMode.DiffGram, XmlReadMode.DiffGram,
                 "NewDataSet", 0);
         }
@@ -184,49 +184,49 @@ namespace System.Data.Tests
 
             // empty XML
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "EmptyString", xml1,
+            DataSetAssertion.AssertReadXml(ds, "EmptyString", Xml1,
                 XmlReadMode.Fragment, XmlReadMode.Fragment,
                 "NewDataSet", 0);
 
             // simple element
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "EmptyElement", xml2,
+            DataSetAssertion.AssertReadXml(ds, "EmptyElement", Xml2,
                 XmlReadMode.Fragment, XmlReadMode.Fragment,
                 "NewDataSet", 0);
 
             // simple element2
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "StartEndTag", xml3,
+            DataSetAssertion.AssertReadXml(ds, "StartEndTag", Xml3,
                 XmlReadMode.Fragment, XmlReadMode.Fragment,
                 "NewDataSet", 0);
 
             // whitespace in simple element
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "Whitespace", xml4,
+            DataSetAssertion.AssertReadXml(ds, "Whitespace", Xml4,
                 XmlReadMode.Fragment, XmlReadMode.Fragment,
                 "NewDataSet", 0);
 
             // text in simple element
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SingleText", xml5,
+            DataSetAssertion.AssertReadXml(ds, "SingleText", Xml5,
                 XmlReadMode.Fragment, XmlReadMode.Fragment,
                 "NewDataSet", 0);
 
             // simple table pattern:
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SimpleTable", xml6,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable", Xml6,
                 XmlReadMode.Fragment, XmlReadMode.Fragment,
                 "NewDataSet", 0);
 
             // simple table with 2 columns:
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SimpleTable2", xml7,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable2", Xml7,
                 XmlReadMode.Fragment, XmlReadMode.Fragment,
                 "NewDataSet", 0);
 
             // simple dataset with 1 table:
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SimpleDataSet", xml8,
+            DataSetAssertion.AssertReadXml(ds, "SimpleDataSet", Xml8,
                 XmlReadMode.Fragment, XmlReadMode.Fragment,
                 "NewDataSet", 0);
         }
@@ -238,49 +238,49 @@ namespace System.Data.Tests
 
             // empty XML
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "EmptyString", xml1,
+            DataSetAssertion.AssertReadXml(ds, "EmptyString", Xml1,
                 XmlReadMode.IgnoreSchema, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 0);
 
             // simple element
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "EmptyElement", xml2,
+            DataSetAssertion.AssertReadXml(ds, "EmptyElement", Xml2,
                 XmlReadMode.IgnoreSchema, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 0);
 
             // simple element2
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "StartEndTag", xml3,
+            DataSetAssertion.AssertReadXml(ds, "StartEndTag", Xml3,
                 XmlReadMode.IgnoreSchema, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 0);
 
             // whitespace in simple element
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "Whitespace", xml4,
+            DataSetAssertion.AssertReadXml(ds, "Whitespace", Xml4,
                 XmlReadMode.IgnoreSchema, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 0);
 
             // text in simple element
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SingleText", xml5,
+            DataSetAssertion.AssertReadXml(ds, "SingleText", Xml5,
                 XmlReadMode.IgnoreSchema, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 0);
 
             // simple table pattern:
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SimpleTable", xml6,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable", Xml6,
                 XmlReadMode.IgnoreSchema, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 0);
 
             // simple table with 2 columns:
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SimpleTable2", xml7,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable2", Xml7,
                 XmlReadMode.IgnoreSchema, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 0);
 
             // simple dataset with 1 table:
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SimpleDataSet", xml8,
+            DataSetAssertion.AssertReadXml(ds, "SimpleDataSet", Xml8,
                 XmlReadMode.IgnoreSchema, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 0);
         }
@@ -292,52 +292,52 @@ namespace System.Data.Tests
 
             // empty XML
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "EmptyString", xml1,
+            DataSetAssertion.AssertReadXml(ds, "EmptyString", Xml1,
                 XmlReadMode.InferSchema, XmlReadMode.InferSchema,
                 "NewDataSet", 0);
 
             // simple element
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "EmptyElement", xml2,
+            DataSetAssertion.AssertReadXml(ds, "EmptyElement", Xml2,
                 XmlReadMode.InferSchema, XmlReadMode.InferSchema,
                 "root", 0);
 
             // simple element2
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "StartEndTag", xml3,
+            DataSetAssertion.AssertReadXml(ds, "StartEndTag", Xml3,
                 XmlReadMode.InferSchema, XmlReadMode.InferSchema,
                 "root", 0);
 
             // whitespace in simple element
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "Whitespace", xml4,
+            DataSetAssertion.AssertReadXml(ds, "Whitespace", Xml4,
                 XmlReadMode.InferSchema, XmlReadMode.InferSchema,
                 "root", 0);
 
             // text in simple element
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SingleText", xml5,
+            DataSetAssertion.AssertReadXml(ds, "SingleText", Xml5,
                 XmlReadMode.InferSchema, XmlReadMode.InferSchema,
                 "root", 0);
 
             // simple table pattern:
             // root becomes a table and test becomes a column.
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SimpleTable", xml6,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable", Xml6,
                 XmlReadMode.InferSchema, XmlReadMode.InferSchema,
                 "NewDataSet", 1);
             DataSetAssertion.AssertDataTable("xml6", ds.Tables[0], "root", 1, 1, 0, 0, 0, 0);
 
             // simple table with 2 columns:
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SimpleTable2", xml7,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable2", Xml7,
                 XmlReadMode.InferSchema, XmlReadMode.InferSchema,
                 "NewDataSet", 1);
             DataSetAssertion.AssertDataTable("xml7", ds.Tables[0], "root", 2, 1, 0, 0, 0, 0);
 
             // simple dataset with 1 table:
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SimpleDataSet", xml8,
+            DataSetAssertion.AssertReadXml(ds, "SimpleDataSet", Xml8,
                 XmlReadMode.InferSchema, XmlReadMode.InferSchema,
                 "dataset", 1);
             DataSetAssertion.AssertDataTable("xml8", ds.Tables[0], "table", 2, 1, 0, 0, 0, 0);
@@ -350,49 +350,49 @@ namespace System.Data.Tests
 
             // empty XML
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "EmptyString", xml1,
+            DataSetAssertion.AssertReadXml(ds, "EmptyString", Xml1,
                 XmlReadMode.ReadSchema, XmlReadMode.ReadSchema,
                 "NewDataSet", 0);
 
             // simple element
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "EmptyElement", xml2,
+            DataSetAssertion.AssertReadXml(ds, "EmptyElement", Xml2,
                 XmlReadMode.ReadSchema, XmlReadMode.ReadSchema,
                 "NewDataSet", 0);
 
             // simple element2
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "StartEndTag", xml3,
+            DataSetAssertion.AssertReadXml(ds, "StartEndTag", Xml3,
                 XmlReadMode.ReadSchema, XmlReadMode.ReadSchema,
                 "NewDataSet", 0);
 
             // whitespace in simple element
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "Whitespace", xml4,
+            DataSetAssertion.AssertReadXml(ds, "Whitespace", Xml4,
                 XmlReadMode.ReadSchema, XmlReadMode.ReadSchema,
                 "NewDataSet", 0);
 
             // text in simple element
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SingleText", xml5,
+            DataSetAssertion.AssertReadXml(ds, "SingleText", Xml5,
                 XmlReadMode.ReadSchema, XmlReadMode.ReadSchema,
                 "NewDataSet", 0);
 
             // simple table pattern:
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SimpleTable", xml6,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable", Xml6,
                 XmlReadMode.ReadSchema, XmlReadMode.ReadSchema,
                 "NewDataSet", 0);
 
             // simple table with 2 columns:
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SimpleTable2", xml7,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable2", Xml7,
                 XmlReadMode.ReadSchema, XmlReadMode.ReadSchema,
                 "NewDataSet", 0);
 
             // simple dataset with 1 table:
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SimpleDataSet", xml8,
+            DataSetAssertion.AssertReadXml(ds, "SimpleDataSet", Xml8,
                 XmlReadMode.ReadSchema, XmlReadMode.ReadSchema,
                 "NewDataSet", 0);
         }
@@ -404,33 +404,33 @@ namespace System.Data.Tests
 
             // ignored
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "Fragment", diff1,
+            DataSetAssertion.AssertReadXml(ds, "Fragment", Diff1,
                 XmlReadMode.Fragment, XmlReadMode.Fragment,
                 "NewDataSet", 0);
 
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "IgnoreSchema", diff1,
+            DataSetAssertion.AssertReadXml(ds, "IgnoreSchema", Diff1,
                 XmlReadMode.IgnoreSchema, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 0);
 
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "InferSchema", diff1,
+            DataSetAssertion.AssertReadXml(ds, "InferSchema", Diff1,
                 XmlReadMode.InferSchema, XmlReadMode.InferSchema,
                 "NewDataSet", 0);
 
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "ReadSchema", diff1,
+            DataSetAssertion.AssertReadXml(ds, "ReadSchema", Diff1,
                 XmlReadMode.ReadSchema, XmlReadMode.ReadSchema,
                 "NewDataSet", 0);
 
             // Auto, DiffGram ... treated as DiffGram
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "Auto", diff1,
+            DataSetAssertion.AssertReadXml(ds, "Auto", Diff1,
                 XmlReadMode.Auto, XmlReadMode.DiffGram,
                 "NewDataSet", 0);
 
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "DiffGram", diff1,
+            DataSetAssertion.AssertReadXml(ds, "DiffGram", Diff1,
                 XmlReadMode.DiffGram, XmlReadMode.DiffGram,
                 "NewDataSet", 0);
         }
@@ -442,34 +442,34 @@ namespace System.Data.Tests
 
             // Fragment ... skipped
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "Fragment", diff2,
+            DataSetAssertion.AssertReadXml(ds, "Fragment", Diff2,
                 XmlReadMode.Fragment, XmlReadMode.Fragment,
                 "NewDataSet", 0);
 
             // others ... kept
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "IgnoreSchema", diff2,
+            DataSetAssertion.AssertReadXml(ds, "IgnoreSchema", Diff2,
                 XmlReadMode.IgnoreSchema, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 0, ReadState.Interactive);
 
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "InferSchema", diff2,
+            DataSetAssertion.AssertReadXml(ds, "InferSchema", Diff2,
                 XmlReadMode.InferSchema, XmlReadMode.InferSchema,
                 "NewDataSet", 0, ReadState.Interactive);
 
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "ReadSchema", diff2,
+            DataSetAssertion.AssertReadXml(ds, "ReadSchema", Diff2,
                 XmlReadMode.ReadSchema, XmlReadMode.ReadSchema,
                 "NewDataSet", 0, ReadState.Interactive);
 
             // Auto, DiffGram ... treated as DiffGram
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "Auto", diff2,
+            DataSetAssertion.AssertReadXml(ds, "Auto", Diff2,
                 XmlReadMode.Auto, XmlReadMode.DiffGram,
                 "NewDataSet", 0, ReadState.Interactive);
 
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "DiffGram", diff2,
+            DataSetAssertion.AssertReadXml(ds, "DiffGram", Diff2,
                 XmlReadMode.DiffGram, XmlReadMode.DiffGram,
                 "NewDataSet", 0, ReadState.Interactive);
         }
@@ -481,36 +481,36 @@ namespace System.Data.Tests
 
             // ignored
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "IgnoreSchema", schema1,
+            DataSetAssertion.AssertReadXml(ds, "IgnoreSchema", Schema1,
                 XmlReadMode.IgnoreSchema, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 0);
 
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "InferSchema", schema1,
+            DataSetAssertion.AssertReadXml(ds, "InferSchema", Schema1,
                 XmlReadMode.InferSchema, XmlReadMode.InferSchema,
                 "NewDataSet", 0);
 
             // misc ... consume schema
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "Fragment", schema1,
+            DataSetAssertion.AssertReadXml(ds, "Fragment", Schema1,
                 XmlReadMode.Fragment, XmlReadMode.Fragment,
                 "NewDataSet", 1);
             DataSetAssertion.AssertDataTable("fragment", ds.Tables[0], "Root", 1, 0, 0, 0, 0, 0);
 
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "ReadSchema", schema1,
+            DataSetAssertion.AssertReadXml(ds, "ReadSchema", Schema1,
                 XmlReadMode.ReadSchema, XmlReadMode.ReadSchema,
                 "NewDataSet", 1);
             DataSetAssertion.AssertDataTable("readschema", ds.Tables[0], "Root", 1, 0, 0, 0, 0, 0);
 
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "Auto", schema1,
+            DataSetAssertion.AssertReadXml(ds, "Auto", Schema1,
                 XmlReadMode.Auto, XmlReadMode.ReadSchema,
                 "NewDataSet", 1);
             DataSetAssertion.AssertDataTable("auto", ds.Tables[0], "Root", 1, 0, 0, 0, 0, 0);
 
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "DiffGram", schema1,
+            DataSetAssertion.AssertReadXml(ds, "DiffGram", Schema1,
                 XmlReadMode.DiffGram, XmlReadMode.DiffGram,
                 "NewDataSet", 1);
         }
@@ -522,37 +522,37 @@ namespace System.Data.Tests
 
             // ignored
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "IgnoreSchema", schema2,
+            DataSetAssertion.AssertReadXml(ds, "IgnoreSchema", Schema2,
                 XmlReadMode.IgnoreSchema, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 0, ReadState.Interactive);
 
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "InferSchema", schema2,
+            DataSetAssertion.AssertReadXml(ds, "InferSchema", Schema2,
                 XmlReadMode.InferSchema, XmlReadMode.InferSchema,
                 "NewDataSet", 0, ReadState.Interactive);
 
             // Fragment ... consumed both
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "Fragment", schema2,
+            DataSetAssertion.AssertReadXml(ds, "Fragment", Schema2,
                 XmlReadMode.Fragment, XmlReadMode.Fragment,
                 "NewDataSet", 1);
             DataSetAssertion.AssertDataTable("fragment", ds.Tables[0], "Root", 1, 0, 0, 0, 0, 0);
 
             // rest ... treated as schema
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "Auto", schema2,
+            DataSetAssertion.AssertReadXml(ds, "Auto", Schema2,
                 XmlReadMode.Auto, XmlReadMode.ReadSchema,
                 "NewDataSet", 1, ReadState.Interactive);
             DataSetAssertion.AssertDataTable("auto", ds.Tables[0], "Root", 1, 0, 0, 0, 0, 0);
 
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "DiffGram", schema2,
+            DataSetAssertion.AssertReadXml(ds, "DiffGram", Schema2,
                 XmlReadMode.DiffGram, XmlReadMode.DiffGram,
                 "NewDataSet", 1, ReadState.Interactive);
             DataSetAssertion.AssertDataTable("diffgram", ds.Tables[0], "Root", 1, 0, 0, 0, 0, 0);
 
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "ReadSchema", schema2,
+            DataSetAssertion.AssertReadXml(ds, "ReadSchema", Schema2,
                 XmlReadMode.ReadSchema, XmlReadMode.ReadSchema,
                 "NewDataSet", 1, ReadState.Interactive);
         }
@@ -563,11 +563,11 @@ namespace System.Data.Tests
             // simple element -> simple table
             var ds = new DataSet();
 
-            DataSetAssertion.AssertReadXml(ds, "SingleText", xml5,
+            DataSetAssertion.AssertReadXml(ds, "SingleText", Xml5,
                 XmlReadMode.Auto, XmlReadMode.InferSchema,
                 "root", 0);
 
-            DataSetAssertion.AssertReadXml(ds, "SimpleTable", xml6,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable", Xml6,
                 XmlReadMode.Auto, XmlReadMode.InferSchema,
                 "NewDataSet", 1);
             DataSetAssertion.AssertDataTable("seq1", ds.Tables[0], "root", 1, 1, 0, 0, 0, 0);
@@ -579,11 +579,11 @@ namespace System.Data.Tests
             // simple element -> simple dataset
             var ds = new DataSet();
 
-            DataSetAssertion.AssertReadXml(ds, "SingleText", xml5,
+            DataSetAssertion.AssertReadXml(ds, "SingleText", Xml5,
                 XmlReadMode.Auto, XmlReadMode.InferSchema,
                 "root", 0);
 
-            DataSetAssertion.AssertReadXml(ds, "SimpleTable2", xml7,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable2", Xml7,
                 XmlReadMode.Auto, XmlReadMode.InferSchema,
                 "NewDataSet", 1);
             DataSetAssertion.AssertDataTable("#1", ds.Tables[0], "root", 2, 1, 0, 0, 0, 0);
@@ -591,7 +591,7 @@ namespace System.Data.Tests
             // simple table -> simple dataset
             ds = new DataSet();
 
-            DataSetAssertion.AssertReadXml(ds, "SimpleTable", xml6,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable", Xml6,
                 XmlReadMode.Auto, XmlReadMode.InferSchema,
                 "NewDataSet", 1);
             DataSetAssertion.AssertDataTable("#2", ds.Tables[0], "root", 1, 1, 0, 0, 0, 0);
@@ -600,7 +600,7 @@ namespace System.Data.Tests
             // already schema information in the dataset.
             // Columns are kept 1 as old table holds.
             // Rows are up to 2 because of accumulative read.
-            DataSetAssertion.AssertReadXml(ds, "SimpleTable2-2", xml7,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable2-2", Xml7,
                 XmlReadMode.Auto, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 1);
             DataSetAssertion.AssertDataTable("#3", ds.Tables[0], "root", 1, 2, 0, 0, 0, 0);
@@ -610,7 +610,7 @@ namespace System.Data.Tests
         public void ReadComplexElementDocument()
         {
             var ds = new DataSet();
-            ds.ReadXml(new StringReader(xml29));
+            ds.ReadXml(new StringReader(Xml29));
         }
 
         [Fact]
@@ -765,10 +765,6 @@ namespace System.Data.Tests
             try
             {
                 dataSet1.WriteXml(file, XmlWriteMode.WriteSchema);
-            }
-            catch (Exception ex)
-            {
-                Assert.False(true);
             }
             finally
             {

--- a/src/System.Data.Common/tests/System/Data/DataSetReadXmlTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataSetReadXmlTest.cs
@@ -33,17 +33,17 @@ namespace System.Data.Tests
 {
     public class DataSetReadXmlTest
     {
-        private const string Xml1 = "";
-        private const string Xml2 = "<root/>";
-        private const string Xml3 = "<root></root>";
-        private const string Xml4 = "<root>   </root>";
-        private const string Xml5 = "<root>test</root>";
-        private const string Xml6 = "<root><test>1</test></root>";
-        private const string Xml7 = "<root><test>1</test><test2>a</test2></root>";
-        private const string Xml8 = "<dataset><table><col1>foo</col1><col2>bar</col2></table></dataset>";
-        private const string Xml29 = @"<PersonalSite><License Name='Sum Wang' Email='sumwang@somewhere.net' Mode='Trial' StartDate='01/01/2004' Serial='aaa' /></PersonalSite>";
+        private const string xml1 = "";
+        private const string xml2 = "<root/>";
+        private const string xml3 = "<root></root>";
+        private const string xml4 = "<root>   </root>";
+        private const string xml5 = "<root>test</root>";
+        private const string xml6 = "<root><test>1</test></root>";
+        private const string xml7 = "<root><test>1</test><test2>a</test2></root>";
+        private const string xml8 = "<dataset><table><col1>foo</col1><col2>bar</col2></table></dataset>";
+        private const string xml29 = @"<PersonalSite><License Name='Sum Wang' Email='sumwang@somewhere.net' Mode='Trial' StartDate='01/01/2004' Serial='aaa' /></PersonalSite>";
 
-        private const string Diff1 = @"<diffgr:diffgram xmlns:msdata='urn:schemas-microsoft-com:xml-msdata' xmlns:diffgr='urn:schemas-microsoft-com:xml-diffgram-v1'>
+        private const string diff1 = @"<diffgr:diffgram xmlns:msdata='urn:schemas-microsoft-com:xml-msdata' xmlns:diffgr='urn:schemas-microsoft-com:xml-diffgram-v1'>
   <NewDataSet>
     <Table1 diffgr:id='Table11' msdata:rowOrder='0' diffgr:hasChanges='inserted'>
       <Column1_1>ppp</Column1_1>
@@ -52,7 +52,7 @@ namespace System.Data.Tests
     </Table1>
   </NewDataSet>
 </diffgr:diffgram>";
-        private const string Diff2 = Diff1 + Xml8;
+        private const string diff2 = diff1 + xml8;
 
         private const string schema1 = @"<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema'>
     <xs:element name='Root'>
@@ -63,7 +63,7 @@ namespace System.Data.Tests
         </xs:complexType>
     </xs:element>
 </xs:schema>";
-        private const string Schema2 = Schema1 + Xml8;
+        private const string schema2 = schema1 + xml8;
 
         [Fact]
         public void ReadSimpleAuto()
@@ -72,52 +72,52 @@ namespace System.Data.Tests
 
             // empty XML
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "EmptyString", Xml1,
+            DataSetAssertion.AssertReadXml(ds, "EmptyString", xml1,
                 XmlReadMode.Auto, XmlReadMode.Auto,
                 "NewDataSet", 0);
 
             // simple element
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "EmptyElement", Xml2,
+            DataSetAssertion.AssertReadXml(ds, "EmptyElement", xml2,
                 XmlReadMode.Auto, XmlReadMode.InferSchema,
                 "root", 0);
 
             // simple element2
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "StartEndTag", Xml3,
+            DataSetAssertion.AssertReadXml(ds, "StartEndTag", xml3,
                 XmlReadMode.Auto, XmlReadMode.InferSchema,
                 "root", 0);
 
             // whitespace in simple element
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "Whitespace", Xml4,
+            DataSetAssertion.AssertReadXml(ds, "Whitespace", xml4,
                 XmlReadMode.Auto, XmlReadMode.InferSchema,
                 "root", 0);
 
             // text in simple element
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SingleText", Xml5,
+            DataSetAssertion.AssertReadXml(ds, "SingleText", xml5,
                 XmlReadMode.Auto, XmlReadMode.InferSchema,
                 "root", 0);
 
             // simple table pattern:
             // root becomes a table and test becomes a column.
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SimpleTable", Xml6,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable", xml6,
                 XmlReadMode.Auto, XmlReadMode.InferSchema,
                 "NewDataSet", 1);
             DataSetAssertion.AssertDataTable("xml6", ds.Tables[0], "root", 1, 1, 0, 0, 0, 0);
 
             // simple table with 2 columns:
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SimpleTable2", Xml7,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable2", xml7,
                 XmlReadMode.Auto, XmlReadMode.InferSchema,
                 "NewDataSet", 1);
             DataSetAssertion.AssertDataTable("xml7", ds.Tables[0], "root", 2, 1, 0, 0, 0, 0);
 
             // simple dataset with 1 table:
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SimpleDataSet", Xml8,
+            DataSetAssertion.AssertReadXml(ds, "SimpleDataSet", xml8,
                 XmlReadMode.Auto, XmlReadMode.InferSchema,
                 "dataset", 1);
             DataSetAssertion.AssertDataTable("xml8", ds.Tables[0], "table", 2, 1, 0, 0, 0, 0);
@@ -130,49 +130,49 @@ namespace System.Data.Tests
 
             // empty XML
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "EmptyString", Xml1,
+            DataSetAssertion.AssertReadXml(ds, "EmptyString", xml1,
                 XmlReadMode.DiffGram, XmlReadMode.DiffGram,
                 "NewDataSet", 0);
 
             // simple element
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "EmptyElement", Xml2,
+            DataSetAssertion.AssertReadXml(ds, "EmptyElement", xml2,
                 XmlReadMode.DiffGram, XmlReadMode.DiffGram,
                 "NewDataSet", 0);
 
             // simple element2
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "StartEndTag", Xml3,
+            DataSetAssertion.AssertReadXml(ds, "StartEndTag", xml3,
                 XmlReadMode.DiffGram, XmlReadMode.DiffGram,
                 "NewDataSet", 0);
 
             // whitespace in simple element
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "Whitespace", Xml4,
+            DataSetAssertion.AssertReadXml(ds, "Whitespace", xml4,
                 XmlReadMode.DiffGram, XmlReadMode.DiffGram,
                 "NewDataSet", 0);
 
             // text in simple element
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SingleText", Xml5,
+            DataSetAssertion.AssertReadXml(ds, "SingleText", xml5,
                 XmlReadMode.DiffGram, XmlReadMode.DiffGram,
                 "NewDataSet", 0);
 
             // simple table pattern:
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SimpleTable", Xml6,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable", xml6,
                 XmlReadMode.DiffGram, XmlReadMode.DiffGram,
                 "NewDataSet", 0);
 
             // simple table with 2 columns:
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SimpleTable2", Xml7,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable2", xml7,
                 XmlReadMode.DiffGram, XmlReadMode.DiffGram,
                 "NewDataSet", 0);
 
             // simple dataset with 1 table:
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SimpleDataSet", Xml8,
+            DataSetAssertion.AssertReadXml(ds, "SimpleDataSet", xml8,
                 XmlReadMode.DiffGram, XmlReadMode.DiffGram,
                 "NewDataSet", 0);
         }
@@ -184,49 +184,49 @@ namespace System.Data.Tests
 
             // empty XML
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "EmptyString", Xml1,
+            DataSetAssertion.AssertReadXml(ds, "EmptyString", xml1,
                 XmlReadMode.Fragment, XmlReadMode.Fragment,
                 "NewDataSet", 0);
 
             // simple element
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "EmptyElement", Xml2,
+            DataSetAssertion.AssertReadXml(ds, "EmptyElement", xml2,
                 XmlReadMode.Fragment, XmlReadMode.Fragment,
                 "NewDataSet", 0);
 
             // simple element2
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "StartEndTag", Xml3,
+            DataSetAssertion.AssertReadXml(ds, "StartEndTag", xml3,
                 XmlReadMode.Fragment, XmlReadMode.Fragment,
                 "NewDataSet", 0);
 
             // whitespace in simple element
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "Whitespace", Xml4,
+            DataSetAssertion.AssertReadXml(ds, "Whitespace", xml4,
                 XmlReadMode.Fragment, XmlReadMode.Fragment,
                 "NewDataSet", 0);
 
             // text in simple element
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SingleText", Xml5,
+            DataSetAssertion.AssertReadXml(ds, "SingleText", xml5,
                 XmlReadMode.Fragment, XmlReadMode.Fragment,
                 "NewDataSet", 0);
 
             // simple table pattern:
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SimpleTable", Xml6,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable", xml6,
                 XmlReadMode.Fragment, XmlReadMode.Fragment,
                 "NewDataSet", 0);
 
             // simple table with 2 columns:
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SimpleTable2", Xml7,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable2", xml7,
                 XmlReadMode.Fragment, XmlReadMode.Fragment,
                 "NewDataSet", 0);
 
             // simple dataset with 1 table:
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SimpleDataSet", Xml8,
+            DataSetAssertion.AssertReadXml(ds, "SimpleDataSet", xml8,
                 XmlReadMode.Fragment, XmlReadMode.Fragment,
                 "NewDataSet", 0);
         }
@@ -238,49 +238,49 @@ namespace System.Data.Tests
 
             // empty XML
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "EmptyString", Xml1,
+            DataSetAssertion.AssertReadXml(ds, "EmptyString", xml1,
                 XmlReadMode.IgnoreSchema, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 0);
 
             // simple element
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "EmptyElement", Xml2,
+            DataSetAssertion.AssertReadXml(ds, "EmptyElement", xml2,
                 XmlReadMode.IgnoreSchema, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 0);
 
             // simple element2
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "StartEndTag", Xml3,
+            DataSetAssertion.AssertReadXml(ds, "StartEndTag", xml3,
                 XmlReadMode.IgnoreSchema, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 0);
 
             // whitespace in simple element
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "Whitespace", Xml4,
+            DataSetAssertion.AssertReadXml(ds, "Whitespace", xml4,
                 XmlReadMode.IgnoreSchema, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 0);
 
             // text in simple element
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SingleText", Xml5,
+            DataSetAssertion.AssertReadXml(ds, "SingleText", xml5,
                 XmlReadMode.IgnoreSchema, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 0);
 
             // simple table pattern:
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SimpleTable", Xml6,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable", xml6,
                 XmlReadMode.IgnoreSchema, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 0);
 
             // simple table with 2 columns:
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SimpleTable2", Xml7,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable2", xml7,
                 XmlReadMode.IgnoreSchema, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 0);
 
             // simple dataset with 1 table:
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SimpleDataSet", Xml8,
+            DataSetAssertion.AssertReadXml(ds, "SimpleDataSet", xml8,
                 XmlReadMode.IgnoreSchema, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 0);
         }
@@ -292,52 +292,52 @@ namespace System.Data.Tests
 
             // empty XML
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "EmptyString", Xml1,
+            DataSetAssertion.AssertReadXml(ds, "EmptyString", xml1,
                 XmlReadMode.InferSchema, XmlReadMode.InferSchema,
                 "NewDataSet", 0);
 
             // simple element
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "EmptyElement", Xml2,
+            DataSetAssertion.AssertReadXml(ds, "EmptyElement", xml2,
                 XmlReadMode.InferSchema, XmlReadMode.InferSchema,
                 "root", 0);
 
             // simple element2
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "StartEndTag", Xml3,
+            DataSetAssertion.AssertReadXml(ds, "StartEndTag", xml3,
                 XmlReadMode.InferSchema, XmlReadMode.InferSchema,
                 "root", 0);
 
             // whitespace in simple element
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "Whitespace", Xml4,
+            DataSetAssertion.AssertReadXml(ds, "Whitespace", xml4,
                 XmlReadMode.InferSchema, XmlReadMode.InferSchema,
                 "root", 0);
 
             // text in simple element
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SingleText", Xml5,
+            DataSetAssertion.AssertReadXml(ds, "SingleText", xml5,
                 XmlReadMode.InferSchema, XmlReadMode.InferSchema,
                 "root", 0);
 
             // simple table pattern:
             // root becomes a table and test becomes a column.
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SimpleTable", Xml6,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable", xml6,
                 XmlReadMode.InferSchema, XmlReadMode.InferSchema,
                 "NewDataSet", 1);
             DataSetAssertion.AssertDataTable("xml6", ds.Tables[0], "root", 1, 1, 0, 0, 0, 0);
 
             // simple table with 2 columns:
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SimpleTable2", Xml7,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable2", xml7,
                 XmlReadMode.InferSchema, XmlReadMode.InferSchema,
                 "NewDataSet", 1);
             DataSetAssertion.AssertDataTable("xml7", ds.Tables[0], "root", 2, 1, 0, 0, 0, 0);
 
             // simple dataset with 1 table:
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SimpleDataSet", Xml8,
+            DataSetAssertion.AssertReadXml(ds, "SimpleDataSet", xml8,
                 XmlReadMode.InferSchema, XmlReadMode.InferSchema,
                 "dataset", 1);
             DataSetAssertion.AssertDataTable("xml8", ds.Tables[0], "table", 2, 1, 0, 0, 0, 0);
@@ -350,49 +350,49 @@ namespace System.Data.Tests
 
             // empty XML
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "EmptyString", Xml1,
+            DataSetAssertion.AssertReadXml(ds, "EmptyString", xml1,
                 XmlReadMode.ReadSchema, XmlReadMode.ReadSchema,
                 "NewDataSet", 0);
 
             // simple element
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "EmptyElement", Xml2,
+            DataSetAssertion.AssertReadXml(ds, "EmptyElement", xml2,
                 XmlReadMode.ReadSchema, XmlReadMode.ReadSchema,
                 "NewDataSet", 0);
 
             // simple element2
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "StartEndTag", Xml3,
+            DataSetAssertion.AssertReadXml(ds, "StartEndTag", xml3,
                 XmlReadMode.ReadSchema, XmlReadMode.ReadSchema,
                 "NewDataSet", 0);
 
             // whitespace in simple element
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "Whitespace", Xml4,
+            DataSetAssertion.AssertReadXml(ds, "Whitespace", xml4,
                 XmlReadMode.ReadSchema, XmlReadMode.ReadSchema,
                 "NewDataSet", 0);
 
             // text in simple element
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SingleText", Xml5,
+            DataSetAssertion.AssertReadXml(ds, "SingleText", xml5,
                 XmlReadMode.ReadSchema, XmlReadMode.ReadSchema,
                 "NewDataSet", 0);
 
             // simple table pattern:
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SimpleTable", Xml6,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable", xml6,
                 XmlReadMode.ReadSchema, XmlReadMode.ReadSchema,
                 "NewDataSet", 0);
 
             // simple table with 2 columns:
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SimpleTable2", Xml7,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable2", xml7,
                 XmlReadMode.ReadSchema, XmlReadMode.ReadSchema,
                 "NewDataSet", 0);
 
             // simple dataset with 1 table:
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "SimpleDataSet", Xml8,
+            DataSetAssertion.AssertReadXml(ds, "SimpleDataSet", xml8,
                 XmlReadMode.ReadSchema, XmlReadMode.ReadSchema,
                 "NewDataSet", 0);
         }
@@ -404,33 +404,33 @@ namespace System.Data.Tests
 
             // ignored
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "Fragment", Diff1,
+            DataSetAssertion.AssertReadXml(ds, "Fragment", diff1,
                 XmlReadMode.Fragment, XmlReadMode.Fragment,
                 "NewDataSet", 0);
 
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "IgnoreSchema", Diff1,
+            DataSetAssertion.AssertReadXml(ds, "IgnoreSchema", diff1,
                 XmlReadMode.IgnoreSchema, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 0);
 
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "InferSchema", Diff1,
+            DataSetAssertion.AssertReadXml(ds, "InferSchema", diff1,
                 XmlReadMode.InferSchema, XmlReadMode.InferSchema,
                 "NewDataSet", 0);
 
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "ReadSchema", Diff1,
+            DataSetAssertion.AssertReadXml(ds, "ReadSchema", diff1,
                 XmlReadMode.ReadSchema, XmlReadMode.ReadSchema,
                 "NewDataSet", 0);
 
             // Auto, DiffGram ... treated as DiffGram
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "Auto", Diff1,
+            DataSetAssertion.AssertReadXml(ds, "Auto", diff1,
                 XmlReadMode.Auto, XmlReadMode.DiffGram,
                 "NewDataSet", 0);
 
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "DiffGram", Diff1,
+            DataSetAssertion.AssertReadXml(ds, "DiffGram", diff1,
                 XmlReadMode.DiffGram, XmlReadMode.DiffGram,
                 "NewDataSet", 0);
         }
@@ -442,34 +442,34 @@ namespace System.Data.Tests
 
             // Fragment ... skipped
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "Fragment", Diff2,
+            DataSetAssertion.AssertReadXml(ds, "Fragment", diff2,
                 XmlReadMode.Fragment, XmlReadMode.Fragment,
                 "NewDataSet", 0);
 
             // others ... kept
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "IgnoreSchema", Diff2,
+            DataSetAssertion.AssertReadXml(ds, "IgnoreSchema", diff2,
                 XmlReadMode.IgnoreSchema, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 0, ReadState.Interactive);
 
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "InferSchema", Diff2,
+            DataSetAssertion.AssertReadXml(ds, "InferSchema", diff2,
                 XmlReadMode.InferSchema, XmlReadMode.InferSchema,
                 "NewDataSet", 0, ReadState.Interactive);
 
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "ReadSchema", Diff2,
+            DataSetAssertion.AssertReadXml(ds, "ReadSchema", diff2,
                 XmlReadMode.ReadSchema, XmlReadMode.ReadSchema,
                 "NewDataSet", 0, ReadState.Interactive);
 
             // Auto, DiffGram ... treated as DiffGram
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "Auto", Diff2,
+            DataSetAssertion.AssertReadXml(ds, "Auto", diff2,
                 XmlReadMode.Auto, XmlReadMode.DiffGram,
                 "NewDataSet", 0, ReadState.Interactive);
 
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "DiffGram", Diff2,
+            DataSetAssertion.AssertReadXml(ds, "DiffGram", diff2,
                 XmlReadMode.DiffGram, XmlReadMode.DiffGram,
                 "NewDataSet", 0, ReadState.Interactive);
         }
@@ -481,36 +481,36 @@ namespace System.Data.Tests
 
             // ignored
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "IgnoreSchema", Schema1,
+            DataSetAssertion.AssertReadXml(ds, "IgnoreSchema", schema1,
                 XmlReadMode.IgnoreSchema, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 0);
 
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "InferSchema", Schema1,
+            DataSetAssertion.AssertReadXml(ds, "InferSchema", schema1,
                 XmlReadMode.InferSchema, XmlReadMode.InferSchema,
                 "NewDataSet", 0);
 
             // misc ... consume schema
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "Fragment", Schema1,
+            DataSetAssertion.AssertReadXml(ds, "Fragment", schema1,
                 XmlReadMode.Fragment, XmlReadMode.Fragment,
                 "NewDataSet", 1);
             DataSetAssertion.AssertDataTable("fragment", ds.Tables[0], "Root", 1, 0, 0, 0, 0, 0);
 
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "ReadSchema", Schema1,
+            DataSetAssertion.AssertReadXml(ds, "ReadSchema", schema1,
                 XmlReadMode.ReadSchema, XmlReadMode.ReadSchema,
                 "NewDataSet", 1);
             DataSetAssertion.AssertDataTable("readschema", ds.Tables[0], "Root", 1, 0, 0, 0, 0, 0);
 
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "Auto", Schema1,
+            DataSetAssertion.AssertReadXml(ds, "Auto", schema1,
                 XmlReadMode.Auto, XmlReadMode.ReadSchema,
                 "NewDataSet", 1);
             DataSetAssertion.AssertDataTable("auto", ds.Tables[0], "Root", 1, 0, 0, 0, 0, 0);
 
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "DiffGram", Schema1,
+            DataSetAssertion.AssertReadXml(ds, "DiffGram", schema1,
                 XmlReadMode.DiffGram, XmlReadMode.DiffGram,
                 "NewDataSet", 1);
         }
@@ -522,37 +522,37 @@ namespace System.Data.Tests
 
             // ignored
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "IgnoreSchema", Schema2,
+            DataSetAssertion.AssertReadXml(ds, "IgnoreSchema", schema2,
                 XmlReadMode.IgnoreSchema, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 0, ReadState.Interactive);
 
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "InferSchema", Schema2,
+            DataSetAssertion.AssertReadXml(ds, "InferSchema", schema2,
                 XmlReadMode.InferSchema, XmlReadMode.InferSchema,
                 "NewDataSet", 0, ReadState.Interactive);
 
             // Fragment ... consumed both
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "Fragment", Schema2,
+            DataSetAssertion.AssertReadXml(ds, "Fragment", schema2,
                 XmlReadMode.Fragment, XmlReadMode.Fragment,
                 "NewDataSet", 1);
             DataSetAssertion.AssertDataTable("fragment", ds.Tables[0], "Root", 1, 0, 0, 0, 0, 0);
 
             // rest ... treated as schema
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "Auto", Schema2,
+            DataSetAssertion.AssertReadXml(ds, "Auto", schema2,
                 XmlReadMode.Auto, XmlReadMode.ReadSchema,
                 "NewDataSet", 1, ReadState.Interactive);
             DataSetAssertion.AssertDataTable("auto", ds.Tables[0], "Root", 1, 0, 0, 0, 0, 0);
 
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "DiffGram", Schema2,
+            DataSetAssertion.AssertReadXml(ds, "DiffGram", schema2,
                 XmlReadMode.DiffGram, XmlReadMode.DiffGram,
                 "NewDataSet", 1, ReadState.Interactive);
             DataSetAssertion.AssertDataTable("diffgram", ds.Tables[0], "Root", 1, 0, 0, 0, 0, 0);
 
             ds = new DataSet();
-            DataSetAssertion.AssertReadXml(ds, "ReadSchema", Schema2,
+            DataSetAssertion.AssertReadXml(ds, "ReadSchema", schema2,
                 XmlReadMode.ReadSchema, XmlReadMode.ReadSchema,
                 "NewDataSet", 1, ReadState.Interactive);
         }
@@ -563,11 +563,11 @@ namespace System.Data.Tests
             // simple element -> simple table
             var ds = new DataSet();
 
-            DataSetAssertion.AssertReadXml(ds, "SingleText", Xml5,
+            DataSetAssertion.AssertReadXml(ds, "SingleText", xml5,
                 XmlReadMode.Auto, XmlReadMode.InferSchema,
                 "root", 0);
 
-            DataSetAssertion.AssertReadXml(ds, "SimpleTable", Xml6,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable", xml6,
                 XmlReadMode.Auto, XmlReadMode.InferSchema,
                 "NewDataSet", 1);
             DataSetAssertion.AssertDataTable("seq1", ds.Tables[0], "root", 1, 1, 0, 0, 0, 0);
@@ -579,11 +579,11 @@ namespace System.Data.Tests
             // simple element -> simple dataset
             var ds = new DataSet();
 
-            DataSetAssertion.AssertReadXml(ds, "SingleText", Xml5,
+            DataSetAssertion.AssertReadXml(ds, "SingleText", xml5,
                 XmlReadMode.Auto, XmlReadMode.InferSchema,
                 "root", 0);
 
-            DataSetAssertion.AssertReadXml(ds, "SimpleTable2", Xml7,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable2", xml7,
                 XmlReadMode.Auto, XmlReadMode.InferSchema,
                 "NewDataSet", 1);
             DataSetAssertion.AssertDataTable("#1", ds.Tables[0], "root", 2, 1, 0, 0, 0, 0);
@@ -591,7 +591,7 @@ namespace System.Data.Tests
             // simple table -> simple dataset
             ds = new DataSet();
 
-            DataSetAssertion.AssertReadXml(ds, "SimpleTable", Xml6,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable", xml6,
                 XmlReadMode.Auto, XmlReadMode.InferSchema,
                 "NewDataSet", 1);
             DataSetAssertion.AssertDataTable("#2", ds.Tables[0], "root", 1, 1, 0, 0, 0, 0);
@@ -600,7 +600,7 @@ namespace System.Data.Tests
             // already schema information in the dataset.
             // Columns are kept 1 as old table holds.
             // Rows are up to 2 because of accumulative read.
-            DataSetAssertion.AssertReadXml(ds, "SimpleTable2-2", Xml7,
+            DataSetAssertion.AssertReadXml(ds, "SimpleTable2-2", xml7,
                 XmlReadMode.Auto, XmlReadMode.IgnoreSchema,
                 "NewDataSet", 1);
             DataSetAssertion.AssertDataTable("#3", ds.Tables[0], "root", 1, 2, 0, 0, 0, 0);
@@ -610,7 +610,7 @@ namespace System.Data.Tests
         public void ReadComplexElementDocument()
         {
             var ds = new DataSet();
-            ds.ReadXml(new StringReader(Xml29));
+            ds.ReadXml(new StringReader(xml29));
         }
 
         [Fact]

--- a/src/System.Data.Common/tests/System/Data/DataSetTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataSetTest.cs
@@ -783,24 +783,24 @@ namespace System.Data.Tests
 
             DataColumn col = new DataColumn();
             col.ColumnName = "Id";
-            col.DataType = Type.GetType("System.Int32");
+            col.DataType = typeof(int);
             table.Columns.Add(col);
             UniqueConstraint uc = new UniqueConstraint("UK1", table.Columns[0]);
             table.Constraints.Add(uc);
 
             col = new DataColumn();
             col.ColumnName = "Name";
-            col.DataType = Type.GetType("System.String");
+            col.DataType = typeof(string);
             table.Columns.Add(col);
 
             col = new DataColumn();
             col.ColumnName = "Id";
-            col.DataType = Type.GetType("System.Int32");
+            col.DataType = typeof(int);
             table1.Columns.Add(col);
 
             col = new DataColumn();
             col.ColumnName = "Name";
-            col.DataType = Type.GetType("System.String");
+            col.DataType = typeof(string);
             table1.Columns.Add(col);
             ForeignKeyConstraint fc = new ForeignKeyConstraint("FK1", table.Columns[0], table1.Columns[0]);
             table1.Constraints.Add(fc);
@@ -1695,14 +1695,7 @@ namespace System.Data.Tests
             child.Rows.Add(dr);
             dr.AcceptChanges();
 
-            try
-            {
-                ds.Clear(); // this should clear all the rows in parent & child tables
-            }
-            catch (Exception e)
-            {
-                throw (new Exception("Exception should not have been thrown at Clear method" + e.ToString()));
-            }
+            ds.Clear(); // this should clear all the rows in parent & child tables
             Assert.Equal(0, parent.Rows.Count);
             Assert.Equal(0, child.Rows.Count);
         }

--- a/src/System.Data.Common/tests/System/Data/DataSetTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataSetTest.cs
@@ -738,7 +738,7 @@ namespace System.Data.Tests
             ser.Deserialize(new XmlTextReader(
                 xml, XmlNodeType.Document, null));
         }
-        // TODO: what's this?
+
         /* To be added
         [Fact]
         public void WriteDiffReadAutoWriteSchema ()

--- a/src/System.Data.Common/tests/System/Data/DataSetTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataSetTest.cs
@@ -46,7 +46,7 @@ namespace System.Data.Tests
     {
         public DataSetTest()
         {
-            MyDataSet.count = 0;
+            MyDataSet.Count = 0;
         }
 
         [Fact]
@@ -738,7 +738,7 @@ namespace System.Data.Tests
             ser.Deserialize(new XmlTextReader(
                 xml, XmlNodeType.Document, null));
         }
-
+        // TODO: what's this?
         /* To be added
         [Fact]
         public void WriteDiffReadAutoWriteSchema ()
@@ -1712,7 +1712,7 @@ namespace System.Data.Tests
         {
             MyDataSet ds1 = new MyDataSet();
             MyDataSet ds = (MyDataSet)(ds1.Clone());
-            Assert.Equal(2, MyDataSet.count);
+            Assert.Equal(2, MyDataSet.Count);
         }
 
         #region DataSet.GetChanges Tests
@@ -1956,27 +1956,27 @@ namespace System.Data.Tests
            });
         }
 
-        internal struct fillErrorStruct
+        internal struct FillErrorStruct
         {
-            internal string error;
-            internal string tableName;
-            internal int rowKey;
-            internal bool contFlag;
+            internal string _error;
+            internal string _tableName;
+            internal int _rowKey;
+            internal bool _contFlag;
             internal void init(string tbl, int row, bool cont, string err)
             {
-                tableName = tbl;
-                rowKey = row;
-                contFlag = cont;
-                error = err;
+                _tableName = tbl;
+                _rowKey = row;
+                _contFlag = cont;
+                _error = err;
             }
         }
-        private fillErrorStruct[] _fillErr = new fillErrorStruct[3];
+        private readonly FillErrorStruct[] _fillErr = new FillErrorStruct[3];
         private int _fillErrCounter;
-        private void fillErrorHandler(object sender, FillErrorEventArgs e)
+        private void FillErrorHandler(object sender, FillErrorEventArgs e)
         {
-            e.Continue = _fillErr[_fillErrCounter].contFlag;
-            Assert.Equal(_fillErr[_fillErrCounter].tableName, e.DataTable.TableName);
-            Assert.Equal(_fillErr[_fillErrCounter].contFlag, e.Continue);
+            e.Continue = _fillErr[_fillErrCounter]._contFlag;
+            Assert.Equal(_fillErr[_fillErrCounter]._tableName, e.DataTable.TableName);
+            Assert.Equal(_fillErr[_fillErrCounter]._contFlag, e.Continue);
             _fillErrCounter++;
         }
 
@@ -2029,27 +2029,27 @@ namespace System.Data.Tests
             dsLoad.Tables.Add(table2);
             DataTableReader dtr = _ds.CreateDataReader();
             dsLoad.Load(dtr, LoadOption.PreserveChanges,
-                     fillErrorHandler, table1, table2);
+                     FillErrorHandler, table1, table2);
         }
         [Fact]
         public void Load_TableConflictF()
         {
             AssertExtensions.Throws<ArgumentException>(null, () =>
-           {
-               _fillErrCounter = 0;
-               _fillErr[0].init("Table1", 1, false,
-                   "Input string was not in a correct format.Couldn't store <mono 1> in name1 Column.  Expected type is Double.");
-               localSetup();
-               DataSet dsLoad = new DataSet("LoadTableConflict");
-               DataTable table1 = new DataTable();
-               table1.Columns.Add("name1", typeof(double));
-               dsLoad.Tables.Add(table1);
-               DataTable table2 = new DataTable();
-               dsLoad.Tables.Add(table2);
-               DataTableReader dtr = _ds.CreateDataReader();
-               dsLoad.Load(dtr, LoadOption.Upsert,
-                        fillErrorHandler, table1, table2);
-           });
+            {
+                _fillErrCounter = 0;
+                _fillErr[0].init("Table1", 1, false,
+                    "Input string was not in a correct format.Couldn't store <mono 1> in name1 Column.  Expected type is Double.");
+                localSetup();
+                DataSet dsLoad = new DataSet("LoadTableConflict");
+                DataTable table1 = new DataTable();
+                table1.Columns.Add("name1", typeof(double));
+                dsLoad.Tables.Add(table1);
+                DataTable table2 = new DataTable();
+                dsLoad.Tables.Add(table2);
+                DataTableReader dtr = _ds.CreateDataReader();
+                dsLoad.Load(dtr, LoadOption.Upsert,
+                        FillErrorHandler, table1, table2);
+            });
         }
 
         [Fact]
@@ -2190,11 +2190,11 @@ namespace System.Data.Tests
 
     public class MyDataSet : DataSet
     {
-        public static int count;
+        public static int Count;
 
         public MyDataSet()
         {
-            count++;
+            Count++;
         }
     }
 }

--- a/src/System.Data.Common/tests/System/Data/DataSetTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/DataSetTest2.cs
@@ -1676,7 +1676,9 @@ namespace System.Data.Tests
                 ds1.Merge(ds2, true, MissingSchemaAction.Error);
             });
 
-            Assert.Throws<DataException>(() =>
+            //TODO: InvalidConstraintException at 1687 ...Add("fk"..., what are testing exactly?
+            //"This constraint cannot be added since ForeignKey doesn't belong to table table1."
+            Assert.ThrowsAny<DataException>(() =>
             {
                 DataSet ds1 = ds.Copy();
                 DataSet ds2 = ds.Copy();

--- a/src/System.Data.Common/tests/System/Data/DataSetTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/DataSetTest2.cs
@@ -26,9 +26,7 @@
 
 using System.Text;
 using System.IO;
-using System.Diagnostics;
 using System.Xml;
-using System.Runtime.Serialization.Formatters.Binary;
 using System.Runtime.Serialization.Formatters.Tests;
 using System.Globalization;
 using Microsoft.DotNet.RemoteExecutor;
@@ -270,17 +268,19 @@ namespace System.Data.Tests
             ds.Tables[0].PrimaryKey = new DataColumn[] { ds.Tables[0].Columns[0] };
             ds.EnforceConstraints = false;
             ds.Tables[0].Rows.Add(new object[] { null });
-            try
-            {
-                ds.EnforceConstraints = true;
-                Assert.False(true);
-            }
-            catch (ConstraintException e)
-            {
-                // Never premise English.
-                //Assert.Equal ("Failed to enable constraints. One or more rows contain values " +
-                //        "violating non-null, unique, or foreign-key constraints.", e.Message, "#2");
-            }
+            //TODO
+            //try
+            //{
+            //    ds.EnforceConstraints = true;
+            //    Assert.False(true);
+            //}
+            //catch (ConstraintException e)
+            //{
+            //    // Never premise English.
+            //    //Assert.Equal ("Failed to enable constraints. One or more rows contain values " + 
+            //    //		"violating non-null, unique, or foreign-key constraints.", e.Message, "#2");
+            //}
+            Assert.Throws<ConstraintException>(() => ds.EnforceConstraints = true);
         }
 
         [Fact]
@@ -293,17 +293,19 @@ namespace System.Data.Tests
 
             ds.EnforceConstraints = false;
             ds.Tables[0].Rows.Add(new object[] { null });
-            try
-            {
-                ds.EnforceConstraints = true;
-                Assert.False(true);
-            }
-            catch (ConstraintException e)
-            {
-                // Never premise English.
-                //Assert.Equal ("Failed to enable constraints. One or more rows contain values " +
-                //        "violating non-null, unique, or foreign-key constraints.", e.Message, "#2");
-            }
+            //TODO
+            //try
+            //{
+            //    ds.EnforceConstraints = true;
+            //    Assert.False(true);
+            //}
+            //catch (ConstraintException e)
+            //{
+            //    // Never premise English.
+            //    //Assert.Equal ("Failed to enable constraints. One or more rows contain values " + 
+            //    //		"violating non-null, unique, or foreign-key constraints.", e.Message, "#2");
+            //}
+            Assert.Throws<ConstraintException>(() => ds.EnforceConstraints = true);
         }
 
         [Fact]
@@ -1068,7 +1070,7 @@ namespace System.Data.Tests
 
             DataRow[] drArr = new DataRow[3];
             //Update row
-            string OldValue = dt.Select("ParentId=1")[0][1].ToString();
+            string oldValue = dt.Select("ParentId=1")[0][1].ToString();
             drArr[0] = dt.Select("ParentId=1")[0];
             drArr[0][1] = "NewValue";
             //delete rows
@@ -1346,12 +1348,12 @@ namespace System.Data.Tests
 
             // Merge MissingSchemaAction.Add - Table
             Assert.True(dsTarget1.Tables.Contains("NewTable"));
-
+            //TODO
             //failed, should be success by MSDN Library documentation
             //        // Merge MissingSchemaAction.Add - PrimaryKey
             //        Assert.Equal(0, dsTarget1.Tables["NewTable"].PrimaryKey.Length);
             #endregion
-
+            //TODO
             #region "ds,false,MissingSchemaAction.AddWithKey)"
             //MissingSchemaAction.Add,MissingSchemaAction.AddWithKey - behave the same, checked only Add
 
@@ -1487,7 +1489,7 @@ namespace System.Data.Tests
 
             ds1.Tables[1].Constraints.Add("fk", ds1.Tables[0].Columns[0], ds1.Tables[1].Columns[0]);
 
-            // No Exceptions shud be thrown
+            // No Exceptions should be thrown
             ds.Merge(ds1);
             Assert.Equal(1, table2.Constraints.Count);
         }
@@ -1510,7 +1512,7 @@ namespace System.Data.Tests
             table2.Constraints.Add("fk", pcol, ccol);
             ds1.Tables[1].Constraints.Add("fk", ds1.Tables[0].Columns["col2"], ds1.Tables[1].Columns["col2"]);
 
-            // No Exceptions shud be thrown
+            // No Exceptions should be thrown
             ds.Merge(ds1);
             Assert.Equal(2, table2.Constraints.Count);
             Assert.Equal("Constraint1", table2.Constraints[1].ConstraintName);
@@ -1666,42 +1668,30 @@ namespace System.Data.Tests
             table1.Columns.Add("col1", typeof(int));
             table2.Columns.Add("col1", typeof(int));
 
-            try
+            Assert.Throws<DataException>(() =>
             {
                 DataSet ds1 = ds.Copy();
                 DataSet ds2 = ds.Copy();
                 ds2.Tables[0].Constraints.Add("uc", ds2.Tables[0].Columns[0], false);
                 ds1.Merge(ds2, true, MissingSchemaAction.Error);
-                Assert.False(true);
-            }
-            catch (DataException e)
-            {
-            }
+            });
 
-            try
+            Assert.Throws<DataException>(() =>
             {
                 DataSet ds1 = ds.Copy();
                 DataSet ds2 = ds.Copy();
                 ds2.Tables[0].Constraints.Add("fk", ds2.Tables[0].Columns[0], ds2.Tables[1].Columns[0]);
                 ds1.Tables[0].Constraints.Add("uc", ds1.Tables[0].Columns[0], false);
                 ds1.Merge(ds2, true, MissingSchemaAction.Error);
-                Assert.False(true);
-            }
-            catch (DataException e)
-            {
-            }
+            });
 
-            try
+            Assert.Throws<ArgumentException>(() =>
             {
                 DataSet ds1 = ds.Copy();
                 DataSet ds2 = ds.Copy();
                 ds2.Relations.Add("rel", ds2.Tables[0].Columns[0], ds2.Tables[1].Columns[0], false);
                 ds1.Merge(ds2, true, MissingSchemaAction.Error);
-                Assert.False(true);
-            }
-            catch (ArgumentException e)
-            {
-            }
+            });
         }
 
         [Fact]
@@ -2891,12 +2881,12 @@ namespace System.Data.Tests
         public void ShouldSerializeTables()
         {
             // DataSet ShouldSerializeTables
-            newDataSet1 ds = new newDataSet1();
+            NewDataSet1 ds = new NewDataSet1();
 
             Assert.True(ds.testMethod());
         }
 
-        private class newDataSet1 : DataSet
+        private class NewDataSet1 : DataSet
         {
             public bool testMethod()
             {
@@ -2978,34 +2968,29 @@ namespace System.Data.Tests
             finally
             {
                 sw.Close();
+                sr.Close();
             }
         }
 
         [Fact]
-        public void ctor()
+        public void Ctor()
         {
-            DataSet ds;
-
             // ctor
-            ds = new DataSet();
-            Assert.True(ds != null);
+            DataSet ds = new DataSet();
         }
 
         [Fact]
-        public void ctor_ByDataSetName()
+        public void Ctor_ByDataSetName()
         {
-            DataSet ds = null;
-
             // ctor
-            ds = new DataSet("NewDataSet");
-            Assert.True(ds != null);
+            DataSet ds = new DataSet("NewDataSet");
 
             // ctor - name
             Assert.Equal("NewDataSet", ds.DataSetName);
         }
 
         [Fact]
-        public void extendedProperties()
+        public void ExtendedProperties()
         {
             var ds = new DataSet();
             PropertyCollection pc;
@@ -3024,15 +3009,8 @@ namespace System.Data.Tests
         {
             DataSet ds = new DataSet();
             Assert.Equal(SchemaSerializationMode.IncludeSchema, ds.SchemaSerializationMode);
-            try
-            {
-                ds.SchemaSerializationMode = SchemaSerializationMode.ExcludeSchema;
-                Assert.False(true);
-            }
-            catch (InvalidOperationException e)
-            {
-                //ok
-            }
+
+            Assert.Throws<InvalidOperationException>(() => ds.SchemaSerializationMode = SchemaSerializationMode.ExcludeSchema);
         }
 
         ///<?xml version="1.0" encoding="utf-16"?>
@@ -3410,12 +3388,7 @@ namespace System.Data.Tests
             ds.Tables.Add(new DataTable());
             ds.Tables[0].Columns.Add(new DataColumn("id", typeof(string)));
 
-            try
-            {
-                ds.Merge(dataSet, true, MissingSchemaAction.Add);
-                Assert.False(true);
-            }
-            catch (DataException e) { }
+            Assert.Throws<DataException>(() => ds.Merge(dataSet, true, MissingSchemaAction.Add));
 
             ds = new DataSet();
             ds.Tables.Add(new DataTable());

--- a/src/System.Data.Common/tests/System/Data/DataSetTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/DataSetTest2.cs
@@ -268,18 +268,8 @@ namespace System.Data.Tests
             ds.Tables[0].PrimaryKey = new DataColumn[] { ds.Tables[0].Columns[0] };
             ds.EnforceConstraints = false;
             ds.Tables[0].Rows.Add(new object[] { null });
-            //TODO
-            //try
-            //{
-            //    ds.EnforceConstraints = true;
-            //    Assert.False(true);
-            //}
-            //catch (ConstraintException e)
-            //{
-            //    // Never premise English.
-            //    //Assert.Equal ("Failed to enable constraints. One or more rows contain values " + 
-            //    //		"violating non-null, unique, or foreign-key constraints.", e.Message, "#2");
-            //}
+
+            // Failed to enable constraints. One or more rows contain values violating non-null, unique, or foreign-key constraints.
             Assert.Throws<ConstraintException>(() => ds.EnforceConstraints = true);
         }
 
@@ -293,18 +283,8 @@ namespace System.Data.Tests
 
             ds.EnforceConstraints = false;
             ds.Tables[0].Rows.Add(new object[] { null });
-            //TODO
-            //try
-            //{
-            //    ds.EnforceConstraints = true;
-            //    Assert.False(true);
-            //}
-            //catch (ConstraintException e)
-            //{
-            //    // Never premise English.
-            //    //Assert.Equal ("Failed to enable constraints. One or more rows contain values " + 
-            //    //		"violating non-null, unique, or foreign-key constraints.", e.Message, "#2");
-            //}
+
+            // Failed to enable constraints. One or more rows contain values violating non-null, unique, or foreign-key constraints.
             Assert.Throws<ConstraintException>(() => ds.EnforceConstraints = true);
         }
 
@@ -1348,12 +1328,12 @@ namespace System.Data.Tests
 
             // Merge MissingSchemaAction.Add - Table
             Assert.True(dsTarget1.Tables.Contains("NewTable"));
-            //TODO
+
             //failed, should be success by MSDN Library documentation
             //        // Merge MissingSchemaAction.Add - PrimaryKey
             //        Assert.Equal(0, dsTarget1.Tables["NewTable"].PrimaryKey.Length);
             #endregion
-            //TODO
+
             #region "ds,false,MissingSchemaAction.AddWithKey)"
             //MissingSchemaAction.Add,MissingSchemaAction.AddWithKey - behave the same, checked only Add
 
@@ -1676,7 +1656,6 @@ namespace System.Data.Tests
                 ds1.Merge(ds2, true, MissingSchemaAction.Error);
             });
 
-            //TODO: InvalidConstraintException at 1687 ...Add("fk"..., what are testing exactly?
             //"This constraint cannot be added since ForeignKey doesn't belong to table table1."
             Assert.ThrowsAny<DataException>(() =>
             {

--- a/src/System.Data.Common/tests/System/Data/DataSetTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/DataSetTest2.cs
@@ -205,7 +205,7 @@ namespace System.Data.Tests
             Assert.Equal(DataProvider.GetDSSchema(ds), DataProvider.GetDSSchema(dsTarget));
 
             // Clone 2
-            Assert.False(dsTarget.GetXml() == ds.GetXml());
+            Assert.NotEqual(dsTarget.GetXml(), ds.GetXml());
         }
 
         [Fact]
@@ -228,7 +228,7 @@ namespace System.Data.Tests
             Assert.Equal(DataProvider.GetDSSchema(ds), DataProvider.GetDSSchema(dsTarget));
 
             // Copy 2
-            Assert.True(dsTarget.GetXml() == ds.GetXml());
+            Assert.Equal(dsTarget.GetXml(), ds.GetXml());
         }
 
         [Fact]
@@ -322,7 +322,7 @@ namespace System.Data.Tests
             ds.Tables[0].Rows.Add(dr);
 
             // GetChanges 2
-            Assert.True(ds.GetChanges() != null);
+            Assert.NotNull(ds.GetChanges());
 
             // GetChanges 3
             Assert.Equal(dr.ItemArray, ds.GetChanges().Tables[0].Rows[0].ItemArray);
@@ -1247,7 +1247,7 @@ namespace System.Data.Tests
 
             //SomeTable - new table
             // Merge - new table
-            Assert.True(dsTarget.Tables["SomeTable"] != null);
+            Assert.NotNull(dsTarget.Tables["SomeTable"]);
         }
 
         [Fact]
@@ -1763,7 +1763,7 @@ namespace System.Data.Tests
             Assert.Equal(dsTarget.Tables["Parent"].Columns["Indentity"].AutoIncrement, ds.Tables["Parent"].Columns["Indentity"].AutoIncrement);
 
             // check Indentity column - DefaultValue
-            Assert.True(dsTarget.Tables["Child"].Columns["String1"].DefaultValue == DBNull.Value);
+            Assert.Equal(DBNull.Value, dsTarget.Tables["Child"].Columns["String1"].DefaultValue);
 
             // check remove colum
             Assert.True(dsTarget.Tables["Child"].Columns.Contains("String2"));
@@ -1814,7 +1814,7 @@ namespace System.Data.Tests
             Assert.Equal(dsTarget.Tables["Parent"].Columns["Indentity"].AutoIncrement, ds.Tables["Parent"].Columns["Indentity"].AutoIncrement);
 
             // check Indentity column - DefaultValue
-            Assert.True(dsTarget.Tables["Child"].Columns["String1"].DefaultValue == DBNull.Value);
+            Assert.Equal(DBNull.Value, dsTarget.Tables["Child"].Columns["String1"].DefaultValue);
 
             // check remove colum
             Assert.True(dsTarget.Tables["Child"].Columns.Contains("String2"));
@@ -3000,7 +3000,7 @@ namespace System.Data.Tests
             pc = ds.ExtendedProperties;
 
             // Checking ExtendedProperties default
-            Assert.True(pc != null);
+            Assert.NotNull(pc);
 
             // Checking ExtendedProperties count
             Assert.Equal(0, pc.Count);

--- a/src/System.Data.Common/tests/System/Data/DataSetTypedDataSetTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataSetTypedDataSetTest.cs
@@ -940,16 +940,14 @@ namespace System.Data.Tests
                 Orders = new OrdersDataTable();
                 Tables.Add(Orders);
                 ForeignKeyConstraint fkc;
-                fkc = new ForeignKeyConstraint("OrdersOrder_x0020_Details", new DataColumn[] {
-                                                                                                 Orders.OrderIDColumn}, new DataColumn[] {
-                                                                                                                                                       Order_Details.OrderIDColumn});
+                fkc = new ForeignKeyConstraint("OrdersOrder_x0020_Details",
+                    new DataColumn[] { Orders.OrderIDColumn}, new DataColumn[] { Order_Details.OrderIDColumn });
                 Order_Details.Constraints.Add(fkc);
                 fkc.AcceptRejectRule = AcceptRejectRule.None;
                 fkc.DeleteRule = Rule.Cascade;
                 fkc.UpdateRule = Rule.Cascade;
-                _relationOrdersOrder_x0020_Details = new DataRelation("OrdersOrder_x0020_Details", new DataColumn[] {
-                                                                                                                            Orders.OrderIDColumn}, new DataColumn[] {
-                                                                                                                                                                                  Order_Details.OrderIDColumn}, false);
+                _relationOrdersOrder_x0020_Details = new DataRelation("OrdersOrder_x0020_Details",
+                    new DataColumn[] { Orders.OrderIDColumn }, new DataColumn[] { Order_Details.OrderIDColumn }, false);
                 Relations.Add(_relationOrdersOrder_x0020_Details);
             }
 
@@ -1058,9 +1056,7 @@ namespace System.Data.Tests
 
                 public Order_DetailsRow FindByOrderIDProductID(int OrderID, int ProductID)
                 {
-                    return ((Order_DetailsRow)(Rows.Find(new object[] {
-                                                                               OrderID,
-                                                                               ProductID})));
+                    return (Order_DetailsRow)Rows.Find(new object[] { OrderID, ProductID });
                 }
 
                 public IEnumerator GetEnumerator()

--- a/src/System.Data.Common/tests/System/Data/DataSetTypedDataSetTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataSetTypedDataSetTest.cs
@@ -731,12 +731,12 @@ namespace System.Data.Tests
 
             //check relations
             //ChildTableRow has property ParentTableRow
-            myTypedDataSet.OrdersRow dr1 = ds.Order_Details[0].OrdersRow;
-            DataRow dr2 = ds.Order_Details[0].GetParentRow(ds.Relations[0]);
+            myTypedDataSet.OrdersRow dr1 = ds.OrderDetails[0].OrdersRow;
+            DataRow dr2 = ds.OrderDetails[0].GetParentRow(ds.Relations[0]);
             Assert.Equal(dr1, dr2);
 
             //ParentTableRow has property ChildTableRow
-            myTypedDataSet.Order_DetailsRow[] drArr1 = ds.Orders[0].GetOrder_DetailsRows();
+            myTypedDataSet.OrderDetailsRow[] drArr1 = ds.Orders[0].GetOrderDetailsRows();
             DataRow[] drArr2 = ds.Orders[0].GetChildRows(ds.Relations[0]);
             Assert.Equal(drArr1, drArr2);
 
@@ -831,7 +831,7 @@ namespace System.Data.Tests
                     ds.ReadXmlSchema(new XmlTextReader(new StringReader(strSchema)));
                     if ((ds.Tables["Order Details"] != null))
                     {
-                        Tables.Add(new Order_DetailsDataTable(ds.Tables["Order Details"]));
+                        Tables.Add(new OrderDetailsDataTable(ds.Tables["Order Details"]));
                     }
                     if ((ds.Tables["Orders"] != null))
                     {
@@ -858,7 +858,7 @@ namespace System.Data.Tests
 
             [Browsable(false)]
             [DesignerSerializationVisibilityAttribute(DesignerSerializationVisibility.Content)]
-            public Order_DetailsDataTable Order_Details { get; private set; }
+            public OrderDetailsDataTable OrderDetails { get; private set; }
 
             [Browsable(false)]
             [DesignerSerializationVisibilityAttribute(DesignerSerializationVisibility.Content)]
@@ -888,7 +888,7 @@ namespace System.Data.Tests
                 ds.ReadXml(reader);
                 if ((ds.Tables["Order Details"] != null))
                 {
-                    Tables.Add(new Order_DetailsDataTable(ds.Tables["Order Details"]));
+                    Tables.Add(new OrderDetailsDataTable(ds.Tables["Order Details"]));
                 }
                 if ((ds.Tables["Orders"] != null))
                 {
@@ -914,10 +914,10 @@ namespace System.Data.Tests
 
             internal void InitVars()
             {
-                Order_Details = ((Order_DetailsDataTable)(Tables["Order Details"]));
-                if ((Order_Details != null))
+                OrderDetails = ((OrderDetailsDataTable)(Tables["Order Details"]));
+                if ((OrderDetails != null))
                 {
-                    Order_Details.InitVars();
+                    OrderDetails.InitVars();
                 }
                 Orders = ((OrdersDataTable)(Tables["Orders"]));
                 if ((Orders != null))
@@ -935,19 +935,19 @@ namespace System.Data.Tests
                 Locale = new CultureInfo("en-US");
                 CaseSensitive = false;
                 EnforceConstraints = true;
-                Order_Details = new Order_DetailsDataTable();
-                Tables.Add(Order_Details);
+                OrderDetails = new OrderDetailsDataTable();
+                Tables.Add(OrderDetails);
                 Orders = new OrdersDataTable();
                 Tables.Add(Orders);
                 ForeignKeyConstraint fkc;
                 fkc = new ForeignKeyConstraint("OrdersOrder_x0020_Details",
-                    new DataColumn[] { Orders.OrderIDColumn}, new DataColumn[] { Order_Details.OrderIDColumn });
-                Order_Details.Constraints.Add(fkc);
+                    new DataColumn[] { Orders.OrderIDColumn}, new DataColumn[] { OrderDetails.OrderIDColumn });
+                OrderDetails.Constraints.Add(fkc);
                 fkc.AcceptRejectRule = AcceptRejectRule.None;
                 fkc.DeleteRule = Rule.Cascade;
                 fkc.UpdateRule = Rule.Cascade;
                 _relationOrdersOrder_x0020_Details = new DataRelation("OrdersOrder_x0020_Details",
-                    new DataColumn[] { Orders.OrderIDColumn }, new DataColumn[] { Order_Details.OrderIDColumn }, false);
+                    new DataColumn[] { Orders.OrderIDColumn }, new DataColumn[] { OrderDetails.OrderIDColumn }, false);
                 Relations.Add(_relationOrdersOrder_x0020_Details);
             }
 
@@ -969,19 +969,19 @@ namespace System.Data.Tests
                 }
             }
 
-            public delegate void Order_DetailsRowChangeEventHandler(object sender, Order_DetailsRowChangeEvent e);
+            public delegate void OrderDetailsRowChangeEventHandler(object sender, OrderDetailsRowChangeEvent e);
 
             public delegate void OrdersRowChangeEventHandler(object sender, OrdersRowChangeEvent e);
 
-            public class Order_DetailsDataTable : DataTable, IEnumerable
+            public class OrderDetailsDataTable : DataTable, IEnumerable
             {
-                internal Order_DetailsDataTable() :
+                internal OrderDetailsDataTable() :
                     base("Order Details")
                 {
                     InitClass();
                 }
 
-                internal Order_DetailsDataTable(DataTable table) :
+                internal OrderDetailsDataTable(DataTable table) :
                     base(table.TableName)
                 {
                     if ((table.CaseSensitive != table.DataSet.CaseSensitive))
@@ -1020,43 +1020,43 @@ namespace System.Data.Tests
 
                 internal DataColumn DiscountColumn { get; private set; }
 
-                public Order_DetailsRow this[int index]
+                public OrderDetailsRow this[int index]
                 {
                     get
                     {
-                        return ((Order_DetailsRow)(Rows[index]));
+                        return ((OrderDetailsRow)(Rows[index]));
                     }
                 }
 
-                public event Order_DetailsRowChangeEventHandler Order_DetailsRowChanged;
+                public event OrderDetailsRowChangeEventHandler OrderDetailsRowChanged;
 
-                public event Order_DetailsRowChangeEventHandler Order_DetailsRowChanging;
+                public event OrderDetailsRowChangeEventHandler OrderDetailsRowChanging;
 
-                public event Order_DetailsRowChangeEventHandler Order_DetailsRowDeleted;
+                public event OrderDetailsRowChangeEventHandler OrderDetailsRowDeleted;
 
-                public event Order_DetailsRowChangeEventHandler Order_DetailsRowDeleting;
+                public event OrderDetailsRowChangeEventHandler OrderDetailsRowDeleting;
 
-                public void AddOrder_DetailsRow(Order_DetailsRow row)
+                public void AddOrder_DetailsRow(OrderDetailsRow row)
                 {
                     Rows.Add(row);
                 }
 
-                public Order_DetailsRow AddOrder_DetailsRow(OrdersRow parentOrdersRowByOrdersOrder_x0020_Details, int ProductID, decimal UnitPrice, short Quantity, string Discount)
+                public OrderDetailsRow AddOrder_DetailsRow(OrdersRow parentOrdersRowByOrdersOrder_x0020_Details, int ProductID, decimal UnitPrice, short Quantity, string Discount)
                 {
-                    Order_DetailsRow rowOrder_DetailsRow = ((Order_DetailsRow)(NewRow()));
-                    rowOrder_DetailsRow.ItemArray = new object[] {
+                    OrderDetailsRow rowOrderDetailsRow = ((OrderDetailsRow)(NewRow()));
+                    rowOrderDetailsRow.ItemArray = new object[] {
                                                                      parentOrdersRowByOrdersOrder_x0020_Details[0],
                                                                      ProductID,
                                                                      UnitPrice,
                                                                      Quantity,
                                                                      Discount};
-                    Rows.Add(rowOrder_DetailsRow);
-                    return rowOrder_DetailsRow;
+                    Rows.Add(rowOrderDetailsRow);
+                    return rowOrderDetailsRow;
                 }
 
-                public Order_DetailsRow FindByOrderIDProductID(int OrderID, int ProductID)
+                public OrderDetailsRow FindByOrderIDProductID(int OrderID, int ProductID)
                 {
-                    return (Order_DetailsRow)Rows.Find(new object[] { OrderID, ProductID });
+                    return (OrderDetailsRow)Rows.Find(new object[] { OrderID, ProductID });
                 }
 
                 public IEnumerator GetEnumerator()
@@ -1066,14 +1066,14 @@ namespace System.Data.Tests
 
                 public override DataTable Clone()
                 {
-                    Order_DetailsDataTable cln = ((Order_DetailsDataTable)(base.Clone()));
+                    OrderDetailsDataTable cln = ((OrderDetailsDataTable)(base.Clone()));
                     cln.InitVars();
                     return cln;
                 }
 
                 protected override DataTable CreateInstance()
                 {
-                    return new Order_DetailsDataTable();
+                    return new OrderDetailsDataTable();
                 }
 
                 internal void InitVars()
@@ -1107,82 +1107,82 @@ namespace System.Data.Tests
                     DiscountColumn.ReadOnly = true;
                 }
 
-                public Order_DetailsRow NewOrder_DetailsRow()
+                public OrderDetailsRow NewOrder_DetailsRow()
                 {
-                    return ((Order_DetailsRow)(NewRow()));
+                    return ((OrderDetailsRow)(NewRow()));
                 }
 
                 protected override DataRow NewRowFromBuilder(DataRowBuilder builder)
                 {
-                    return new Order_DetailsRow(builder);
+                    return new OrderDetailsRow(builder);
                 }
 
                 protected override Type GetRowType()
                 {
-                    return typeof(Order_DetailsRow);
+                    return typeof(OrderDetailsRow);
                 }
 
                 protected override void OnRowChanged(DataRowChangeEventArgs e)
                 {
                     base.OnRowChanged(e);
-                    if ((Order_DetailsRowChanged != null))
+                    if ((OrderDetailsRowChanged != null))
                     {
-                        Order_DetailsRowChanged(this, new Order_DetailsRowChangeEvent(((Order_DetailsRow)(e.Row)), e.Action));
+                        OrderDetailsRowChanged(this, new OrderDetailsRowChangeEvent(((OrderDetailsRow)(e.Row)), e.Action));
                     }
                 }
 
                 protected override void OnRowChanging(DataRowChangeEventArgs e)
                 {
                     base.OnRowChanging(e);
-                    if ((Order_DetailsRowChanging != null))
+                    if ((OrderDetailsRowChanging != null))
                     {
-                        Order_DetailsRowChanging(this, new Order_DetailsRowChangeEvent(((Order_DetailsRow)(e.Row)), e.Action));
+                        OrderDetailsRowChanging(this, new OrderDetailsRowChangeEvent(((OrderDetailsRow)(e.Row)), e.Action));
                     }
                 }
 
                 protected override void OnRowDeleted(DataRowChangeEventArgs e)
                 {
                     base.OnRowDeleted(e);
-                    if ((Order_DetailsRowDeleted != null))
+                    if ((OrderDetailsRowDeleted != null))
                     {
-                        Order_DetailsRowDeleted(this, new Order_DetailsRowChangeEvent(((Order_DetailsRow)(e.Row)), e.Action));
+                        OrderDetailsRowDeleted(this, new OrderDetailsRowChangeEvent(((OrderDetailsRow)(e.Row)), e.Action));
                     }
                 }
 
                 protected override void OnRowDeleting(DataRowChangeEventArgs e)
                 {
                     base.OnRowDeleting(e);
-                    if ((Order_DetailsRowDeleting != null))
+                    if ((OrderDetailsRowDeleting != null))
                     {
-                        Order_DetailsRowDeleting(this, new Order_DetailsRowChangeEvent(((Order_DetailsRow)(e.Row)), e.Action));
+                        OrderDetailsRowDeleting(this, new OrderDetailsRowChangeEvent(((OrderDetailsRow)(e.Row)), e.Action));
                     }
                 }
 
-                public void RemoveOrder_DetailsRow(Order_DetailsRow row)
+                public void RemoveOrder_DetailsRow(OrderDetailsRow row)
                 {
                     Rows.Remove(row);
                 }
             }
 
-            public class Order_DetailsRow : DataRow
+            public class OrderDetailsRow : DataRow
             {
-                private Order_DetailsDataTable _tableOrder_Details;
+                private OrderDetailsDataTable _tableOrderDetails;
 
-                internal Order_DetailsRow(DataRowBuilder rb) :
+                internal OrderDetailsRow(DataRowBuilder rb) :
                     base(rb)
                 {
-                    _tableOrder_Details = ((Order_DetailsDataTable)(Table));
+                    _tableOrderDetails = ((OrderDetailsDataTable)(Table));
                 }
 
                 public int OrderID
                 {
                     get
                     {
-                        return ((int)(this[_tableOrder_Details.OrderIDColumn]));
+                        return ((int)(this[_tableOrderDetails.OrderIDColumn]));
                     }
                     set
                     {
-                        this[_tableOrder_Details.OrderIDColumn] = value;
+                        this[_tableOrderDetails.OrderIDColumn] = value;
                     }
                 }
 
@@ -1190,11 +1190,11 @@ namespace System.Data.Tests
                 {
                     get
                     {
-                        return ((int)(this[_tableOrder_Details.ProductIDColumn]));
+                        return ((int)(this[_tableOrderDetails.ProductIDColumn]));
                     }
                     set
                     {
-                        this[_tableOrder_Details.ProductIDColumn] = value;
+                        this[_tableOrderDetails.ProductIDColumn] = value;
                     }
                 }
 
@@ -1202,11 +1202,11 @@ namespace System.Data.Tests
                 {
                     get
                     {
-                        return ((decimal)(this[_tableOrder_Details.UnitPriceColumn]));
+                        return ((decimal)(this[_tableOrderDetails.UnitPriceColumn]));
                     }
                     set
                     {
-                        this[_tableOrder_Details.UnitPriceColumn] = value;
+                        this[_tableOrderDetails.UnitPriceColumn] = value;
                     }
                 }
 
@@ -1214,11 +1214,11 @@ namespace System.Data.Tests
                 {
                     get
                     {
-                        return ((short)(this[_tableOrder_Details.QuantityColumn]));
+                        return ((short)(this[_tableOrderDetails.QuantityColumn]));
                     }
                     set
                     {
-                        this[_tableOrder_Details.QuantityColumn] = value;
+                        this[_tableOrderDetails.QuantityColumn] = value;
                     }
                 }
 
@@ -1228,7 +1228,7 @@ namespace System.Data.Tests
                     {
                         try
                         {
-                            return ((string)(this[_tableOrder_Details.DiscountColumn]));
+                            return ((string)(this[_tableOrderDetails.DiscountColumn]));
                         }
                         catch (InvalidCastException e)
                         {
@@ -1237,7 +1237,7 @@ namespace System.Data.Tests
                     }
                     set
                     {
-                        this[_tableOrder_Details.DiscountColumn] = value;
+                        this[_tableOrderDetails.DiscountColumn] = value;
                     }
                 }
 
@@ -1255,24 +1255,24 @@ namespace System.Data.Tests
 
                 public bool IsDiscountNull()
                 {
-                    return IsNull(_tableOrder_Details.DiscountColumn);
+                    return IsNull(_tableOrderDetails.DiscountColumn);
                 }
 
                 public void SetDiscountNull()
                 {
-                    this[_tableOrder_Details.DiscountColumn] = DBNull.Value;
+                    this[_tableOrderDetails.DiscountColumn] = DBNull.Value;
                 }
             }
 
-            public class Order_DetailsRowChangeEvent : EventArgs
+            public class OrderDetailsRowChangeEvent : EventArgs
             {
-                public Order_DetailsRowChangeEvent(Order_DetailsRow row, DataRowAction action)
+                public OrderDetailsRowChangeEvent(OrderDetailsRow row, DataRowAction action)
                 {
                     Row = row;
                     Action = action;
                 }
 
-                public Order_DetailsRow Row { get; }
+                public OrderDetailsRow Row { get; }
 
                 public DataRowAction Action { get; }
             }
@@ -1920,9 +1920,9 @@ namespace System.Data.Tests
                     this[_tableOrders.ShipCountryColumn] = DBNull.Value;
                 }
 
-                public Order_DetailsRow[] GetOrder_DetailsRows()
+                public OrderDetailsRow[] GetOrderDetailsRows()
                 {
-                    return ((Order_DetailsRow[])(GetChildRows(Table.ChildRelations["OrdersOrder_x0020_Details"])));
+                    return ((OrderDetailsRow[])(GetChildRows(Table.ChildRelations["OrdersOrder_x0020_Details"])));
                 }
             }
 

--- a/src/System.Data.Common/tests/System/Data/DataSetTypedDataSetTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataSetTypedDataSetTest.cs
@@ -48,7 +48,6 @@ namespace System.Data.Tests
             myTypedDataSet ds = null;
             DataSet unTypedDs = new DataSet();
             ds = new myTypedDataSet();
-            Assert.False(ds == null);
             Assert.Equal(typeof(myTypedDataSet), ds.GetType());
 
             // fill dataset
@@ -641,7 +640,7 @@ namespace System.Data.Tests
             //Create New Row using NewTableNameRow, check row != null
             myTypedDataSet.OrdersRow drOrders = null;
             drOrders = tblOrders.NewOrdersRow();
-            Assert.False(drOrders == null);
+            Assert.NotNull(drOrders);
 
             //Create New Row using NewTableNameRow, check row state
             Assert.Equal(DataRowState.Detached, drOrders.RowState);
@@ -813,10 +812,6 @@ namespace System.Data.Tests
         [ToolboxItem(true)]
         public class myTypedDataSet : DataSet
         {
-            private Order_DetailsDataTable _tableOrder_Details;
-
-            private OrdersDataTable _tableOrders;
-
             private DataRelation _relationOrdersOrder_x0020_Details;
 
             public myTypedDataSet()
@@ -863,23 +858,11 @@ namespace System.Data.Tests
 
             [Browsable(false)]
             [DesignerSerializationVisibilityAttribute(DesignerSerializationVisibility.Content)]
-            public Order_DetailsDataTable Order_Details
-            {
-                get
-                {
-                    return _tableOrder_Details;
-                }
-            }
+            public Order_DetailsDataTable Order_Details { get; private set; }
 
             [Browsable(false)]
             [DesignerSerializationVisibilityAttribute(DesignerSerializationVisibility.Content)]
-            public OrdersDataTable Orders
-            {
-                get
-                {
-                    return _tableOrders;
-                }
-            }
+            public OrdersDataTable Orders { get; private set; }
 
             public override DataSet Clone()
             {
@@ -931,15 +914,15 @@ namespace System.Data.Tests
 
             internal void InitVars()
             {
-                _tableOrder_Details = ((Order_DetailsDataTable)(Tables["Order Details"]));
-                if ((_tableOrder_Details != null))
+                Order_Details = ((Order_DetailsDataTable)(Tables["Order Details"]));
+                if ((Order_Details != null))
                 {
-                    _tableOrder_Details.InitVars();
+                    Order_Details.InitVars();
                 }
-                _tableOrders = ((OrdersDataTable)(Tables["Orders"]));
-                if ((_tableOrders != null))
+                Orders = ((OrdersDataTable)(Tables["Orders"]));
+                if ((Orders != null))
                 {
-                    _tableOrders.InitVars();
+                    Orders.InitVars();
                 }
                 _relationOrdersOrder_x0020_Details = Relations["OrdersOrder_x0020_Details"];
             }
@@ -952,21 +935,21 @@ namespace System.Data.Tests
                 Locale = new CultureInfo("en-US");
                 CaseSensitive = false;
                 EnforceConstraints = true;
-                _tableOrder_Details = new Order_DetailsDataTable();
-                Tables.Add(_tableOrder_Details);
-                _tableOrders = new OrdersDataTable();
-                Tables.Add(_tableOrders);
+                Order_Details = new Order_DetailsDataTable();
+                Tables.Add(Order_Details);
+                Orders = new OrdersDataTable();
+                Tables.Add(Orders);
                 ForeignKeyConstraint fkc;
                 fkc = new ForeignKeyConstraint("OrdersOrder_x0020_Details", new DataColumn[] {
-                                                                                                 _tableOrders.OrderIDColumn}, new DataColumn[] {
-                                                                                                                                                       _tableOrder_Details.OrderIDColumn});
-                _tableOrder_Details.Constraints.Add(fkc);
+                                                                                                 Orders.OrderIDColumn}, new DataColumn[] {
+                                                                                                                                                       Order_Details.OrderIDColumn});
+                Order_Details.Constraints.Add(fkc);
                 fkc.AcceptRejectRule = AcceptRejectRule.None;
                 fkc.DeleteRule = Rule.Cascade;
                 fkc.UpdateRule = Rule.Cascade;
                 _relationOrdersOrder_x0020_Details = new DataRelation("OrdersOrder_x0020_Details", new DataColumn[] {
-                                                                                                                            _tableOrders.OrderIDColumn}, new DataColumn[] {
-                                                                                                                                                                                  _tableOrder_Details.OrderIDColumn}, false);
+                                                                                                                            Orders.OrderIDColumn}, new DataColumn[] {
+                                                                                                                                                                                  Order_Details.OrderIDColumn}, false);
                 Relations.Add(_relationOrdersOrder_x0020_Details);
             }
 
@@ -994,16 +977,6 @@ namespace System.Data.Tests
 
             public class Order_DetailsDataTable : DataTable, IEnumerable
             {
-                private DataColumn _columnOrderID;
-
-                private DataColumn _columnProductID;
-
-                private DataColumn _columnUnitPrice;
-
-                private DataColumn _columnQuantity;
-
-                private DataColumn _columnDiscount;
-
                 internal Order_DetailsDataTable() :
                     base("Order Details")
                 {
@@ -1039,45 +1012,15 @@ namespace System.Data.Tests
                     }
                 }
 
-                internal DataColumn OrderIDColumn
-                {
-                    get
-                    {
-                        return _columnOrderID;
-                    }
-                }
+                internal DataColumn OrderIDColumn { get; private set; }
 
-                internal DataColumn ProductIDColumn
-                {
-                    get
-                    {
-                        return _columnProductID;
-                    }
-                }
+                internal DataColumn ProductIDColumn { get; private set; }
 
-                internal DataColumn UnitPriceColumn
-                {
-                    get
-                    {
-                        return _columnUnitPrice;
-                    }
-                }
+                internal DataColumn UnitPriceColumn { get; private set; }
 
-                internal DataColumn QuantityColumn
-                {
-                    get
-                    {
-                        return _columnQuantity;
-                    }
-                }
+                internal DataColumn QuantityColumn { get; private set; }
 
-                internal DataColumn DiscountColumn
-                {
-                    get
-                    {
-                        return _columnDiscount;
-                    }
-                }
+                internal DataColumn DiscountColumn { get; private set; }
 
                 public Order_DetailsRow this[int index]
                 {
@@ -1139,33 +1082,33 @@ namespace System.Data.Tests
 
                 internal void InitVars()
                 {
-                    _columnOrderID = Columns["OrderID"];
-                    _columnProductID = Columns["ProductID"];
-                    _columnUnitPrice = Columns["UnitPrice"];
-                    _columnQuantity = Columns["Quantity"];
-                    _columnDiscount = Columns["Discount"];
+                    OrderIDColumn = Columns["OrderID"];
+                    ProductIDColumn = Columns["ProductID"];
+                    UnitPriceColumn = Columns["UnitPrice"];
+                    QuantityColumn = Columns["Quantity"];
+                    DiscountColumn = Columns["Discount"];
                 }
 
                 private void InitClass()
                 {
-                    _columnOrderID = new DataColumn("OrderID", typeof(int), null, MappingType.Element);
-                    Columns.Add(_columnOrderID);
-                    _columnProductID = new DataColumn("ProductID", typeof(int), null, MappingType.Element);
-                    Columns.Add(_columnProductID);
-                    _columnUnitPrice = new DataColumn("UnitPrice", typeof(decimal), null, MappingType.Element);
-                    Columns.Add(_columnUnitPrice);
-                    _columnQuantity = new DataColumn("Quantity", typeof(short), null, MappingType.Element);
-                    Columns.Add(_columnQuantity);
-                    _columnDiscount = new DataColumn("Discount", typeof(string), null, MappingType.Element);
-                    Columns.Add(_columnDiscount);
+                    OrderIDColumn = new DataColumn("OrderID", typeof(int), null, MappingType.Element);
+                    Columns.Add(OrderIDColumn);
+                    ProductIDColumn = new DataColumn("ProductID", typeof(int), null, MappingType.Element);
+                    Columns.Add(ProductIDColumn);
+                    UnitPriceColumn = new DataColumn("UnitPrice", typeof(decimal), null, MappingType.Element);
+                    Columns.Add(UnitPriceColumn);
+                    QuantityColumn = new DataColumn("Quantity", typeof(short), null, MappingType.Element);
+                    Columns.Add(QuantityColumn);
+                    DiscountColumn = new DataColumn("Discount", typeof(string), null, MappingType.Element);
+                    Columns.Add(DiscountColumn);
                     Constraints.Add(new UniqueConstraint("Constraint1", new DataColumn[] {
-                                                                                                  _columnOrderID,
-                                                                                                  _columnProductID}, true));
-                    _columnOrderID.AllowDBNull = false;
-                    _columnProductID.AllowDBNull = false;
-                    _columnUnitPrice.AllowDBNull = false;
-                    _columnQuantity.AllowDBNull = false;
-                    _columnDiscount.ReadOnly = true;
+                                                                                                  OrderIDColumn,
+                                                                                                  ProductIDColumn}, true));
+                    OrderIDColumn.AllowDBNull = false;
+                    ProductIDColumn.AllowDBNull = false;
+                    UnitPriceColumn.AllowDBNull = false;
+                    QuantityColumn.AllowDBNull = false;
+                    DiscountColumn.ReadOnly = true;
                 }
 
                 public Order_DetailsRow NewOrder_DetailsRow()
@@ -1327,63 +1270,19 @@ namespace System.Data.Tests
 
             public class Order_DetailsRowChangeEvent : EventArgs
             {
-                private Order_DetailsRow _eventRow;
-
-                private DataRowAction _eventAction;
-
                 public Order_DetailsRowChangeEvent(Order_DetailsRow row, DataRowAction action)
                 {
-                    _eventRow = row;
-                    _eventAction = action;
+                    Row = row;
+                    Action = action;
                 }
 
-                public Order_DetailsRow Row
-                {
-                    get
-                    {
-                        return _eventRow;
-                    }
-                }
+                public Order_DetailsRow Row { get; }
 
-                public DataRowAction Action
-                {
-                    get
-                    {
-                        return _eventAction;
-                    }
-                }
+                public DataRowAction Action { get; }
             }
 
             public class OrdersDataTable : DataTable, IEnumerable
             {
-                private DataColumn _columnOrderID;
-
-                private DataColumn _columnCustomerID;
-
-                private DataColumn _columnEmployeeID;
-
-                private DataColumn _columnOrderDate;
-
-                private DataColumn _columnRequiredDate;
-
-                private DataColumn _columnShippedDate;
-
-                private DataColumn _columnShipVia;
-
-                private DataColumn _columnFreight;
-
-                private DataColumn _columnShipName;
-
-                private DataColumn _columnShipAddress;
-
-                private DataColumn _columnShipCity;
-
-                private DataColumn _columnShipRegion;
-
-                private DataColumn _columnShipPostalCode;
-
-                private DataColumn _columnShipCountry;
-
                 internal OrdersDataTable() :
                     base("Orders")
                 {
@@ -1419,117 +1318,33 @@ namespace System.Data.Tests
                     }
                 }
 
-                internal DataColumn OrderIDColumn
-                {
-                    get
-                    {
-                        return _columnOrderID;
-                    }
-                }
+                internal DataColumn OrderIDColumn { get; private set; }
 
-                internal DataColumn CustomerIDColumn
-                {
-                    get
-                    {
-                        return _columnCustomerID;
-                    }
-                }
+                internal DataColumn CustomerIDColumn { get; private set; }
 
-                internal DataColumn EmployeeIDColumn
-                {
-                    get
-                    {
-                        return _columnEmployeeID;
-                    }
-                }
+                internal DataColumn EmployeeIDColumn { get; private set; }
 
-                internal DataColumn OrderDateColumn
-                {
-                    get
-                    {
-                        return _columnOrderDate;
-                    }
-                }
+                internal DataColumn OrderDateColumn { get; private set; }
 
-                internal DataColumn RequiredDateColumn
-                {
-                    get
-                    {
-                        return _columnRequiredDate;
-                    }
-                }
+                internal DataColumn RequiredDateColumn { get; private set; }
 
-                internal DataColumn ShippedDateColumn
-                {
-                    get
-                    {
-                        return _columnShippedDate;
-                    }
-                }
+                internal DataColumn ShippedDateColumn { get; private set; }
 
-                internal DataColumn ShipViaColumn
-                {
-                    get
-                    {
-                        return _columnShipVia;
-                    }
-                }
+                internal DataColumn ShipViaColumn { get; private set; }
 
-                internal DataColumn FreightColumn
-                {
-                    get
-                    {
-                        return _columnFreight;
-                    }
-                }
+                internal DataColumn FreightColumn { get; private set; }
 
-                internal DataColumn ShipNameColumn
-                {
-                    get
-                    {
-                        return _columnShipName;
-                    }
-                }
+                internal DataColumn ShipNameColumn { get; private set; }
 
-                internal DataColumn ShipAddressColumn
-                {
-                    get
-                    {
-                        return _columnShipAddress;
-                    }
-                }
+                internal DataColumn ShipAddressColumn { get; private set; }
 
-                internal DataColumn ShipCityColumn
-                {
-                    get
-                    {
-                        return _columnShipCity;
-                    }
-                }
+                internal DataColumn ShipCityColumn { get; private set; }
 
-                internal DataColumn ShipRegionColumn
-                {
-                    get
-                    {
-                        return _columnShipRegion;
-                    }
-                }
+                internal DataColumn ShipRegionColumn { get; private set; }
 
-                internal DataColumn ShipPostalCodeColumn
-                {
-                    get
-                    {
-                        return _columnShipPostalCode;
-                    }
-                }
+                internal DataColumn ShipPostalCodeColumn { get; private set; }
 
-                internal DataColumn ShipCountryColumn
-                {
-                    get
-                    {
-                        return _columnShipCountry;
-                    }
-                }
+                internal DataColumn ShipCountryColumn { get; private set; }
 
                 public OrdersRow this[int index]
                 {
@@ -1599,58 +1414,58 @@ namespace System.Data.Tests
 
                 internal void InitVars()
                 {
-                    _columnOrderID = Columns["OrderID"];
-                    _columnCustomerID = Columns["CustomerID"];
-                    _columnEmployeeID = Columns["EmployeeID"];
-                    _columnOrderDate = Columns["OrderDate"];
-                    _columnRequiredDate = Columns["RequiredDate"];
-                    _columnShippedDate = Columns["ShippedDate"];
-                    _columnShipVia = Columns["ShipVia"];
-                    _columnFreight = Columns["Freight"];
-                    _columnShipName = Columns["ShipName"];
-                    _columnShipAddress = Columns["ShipAddress"];
-                    _columnShipCity = Columns["ShipCity"];
-                    _columnShipRegion = Columns["ShipRegion"];
-                    _columnShipPostalCode = Columns["ShipPostalCode"];
-                    _columnShipCountry = Columns["ShipCountry"];
+                    OrderIDColumn = Columns["OrderID"];
+                    CustomerIDColumn = Columns["CustomerID"];
+                    EmployeeIDColumn = Columns["EmployeeID"];
+                    OrderDateColumn = Columns["OrderDate"];
+                    RequiredDateColumn = Columns["RequiredDate"];
+                    ShippedDateColumn = Columns["ShippedDate"];
+                    ShipViaColumn = Columns["ShipVia"];
+                    FreightColumn = Columns["Freight"];
+                    ShipNameColumn = Columns["ShipName"];
+                    ShipAddressColumn = Columns["ShipAddress"];
+                    ShipCityColumn = Columns["ShipCity"];
+                    ShipRegionColumn = Columns["ShipRegion"];
+                    ShipPostalCodeColumn = Columns["ShipPostalCode"];
+                    ShipCountryColumn = Columns["ShipCountry"];
                 }
 
                 private void InitClass()
                 {
-                    _columnOrderID = new DataColumn("OrderID", typeof(int), null, MappingType.Element);
-                    Columns.Add(_columnOrderID);
-                    _columnCustomerID = new DataColumn("CustomerID", typeof(string), null, MappingType.Element);
-                    Columns.Add(_columnCustomerID);
-                    _columnEmployeeID = new DataColumn("EmployeeID", typeof(int), null, MappingType.Element);
-                    Columns.Add(_columnEmployeeID);
-                    _columnOrderDate = new DataColumn("OrderDate", typeof(DateTime), null, MappingType.Element);
-                    Columns.Add(_columnOrderDate);
-                    _columnRequiredDate = new DataColumn("RequiredDate", typeof(DateTime), null, MappingType.Element);
-                    Columns.Add(_columnRequiredDate);
-                    _columnShippedDate = new DataColumn("ShippedDate", typeof(DateTime), null, MappingType.Element);
-                    Columns.Add(_columnShippedDate);
-                    _columnShipVia = new DataColumn("ShipVia", typeof(int), null, MappingType.Element);
-                    Columns.Add(_columnShipVia);
-                    _columnFreight = new DataColumn("Freight", typeof(decimal), null, MappingType.Element);
-                    Columns.Add(_columnFreight);
-                    _columnShipName = new DataColumn("ShipName", typeof(string), null, MappingType.Element);
-                    Columns.Add(_columnShipName);
-                    _columnShipAddress = new DataColumn("ShipAddress", typeof(string), null, MappingType.Element);
-                    Columns.Add(_columnShipAddress);
-                    _columnShipCity = new DataColumn("ShipCity", typeof(string), null, MappingType.Element);
-                    Columns.Add(_columnShipCity);
-                    _columnShipRegion = new DataColumn("ShipRegion", typeof(string), null, MappingType.Element);
-                    Columns.Add(_columnShipRegion);
-                    _columnShipPostalCode = new DataColumn("ShipPostalCode", typeof(string), null, MappingType.Element);
-                    Columns.Add(_columnShipPostalCode);
-                    _columnShipCountry = new DataColumn("ShipCountry", typeof(string), null, MappingType.Element);
-                    Columns.Add(_columnShipCountry);
+                    OrderIDColumn = new DataColumn("OrderID", typeof(int), null, MappingType.Element);
+                    Columns.Add(OrderIDColumn);
+                    CustomerIDColumn = new DataColumn("CustomerID", typeof(string), null, MappingType.Element);
+                    Columns.Add(CustomerIDColumn);
+                    EmployeeIDColumn = new DataColumn("EmployeeID", typeof(int), null, MappingType.Element);
+                    Columns.Add(EmployeeIDColumn);
+                    OrderDateColumn = new DataColumn("OrderDate", typeof(DateTime), null, MappingType.Element);
+                    Columns.Add(OrderDateColumn);
+                    RequiredDateColumn = new DataColumn("RequiredDate", typeof(DateTime), null, MappingType.Element);
+                    Columns.Add(RequiredDateColumn);
+                    ShippedDateColumn = new DataColumn("ShippedDate", typeof(DateTime), null, MappingType.Element);
+                    Columns.Add(ShippedDateColumn);
+                    ShipViaColumn = new DataColumn("ShipVia", typeof(int), null, MappingType.Element);
+                    Columns.Add(ShipViaColumn);
+                    FreightColumn = new DataColumn("Freight", typeof(decimal), null, MappingType.Element);
+                    Columns.Add(FreightColumn);
+                    ShipNameColumn = new DataColumn("ShipName", typeof(string), null, MappingType.Element);
+                    Columns.Add(ShipNameColumn);
+                    ShipAddressColumn = new DataColumn("ShipAddress", typeof(string), null, MappingType.Element);
+                    Columns.Add(ShipAddressColumn);
+                    ShipCityColumn = new DataColumn("ShipCity", typeof(string), null, MappingType.Element);
+                    Columns.Add(ShipCityColumn);
+                    ShipRegionColumn = new DataColumn("ShipRegion", typeof(string), null, MappingType.Element);
+                    Columns.Add(ShipRegionColumn);
+                    ShipPostalCodeColumn = new DataColumn("ShipPostalCode", typeof(string), null, MappingType.Element);
+                    Columns.Add(ShipPostalCodeColumn);
+                    ShipCountryColumn = new DataColumn("ShipCountry", typeof(string), null, MappingType.Element);
+                    Columns.Add(ShipCountryColumn);
                     Constraints.Add(new UniqueConstraint("Constraint1", new DataColumn[] {
-                                                                                                  _columnOrderID}, true));
-                    _columnOrderID.AutoIncrement = true;
-                    _columnOrderID.AllowDBNull = false;
-                    _columnOrderID.ReadOnly = true;
-                    _columnOrderID.Unique = true;
+                                                                                                  OrderIDColumn}, true));
+                    OrderIDColumn.AutoIncrement = true;
+                    OrderIDColumn.AllowDBNull = false;
+                    OrderIDColumn.ReadOnly = true;
+                    OrderIDColumn.Unique = true;
                 }
 
                 public OrdersRow NewOrdersRow()
@@ -2117,31 +1932,15 @@ namespace System.Data.Tests
 
             public class OrdersRowChangeEvent : EventArgs
             {
-                private OrdersRow _eventRow;
-
-                private DataRowAction _eventAction;
-
                 public OrdersRowChangeEvent(OrdersRow row, DataRowAction action)
                 {
-                    _eventRow = row;
-                    _eventAction = action;
+                    Row = row;
+                    Action = action;
                 }
 
-                public OrdersRow Row
-                {
-                    get
-                    {
-                        return _eventRow;
-                    }
-                }
+                public OrdersRow Row { get; }
 
-                public DataRowAction Action
-                {
-                    get
-                    {
-                        return _eventAction;
-                    }
-                }
+                public DataRowAction Action { get; }
             }
         }
     }

--- a/src/System.Data.Common/tests/System/Data/DataSetWriteXMLTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataSetWriteXMLTest.cs
@@ -35,21 +35,21 @@ namespace System.Data.Tests
                 </Table>
             </NewDataSet>";
             DataSet ds = new DataSet();
-            System.IO.StringReader xmlSR = new System.IO.StringReader(sampleXml);
+            StringReader xmlSR = new StringReader(sampleXml);
 
             ds.ReadXml(xmlSR, XmlReadMode.ReadSchema);
-            System.Text.StringBuilder sb = new System.Text.StringBuilder();
+            Text.StringBuilder sb = new System.Text.StringBuilder();
 
-            using (System.Xml.XmlWriter xw = System.Xml.XmlWriter.Create(sb, new System.Xml.XmlWriterSettings() { }))
+            using (XmlWriter xw = XmlWriter.Create(sb, new XmlWriterSettings() { }))
             {
-                ds.WriteXml(xw, System.Data.XmlWriteMode.WriteSchema);
+                ds.WriteXml(xw, XmlWriteMode.WriteSchema);
             }
             Assert.Equal(@"ServerName", ds.Tables[0].Columns[0].ColumnName);
             Assert.Equal(@"MACHINENAME", ds.Tables[0].Rows[0].Field<string>(ds.Tables[0].Columns[0]));
 
-            using (System.IO.StringWriter sw = new System.IO.StringWriter(sb))
+            using (StringWriter sw = new StringWriter(sb))
             {
-                ds.WriteXml(sw, System.Data.XmlWriteMode.WriteSchema);
+                ds.WriteXml(sw, XmlWriteMode.WriteSchema);
             }
             Assert.Equal(@"ServerName", ds.Tables[0].Columns[0].ColumnName);
             Assert.Equal(@"MACHINENAME", ds.Tables[0].Rows[0].Field<string>(ds.Tables[0].Columns[0]));

--- a/src/System.Data.Common/tests/System/Data/DataTableCollectionTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataTableCollectionTest.cs
@@ -201,25 +201,9 @@ namespace System.Data.Tests
             Assert.Equal(count - 1, tbcol.Count);
             DataTable tbl = null;
             /* removing a null reference. must generate an Exception */
-            try
-            {
-                tbcol.Remove(tbl);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(ArgumentNullException), e.GetType());
-            }
+            Assert.Throws<ArgumentNullException>(() => tbcol.Remove(tbl));
             /* removing a table that is not there in collection */
-            try
-            {
-                tbcol.Remove(new DataTable("newTable"));
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(ArgumentException), e.GetType());
-            }
+            Assert.Throws<ArgumentException>(() => tbcol.Remove(new DataTable("newTable")));
         }
         [Fact]
         public void Clear()
@@ -324,22 +308,9 @@ namespace System.Data.Tests
             tbcol.Add(_tables[0]);
             tbcol.Add("table1");
 
-            try
-            {
-                tbcol.RemoveAt(-1);
-                Assert.False(true);
-            }
-            catch (IndexOutOfRangeException e)
-            {
-            }
-            try
-            {
-                tbcol.RemoveAt(101);
-                Assert.False(true);
-            }
-            catch (IndexOutOfRangeException e)
-            {
-            }
+            Assert.Throws<IndexOutOfRangeException>(() => tbcol.RemoveAt(-1));
+
+            Assert.Throws<IndexOutOfRangeException>(() => tbcol.RemoveAt(101));
             tbcol.RemoveAt(1);
             Assert.Equal(1, tbcol.Count);
             tbcol.RemoveAt(0);

--- a/src/System.Data.Common/tests/System/Data/DataTableCollectionTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataTableCollectionTest.cs
@@ -271,16 +271,9 @@ namespace System.Data.Tests
             tbcol2.Add(_tables[1]);
             tbcol3 = tbcol1;
 
-            Assert.True(tbcol1.Equals(tbcol1));
-            Assert.True(tbcol1.Equals(tbcol3));
-            Assert.True(tbcol3.Equals(tbcol1));
+            Assert.Same(tbcol1, tbcol3);
 
-            Assert.False(tbcol1.Equals(tbcol2));
-            Assert.False(tbcol2.Equals(tbcol1));
-
-            Assert.True(object.Equals(tbcol1, tbcol3));
-            Assert.True(object.Equals(tbcol1, tbcol1));
-            Assert.False(object.Equals(tbcol1, tbcol2));
+            Assert.NotSame(tbcol1, tbcol2);
         }
         [Fact]
         public void IndexOf()

--- a/src/System.Data.Common/tests/System/Data/DataTableCollectionTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/DataTableCollectionTest2.cs
@@ -469,20 +469,10 @@ namespace System.Data.Tests
             ds.Tables.Add("table", "namespace2");
             Assert.Equal(2, ds.Tables.Count);
 
-            try
-            {
-                ds.Tables.Add("table", "namespace1");
-                Assert.False(true);
-            }
-            catch (DuplicateNameException e) { }
+            Assert.Throws<DuplicateNameException>(() => ds.Tables.Add("table", "namespace1"));
 
             ds.Tables.Add("table");
-            try
-            {
-                ds.Tables.Add("table", null);
-                Assert.False(true);
-            }
-            catch (DuplicateNameException e) { }
+            Assert.Throws<DuplicateNameException>(() => ds.Tables.Add("table", null));
         }
 
         [Fact]
@@ -498,12 +488,7 @@ namespace System.Data.Tests
             // Should fail if it cannot be resolved to a single table
             Assert.False(ds.Tables.Contains("table"));
 
-            try
-            {
-                ds.Tables.Contains("table", null);
-                Assert.False(true);
-            }
-            catch (ArgumentNullException e) { }
+            Assert.Throws<ArgumentNullException>(() => ds.Tables.Contains("table", null));
 
             Assert.True(ds.Tables.Contains("table", "namespace1"));
             Assert.False(ds.Tables.Contains("table", "namespace3"));
@@ -530,23 +515,13 @@ namespace System.Data.Tests
             ds.Tables.Add("table", "namespace1");
             ds.Tables.Add("table", "namespace2");
 
-            try
-            {
-                ds.Tables.Remove("table");
-                Assert.False(true);
-            }
-            catch (ArgumentException e) { }
+            Assert.Throws<ArgumentException>(() => ds.Tables.Remove("table"));
 
             ds.Tables.Remove("table", "namespace2");
             Assert.Equal(2, ds.Tables.Count);
             Assert.Equal("namespace1", ds.Tables[1].Namespace);
 
-            try
-            {
-                ds.Tables.Remove("table", "namespace2");
-                Assert.False(true);
-            }
-            catch (ArgumentException e) { }
+            Assert.Throws<ArgumentException>(() => ds.Tables.Remove("table", "namespace2"));
         }
     }
 }

--- a/src/System.Data.Common/tests/System/Data/DataTableLoadRowTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataTableLoadRowTest.cs
@@ -143,12 +143,7 @@ namespace System.Data.Tests
                 ResetEventFlags();
                 dt.LoadDataRow(new object[] { 4, "mono 4" }, LoadOption.Upsert);
                 Assert.Equal("mono 4", dt.Rows[3][1]);
-                try
-                {
-                    object o = dt.Rows[3][1, DataRowVersion.Original];
-                    Assert.False(true);
-                }
-                catch (VersionNotFoundException) { }
+                Assert.Throws<VersionNotFoundException>(() => dt.Rows[3][1, DataRowVersion.Original]);
                 Assert.Equal(DataRowState.Added, dt.Rows[3].RowState);
                 Assert.True(_rowChanging);
                 Assert.Equal(dt.Rows[3], _rowInAction_Changing);
@@ -162,12 +157,7 @@ namespace System.Data.Tests
                 ResetEventFlags();
                 dt.LoadDataRow(new object[] { 5, "mono 5" }, LoadOption.Upsert);
                 Assert.Equal("mono 5", dt.Rows[4][1]);
-                try
-                {
-                    object o = dt.Rows[4][1, DataRowVersion.Original];
-                    Assert.False(true);
-                }
-                catch (VersionNotFoundException) { }
+                Assert.Throws<VersionNotFoundException>(() => dt.Rows[4][1, DataRowVersion.Original]);
                 Assert.Equal(DataRowState.Added, dt.Rows[4].RowState);
                 Assert.True(_rowChanging);
                 Assert.Equal(dt.Rows[4], _rowInAction_Changing);
@@ -190,12 +180,7 @@ namespace System.Data.Tests
                 dt.LoadDataRow(new object[] { 5, "mono 5" }, LoadOption.Upsert);
                 Assert.Equal(6, dt.Rows.Count);
                 Assert.Equal("mono 5", dt.Rows[5][1]);
-                try
-                {
-                    object o = dt.Rows[5][1, DataRowVersion.Original];
-                    Assert.False(true);
-                }
-                catch (VersionNotFoundException) { }
+                Assert.Throws<VersionNotFoundException>(() => dt.Rows[5][1, DataRowVersion.Original]);
                 Assert.Equal(DataRowState.Added, dt.Rows[5].RowState);
                 Assert.True(_rowChanging);
                 Assert.Equal(dt.Rows[5], _rowInAction_Changing);

--- a/src/System.Data.Common/tests/System/Data/DataTableReadWriteXmlTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataTableReadWriteXmlTest.cs
@@ -327,25 +327,11 @@ namespace System.Data.Tests
 
             DataTable newdt = new DataTable();
 
-            try
-            {
-                newdt.ReadXml(new StringReader(xmlDTNone));
-                Assert.False(true);
-            }
-            catch (InvalidOperationException)
-            {
-                // DataTable does not support schema inference from Xml.
-            }
+            // DataTable does not support schema inference from Xml.
+            Assert.Throws<InvalidOperationException>(() => newdt.ReadXml(new StringReader(xmlDTNone)));
 
-            try
-            {
-                newdt.ReadXml(new StringReader(xmlDTDiffGram));
-                Assert.False(true);
-            }
-            catch (InvalidOperationException)
-            {
-                // DataTable does not support schema inference from Xml.
-            }
+            // DataTable does not support schema inference from Xml.
+            Assert.Throws<InvalidOperationException>(() => newdt.ReadXml(new StringReader(xmlDTDiffGram)));
 
             DataTable multiTable = new DataTable();
             multiTable.ReadXml(new StringReader(xmlMultiTable));

--- a/src/System.Data.Common/tests/System/Data/DataTableReaderTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataTableReaderTest.cs
@@ -753,32 +753,36 @@ namespace System.Data.Tests
             Assert.Equal(1, rdr.GetSchemaTable().Rows.Count);
 
             table.Columns[0].ColumnName = "newcol1";
-            try
-            {
-                rdr.GetSchemaTable();
-                Assert.False(true);
-            }
-            catch (InvalidOperationException)
-            {
-                // Never premise English.
-                //Assert.Equal ("Schema of current DataTable '" + table.TableName +
-                //        "' in DataTableReader has changed, DataTableReader is invalid.", e.Message, "#1");
-            }
+            //TODO
+            //try
+            //{
+            //    rdr.GetSchemaTable();
+            //    Assert.False(true);
+            //}
+            //catch (InvalidOperationException)
+            //{
+            //    // Never premise English.
+            //    //Assert.Equal ("Schema of current DataTable '" + table.TableName + 
+            //    //		"' in DataTableReader has changed, DataTableReader is invalid.", e.Message, "#1");
+            //}
+            Assert.Throws<InvalidOperationException>(() => rdr.GetSchemaTable());
 
             rdr = table.CreateDataReader();
             rdr.GetSchemaTable(); //no exception
             table.Columns.Add("col2");
-            try
-            {
-                rdr.GetSchemaTable();
-                Assert.False(true);
-            }
-            catch (InvalidOperationException)
-            {
-                // Never premise English.
-                //Assert.Equal ("Schema of current DataTable '" + table.TableName +
-                //        "' in DataTableReader has changed, DataTableReader is invalid.", e.Message, "#1");
-            }
+            //TODO
+            //try
+            //{
+            //    rdr.GetSchemaTable();
+            //    Assert.False(true);
+            //}
+            //catch (InvalidOperationException)
+            //{
+            //    // Never premise English.
+            //    //Assert.Equal ("Schema of current DataTable '" + table.TableName + 
+            //    //		"' in DataTableReader has changed, DataTableReader is invalid.", e.Message, "#1");
+            //}
+            Assert.Throws<InvalidOperationException>(() => rdr.GetSchemaTable());
         }
 
         [Fact]
@@ -817,17 +821,19 @@ namespace System.Data.Tests
 
             rdr.Read();
 
-            try
-            {
-                rdr.GetChars(1, 0, null, 0, 10);
-                Assert.False(true);
-            }
-            catch (InvalidCastException e)
-            {
-                // Never premise English.
-                //Assert.Equal ("Unable to cast object of type 'System.String'" +
-                //    " to type 'System.Char[]'.", e.Message, "#1");
-            }
+            //TODO
+            //try
+            //{
+            //    rdr.GetChars(1, 0, null, 0, 10);
+            //    Assert.False(true);
+            //}
+            //catch (InvalidCastException e)
+            //{
+            //    // Never premise English.
+            //    //Assert.Equal ("Unable to cast object of type 'System.String'" +
+            //    //	" to type 'System.Char[]'.", e.Message, "#1");
+            //}
+            Assert.Throws<InvalidCastException>(() => rdr.GetChars(1, 0, null, 0, 10));
             char[] char_arr = null;
             long len = 0;
 

--- a/src/System.Data.Common/tests/System/Data/DataTableReaderTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataTableReaderTest.cs
@@ -745,35 +745,15 @@ namespace System.Data.Tests
             Assert.Equal(1, rdr.GetSchemaTable().Rows.Count);
 
             table.Columns[0].ColumnName = "newcol1";
-            //TODO
-            //try
-            //{
-            //    rdr.GetSchemaTable();
-            //    Assert.False(true);
-            //}
-            //catch (InvalidOperationException)
-            //{
-            //    // Never premise English.
-            //    //Assert.Equal ("Schema of current DataTable '" + table.TableName + 
-            //    //		"' in DataTableReader has changed, DataTableReader is invalid.", e.Message, "#1");
-            //}
+
+            // Schema of current DataTable '' in DataTableReader has changed, DataTableReader is invalid.
             Assert.Throws<InvalidOperationException>(() => rdr.GetSchemaTable());
 
             rdr = table.CreateDataReader();
             rdr.GetSchemaTable(); //no exception
             table.Columns.Add("col2");
-            //TODO
-            //try
-            //{
-            //    rdr.GetSchemaTable();
-            //    Assert.False(true);
-            //}
-            //catch (InvalidOperationException)
-            //{
-            //    // Never premise English.
-            //    //Assert.Equal ("Schema of current DataTable '" + table.TableName + 
-            //    //		"' in DataTableReader has changed, DataTableReader is invalid.", e.Message, "#1");
-            //}
+
+            // Schema of current DataTable '' in DataTableReader has changed, DataTableReader is invalid.
             Assert.Throws<InvalidOperationException>(() => rdr.GetSchemaTable());
         }
 
@@ -813,18 +793,7 @@ namespace System.Data.Tests
 
             rdr.Read();
 
-            //TODO
-            //try
-            //{
-            //    rdr.GetChars(1, 0, null, 0, 10);
-            //    Assert.False(true);
-            //}
-            //catch (InvalidCastException e)
-            //{
-            //    // Never premise English.
-            //    //Assert.Equal ("Unable to cast object of type 'System.String'" +
-            //    //	" to type 'System.Char[]'.", e.Message, "#1");
-            //}
+            // Unable to cast object of type 'System.String' to type 'System.Char[]'.
             Assert.Throws<InvalidCastException>(() => rdr.GetChars(1, 0, null, 0, 10));
             char[] char_arr = null;
             long len = 0;

--- a/src/System.Data.Common/tests/System/Data/DataTableReaderTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataTableReaderTest.cs
@@ -320,8 +320,7 @@ namespace System.Data.Tests
                 {
                     reader.Read();
                     reader.Close();
-                    int i = (int)reader[0];
-                    i++; // to suppress warning
+                    _ = (int)reader[0];
                 }
                 finally
                 {
@@ -339,8 +338,7 @@ namespace System.Data.Tests
                 DataTableReader reader = new DataTableReader(_dt);
                 try
                 {
-                    int i = (int)reader[0];
-                    i++; // to suppress warning
+                    _ = (int)reader[0];
                 }
                 finally
                 {
@@ -359,8 +357,7 @@ namespace System.Data.Tests
                 try
                 {
                     reader.Read();
-                    int i = (int)reader[90]; // kidding, ;-)
-                    i++; // to suppress warning
+                    _ = (int)reader[90]; // kidding, ;-)
                 }
                 finally
                 {
@@ -527,13 +524,8 @@ namespace System.Data.Tests
                 reader.Read(); // first row
                 reader.Read(); // second row
                 _dt.Clear();
-                try
-                {
-                    int i = (int)reader[0];
-                    i++; // suppress warning
-                    Assert.False(true);
-                }
-                catch (RowNotInTableException) { }
+                
+                Assert.Throws<RowNotInTableException>(() => (int)reader[0]);
 
                 // clear and add test
                 reader.Close();

--- a/src/System.Data.Common/tests/System/Data/DataTableTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataTableTest.cs
@@ -46,10 +46,8 @@ namespace System.Data.Tests
     {
         public DataTableTest()
         {
-            MyDataTable.count = 0;
+            MyDataTable.Count = 0;
         }
-
-        private string _EOL = Environment.NewLine;
 
         [Fact]
         public void Ctor()
@@ -58,6 +56,7 @@ namespace System.Data.Tests
 
             Assert.False(dt.CaseSensitive);
             Assert.NotNull(dt.Columns);
+            //TODO: why is this commented out?
             //Assert.True (dt.ChildRelations != null);
             Assert.NotNull(dt.Constraints);
             Assert.Null(dt.DataSet);
@@ -79,257 +78,241 @@ namespace System.Data.Tests
         [Fact]
         public void Select()
         {
-            DataSet Set = new DataSet();
-            DataTable Mom = new DataTable("Mom");
-            DataTable Child = new DataTable("Child");
-            Set.Tables.Add(Mom);
-            Set.Tables.Add(Child);
+            DataSet set = new DataSet();
+            DataTable mom = new DataTable("Mom");
+            DataTable child = new DataTable("Child");
+            set.Tables.Add(mom);
+            set.Tables.Add(child);
 
-            DataColumn Col = new DataColumn("Name");
-            DataColumn Col2 = new DataColumn("ChildName");
-            Mom.Columns.Add(Col);
-            Mom.Columns.Add(Col2);
+            DataColumn col = new DataColumn("Name");
+            DataColumn col2 = new DataColumn("ChildName");
+            mom.Columns.Add(col);
+            mom.Columns.Add(col2);
 
-            DataColumn Col3 = new DataColumn("Name");
-            DataColumn Col4 = new DataColumn("Age");
-            Col4.DataType = typeof(short);
-            Child.Columns.Add(Col3);
-            Child.Columns.Add(Col4);
+            DataColumn col3 = new DataColumn("Name");
+            DataColumn col4 = new DataColumn("Age");
+            col4.DataType = typeof(short);
+            child.Columns.Add(col3);
+            child.Columns.Add(col4);
 
-            DataRelation Relation = new DataRelation("Rel", Mom.Columns[1], Child.Columns[0]);
-            Set.Relations.Add(Relation);
+            DataRelation relation = new DataRelation("Rel", mom.Columns[1], child.Columns[0]);
+            set.Relations.Add(relation);
 
-            DataRow Row = Mom.NewRow();
-            Row[0] = "Laura";
-            Row[1] = "Nick";
-            Mom.Rows.Add(Row);
+            DataRow row = mom.NewRow();
+            row[0] = "Laura";
+            row[1] = "Nick";
+            mom.Rows.Add(row);
 
-            Row = Mom.NewRow();
-            Row[0] = "Laura";
-            Row[1] = "Dick";
-            Mom.Rows.Add(Row);
+            row = mom.NewRow();
+            row[0] = "Laura";
+            row[1] = "Dick";
+            mom.Rows.Add(row);
 
-            Row = Mom.NewRow();
-            Row[0] = "Laura";
-            Row[1] = "Mick";
-            Mom.Rows.Add(Row);
+            row = mom.NewRow();
+            row[0] = "Laura";
+            row[1] = "Mick";
+            mom.Rows.Add(row);
 
-            Row = Mom.NewRow();
-            Row[0] = "Teresa";
-            Row[1] = "Jack";
-            Mom.Rows.Add(Row);
+            row = mom.NewRow();
+            row[0] = "Teresa";
+            row[1] = "Jack";
+            mom.Rows.Add(row);
 
-            Row = Mom.NewRow();
-            Row[0] = "Teresa";
-            Row[1] = "Mack";
-            Mom.Rows.Add(Row);
+            row = mom.NewRow();
+            row[0] = "Teresa";
+            row[1] = "Mack";
+            mom.Rows.Add(row);
 
-            Row = Mom.NewRow();
-            Row[0] = "'Jhon O'' Collenal'";
-            Row[1] = "Pack";
-            Mom.Rows.Add(Row);
+            row = mom.NewRow();
+            row[0] = "'Jhon O'' Collenal'";
+            row[1] = "Pack";
+            mom.Rows.Add(row);
 
-            Row = Child.NewRow();
-            Row[0] = "Nick";
-            Row[1] = 15;
-            Child.Rows.Add(Row);
+            row = child.NewRow();
+            row[0] = "Nick";
+            row[1] = 15;
+            child.Rows.Add(row);
 
-            Row = Child.NewRow();
-            Row[0] = "Dick";
-            Row[1] = 25;
-            Child.Rows.Add(Row);
+            row = child.NewRow();
+            row[0] = "Dick";
+            row[1] = 25;
+            child.Rows.Add(row);
 
-            Row = Child.NewRow();
-            Row[0] = "Mick";
-            Row[1] = 35;
-            Child.Rows.Add(Row);
+            row = child.NewRow();
+            row[0] = "Mick";
+            row[1] = 35;
+            child.Rows.Add(row);
 
-            Row = Child.NewRow();
-            Row[0] = "Jack";
-            Row[1] = 10;
-            Child.Rows.Add(Row);
+            row = child.NewRow();
+            row[0] = "Jack";
+            row[1] = 10;
+            child.Rows.Add(row);
 
-            Row = Child.NewRow();
-            Row[0] = "Mack";
-            Row[1] = 19;
-            Child.Rows.Add(Row);
+            row = child.NewRow();
+            row[0] = "Mack";
+            row[1] = 19;
+            child.Rows.Add(row);
 
-            Row = Child.NewRow();
-            Row[0] = "Mack";
-            Row[1] = 99;
-            Child.Rows.Add(Row);
+            row = child.NewRow();
+            row[0] = "Mack";
+            row[1] = 99;
+            child.Rows.Add(row);
 
-            Row = Child.NewRow();
-            Row[0] = "Pack";
-            Row[1] = 66;
-            Child.Rows.Add(Row);
+            row = child.NewRow();
+            row[0] = "Pack";
+            row[1] = 66;
+            child.Rows.Add(row);
 
-            DataRow[] Rows = Mom.Select("Name = 'Teresa'");
-            Assert.Equal(2, Rows.Length);
+            DataRow[] rows = mom.Select("Name = 'Teresa'");
+            Assert.Equal(2, rows.Length);
 
             // test with apos escaped
-            Rows = Mom.Select("Name = '''Jhon O'''' Collenal'''");
-            Assert.Equal(1, Rows.Length);
+            rows = mom.Select("Name = '''Jhon O'''' Collenal'''");
+            Assert.Equal(1, rows.Length);
 
-            Rows = Mom.Select("Name = 'Teresa' and ChildName = 'Nick'");
-            Assert.Equal(0, Rows.Length);
+            rows = mom.Select("Name = 'Teresa' and ChildName = 'Nick'");
+            Assert.Equal(0, rows.Length);
 
-            Rows = Mom.Select("Name = 'Teresa' and ChildName = 'Jack'");
-            Assert.Equal(1, Rows.Length);
+            rows = mom.Select("Name = 'Teresa' and ChildName = 'Jack'");
+            Assert.Equal(1, rows.Length);
 
-            Rows = Mom.Select("Name = 'Teresa' and ChildName <> 'Jack'");
-            Assert.Equal("Mack", Rows[0][1]);
+            rows = mom.Select("Name = 'Teresa' and ChildName <> 'Jack'");
+            Assert.Equal("Mack", rows[0][1]);
 
-            Rows = Mom.Select("Name = 'Teresa' or ChildName <> 'Jack'");
-            Assert.Equal(6, Rows.Length);
+            rows = mom.Select("Name = 'Teresa' or ChildName <> 'Jack'");
+            Assert.Equal(6, rows.Length);
 
-            Rows = Child.Select("age = 20 - 1");
-            Assert.Equal(1, Rows.Length);
+            rows = child.Select("age = 20 - 1");
+            Assert.Equal(1, rows.Length);
 
-            Rows = Child.Select("age <= 20");
-            Assert.Equal(3, Rows.Length);
+            rows = child.Select("age <= 20");
+            Assert.Equal(3, rows.Length);
 
-            Rows = Child.Select("age >= 20");
-            Assert.Equal(4, Rows.Length);
+            rows = child.Select("age >= 20");
+            Assert.Equal(4, rows.Length);
 
-            Rows = Child.Select("age >= 20 and name = 'Mack' or name = 'Nick'");
-            Assert.Equal(2, Rows.Length);
+            rows = child.Select("age >= 20 and name = 'Mack' or name = 'Nick'");
+            Assert.Equal(2, rows.Length);
 
-            Rows = Child.Select("age >= 20 and (name = 'Mack' or name = 'Nick')");
-            Assert.Equal(1, Rows.Length);
-            Assert.Equal("Mack", Rows[0][0]);
+            rows = child.Select("age >= 20 and (name = 'Mack' or name = 'Nick')");
+            Assert.Equal(1, rows.Length);
+            Assert.Equal("Mack", rows[0][0]);
 
-            Rows = Child.Select("not (Name = 'Jack')");
-            Assert.Equal(6, Rows.Length);
+            rows = child.Select("not (Name = 'Jack')");
+            Assert.Equal(6, rows.Length);
         }
 
         [Fact]
         public void Select2()
         {
-            DataSet Set = new DataSet();
-            DataTable Child = new DataTable("Child");
+            DataSet set = new DataSet();
+            DataTable child = new DataTable("Child");
 
-            Set.Tables.Add(Child);
+            set.Tables.Add(child);
 
-            DataColumn Col3 = new DataColumn("Name");
-            DataColumn Col4 = new DataColumn("Age");
-            Col4.DataType = typeof(short);
-            Child.Columns.Add(Col3);
-            Child.Columns.Add(Col4);
+            DataColumn col3 = new DataColumn("Name");
+            DataColumn col4 = new DataColumn("Age");
+            col4.DataType = typeof(short);
+            child.Columns.Add(col3);
+            child.Columns.Add(col4);
 
-            DataRow Row = Child.NewRow();
-            Row[0] = "Nick";
-            Row[1] = 15;
-            Child.Rows.Add(Row);
+            DataRow row = child.NewRow();
+            row[0] = "Nick";
+            row[1] = 15;
+            child.Rows.Add(row);
 
-            Row = Child.NewRow();
-            Row[0] = "Dick";
-            Row[1] = 25;
-            Child.Rows.Add(Row);
+            row = child.NewRow();
+            row[0] = "Dick";
+            row[1] = 25;
+            child.Rows.Add(row);
 
-            Row = Child.NewRow();
-            Row[0] = "Mick";
-            Row[1] = 35;
-            Child.Rows.Add(Row);
+            row = child.NewRow();
+            row[0] = "Mick";
+            row[1] = 35;
+            child.Rows.Add(row);
 
-            Row = Child.NewRow();
-            Row[0] = "Jack";
-            Row[1] = 10;
-            Child.Rows.Add(Row);
+            row = child.NewRow();
+            row[0] = "Jack";
+            row[1] = 10;
+            child.Rows.Add(row);
 
-            Row = Child.NewRow();
-            Row[0] = "Mack";
-            Row[1] = 19;
-            Child.Rows.Add(Row);
+            row = child.NewRow();
+            row[0] = "Mack";
+            row[1] = 19;
+            child.Rows.Add(row);
 
-            Row = Child.NewRow();
-            Row[0] = "Mack";
-            Row[1] = 99;
-            Child.Rows.Add(Row);
+            row = child.NewRow();
+            row[0] = "Mack";
+            row[1] = 99;
+            child.Rows.Add(row);
 
-            DataRow[] Rows = Child.Select("age >= 20", "age DESC");
-            Assert.Equal(3, Rows.Length);
-            Assert.Equal("Mack", Rows[0][0]);
-            Assert.Equal("Mick", Rows[1][0]);
-            Assert.Equal("Dick", Rows[2][0]);
+            DataRow[] rows = child.Select("age >= 20", "age DESC");
+            Assert.Equal(3, rows.Length);
+            Assert.Equal("Mack", rows[0][0]);
+            Assert.Equal("Mick", rows[1][0]);
+            Assert.Equal("Dick", rows[2][0]);
 
-            Rows = Child.Select("age >= 20", "age asc");
-            Assert.Equal(3, Rows.Length);
-            Assert.Equal("Dick", Rows[0][0]);
-            Assert.Equal("Mick", Rows[1][0]);
-            Assert.Equal("Mack", Rows[2][0]);
+            rows = child.Select("age >= 20", "age asc");
+            Assert.Equal(3, rows.Length);
+            Assert.Equal("Dick", rows[0][0]);
+            Assert.Equal("Mick", rows[1][0]);
+            Assert.Equal("Mack", rows[2][0]);
 
-            Rows = Child.Select("age >= 20", "name asc");
-            Assert.Equal(3, Rows.Length);
-            Assert.Equal("Dick", Rows[0][0]);
-            Assert.Equal("Mack", Rows[1][0]);
-            Assert.Equal("Mick", Rows[2][0]);
+            rows = child.Select("age >= 20", "name asc");
+            Assert.Equal(3, rows.Length);
+            Assert.Equal("Dick", rows[0][0]);
+            Assert.Equal("Mack", rows[1][0]);
+            Assert.Equal("Mick", rows[2][0]);
 
-            Rows = Child.Select("age >= 20", "name desc");
-            Assert.Equal(3, Rows.Length);
-            Assert.Equal("Mick", Rows[0][0]);
-            Assert.Equal("Mack", Rows[1][0]);
-            Assert.Equal("Dick", Rows[2][0]);
+            rows = child.Select("age >= 20", "name desc");
+            Assert.Equal(3, rows.Length);
+            Assert.Equal("Mick", rows[0][0]);
+            Assert.Equal("Mack", rows[1][0]);
+            Assert.Equal("Dick", rows[2][0]);
         }
 
         [Fact]
         public void SelectParsing()
         {
-            DataTable T = new DataTable("test");
-            DataColumn C = new DataColumn("name");
-            T.Columns.Add(C);
-            C = new DataColumn("age");
-            C.DataType = typeof(int);
-            T.Columns.Add(C);
-            C = new DataColumn("id");
-            T.Columns.Add(C);
+            DataTable t = new DataTable("test");
+            DataColumn c = new DataColumn("name");
+            t.Columns.Add(c);
+            c = new DataColumn("age");
+            c.DataType = typeof(int);
+            t.Columns.Add(c);
+            c = new DataColumn("id");
+            t.Columns.Add(c);
 
-            DataSet Set = new DataSet("TestSet");
-            Set.Tables.Add(T);
+            DataSet set = new DataSet("TestSet");
+            set.Tables.Add(t);
 
-            DataRow Row = null;
+            DataRow row = null;
             for (int i = 0; i < 100; i++)
             {
-                Row = T.NewRow();
-                Row[0] = "human" + i;
-                Row[1] = i;
-                Row[2] = i;
-                T.Rows.Add(Row);
+                row = t.NewRow();
+                row[0] = "human" + i;
+                row[1] = i;
+                row[2] = i;
+                t.Rows.Add(row);
             }
 
-            Row = T.NewRow();
-            Row[0] = "h*an";
-            Row[1] = 1;
-            Row[2] = 1;
-            T.Rows.Add(Row);
+            row = t.NewRow();
+            row[0] = "h*an";
+            row[1] = 1;
+            row[2] = 1;
+            t.Rows.Add(row);
 
-            Assert.Equal(12, T.Select("age<=10").Length);
+            Assert.Equal(12, t.Select("age<=10").Length);
 
-            Assert.Equal(12, T.Select("age\n\t<\n\t=\t\n10").Length);
+            Assert.Equal(12, t.Select("age\n\t<\n\t=\t\n10").Length);
 
-            try
-            {
-                T.Select("name = 1human ");
-                Assert.False(true);
-            }
-            catch (SyntaxErrorException e)
-            {
-                // missing operand after 'human' operand
-                Assert.Equal(typeof(SyntaxErrorException), e.GetType());
-            }
+            // missing operand after 'human' operand
+            Assert.Throws<SyntaxErrorException>(() => t.Select("name = 1human "));
 
-            try
-            {
-                T.Select("name = 1");
-                Assert.False(true);
-            }
-            catch (EvaluateException e)
-            {
-                // Cannot perform '=' operation between string and Int32
-                Assert.Equal(typeof(EvaluateException), e.GetType());
-            }
+            // Cannot perform '=' operation between string and Int32
+            Assert.Throws<SyntaxErrorException>(() => t.Select("name = 1"));
 
-            Assert.Equal(1, T.Select("age = '13'").Length);
+            Assert.Equal(1, t.Select("age = '13'").Length);
         }
 
         [Fact]
@@ -349,42 +332,43 @@ namespace System.Data.Tests
         [Fact]
         public void SelectOperators()
         {
-            DataTable T = new DataTable("test");
-            DataColumn C = new DataColumn("name");
-            T.Columns.Add(C);
-            C = new DataColumn("age");
-            C.DataType = typeof(int);
-            T.Columns.Add(C);
-            C = new DataColumn("id");
-            T.Columns.Add(C);
+            DataTable t = new DataTable("test");
+            DataColumn c = new DataColumn("name");
+            t.Columns.Add(c);
+            c = new DataColumn("age");
+            c.DataType = typeof(int);
+            t.Columns.Add(c);
+            c = new DataColumn("id");
+            t.Columns.Add(c);
 
-            DataSet Set = new DataSet("TestSet");
-            Set.Tables.Add(T);
+            DataSet set = new DataSet("TestSet");
+            set.Tables.Add(t);
 
-            DataRow Row = null;
+            DataRow row = null;
             for (int i = 0; i < 100; i++)
             {
-                Row = T.NewRow();
-                Row[0] = "human" + i;
-                Row[1] = i;
-                Row[2] = i;
-                T.Rows.Add(Row);
+                row = t.NewRow();
+                row[0] = "human" + i;
+                row[1] = i;
+                row[2] = i;
+                t.Rows.Add(row);
             }
 
-            Row = T.NewRow();
-            Row[0] = "h*an";
-            Row[1] = 1;
-            Row[2] = 1;
-            T.Rows.Add(Row);
+            row = t.NewRow();
+            row[0] = "h*an";
+            row[1] = 1;
+            row[2] = 1;
+            t.Rows.Add(row);
 
-            Assert.Equal(11, T.Select("age < 10").Length);
-            Assert.Equal(12, T.Select("age <= 10").Length);
-            Assert.Equal(12, T.Select("age< =10").Length);
-            Assert.Equal(89, T.Select("age > 10").Length);
-            Assert.Equal(90, T.Select("age >= 10").Length);
-            Assert.Equal(100, T.Select("age <> 10").Length);
-            Assert.Equal(3, T.Select("name < 'human10'").Length);
-            Assert.Equal(3, T.Select("id < '10'").Length);
+            Assert.Equal(11, t.Select("age < 10").Length);
+            Assert.Equal(12, t.Select("age <= 10").Length);
+            Assert.Equal(12, t.Select("age< =10").Length);
+            Assert.Equal(89, t.Select("age > 10").Length);
+            Assert.Equal(90, t.Select("age >= 10").Length);
+            Assert.Equal(100, t.Select("age <> 10").Length);
+            Assert.Equal(3, t.Select("name < 'human10'").Length);
+            Assert.Equal(3, t.Select("id < '10'").Length);
+            //TODO
             // FIXME: Somebody explain how this can be possible.
             // it seems that it is no matter between 10 - 30. The
             // result is always 25 :-P
@@ -414,290 +398,258 @@ namespace System.Data.Tests
         [Fact]
         public void SelectExceptions()
         {
-            DataTable T = new DataTable("test");
-            DataColumn C = new DataColumn("name");
-            T.Columns.Add(C);
-            C = new DataColumn("age");
-            C.DataType = typeof(int);
-            T.Columns.Add(C);
-            C = new DataColumn("id");
-            T.Columns.Add(C);
+            DataTable t = new DataTable("test");
+            DataColumn c = new DataColumn("name");
+            t.Columns.Add(c);
+            c = new DataColumn("age");
+            c.DataType = typeof(int);
+            t.Columns.Add(c);
+            c = new DataColumn("id");
+            t.Columns.Add(c);
 
             for (int i = 0; i < 100; i++)
             {
-                DataRow Row = T.NewRow();
-                Row[0] = "human" + i;
-                Row[1] = i;
-                Row[2] = i;
-                T.Rows.Add(Row);
+                DataRow row = t.NewRow();
+                row[0] = "human" + i;
+                row[1] = i;
+                row[2] = i;
+                t.Rows.Add(row);
             }
 
-            try
-            {
-                T.Select("name = human1");
-                Assert.False(true);
-            }
-            catch (EvaluateException e)
-            {
-                // column name human not found
-                Assert.Equal(typeof(EvaluateException), e.GetType());
-            }
+            // column name human not found
+            Assert.Throws<EvaluateException>(() => t.Select("name = human1"));
 
-            Assert.Equal(1, T.Select("id = '12'").Length);
-            Assert.Equal(1, T.Select("id = 12").Length);
+            Assert.Equal(1, t.Select("id = '12'").Length);
+            Assert.Equal(1, t.Select("id = 12").Length);
 
-            try
-            {
-                T.Select("id = 1k3");
-                Assert.False(true);
-            }
-            catch (SyntaxErrorException e)
-            {
-                // no operands after k3 operator
-                Assert.Equal(typeof(SyntaxErrorException), e.GetType());
-            }
+            // no operands after k3 operator
+            Assert.Throws<SyntaxErrorException>(() => t.Select("id = 1k3"));
         }
 
         [Fact]
         public void SelectStringOperators()
         {
-            DataTable T = new DataTable("test");
-            DataColumn C = new DataColumn("name");
-            T.Columns.Add(C);
-            C = new DataColumn("age");
-            C.DataType = typeof(int);
-            T.Columns.Add(C);
-            C = new DataColumn("id");
-            T.Columns.Add(C);
+            DataTable t = new DataTable("test");
+            DataColumn c = new DataColumn("name");
+            t.Columns.Add(c);
+            c = new DataColumn("age");
+            c.DataType = typeof(int);
+            t.Columns.Add(c);
+            c = new DataColumn("id");
+            t.Columns.Add(c);
 
-            DataSet Set = new DataSet("TestSet");
-            Set.Tables.Add(T);
+            DataSet set = new DataSet("TestSet");
+            set.Tables.Add(t);
 
-            DataRow Row = null;
+            DataRow row = null;
             for (int i = 0; i < 100; i++)
             {
-                Row = T.NewRow();
-                Row[0] = "human" + i;
-                Row[1] = i;
-                Row[2] = i;
-                T.Rows.Add(Row);
+                row = t.NewRow();
+                row[0] = "human" + i;
+                row[1] = i;
+                row[2] = i;
+                t.Rows.Add(row);
             }
-            Row = T.NewRow();
-            Row[0] = "h*an";
-            Row[1] = 1;
-            Row[2] = 1;
-            T.Rows.Add(Row);
+            row = t.NewRow();
+            row[0] = "h*an";
+            row[1] = 1;
+            row[2] = 1;
+            t.Rows.Add(row);
 
-            Assert.Equal(1, T.Select("name = 'human' + 1").Length);
+            Assert.Equal(1, t.Select("name = 'human' + 1").Length);
 
-            Assert.Equal("human1", T.Select("name = 'human' + 1")[0]["name"]);
-            Assert.Equal(1, T.Select("name = 'human' + '1'").Length);
-            Assert.Equal("human1", T.Select("name = 'human' + '1'")[0]["name"]);
-            Assert.Equal(1, T.Select("name = 'human' + 1 + 2").Length);
-            Assert.Equal("human12", T.Select("name = 'human' + '1' + '2'")[0]["name"]);
+            Assert.Equal("human1", t.Select("name = 'human' + 1")[0]["name"]);
+            Assert.Equal(1, t.Select("name = 'human' + '1'").Length);
+            Assert.Equal("human1", t.Select("name = 'human' + '1'")[0]["name"]);
+            Assert.Equal(1, t.Select("name = 'human' + 1 + 2").Length);
+            Assert.Equal("human12", t.Select("name = 'human' + '1' + '2'")[0]["name"]);
 
-            Assert.Equal(1, T.Select("name = 'huMAn' + 1").Length);
+            Assert.Equal(1, t.Select("name = 'huMAn' + 1").Length);
 
-            Set.CaseSensitive = true;
-            Assert.Equal(0, T.Select("name = 'huMAn' + 1").Length);
+            set.CaseSensitive = true;
+            Assert.Equal(0, t.Select("name = 'huMAn' + 1").Length);
 
-            T.CaseSensitive = false;
-            Assert.Equal(1, T.Select("name = 'huMAn' + 1").Length);
+            t.CaseSensitive = false;
+            Assert.Equal(1, t.Select("name = 'huMAn' + 1").Length);
 
-            T.CaseSensitive = true;
-            Assert.Equal(0, T.Select("name = 'huMAn' + 1").Length);
+            t.CaseSensitive = true;
+            Assert.Equal(0, t.Select("name = 'huMAn' + 1").Length);
 
-            Set.CaseSensitive = false;
-            Assert.Equal(0, T.Select("name = 'huMAn' + 1").Length);
+            set.CaseSensitive = false;
+            Assert.Equal(0, t.Select("name = 'huMAn' + 1").Length);
 
-            T.CaseSensitive = false;
-            Assert.Equal(1, T.Select("name = 'huMAn' + 1").Length);
+            t.CaseSensitive = false;
+            Assert.Equal(1, t.Select("name = 'huMAn' + 1").Length);
 
-            Assert.Equal(0, T.Select("name = 'human1*'").Length);
-            Assert.Equal(11, T.Select("name like 'human1*'").Length);
-            Assert.Equal(11, T.Select("name like 'human1%'").Length);
+            Assert.Equal(0, t.Select("name = 'human1*'").Length);
+            Assert.Equal(11, t.Select("name like 'human1*'").Length);
+            Assert.Equal(11, t.Select("name like 'human1%'").Length);
 
-            try
-            {
-                Assert.Equal(11, T.Select("name like 'h*an1'").Length);
-                Assert.False(true);
-            }
-            catch (EvaluateException e)
-            {
-                // 'h*an1' is invalid
-                Assert.Equal(typeof(EvaluateException), e.GetType());
-            }
+            // 'h*an1' is invalid
+            Assert.Throws<EvaluateException>(() => t.Select("name like 'h*an1'"));
+            // 'h%an1' is invalid
+            Assert.Throws<EvaluateException>(() => t.Select("name like 'h%an1'"));
 
-            try
-            {
-                Assert.Equal(11, T.Select("name like 'h%an1'").Length);
-                Assert.False(true);
-            }
-            catch (EvaluateException e)
-            {
-                // 'h%an1' is invalid
-                Assert.Equal(typeof(EvaluateException), e.GetType());
-            }
-
-            Assert.Equal(0, T.Select("name like 'h[%]an'").Length);
-            Assert.Equal(1, T.Select("name like 'h[*]an'").Length);
+            Assert.Equal(0, t.Select("name like 'h[%]an'").Length);
+            Assert.Equal(1, t.Select("name like 'h[*]an'").Length);
         }
 
         [Fact]
         public void SelectAggregates()
         {
-            DataTable T = new DataTable("test");
-            DataColumn C = new DataColumn("name");
-            T.Columns.Add(C);
-            C = new DataColumn("age");
-            C.DataType = typeof(int);
-            T.Columns.Add(C);
-            C = new DataColumn("id");
-            T.Columns.Add(C);
-            DataRow Row = null;
+            DataTable t = new DataTable("test");
+            DataColumn c = new DataColumn("name");
+            t.Columns.Add(c);
+            c = new DataColumn("age");
+            c.DataType = typeof(int);
+            t.Columns.Add(c);
+            c = new DataColumn("id");
+            t.Columns.Add(c);
+            DataRow row = null;
 
             for (int i = 0; i < 1000; i++)
             {
-                Row = T.NewRow();
-                Row[0] = "human" + i;
-                Row[1] = i;
-                Row[2] = i;
-                T.Rows.Add(Row);
+                row = t.NewRow();
+                row[0] = "human" + i;
+                row[1] = i;
+                row[2] = i;
+                t.Rows.Add(row);
             }
 
-            Assert.Equal(1000, T.Select("Sum(age) > 10").Length);
-            Assert.Equal(1000, T.Select("avg(age) = 499").Length);
-            Assert.Equal(1000, T.Select("min(age) = 0").Length);
-            Assert.Equal(1000, T.Select("max(age) = 999").Length);
-            Assert.Equal(1000, T.Select("count(age) = 1000").Length);
-            Assert.Equal(1000, T.Select("stdev(age) > 287 and stdev(age) < 289").Length);
-            Assert.Equal(1000, T.Select("var(age) < 83417 and var(age) > 83416").Length);
+            Assert.Equal(1000, t.Select("Sum(age) > 10").Length);
+            Assert.Equal(1000, t.Select("avg(age) = 499").Length);
+            Assert.Equal(1000, t.Select("min(age) = 0").Length);
+            Assert.Equal(1000, t.Select("max(age) = 999").Length);
+            Assert.Equal(1000, t.Select("count(age) = 1000").Length);
+            Assert.Equal(1000, t.Select("stdev(age) > 287 and stdev(age) < 289").Length);
+            Assert.Equal(1000, t.Select("var(age) < 83417 and var(age) > 83416").Length);
         }
 
         [Fact]
         public void SelectFunctions()
         {
-            DataTable T = new DataTable("test");
-            DataColumn C = new DataColumn("name");
-            T.Columns.Add(C);
-            C = new DataColumn("age");
-            C.DataType = typeof(int);
-            T.Columns.Add(C);
-            C = new DataColumn("id");
-            T.Columns.Add(C);
-            DataRow Row = null;
+            DataTable t = new DataTable("test");
+            DataColumn c = new DataColumn("name");
+            t.Columns.Add(c);
+            c = new DataColumn("age");
+            c.DataType = typeof(int);
+            t.Columns.Add(c);
+            c = new DataColumn("id");
+            t.Columns.Add(c);
+            DataRow row = null;
 
             for (int i = 0; i < 1000; i++)
             {
-                Row = T.NewRow();
-                Row[0] = "human" + i;
-                Row[1] = i;
-                Row[2] = i;
-                T.Rows.Add(Row);
+                row = t.NewRow();
+                row[0] = "human" + i;
+                row[1] = i;
+                row[2] = i;
+                t.Rows.Add(row);
             }
 
-            Row = T.NewRow();
-            Row[0] = "human" + "test";
-            Row[1] = DBNull.Value;
-            Row[2] = DBNull.Value;
-            T.Rows.Add(Row);
+            row = t.NewRow();
+            row[0] = "human" + "test";
+            row[1] = DBNull.Value;
+            row[2] = DBNull.Value;
+            t.Rows.Add(row);
 
-            Assert.Equal(25, T.Select("age = 5*5")[0]["age"]);
-            Assert.Equal(901, T.Select("len(name) > 7").Length);
-            Assert.Equal(125, T.Select("age = 5*5*5 AND len(name)>7")[0]["age"]);
-            Assert.Equal(1, T.Select("isnull(id, 'test') = 'test'").Length);
-            Assert.Equal(1000, T.Select("iif(id = '56', 'test', 'false') = 'false'").Length);
-            Assert.Equal(1, T.Select("iif(id = '56', 'test', 'false') = 'test'").Length);
-            Assert.Equal(9, T.Select("substring(id, 2, 3) = '23'").Length);
-            Assert.Equal("123", T.Select("substring(id, 2, 3) = '23'")[0]["id"]);
-            Assert.Equal("423", T.Select("substring(id, 2, 3) = '23'")[3]["id"]);
-            Assert.Equal("923", T.Select("substring(id, 2, 3) = '23'")[8]["id"]);
+            Assert.Equal(25, t.Select("age = 5*5")[0]["age"]);
+            Assert.Equal(901, t.Select("len(name) > 7").Length);
+            Assert.Equal(125, t.Select("age = 5*5*5 AND len(name)>7")[0]["age"]);
+            Assert.Equal(1, t.Select("isnull(id, 'test') = 'test'").Length);
+            Assert.Equal(1000, t.Select("iif(id = '56', 'test', 'false') = 'false'").Length);
+            Assert.Equal(1, t.Select("iif(id = '56', 'test', 'false') = 'test'").Length);
+            Assert.Equal(9, t.Select("substring(id, 2, 3) = '23'").Length);
+            Assert.Equal("123", t.Select("substring(id, 2, 3) = '23'")[0]["id"]);
+            Assert.Equal("423", t.Select("substring(id, 2, 3) = '23'")[3]["id"]);
+            Assert.Equal("923", t.Select("substring(id, 2, 3) = '23'")[8]["id"]);
         }
 
         [Fact]
         public void SelectRelations()
         {
-            DataSet Set = new DataSet();
-            DataTable Mom = new DataTable("Mom");
-            DataTable Child = new DataTable("Child");
+            DataSet set = new DataSet();
+            DataTable m = new DataTable("Mom");
+            DataTable child = new DataTable("Child");
 
-            Set.Tables.Add(Mom);
-            Set.Tables.Add(Child);
+            set.Tables.Add(m);
+            set.Tables.Add(child);
 
-            DataColumn Col = new DataColumn("Name");
-            DataColumn Col2 = new DataColumn("ChildName");
-            Mom.Columns.Add(Col);
-            Mom.Columns.Add(Col2);
+            DataColumn col = new DataColumn("Name");
+            DataColumn col2 = new DataColumn("ChildName");
+            m.Columns.Add(col);
+            m.Columns.Add(col2);
 
-            DataColumn Col3 = new DataColumn("Name");
-            DataColumn Col4 = new DataColumn("Age");
-            Col4.DataType = typeof(short);
-            Child.Columns.Add(Col3);
-            Child.Columns.Add(Col4);
+            DataColumn col3 = new DataColumn("Name");
+            DataColumn col4 = new DataColumn("Age");
+            col4.DataType = typeof(short);
+            child.Columns.Add(col3);
+            child.Columns.Add(col4);
 
-            DataRelation Relation = new DataRelation("Rel", Mom.Columns[1], Child.Columns[0]);
-            Set.Relations.Add(Relation);
+            DataRelation r = new DataRelation("Rel", m.Columns[1], child.Columns[0]);
+            set.Relations.Add(r);
 
-            DataRow Row = Mom.NewRow();
-            Row[0] = "Laura";
-            Row[1] = "Nick";
-            Mom.Rows.Add(Row);
+            DataRow row = m.NewRow();
+            row[0] = "Laura";
+            row[1] = "Nick";
+            m.Rows.Add(row);
 
-            Row = Mom.NewRow();
-            Row[0] = "Laura";
-            Row[1] = "Dick";
-            Mom.Rows.Add(Row);
+            row = m.NewRow();
+            row[0] = "Laura";
+            row[1] = "Dick";
+            m.Rows.Add(row);
 
-            Row = Mom.NewRow();
-            Row[0] = "Laura";
-            Row[1] = "Mick";
-            Mom.Rows.Add(Row);
+            row = m.NewRow();
+            row[0] = "Laura";
+            row[1] = "Mick";
+            m.Rows.Add(row);
 
-            Row = Mom.NewRow();
-            Row[0] = "Teresa";
-            Row[1] = "Jack";
-            Mom.Rows.Add(Row);
+            row = m.NewRow();
+            row[0] = "Teresa";
+            row[1] = "Jack";
+            m.Rows.Add(row);
 
-            Row = Mom.NewRow();
-            Row[0] = "Teresa";
-            Row[1] = "Mack";
-            Mom.Rows.Add(Row);
+            row = m.NewRow();
+            row[0] = "Teresa";
+            row[1] = "Mack";
+            m.Rows.Add(row);
 
-            Row = Child.NewRow();
-            Row[0] = "Nick";
-            Row[1] = 15;
-            Child.Rows.Add(Row);
+            row = child.NewRow();
+            row[0] = "Nick";
+            row[1] = 15;
+            child.Rows.Add(row);
 
-            Row = Child.NewRow();
-            Row[0] = "Dick";
-            Row[1] = 25;
-            Child.Rows.Add(Row);
+            row = child.NewRow();
+            row[0] = "Dick";
+            row[1] = 25;
+            child.Rows.Add(row);
 
-            Row = Child.NewRow();
-            Row[0] = "Mick";
-            Row[1] = 35;
-            Child.Rows.Add(Row);
+            row = child.NewRow();
+            row[0] = "Mick";
+            row[1] = 35;
+            child.Rows.Add(row);
 
-            Row = Child.NewRow();
-            Row[0] = "Jack";
-            Row[1] = 10;
-            Child.Rows.Add(Row);
+            row = child.NewRow();
+            row[0] = "Jack";
+            row[1] = 10;
+            child.Rows.Add(row);
 
-            Row = Child.NewRow();
-            Row[0] = "Mack";
-            Row[1] = 19;
-            Child.Rows.Add(Row);
+            row = child.NewRow();
+            row[0] = "Mack";
+            row[1] = 19;
+            child.Rows.Add(row);
 
-            Row = Child.NewRow();
-            Row[0] = "Mack";
-            Row[1] = 99;
-            Child.Rows.Add(Row);
+            row = child.NewRow();
+            row[0] = "Mack";
+            row[1] = 99;
+            child.Rows.Add(row);
 
-            DataRow[] Rows = Child.Select("name = Parent.Childname");
-            Assert.Equal(6, Rows.Length);
-            Rows = Child.Select("Parent.childname = 'Jack'");
-            Assert.Equal(1, Rows.Length);
+            DataRow[] rows = child.Select("name = Parent.Childname");
+            Assert.Equal(6, rows.Length);
+            rows = child.Select("Parent.childname = 'Jack'");
+            Assert.Equal(1, rows.Length);
 
+            //TODO: why is this disabled?
             /*
             try {
                 Mom.Select ("Child.Name = 'Jack'");
@@ -708,73 +660,75 @@ Assert.False(true);
             }
             */
 
-            Rows = Child.Select("Parent.name = 'Laura'");
-            Assert.Equal(3, Rows.Length);
+            rows = child.Select("Parent.name = 'Laura'");
+            Assert.Equal(3, rows.Length);
 
             DataTable Parent2 = new DataTable("Parent2");
-            Col = new DataColumn("Name");
-            Col2 = new DataColumn("ChildName");
+            col = new DataColumn("Name");
+            col2 = new DataColumn("ChildName");
 
-            Parent2.Columns.Add(Col);
-            Parent2.Columns.Add(Col2);
-            Set.Tables.Add(Parent2);
+            Parent2.Columns.Add(col);
+            Parent2.Columns.Add(col2);
+            set.Tables.Add(Parent2);
 
-            Row = Parent2.NewRow();
-            Row[0] = "Laura";
-            Row[1] = "Nick";
-            Parent2.Rows.Add(Row);
+            row = Parent2.NewRow();
+            row[0] = "Laura";
+            row[1] = "Nick";
+            Parent2.Rows.Add(row);
 
-            Row = Parent2.NewRow();
-            Row[0] = "Laura";
-            Row[1] = "Dick";
-            Parent2.Rows.Add(Row);
+            row = Parent2.NewRow();
+            row[0] = "Laura";
+            row[1] = "Dick";
+            Parent2.Rows.Add(row);
 
-            Row = Parent2.NewRow();
-            Row[0] = "Laura";
-            Row[1] = "Mick";
-            Parent2.Rows.Add(Row);
+            row = Parent2.NewRow();
+            row[0] = "Laura";
+            row[1] = "Mick";
+            Parent2.Rows.Add(row);
 
-            Row = Parent2.NewRow();
-            Row[0] = "Teresa";
-            Row[1] = "Jack";
-            Parent2.Rows.Add(Row);
+            row = Parent2.NewRow();
+            row[0] = "Teresa";
+            row[1] = "Jack";
+            Parent2.Rows.Add(row);
 
-            Row = Parent2.NewRow();
-            Row[0] = "Teresa";
-            Row[1] = "Mack";
-            Parent2.Rows.Add(Row);
+            row = Parent2.NewRow();
+            row[0] = "Teresa";
+            row[1] = "Mack";
+            Parent2.Rows.Add(row);
 
-            Relation = new DataRelation("Rel2", Parent2.Columns[1], Child.Columns[0]);
-            Set.Relations.Add(Relation);
+            r = new DataRelation("Rel2", Parent2.Columns[1], child.Columns[0]);
+            set.Relations.Add(r);
+            //TODO
+            //try
+            //{
+            //    rows = child.Select("Parent.ChildName = 'Jack'");
+            //    Assert.False(true);
+            //}
+            //catch (EvaluateException e)
+            //{
+            //    Assert.Equal(typeof(EvaluateException), e.GetType());
+            //    // Do not compare exception messages!
+            //    //Assert.Equal ("The table [Child] involved in more than one relation. You must explicitly mention a relation name in the expression 'parent.[ChildName]'.", e.Message);
+            //}
+            Assert.Throws<EvaluateException>(() => child.Select("Parent.ChildName = 'Jack'"));
 
-            try
-            {
-                Rows = Child.Select("Parent.ChildName = 'Jack'");
-                Assert.False(true);
-            }
-            catch (EvaluateException e)
-            {
-                Assert.Equal(typeof(EvaluateException), e.GetType());
-                // Do not compare exception messages!
-                //Assert.Equal ("The table [Child] involved in more than one relation. You must explicitly mention a relation name in the expression 'parent.[ChildName]'.", e.Message);
-            }
+            rows = child.Select("Parent(rel).ChildName = 'Jack'");
+            Assert.Equal(1, rows.Length);
 
-            Rows = Child.Select("Parent(rel).ChildName = 'Jack'");
-            Assert.Equal(1, Rows.Length);
-
-            Rows = Child.Select("Parent(Rel2).ChildName = 'Jack'");
-            Assert.Equal(1, Rows.Length);
-
-            try
-            {
-                Mom.Select("Parent.name  = 'John'");
-            }
-            catch (IndexOutOfRangeException e)
-            {
-                Assert.Equal(typeof(IndexOutOfRangeException), e.GetType());
-                // Do not compare exception messages!
-                //Assert.Equal ("Cannot find relation 0.", e.Message);
-            }
+            rows = child.Select("Parent(Rel2).ChildName = 'Jack'");
+            Assert.Equal(1, rows.Length);
+            //TODO
+            //try
+            //{
+            //    m.Select("Parent.name  = 'John'");
+            //}
+            //catch (IndexOutOfRangeException e)
+            //{
+            //    Assert.Equal(typeof(IndexOutOfRangeException), e.GetType());
+            //    // Do not compare exception messages!
+            //    //Assert.Equal ("Cannot find relation 0.", e.Message);
+            //}
+            Assert.Throws<IndexOutOfRangeException>(() => m.Select("Parent.name  = 'John'"));
         }
 
         [Fact]
@@ -826,32 +780,36 @@ Assert.False(true);
 
             Col = new DataColumn("failed");
 
-            try
-            {
-                dt.PrimaryKey = new DataColumn[] { Col };
-                Assert.False(true);
-            }
-            catch (ArgumentException e)
-            {
-                Assert.Equal(typeof(ArgumentException), e.GetType());
-                // Never expect English message
-                // Assert.Equal ("Column must belong to a table.", e.Message);
-            }
+            //TODO
+            //try
+            //{
+            //    dt.PrimaryKey = new DataColumn[] { Col };
+            //    Assert.False(true);
+            //}
+            //catch (ArgumentException e)
+            //{
+            //    Assert.Equal(typeof(ArgumentException), e.GetType());
+            //    // Never expect English message
+            //    // Assert.Equal ("Column must belong to a table.", e.Message);
+            //}
+            Assert.Throws<ArgumentException>(() => dt.PrimaryKey = new DataColumn[] { Col });
 
             DataTable dt2 = new DataTable();
             dt2.Columns.Add();
 
-            try
-            {
-                dt.PrimaryKey = new DataColumn[] { dt2.Columns[0] };
-                Assert.False(true);
-            }
-            catch (ArgumentException e)
-            {
-                Assert.Equal(typeof(ArgumentException), e.GetType());
-                // Never expect English message
-                // Assert.Equal ("PrimaryKey columns do not belong to this table.", e.Message);
-            }
+            //TODO
+            //try
+            //{
+            //    dt.PrimaryKey = new DataColumn[] { dt2.Columns[0] };
+            //    Assert.False(true);
+            //}
+            //catch (ArgumentException e)
+            //{
+            //    Assert.Equal(typeof(ArgumentException), e.GetType());
+            //    // Never expect English message
+            //    // Assert.Equal ("PrimaryKey columns do not belong to this table.", e.Message);
+            //}
+            Assert.Throws<ArgumentException>(() => dt.PrimaryKey = new DataColumn[] { dt2.Columns[0] });
 
             Assert.Equal(0, dt.Constraints.Count);
 
@@ -1135,14 +1093,7 @@ Assert.False(true);
             object[] row2 = { 143, "Hij" };
             DataRow newRow2 = table.LoadDataRow(row2, true);
 
-            try
-            {
-                table.EndLoadData();
-                Assert.False(true);
-            }
-            catch (ConstraintException)
-            {
-            }
+            Assert.Throws<ConstraintException>(() => table.EndLoadData());
         }
 
         [Fact]
@@ -1180,14 +1131,7 @@ Assert.False(true);
             table.AcceptChanges();
             changesTable = table.GetChanges();
 
-            try
-            {
-                int cnt = changesTable.Rows.Count;
-                Assert.False(true);
-            }
-            catch (NullReferenceException)
-            {
-            }
+            Assert.Null(changesTable);
 
             //Testing RejectChanges
             row = table.NewRow();
@@ -1234,25 +1178,19 @@ Assert.False(true);
             target.ImportRow(src.Rows[2]);     // import 3rd row
             target.ImportRow(src.Rows[3]);     // import 4th row
 
-            try
-            {
-                target.ImportRow(src.Rows[2]); // import 3rd row again
-                Assert.False(true);
-            }
-            catch (ConstraintException ex)
-            {
-                // Column 'id' is constrained to be unique.
-                // Value '3' is already present
-                Assert.Equal(typeof(ConstraintException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
+            // import 3rd row again
+            ConstraintException ex = Assert.Throws<ConstraintException>(() => target.ImportRow(src.Rows[2]));
+            // Column 'id' is constrained to be unique.
+            // Value '3' is already present
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+            // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
+            // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
+            // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
+            Assert.Matches(@"[\p{Pi}\p{Po}]" + "id" + @"[\p{Pf}\p{Po}]", ex.Message);
+            Assert.Matches(@"[\p{Pi}\p{Po}]" + "3" + @"[\p{Pf}\p{Po}]", ex.Message);
 
-                // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
-                // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
-                // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
-                Assert.Matches(@"[\p{Pi}\p{Po}]" + "id" + @"[\p{Pf}\p{Po}]", ex.Message);
-                Assert.Matches(@"[\p{Pi}\p{Po}]" + "3" + @"[\p{Pf}\p{Po}]", ex.Message);
-            }
+
 
             // check row states
             Assert.Equal(src.Rows[0].RowState, target.Rows[0].RowState);
@@ -1342,25 +1280,16 @@ Assert.False(true);
             Assert.Equal(2, table.Rows.Count);
             Assert.Equal(DataRowState.Deleted, table.Rows[1].RowState);
 
-            try
-            {
-                table.RejectChanges();
-                Assert.False(true);
-            }
-            catch (ConstraintException ex)
-            {
-                // Column 'col' is constrained to be unique.
-                // Value '1' is already present
-                Assert.Equal(typeof(ConstraintException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-
-                // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
-                // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
-                // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
-                Assert.Matches(@"[\p{Pi}\p{Po}]" + "col" + @"[\p{Pf}\p{Po}]", ex.Message);
-                Assert.Matches(@"[\p{Pi}\p{Po}]" + "1" + @"[\p{Pf}\p{Po}]", ex.Message);
-            }
+            ConstraintException ex = Assert.Throws<ConstraintException>(() => table.RejectChanges());
+            // Column 'col' is constrained to be unique.
+            // Value '1' is already present
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+            // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
+            // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
+            // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
+            Assert.Matches(@"[\p{Pi}\p{Po}]" + "col" + @"[\p{Pf}\p{Po}]", ex.Message);
+            Assert.Matches(@"[\p{Pi}\p{Po}]" + "1" + @"[\p{Pf}\p{Po}]", ex.Message);
         }
 
         [Fact]
@@ -1425,6 +1354,7 @@ Assert.False(true);
 
                     if (invalid.Contains(Tuple.Create(types[a], types[b])))
                     {
+                        //TODO: what
                         try
                         {
                             dt2.ImportRow(r1);
@@ -1478,14 +1408,7 @@ Assert.False(true);
 
             Assert.Equal(2, table.Rows.Count);
             Assert.Equal(1, table.ChildRelations.Count);
-            try
-            {
-                table.Reset();
-                Assert.False(true);
-            }
-            catch (ArgumentException)
-            {
-            }
+            Assert.Throws<ArgumentException>(() => table.Reset());
 
             Assert.Equal(0, table.Rows.Count);
             Assert.Equal(0, table.ChildRelations.Count);
@@ -1529,7 +1452,7 @@ Assert.False(true);
             Assert.True(_tableClearedEventFired);
 
             DataRow r = table.Rows.Find(1);
-            Assert.True(r == null);
+            Assert.Null(r);
 
             // try adding new row. indexes should have cleared
             table.Rows.Add(new object[] { 2, "mono 2" });
@@ -1573,69 +1496,69 @@ Assert.False(true);
             dt1.Rows.Add(dr1);
             TextWriter writer = new StringWriter();
             dt.WriteXmlSchema(writer);
-            string TextString = writer.ToString();
-            string substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            string textString = writer.ToString();
+            string substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("<?xml version=\"1.0\" encoding=\"utf-16\"?>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("<xs:schema id=\"NewDataSet\" xmlns=\"\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xmlns:msdata=\"urn:schemas-microsoft-com:xml-msdata\">", substring);
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("  <xs:element name=\"NewDataSet\" msdata:IsDataSet=\"true\" msdata:MainDataTable=\"TestWriteXmlSchema\" msdata:UseCurrentLocale=\"true\">", substring);
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("    <xs:complexType>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("      <xs:choice minOccurs=\"0\" maxOccurs=\"unbounded\">", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("        <xs:element name=\"TestWriteXmlSchema\">", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("          <xs:complexType>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("            <xs:sequence>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("              <xs:element name=\"Col1\" type=\"xs:int\" minOccurs=\"0\" />", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("              <xs:element name=\"Col2\" type=\"xs:int\" minOccurs=\"0\" />", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("            </xs:sequence>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("          </xs:complexType>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("        </xs:element>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("      </xs:choice>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("    </xs:complexType>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("  </xs:element>", substring);
-            Assert.Equal("</xs:schema>", TextString);
+            Assert.Equal("</xs:schema>", textString);
         }
 
         [Fact]
@@ -1662,85 +1585,85 @@ Assert.False(true);
             ds.Relations.Add(rel);
             TextWriter writer = new StringWriter();
             dt.WriteXmlSchema(writer);
-            string TextString = writer.ToString();
-            string substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            string textString = writer.ToString();
+            string substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("<?xml version=\"1.0\" encoding=\"utf-16\"?>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("<xs:schema id=\"NewDataSet\" xmlns=\"\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xmlns:msdata=\"urn:schemas-microsoft-com:xml-msdata\">", substring);
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("  <xs:element name=\"NewDataSet\" msdata:IsDataSet=\"true\" msdata:MainDataTable=\"TestWriteXmlSchema\" msdata:UseCurrentLocale=\"true\">", substring);
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("    <xs:complexType>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("      <xs:choice minOccurs=\"0\" maxOccurs=\"unbounded\">", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("        <xs:element name=\"TestWriteXmlSchema\">", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("          <xs:complexType>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("            <xs:sequence>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("              <xs:element name=\"Col1\" type=\"xs:int\" minOccurs=\"0\" />", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("              <xs:element name=\"Col2\" type=\"xs:int\" minOccurs=\"0\" />", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("            </xs:sequence>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("          </xs:complexType>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("        </xs:element>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("      </xs:choice>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("    </xs:complexType>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("    <xs:unique name=\"Constraint1\">", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("      <xs:selector xpath=\".//TestWriteXmlSchema\" />", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("      <xs:field xpath=\"Col1\" />", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("    </xs:unique>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("  </xs:element>", substring);
-            Assert.Equal("</xs:schema>", TextString);
+            Assert.Equal("</xs:schema>", textString);
         }
 
         [Fact]
@@ -1767,133 +1690,133 @@ Assert.False(true);
             ds.Relations.Add(rel);
             TextWriter writer = new StringWriter();
             dt.WriteXmlSchema(writer, true);
-            string TextString = writer.ToString();
-            string substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            string textString = writer.ToString();
+            string substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("<?xml version=\"1.0\" encoding=\"utf-16\"?>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("<xs:schema id=\"NewDataSet\" xmlns=\"\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xmlns:msdata=\"urn:schemas-microsoft-com:xml-msdata\">", substring);
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("  <xs:element name=\"NewDataSet\" msdata:IsDataSet=\"true\" msdata:MainDataTable=\"TestWriteXmlSchema\" msdata:UseCurrentLocale=\"true\">", substring);
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("    <xs:complexType>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("      <xs:choice minOccurs=\"0\" maxOccurs=\"unbounded\">", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("        <xs:element name=\"TestWriteXmlSchema\">", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("          <xs:complexType>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("            <xs:sequence>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("              <xs:element name=\"Col1\" type=\"xs:int\" minOccurs=\"0\" />", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("              <xs:element name=\"Col2\" type=\"xs:int\" minOccurs=\"0\" />", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("            </xs:sequence>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("          </xs:complexType>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("        </xs:element>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("        <xs:element name=\"HelloWorld\">", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("          <xs:complexType>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("            <xs:sequence>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("              <xs:element name=\"T1\" type=\"xs:int\" minOccurs=\"0\" />", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("              <xs:element name=\"T2\" type=\"xs:int\" minOccurs=\"0\" />", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("            </xs:sequence>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("          </xs:complexType>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("        </xs:element>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("      </xs:choice>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("    </xs:complexType>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("    <xs:unique name=\"Constraint1\">", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("      <xs:selector xpath=\".//TestWriteXmlSchema\" />", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("      <xs:field xpath=\"Col1\" />", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("    </xs:unique>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("    <xs:keyref name=\"Relation1\" refer=\"Constraint1\">", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("      <xs:selector xpath=\".//HelloWorld\" />", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("      <xs:field xpath=\"T1\" />", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("    </xs:keyref>", substring);
 
-            substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-            TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+            substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+            textString = textString.Substring(textString.IndexOf('\n') + 1);
             Assert.Equal("  </xs:element>", substring);
-            Assert.Equal("</xs:schema>", TextString);
+            Assert.Equal("</xs:schema>", textString);
         }
 
         [Fact]
@@ -1940,15 +1863,7 @@ Assert.False(true);
             dt.Constraints.Add(new UniqueConstraint(dt.Columns[0]));
             dt.Rows.Add(new object[] { 1, 3 });
             dt.Rows.Add(new object[] { DBNull.Value, 3 });
-
-            try
-            {
-                dt.PrimaryKey = new DataColumn[] { dt.Columns[0] };
-                Assert.False(true);
-            }
-            catch (DataException)
-            {
-            }
+            Assert.Throws<DataException>(() => dt.PrimaryKey = new DataColumn[] { dt.Columns[0] });
         }
 
         [Fact]
@@ -1961,14 +1876,7 @@ Assert.False(true);
             dt.PrimaryKey = new DataColumn[] { dt.Columns[0] };
             dt.Rows.Add(new object[] { 1, 3 });
 
-            try
-            {
-                dt.Rows.Add(new object[] { DBNull.Value, 3 });
-                Assert.False(true);
-            }
-            catch (NoNullAllowedException)
-            {
-            }
+            Assert.Throws<NoNullAllowedException>(() => dt.Rows.Add(new object[] { DBNull.Value, 3 }));
         }
 
         [Fact]
@@ -2028,7 +1936,7 @@ Assert.False(true);
         {
             MyDataTable dt1 = new MyDataTable();
             MyDataTable dt = (MyDataTable)(dt1.Clone());
-            Assert.Equal(2, MyDataTable.count);
+            Assert.Equal(2, MyDataTable.Count);
         }
 
         private DataRowAction _rowActionChanging = DataRowAction.Nothing;
@@ -2143,7 +2051,7 @@ Assert.False(true);
         }
 
         private DataTable _dt;
-        private void localSetup()
+        private void LocalSetup()
         {
             _dt = new DataTable("test");
             _dt.Columns.Add("id", typeof(int));
@@ -2162,7 +2070,7 @@ Assert.False(true);
         [Fact]
         public void CreateDataReader1()
         {
-            localSetup();
+            LocalSetup();
             DataTableReader dtr = _dt.CreateDataReader();
             Assert.True(dtr.HasRows);
             Assert.Equal(_dt.Columns.Count, dtr.FieldCount);
@@ -2180,7 +2088,7 @@ Assert.False(true);
         [Fact]
         public void CreateDataReader2()
         {
-            localSetup();
+            LocalSetup();
             DataTableReader dtr = _dt.CreateDataReader();
             Assert.True(dtr.HasRows);
             Assert.Equal(_dt.Columns.Count, dtr.FieldCount);
@@ -2202,7 +2110,7 @@ Assert.False(true);
         [Fact]
         public void Load_Basic()
         {
-            localSetup();
+            LocalSetup();
             DataTable dtLoad = new DataTable("LoadBasic");
             dtLoad.Columns.Add("id", typeof(int));
             dtLoad.Columns.Add("name", typeof(string));
@@ -2228,7 +2136,7 @@ Assert.False(true);
         [Fact]
         public void Load_NoSchema()
         {
-            localSetup();
+            LocalSetup();
             DataTable dtLoad = new DataTable("LoadNoSchema");
             DataTableReader dtr = _dt.CreateDataReader();
             dtLoad.Load(dtr);
@@ -2242,29 +2150,30 @@ Assert.False(true);
             Assert.Equal("mono 3", dtLoad.Rows[2][1]);
         }
 
-        internal struct fillErrorStruct
+        internal struct FillErrorStruct
         {
-            internal string error;
-            internal string tableName;
-            internal int rowKey;
-            internal bool contFlag;
+            internal string _error;
+            internal string _tableName;
+            internal int _rowKey;
+            internal bool _contFlag;
 
             internal void init(string tbl, int row, bool cont, string err)
             {
-                tableName = tbl;
-                rowKey = row;
-                contFlag = cont;
-                error = err;
+                _tableName = tbl;
+                _rowKey = row;
+                _contFlag = cont;
+                _error = err;
             }
         }
-        private fillErrorStruct[] _fillErr = new fillErrorStruct[3];
+        private FillErrorStruct[] _fillErr = new FillErrorStruct[3];
         private int _fillErrCounter;
-        private void fillErrorHandler(object sender, FillErrorEventArgs e)
+        private void FillErrorHandler(object sender, FillErrorEventArgs e)
         {
-            e.Continue = _fillErr[_fillErrCounter].contFlag;
-            Assert.Equal(_fillErr[_fillErrCounter].tableName, e.DataTable.TableName);
+            e.Continue = _fillErr[_fillErrCounter]._contFlag;
+            Assert.Equal(_fillErr[_fillErrCounter]._tableName, e.DataTable.TableName);
+            //TODO
             //Assert.Equal (fillErr[fillErrCounter].rowKey, e.Values[0]);
-            Assert.Equal(_fillErr[_fillErrCounter].contFlag, e.Continue);
+            Assert.Equal(_fillErr[_fillErrCounter]._contFlag, e.Continue);
             //Assert.Equal (fillErr[fillErrCounter].error, e.Errors.Message);
             _fillErrCounter++;
         }
@@ -2272,18 +2181,11 @@ Assert.False(true);
         [Fact]
         public void Load_Incompatible()
         {
-            localSetup();
+            LocalSetup();
             DataTable dtLoad = new DataTable("LoadIncompatible");
             dtLoad.Columns.Add("name", typeof(double));
             DataTableReader dtr = _dt.CreateDataReader();
-            try
-            {
-                dtLoad.Load(dtr);
-                Assert.False(true);
-            }
-            catch (ArgumentException)
-            {
-            }
+            Assert.Throws<ArgumentException>(() => dtLoad.Load(dtr));
         }
         [Fact]
         // Load doesn't have a third overload in System.Data
@@ -2297,11 +2199,11 @@ Assert.False(true);
                 "Input string was not in a correct format.Couldn't store <mono 2> in name Column.  Expected type is Double.");
             _fillErr[2].init("LoadIncompatible", 3, true,
                 "Input string was not in a correct format.Couldn't store <mono 3> in name Column.  Expected type is Double.");
-            localSetup();
+            LocalSetup();
             DataTable dtLoad = new DataTable("LoadIncompatible");
             dtLoad.Columns.Add("name", typeof(double));
             DataTableReader dtr = _dt.CreateDataReader();
-            dtLoad.Load(dtr, LoadOption.PreserveChanges, fillErrorHandler);
+            dtLoad.Load(dtr, LoadOption.PreserveChanges, FillErrorHandler);
         }
 
         [Fact]
@@ -2312,24 +2214,17 @@ Assert.False(true);
             _fillErrCounter = 0;
             _fillErr[0].init("LoadIncompatible", 1, false,
                 "Input string was not in a correct format.Couldn't store <mono 1> in name Column.  Expected type is Double.");
-            localSetup();
+            LocalSetup();
             DataTable dtLoad = new DataTable("LoadIncompatible");
             dtLoad.Columns.Add("name", typeof(double));
             DataTableReader dtr = _dt.CreateDataReader();
-            try
-            {
-                dtLoad.Load(dtr, LoadOption.PreserveChanges, fillErrorHandler);
-                Assert.False(true);
-            }
-            catch (ArgumentException)
-            {
-            }
+            Assert.Throws<ArgumentException>(() => dtLoad.Load(dtr, LoadOption.PreserveChanges, FillErrorHandler));
         }
 
         [Fact]
         public void Load_ExtraColsEqualVal()
         {
-            localSetup();
+            LocalSetup();
             DataTable dtLoad = new DataTable("LoadExtraCols");
             dtLoad.Columns.Add("id", typeof(int));
             dtLoad.PrimaryKey = new DataColumn[] { dtLoad.Columns["id"] };
@@ -2352,7 +2247,7 @@ Assert.False(true);
         [Fact]
         public void Load_ExtraColsNonEqualVal()
         {
-            localSetup();
+            LocalSetup();
             DataTable dtLoad = new DataTable("LoadExtraCols");
             dtLoad.Columns.Add("id", typeof(int));
             dtLoad.PrimaryKey = new DataColumn[] { dtLoad.Columns["id"] };
@@ -2378,7 +2273,7 @@ Assert.False(true);
         [Fact]
         public void Load_MissingColsNonNullable()
         {
-            localSetup();
+            LocalSetup();
             DataTable dtLoad = new DataTable("LoadMissingCols");
             dtLoad.Columns.Add("id", typeof(int));
             dtLoad.Columns.Add("name", typeof(string));
@@ -2390,20 +2285,13 @@ Assert.False(true);
             dtLoad.Rows.Add(new object[] { 6, "mono 6", "miss6" });
             dtLoad.AcceptChanges();
             DataTableReader dtr = _dt.CreateDataReader();
-            try
-            {
-                dtLoad.Load(dtr);
-                Assert.False(true);
-            }
-            catch (ConstraintException)
-            {
-            }
+            Assert.Throws<ArgumentException>(() => dtLoad.Load(dtr));
         }
 
         [Fact]
         public void Load_MissingColsDefault()
         {
-            localSetup();
+            LocalSetup();
             DataTable dtLoad = new DataTable("LoadMissingCols");
             dtLoad.Columns.Add("id", typeof(int));
             dtLoad.Columns.Add("name", typeof(string));
@@ -2442,7 +2330,7 @@ Assert.False(true);
         [Fact]
         public void Load_MissingColsNullable()
         {
-            localSetup();
+            LocalSetup();
             DataTable dtLoad = new DataTable("LoadMissingCols");
             dtLoad.Columns.Add("id", typeof(int));
             dtLoad.Columns.Add("name", typeof(string));
@@ -2468,6 +2356,7 @@ Assert.False(true);
             Assert.Equal("miss6", dtLoad.Rows[2][2]);
             Assert.Equal(1, dtLoad.Rows[3][0]);
             Assert.Equal("mono 1", dtLoad.Rows[3][1]);
+            //TODO
             //Assert.Null (dtLoad.Rows[3][2]);
             Assert.Equal(2, dtLoad.Rows[4][0]);
             Assert.Equal("mono 2", dtLoad.Rows[4][1]);
@@ -2538,7 +2427,7 @@ Assert.False(true);
         [Fact]
         public void Load_RowStateChangesDefault()
         {
-            localSetup();
+            LocalSetup();
             _dt.Rows.Add(new object[] { 4, "mono 4" });
             _dt.Rows.Add(new object[] { 5, "mono 5" });
             _dt.AcceptChanges();
@@ -2577,7 +2466,7 @@ Assert.False(true);
         [Fact]
         public void Load_RowStateChangesDefaultDelete()
         {
-            localSetup();
+            LocalSetup();
             DataTable dtLoad = new DataTable("LoadRowStateChanges");
             dtLoad.Columns.Add("id", typeof(int));
             dtLoad.Columns.Add("name", typeof(string));
@@ -2590,20 +2479,13 @@ Assert.False(true);
             DataTableReader dtr = _dt.CreateDataReader();
             dtLoad.Load(dtr);
 
-            try
-            {
-                Assert.Equal(" ", dtLoad.Rows[2][1, DataRowVersion.Current]);
-                Assert.False(true);
-            }
-            catch (VersionNotFoundException)
-            {
-            }
+            Assert.Throws<VersionNotFoundException>(() => dtLoad.Rows[2][1, DataRowVersion.Current]);
         }
 
         [Fact]
         public void Load_RowStatePreserveChanges()
         {
-            localSetup();
+            LocalSetup();
             _dt.Rows.Add(new object[] { 4, "mono 4" });
             _dt.Rows.Add(new object[] { 5, "mono 5" });
             _dt.AcceptChanges();
@@ -2642,7 +2524,7 @@ Assert.False(true);
         [Fact]
         public void Load_RowStatePreserveChangesDelete()
         {
-            localSetup();
+            LocalSetup();
             DataTable dtLoad = new DataTable("LoadRowStateChanges");
             dtLoad.Columns.Add("id", typeof(int));
             dtLoad.Columns.Add("name", typeof(string));
@@ -2655,20 +2537,13 @@ Assert.False(true);
             DataTableReader dtr = _dt.CreateDataReader();
             dtLoad.Load(dtr, LoadOption.PreserveChanges);
 
-            try
-            {
-                Assert.Equal(" ", dtLoad.Rows[2][1, DataRowVersion.Current]);
-                Assert.False(true);
-            }
-            catch (VersionNotFoundException)
-            {
-            }
+            Assert.Throws<VersionNotFoundException>(() => dtLoad.Rows[2][1, DataRowVersion.Current]);
         }
 
         [Fact]
         public void Load_RowStateOverwriteChanges()
         {
-            localSetup();
+            LocalSetup();
             _dt.Rows.Add(new object[] { 4, "mono 4" });
             _dt.Rows.Add(new object[] { 5, "mono 5" });
             _dt.AcceptChanges();
@@ -2708,7 +2583,7 @@ Assert.False(true);
         [Fact]
         public void Load_RowStateUpsert()
         {
-            localSetup();
+            LocalSetup();
             _dt.Rows.Add(new object[] { 4, "mono 4" });
             _dt.Rows.Add(new object[] { 5, "mono 5" });
             _dt.AcceptChanges();
@@ -2751,7 +2626,7 @@ Assert.False(true);
         [Fact]
         public void Load_RowStateUpsertDuplicateKey1()
         {
-            localSetup();
+            LocalSetup();
             _dt.Rows.Add(new object[] { 4, "mono 4" });
             DataTable dtLoad = new DataTable("LoadRowStateChanges");
             dtLoad.Columns.Add("id", typeof(int));
@@ -2788,7 +2663,7 @@ Assert.False(true);
         [Fact]
         public void Load_RowStateUpsertDuplicateKey2()
         {
-            localSetup();
+            LocalSetup();
             _dt.Rows.Add(new object[] { 4, "mono 4" });
             DataTable dtLoad = new DataTable("LoadRowStateChanges");
             dtLoad.Columns.Add("id", typeof(int));
@@ -2803,20 +2678,13 @@ Assert.False(true);
             dtLoad.Load(dtr, LoadOption.Upsert);
             dtLoad.AcceptChanges();
 
-            try
-            {
-                Assert.Equal(" ", dtLoad.Rows[4][1]);
-                Assert.False(true);
-            }
-            catch (IndexOutOfRangeException)
-            {
-            }
+            Assert.Throws<IndexOutOfRangeException>(() => dtLoad.Rows[4][1]);
         }
 
         [Fact]
         public void Load_RowStateUpsertDelete1()
         {
-            localSetup();
+            LocalSetup();
             DataTable dtLoad = new DataTable("LoadRowStateChanges");
             dtLoad.Columns.Add("id", typeof(int));
             dtLoad.Columns.Add("name", typeof(string));
@@ -2829,20 +2697,13 @@ Assert.False(true);
             DataTableReader dtr = _dt.CreateDataReader();
             dtLoad.Load(dtr, LoadOption.Upsert);
 
-            try
-            {
-                Assert.Equal(" ", dtLoad.Rows[2][1, DataRowVersion.Current]);
-                Assert.False(true);
-            }
-            catch (VersionNotFoundException)
-            {
-            }
+            Assert.Throws<VersionNotFoundException>(() => dtLoad.Rows[2][1, DataRowVersion.Current]);
         }
 
         [Fact]
         public void Load_RowStateUpsertDelete2()
         {
-            localSetup();
+            LocalSetup();
             DataTable dtLoad = new DataTable("LoadRowStateChanges");
             dtLoad.Columns.Add("id", typeof(int));
             dtLoad.Columns.Add("name", typeof(string));
@@ -2855,20 +2716,13 @@ Assert.False(true);
             DataTableReader dtr = _dt.CreateDataReader();
             dtLoad.Load(dtr, LoadOption.Upsert);
 
-            try
-            {
-                Assert.Equal(" ", dtLoad.Rows[3][1, DataRowVersion.Original]);
-                Assert.False(true);
-            }
-            catch (VersionNotFoundException)
-            {
-            }
+            Assert.Throws<VersionNotFoundException>(() => dtLoad.Rows[3][1, DataRowVersion.Original]);
         }
 
         [Fact]
         public void Load_RowStateUpsertAdd()
         {
-            localSetup();
+            LocalSetup();
             _dt.Rows.Add(new object[] { 4, "mono 4" });
             DataTable dtLoad = new DataTable("LoadRowStateChanges");
             dtLoad.Columns.Add("id", typeof(int));
@@ -2885,20 +2739,13 @@ Assert.False(true);
             DataTableReader dtr = _dt.CreateDataReader();
             dtLoad.Load(dtr, LoadOption.Upsert);
 
-            try
-            {
-                Assert.Equal(" ", dtLoad.Rows[3][1, DataRowVersion.Original]);
-                Assert.False(true);
-            }
-            catch (VersionNotFoundException)
-            {
-            }
+            Assert.Throws<VersionNotFoundException>(() => dtLoad.Rows[3][1, DataRowVersion.Original]);
         }
 
         [Fact]
         public void Load_RowStateUpsertUnpresent()
         {
-            localSetup();
+            LocalSetup();
             _dt.Rows.Add(new object[] { 4, "mono 4" });
             DataTable dtLoad = new DataTable("LoadRowStateChanges");
             dtLoad.Columns.Add("id", typeof(int));
@@ -2911,20 +2758,13 @@ Assert.False(true);
             DataTableReader dtr = _dt.CreateDataReader();
             dtLoad.Load(dtr, LoadOption.Upsert);
 
-            try
-            {
-                Assert.Equal(" ", dtLoad.Rows[3][1, DataRowVersion.Original]);
-                Assert.False(true);
-            }
-            catch (VersionNotFoundException)
-            {
-            }
+            Assert.Throws<VersionNotFoundException>(() => dtLoad.Rows[3][1, DataRowVersion.Original]);
         }
 
         [Fact]
         public void Load_RowStateUpsertUnchangedEqualVal()
         {
-            localSetup();
+            LocalSetup();
             DataTable dtLoad = new DataTable("LoadRowStateChanges");
             dtLoad.Columns.Add("id", typeof(int));
             dtLoad.Columns.Add("name", typeof(string));
@@ -3335,75 +3175,74 @@ Assert.False(true);
                 TextWriter writer = new StringWriter();
                 ds.Tables[0].WriteXmlSchema(writer);
 
-                string TextString = DataSetAssertion.GetNormalizedSchema(writer.ToString());
-                //string TextString = writer.ToString ();
+                string textString = DataSetAssertion.GetNormalizedSchema(writer.ToString());
 
-                string substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-                TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+                string substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+                textString = textString.Substring(textString.IndexOf('\n') + 1);
                 Assert.Equal("<?xml version=\"1.0\" encoding=\"utf-16\"?>", substring);
 
-                substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-                TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+                substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+                textString = textString.Substring(textString.IndexOf('\n') + 1);
                 Assert.Equal("<xs:schema id=\"Root\" xmlns:msdata=\"urn:schemas-microsoft-com:xml-msdata\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">", substring);
 
-                substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-                TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+                substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+                textString = textString.Substring(textString.IndexOf('\n') + 1);
                 // Looks like whoever added this test depended on English culture, which is wrong.
                 Assert.Equal("  <xs:element msdata:IsDataSet=\"true\" msdata:Locale=\"en-US\" msdata:MainDataTable=\"Region\" name=\"Root\">", substring);
 
-                substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-                TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+                substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+                textString = textString.Substring(textString.IndexOf('\n') + 1);
                 Assert.Equal("    <xs:complexType>", substring);
 
-                substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-                TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+                substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+                textString = textString.Substring(textString.IndexOf('\n') + 1);
                 Assert.Equal("      <xs:choice maxOccurs=\"unbounded\" minOccurs=\"0\">", substring);
 
-                substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-                TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+                substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+                textString = textString.Substring(textString.IndexOf('\n') + 1);
                 Assert.Equal("        <xs:element name=\"Region\">", substring);
 
-                substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-                TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+                substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+                textString = textString.Substring(textString.IndexOf('\n') + 1);
                 Assert.Equal("          <xs:complexType>", substring);
 
-                substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-                TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+                substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+                textString = textString.Substring(textString.IndexOf('\n') + 1);
                 Assert.Equal("            <xs:sequence>", substring);
 
-                substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-                TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+                substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+                textString = textString.Substring(textString.IndexOf('\n') + 1);
                 Assert.Equal("              <xs:element minOccurs=\"0\" name=\"RegionID\" type=\"xs:string\" />", substring);
 
-                substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-                TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+                substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+                textString = textString.Substring(textString.IndexOf('\n') + 1);
                 Assert.Equal("              <xs:element minOccurs=\"0\" name=\"RegionDescription\" type=\"xs:string\" />", substring);
 
-                substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-                TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+                substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+                textString = textString.Substring(textString.IndexOf('\n') + 1);
                 Assert.Equal("            </xs:sequence>", substring);
 
-                substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-                TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+                substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+                textString = textString.Substring(textString.IndexOf('\n') + 1);
                 Assert.Equal("          </xs:complexType>", substring);
 
-                substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-                TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+                substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+                textString = textString.Substring(textString.IndexOf('\n') + 1);
                 Assert.Equal("        </xs:element>", substring);
 
-                substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-                TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+                substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+                textString = textString.Substring(textString.IndexOf('\n') + 1);
                 Assert.Equal("      </xs:choice>", substring);
 
-                substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-                TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+                substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+                textString = textString.Substring(textString.IndexOf('\n') + 1);
                 Assert.Equal("    </xs:complexType>", substring);
 
-                substring = TextString.Substring(0, TextString.IndexOfAny(new[] { '\r', '\n' }));
-                TextString = TextString.Substring(TextString.IndexOf('\n') + 1);
+                substring = textString.Substring(0, textString.IndexOfAny(new[] { '\r', '\n' }));
+                textString = textString.Substring(textString.IndexOf('\n') + 1);
                 Assert.Equal("  </xs:element>", substring);
 
-                Assert.Equal("</xs:schema>", TextString);
+                Assert.Equal("</xs:schema>", textString);
             }
         }
 
@@ -3505,7 +3344,6 @@ Assert.False(true);
             string result = sw.ToString();
 
             Assert.Equal(xmlschema.Replace("\r\n", "\n"), result.Replace("\r\n", "\n"));
-            //Assert.Equal (xmlschema, result.Replace ("\r\n");
         }
 
         [Fact]
@@ -3907,14 +3745,8 @@ Assert.False(true);
         {
             MemoryStream ms = new MemoryStream();
             DataTable dtr = new DataTable();
-            try
-            {
-                dtr.ReadXmlSchema(ms);
-                Assert.False(true);
-            }
-            catch (XmlException)
-            {
-            }
+
+            Assert.Throws<XmlException>(() => dtr.ReadXmlSchema(ms));
         }
 
         [Fact]
@@ -3922,28 +3754,15 @@ Assert.False(true);
         {
             DataTable dtw = new DataTable();
             MemoryStream ms = new MemoryStream();
-            try
-            {
-                dtw.WriteXmlSchema(ms);
-                Assert.False(true);
-            }
-            catch (InvalidOperationException)
-            {
-            }
+
+            Assert.Throws<InvalidOperationException>(() => dtw.WriteXmlSchema(ms));
         }
 
         [Fact]
         public void ReadWriteXmlSchemaExp_NoFileName()
         {
             DataTable dtw = new DataTable();
-            try
-            {
-                dtw.WriteXmlSchema(string.Empty);
-                Assert.False(true);
-            }
-            catch (ArgumentException)
-            {
-            }
+            Assert.Throws<InvalidOperationException>(() => dtw.WriteXmlSchema(string.Empty));
         }
 
         [Fact]
@@ -3954,26 +3773,18 @@ Assert.False(true);
             dtw.WriteXmlSchema(writer1);
             DataTable dtr = new DataTable("Table2");
             StringReader reader1 = new StringReader(writer1.ToString());
-            try
-            {
-                dtr.ReadXmlSchema(reader1);
-                Assert.False(true);
-            }
-            catch (ArgumentException)
-            {
-            }
+
+            Assert.Throws<ArgumentException>(() => dtr.ReadXmlSchema(reader1));
         }
 
         [Fact]
         public void ReadXmlSchemeWithoutScheme()
         {
             const string xml = @"<CustomElement />";
-            using (var s = new StringReader(xml))
-            {
-                DataTable dt = new DataTable();
-                dt.ReadXmlSchema(s);
-                Assert.Equal("", dt.TableName);
-            }
+            using var s = new StringReader(xml);
+            DataTable dt = new DataTable();
+            dt.ReadXmlSchema(s);
+            Assert.Equal("", dt.TableName);
         }
 
         [Fact]
@@ -3996,12 +3807,10 @@ Assert.False(true);
                     </xs:element>
                   </xs:schema>
                 </CustomElement>";
-            using (var s = new StringReader(xml))
-            {
-                DataTable dt = new DataTable();
-                dt.ReadXmlSchema(s);
-                Assert.Equal("row", dt.TableName);
-            }
+            using var s = new StringReader(xml);
+            DataTable dt = new DataTable();
+            dt.ReadXmlSchema(s);
+            Assert.Equal("row", dt.TableName);
         }
 
         [Fact]
@@ -4013,11 +3822,9 @@ Assert.False(true);
                 </CustomElement>";
             AssertExtensions.Throws<ArgumentException>(null, () =>
             {
-                using (var s = new StringReader(xml))
-                {
-                    DataTable dt = new DataTable();
-                    dt.ReadXmlSchema(s);
-                }
+                using var s = new StringReader(xml);
+                DataTable dt = new DataTable();
+                dt.ReadXmlSchema(s);
             });
         }
 
@@ -4026,11 +3833,11 @@ Assert.False(true);
 
     public class MyDataTable : DataTable
     {
-        public static int count;
+        public static int Count;
 
         public MyDataTable()
         {
-            count++;
+            Count++;
         }
     }
 
@@ -4067,7 +3874,6 @@ Assert.False(true);
                                 DateTime.Now.AddDays(4));
             Assert.Equal(10, dt.Rows.Count);
             Assert.Equal(2, dv.Count);
-
         }
 
         [Fact]

--- a/src/System.Data.Common/tests/System/Data/DataTableTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataTableTest.cs
@@ -310,7 +310,7 @@ namespace System.Data.Tests
             Assert.Throws<SyntaxErrorException>(() => t.Select("name = 1human "));
 
             // Cannot perform '=' operation between string and Int32
-            Assert.Throws<SyntaxErrorException>(() => t.Select("name = 1"));
+            Assert.Throws<EvaluateException>(() => t.Select("name = 1"));
 
             Assert.Equal(1, t.Select("age = '13'").Length);
         }
@@ -2285,7 +2285,7 @@ Assert.False(true);
             dtLoad.Rows.Add(new object[] { 6, "mono 6", "miss6" });
             dtLoad.AcceptChanges();
             DataTableReader dtr = _dt.CreateDataReader();
-            Assert.Throws<ArgumentException>(() => dtLoad.Load(dtr));
+            Assert.Throws<ConstraintException>(() => dtLoad.Load(dtr));
         }
 
         [Fact]
@@ -3762,7 +3762,7 @@ Assert.False(true);
         public void ReadWriteXmlSchemaExp_NoFileName()
         {
             DataTable dtw = new DataTable();
-            Assert.Throws<InvalidOperationException>(() => dtw.WriteXmlSchema(string.Empty));
+            Assert.Throws<ArgumentException>(() => dtw.WriteXmlSchema(string.Empty));
         }
 
         [Fact]

--- a/src/System.Data.Common/tests/System/Data/DataTableTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataTableTest.cs
@@ -56,7 +56,6 @@ namespace System.Data.Tests
 
             Assert.False(dt.CaseSensitive);
             Assert.NotNull(dt.Columns);
-            //TODO: why is this commented out?
             //Assert.True (dt.ChildRelations != null);
             Assert.NotNull(dt.Constraints);
             Assert.Null(dt.DataSet);
@@ -368,7 +367,7 @@ namespace System.Data.Tests
             Assert.Equal(100, t.Select("age <> 10").Length);
             Assert.Equal(3, t.Select("name < 'human10'").Length);
             Assert.Equal(3, t.Select("id < '10'").Length);
-            //TODO
+
             // FIXME: Somebody explain how this can be possible.
             // it seems that it is no matter between 10 - 30. The
             // result is always 25 :-P
@@ -649,7 +648,6 @@ namespace System.Data.Tests
             rows = child.Select("Parent.childname = 'Jack'");
             Assert.Equal(1, rows.Length);
 
-            //TODO: why is this disabled?
             /*
             try {
                 Mom.Select ("Child.Name = 'Jack'");
@@ -698,18 +696,8 @@ Assert.False(true);
 
             r = new DataRelation("Rel2", Parent2.Columns[1], child.Columns[0]);
             set.Relations.Add(r);
-            //TODO
-            //try
-            //{
-            //    rows = child.Select("Parent.ChildName = 'Jack'");
-            //    Assert.False(true);
-            //}
-            //catch (EvaluateException e)
-            //{
-            //    Assert.Equal(typeof(EvaluateException), e.GetType());
-            //    // Do not compare exception messages!
-            //    //Assert.Equal ("The table [Child] involved in more than one relation. You must explicitly mention a relation name in the expression 'parent.[ChildName]'.", e.Message);
-            //}
+
+            // The table [Child] involved in more than one relation. You must explicitly mention a relation name in the expression 'parent.[ChildName]'
             Assert.Throws<EvaluateException>(() => child.Select("Parent.ChildName = 'Jack'"));
 
             rows = child.Select("Parent(rel).ChildName = 'Jack'");
@@ -717,17 +705,8 @@ Assert.False(true);
 
             rows = child.Select("Parent(Rel2).ChildName = 'Jack'");
             Assert.Equal(1, rows.Length);
-            //TODO
-            //try
-            //{
-            //    m.Select("Parent.name  = 'John'");
-            //}
-            //catch (IndexOutOfRangeException e)
-            //{
-            //    Assert.Equal(typeof(IndexOutOfRangeException), e.GetType());
-            //    // Do not compare exception messages!
-            //    //Assert.Equal ("Cannot find relation 0.", e.Message);
-            //}
+
+            // Cannot find relation 0.
             Assert.Throws<IndexOutOfRangeException>(() => m.Select("Parent.name  = 'John'"));
         }
 
@@ -780,35 +759,13 @@ Assert.False(true);
 
             Col = new DataColumn("failed");
 
-            //TODO
-            //try
-            //{
-            //    dt.PrimaryKey = new DataColumn[] { Col };
-            //    Assert.False(true);
-            //}
-            //catch (ArgumentException e)
-            //{
-            //    Assert.Equal(typeof(ArgumentException), e.GetType());
-            //    // Never expect English message
-            //    // Assert.Equal ("Column must belong to a table.", e.Message);
-            //}
+            // Column must belong to a table.
             Assert.Throws<ArgumentException>(() => dt.PrimaryKey = new DataColumn[] { Col });
 
             DataTable dt2 = new DataTable();
             dt2.Columns.Add();
 
-            //TODO
-            //try
-            //{
-            //    dt.PrimaryKey = new DataColumn[] { dt2.Columns[0] };
-            //    Assert.False(true);
-            //}
-            //catch (ArgumentException e)
-            //{
-            //    Assert.Equal(typeof(ArgumentException), e.GetType());
-            //    // Never expect English message
-            //    // Assert.Equal ("PrimaryKey columns do not belong to this table.", e.Message);
-            //}
+            // PrimaryKey columns do not belong to this table.
             Assert.Throws<ArgumentException>(() => dt.PrimaryKey = new DataColumn[] { dt2.Columns[0] });
 
             Assert.Equal(0, dt.Constraints.Count);
@@ -1354,16 +1311,7 @@ Assert.False(true);
 
                     if (invalid.Contains(Tuple.Create(types[a], types[b])))
                     {
-                        //TODO: what
-                        try
-                        {
-                            dt2.ImportRow(r1);
-                            Assert.False(true);
-                        }
-                        catch /*(ArgumentException)*/
-                        {
-                            continue;
-                        }
+                        Assert.Throws<ArgumentException>(() => dt2.ImportRow(r1));
                     }
                     else
                     {
@@ -2171,7 +2119,6 @@ Assert.False(true);
         {
             e.Continue = _fillErr[_fillErrCounter]._contFlag;
             Assert.Equal(_fillErr[_fillErrCounter]._tableName, e.DataTable.TableName);
-            //TODO
             //Assert.Equal (fillErr[fillErrCounter].rowKey, e.Values[0]);
             Assert.Equal(_fillErr[_fillErrCounter]._contFlag, e.Continue);
             //Assert.Equal (fillErr[fillErrCounter].error, e.Errors.Message);
@@ -2356,14 +2303,13 @@ Assert.False(true);
             Assert.Equal("miss6", dtLoad.Rows[2][2]);
             Assert.Equal(1, dtLoad.Rows[3][0]);
             Assert.Equal("mono 1", dtLoad.Rows[3][1]);
-            //TODO
-            //Assert.Null (dtLoad.Rows[3][2]);
+            //Assert.Null(dtLoad.Rows[3][2]);
             Assert.Equal(2, dtLoad.Rows[4][0]);
             Assert.Equal("mono 2", dtLoad.Rows[4][1]);
-            //Assert.Null (dtLoad.Rows[4][2]);
+            //Assert.Null(dtLoad.Rows[4][2]);
             Assert.Equal(3, dtLoad.Rows[5][0]);
             Assert.Equal("mono 3", dtLoad.Rows[5][1]);
-            //Assert.Null (dtLoad.Rows[5][2]);
+            //Assert.Null(dtLoad.Rows[5][2]);
         }
 
         private DataTable setupRowState()

--- a/src/System.Data.Common/tests/System/Data/DataTableTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/DataTableTest2.cs
@@ -2033,8 +2033,8 @@ namespace System.Data.Tests
             table3.Merge(table2, false, MissingSchemaAction.Ignore);
             Assert.Equal(0, table3.Constraints.Count);
 
-            //FIXME : If both source and target have PK, then 
-            // shud be the exception raised when schema is merged? 
+            //FIXME : If both source and target have PK, then
+            // shud be the exception raised when schema is merged?
             // ms.net throws a nullreference exception.
             // If any data is merged, exception is anyways raised.
             /*

--- a/src/System.Data.Common/tests/System/Data/DataTableTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/DataTableTest2.cs
@@ -1944,7 +1944,7 @@ namespace System.Data.Tests
             // Cannot find column ParentId1
             Assert.Null(ex.InnerException);
             Assert.NotNull(ex.Message);
-            Assert.True(ex.Message.IndexOf("ParentId1") != -1);
+            Assert.Contains("ParentId1", ex.Message);
         }
 
         [Fact]

--- a/src/System.Data.Common/tests/System/Data/DataTableTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/DataTableTest2.cs
@@ -912,14 +912,7 @@ namespace System.Data.Tests
         private void DataColumnChangeHandler(object sender, DataColumnChangeEventArgs e)
         {
             DataTable dt = (DataTable)sender;
-            if ((e.Column.Equals(dt.Columns["Value"])) && (e.Row.Equals(dt.Rows[0])) && (e.ProposedValue.Equals("NewValue")))
-            {
-                _eventValues = true;
-            }
-            else
-            {
-                _eventValues = false;
-            }
+            _eventValues = e.Column.Equals(dt.Columns["Value"]) && e.Row.Equals(dt.Rows[0]) && e.ProposedValue.Equals("NewValue");
             _eventRaised = true;
         }
 
@@ -1321,17 +1314,7 @@ namespace System.Data.Tests
             // Select_S - ChildDateTime >= #12/3/2005 5:06:30 PM# or ChildDateTime <= #11/3/1980#
             drSelect = dt.Select("ChildDateTime >= #12/3/2005 5:06:30 PM# or ChildDateTime <= #11/3/1980#  ");
             CompareUnsorted(drSelect, al.ToArray());
-            //TODO
-#if LATER
-            //-------------------------------------------------------------
-            al.Clear();
-            foreach (DataRow dr in dt.Rows)
-                if (dr["ChildDouble"].ToString().Length > 10)
-                    al.Add(dr);
-                // Select_S - Len(Convert(ChildDouble,'System.String')) > 10
-                drSelect = dt.Select ("Len(Convert(ChildDouble,'System.String')) > 10");
-                Assert.Equal (al.ToArray(), drSelect);
-#endif
+
             //-------------------------------------------------------------
             al.Clear();
             foreach (DataRow dr in dt.Rows)
@@ -1340,7 +1323,6 @@ namespace System.Data.Tests
             // Select_S - SubString(Trim(String1),1,2) = '1-'
             drSelect = dt.Select("SubString(Trim(String1),1,2) = '1-'");
             Assert.Equal(al.ToArray(), drSelect);
-            //TODO
             //-------------------------------------------------------------
             /*
             al.Clear();
@@ -1369,12 +1351,7 @@ namespace System.Data.Tests
             Assert.Equal(al.ToArray(), drSelect);
         }
 
-        private void CompareUnsorted<T>(T[] a, T[] b)
-        {
-            IEnumerable<T> union = a.Union(b);
-            IEnumerable<T> intersection = a.Intersect(b);
-            Assert.Equal(union.Count(), intersection.Count());
-        }
+        private void CompareUnsorted<T>(T[] a, T[] b) => Assert.Equal(a.Union(b).Count(), a.Intersect(b).Count());
 
         [Fact]
         public void Select_ByFilterDataViewRowState()
@@ -1912,7 +1889,7 @@ namespace System.Data.Tests
                 if ((int)dr["ChildId"] == 1 && dr["String1"].ToString() == "1-String1")
                     al.Add(dr);
             }
-            //TODO
+
             //al.Reverse();
             al.Sort(new DataRowsComparer("ParentId", "Desc"));
 
@@ -1927,7 +1904,7 @@ namespace System.Data.Tests
                 if (dr["String1"].ToString().Length < 4)
                     al.Add(dr);
             }
-            //TODO
+
             //al.Reverse();
             al.Sort(new DataRowsComparer("ParentId", "Desc"));
 
@@ -1967,9 +1944,9 @@ namespace System.Data.Tests
             // to a Boolean term
             Assert.Null(ex.InnerException);
             Assert.NotNull(ex.Message);
-            //TODO
-            //Assert.True (ex.Message.IndexOf ("'col1*10'") != -1);
-            //Assert.True (ex.Message.IndexOf ("Boolean") != -1);
+
+            Assert.Contains("'col1*10'", ex.Message);
+            Assert.Contains("Boolean", ex.Message);
         }
 
         [Fact]
@@ -1988,8 +1965,8 @@ namespace System.Data.Tests
             // a Boolean term
             Assert.Null(ex.InnerException);
             Assert.NotNull(ex.Message);
-            //Assert.True (ex.Message.IndexOf ("'col1'") != -1);
-            //Assert.True (ex.Message.IndexOf ("Boolean") != -1);
+            Assert.Contains("'col1'", ex.Message);
+            Assert.Contains("Boolean", ex.Message);
 
             //col2 is a boolean expression, and a null value translates to
             //false.
@@ -2056,7 +2033,6 @@ namespace System.Data.Tests
             table3.Merge(table2, false, MissingSchemaAction.Ignore);
             Assert.Equal(0, table3.Constraints.Count);
 
-            //TODO
             //FIXME : If both source and target have PK, then 
             // shud be the exception raised when schema is merged? 
             // ms.net throws a nullreference exception.

--- a/src/System.Data.Common/tests/System/Data/DataTableTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/DataTableTest2.cs
@@ -704,16 +704,6 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public new void GetType()
-        {
-            DataTable dt = DataProvider.CreateParentDataTable();
-            Type tmpType = typeof(DataTable);
-
-            // GetType
-            Assert.Equal(tmpType, dt.GetType());
-        }
-
-        [Fact]
         public void HasErrors()
         {
             DataTable dtParent;
@@ -2089,6 +2079,7 @@ Assert.False(true);
             table1.Columns["col_datetime"].DateTimeMode = DataSetDateTime.Local;
             table2.Columns["col_datetime"].DateTimeMode = DataSetDateTime.Unspecified;
 
+            table3 = table1.Clone();
             // <target>.col_datetime and <source>.col_datetime
             // have conflicting properties: DataType property mismatch.
             Assert.Throws<DataException>(() => table3.Merge(table2));

--- a/src/System.Data.Common/tests/System/Data/DataTableTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/DataTableTest2.cs
@@ -26,8 +26,7 @@
 using System.Collections;
 using System.Globalization;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
-
+using System.Linq;
 
 using Xunit;
 
@@ -35,7 +34,7 @@ namespace System.Data.Tests
 {
     public class DataTableTest2
     {
-        private bool _EventTriggered;
+        private bool _eventTriggered;
         private bool _eventRaised;
         private bool _eventValues;
 
@@ -197,21 +196,21 @@ namespace System.Data.Tests
 
             dt.ColumnChanged += new DataColumnChangeEventHandler(Column_Changed);
 
-            _EventTriggered = false;
+            _eventTriggered = false;
             // ColumnChanged - EventTriggered
             dt.Rows[0][1] = "NewValue";
-            Assert.True(_EventTriggered);
+            Assert.True(_eventTriggered);
 
-            _EventTriggered = false;
+            _eventTriggered = false;
             dt.ColumnChanged -= new DataColumnChangeEventHandler(Column_Changed);
             // ColumnChanged - NO EventTriggered
             dt.Rows[0][1] = "VeryNewValue";
-            Assert.False(_EventTriggered);
+            Assert.False(_eventTriggered);
         }
 
         private void Column_Changed(object sender, DataColumnChangeEventArgs e)
         {
-            _EventTriggered = true;
+            _eventTriggered = true;
         }
 
         [Fact]
@@ -221,21 +220,21 @@ namespace System.Data.Tests
 
             dt.ColumnChanging += new DataColumnChangeEventHandler(Column_Changeding);
 
-            _EventTriggered = false;
+            _eventTriggered = false;
             // ColumnChanged - EventTriggered
             dt.Rows[0][1] = "NewValue";
-            Assert.True(_EventTriggered);
+            Assert.True(_eventTriggered);
 
-            _EventTriggered = false;
+            _eventTriggered = false;
             dt.ColumnChanging -= new DataColumnChangeEventHandler(Column_Changeding);
             // ColumnChanged - NO EventTriggered
             dt.Rows[0][1] = "VeryNewValue";
-            Assert.False(_EventTriggered);
+            Assert.False(_eventTriggered);
         }
 
         private void Column_Changeding(object sender, DataColumnChangeEventArgs e)
         {
-            _EventTriggered = true;
+            _eventTriggered = true;
         }
 
         [Fact]
@@ -253,28 +252,18 @@ namespace System.Data.Tests
             dtParent.Columns.Add(new DataColumn("test"));
             Assert.Equal(8, dcl.Count);
 
-            try
-            {
-                tmp = dtParent.Columns["TEST"];
-                Assert.False(true);
-            }
-            catch (ArgumentException ex)
-            {
-                // The given name 'TEST' matches at least two
-                // names in the collection object with different
-                // cases, but does not match either of them with
-                // the same case
-                Assert.Equal(typeof(ArgumentException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-
-                // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
-                // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
-                // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
-                Assert.Matches(@"[\p{Pi}\p{Po}]" + "TEST" + @"[\p{Pf}\p{Po}]", ex.Message);
-
-                Assert.Null(ex.ParamName);
-            }
+            ArgumentException ex = Assert.Throws<ArgumentException>(() => dtParent.Columns["TEST"]);
+            // The given name 'TEST' matches at least two
+            // names in the collection object with different
+            // cases, but does not match either of them with
+            // the same case
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+            // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
+            // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
+            // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
+            Assert.Matches(@"[\p{Pi}\p{Po}]" + "TEST" + @"[\p{Pf}\p{Po}]", ex.Message);
+            Assert.Null(ex.ParamName);
         }
 
         [Fact]
@@ -287,9 +276,8 @@ namespace System.Data.Tests
             long iExSum = 0;
             foreach (DataRow dr in drArr)
                 iExSum += (int)dr["ChildId"];
-            object objCompute = null;
             // Compute - sum values
-            objCompute = dt.Compute("Sum(ChildId)", "ParentId=1");
+            object objCompute = dt.Compute("Sum(ChildId)", "ParentId=1");
             Assert.Equal(long.Parse(objCompute.ToString()), long.Parse(iExSum.ToString()));
 
             // Compute - sum type
@@ -419,20 +407,12 @@ namespace System.Data.Tests
             dt.BeginLoadData();
             dt.LoadDataRow(new object[] { null, "A", "B" }, false);
 
-            try
-            {
-                dt.EndLoadData();
-                Assert.False(true);
-            }
-            catch (ConstraintException ex)
-            {
-                // Failed to enable constraints. One or more rows
-                // contain values violating non-null, unique, or
-                // foreign-key constraints
-                Assert.Equal(typeof(ConstraintException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-            }
+            ConstraintException ex = Assert.Throws<ConstraintException>(() => dt.EndLoadData());
+            // Failed to enable constraints. One or more rows
+            // contain values violating non-null, unique, or
+            // foreign-key constraints
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
         }
 
         [Fact] // LoadDataRow (Object [], Boolean)
@@ -475,20 +455,12 @@ namespace System.Data.Tests
             table.LoadDataRow(new object[] { 1, 1 }, false);
             table.LoadDataRow(new object[] { 1, 10 }, false);
 
-            try
-            {
-                table.EndLoadData();
-                Assert.False(true);
-            }
-            catch (ConstraintException ex)
-            {
-                // Failed to enable constraints. One or more rows
-                // contain values violating non-null, unique, or
-                // foreign-key constraints
-                Assert.Equal(typeof(ConstraintException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-            }
+            ConstraintException ex = Assert.Throws<ConstraintException>(() => table.EndLoadData());
+            // Failed to enable constraints. One or more rows
+            // contain values violating non-null, unique, or
+            // foreign-key constraints
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
         }
 
         [Fact]
@@ -918,27 +890,13 @@ namespace System.Data.Tests
             Assert.False(_eventRaised);
             _eventRaised = false;
             _eventValues = false;
-            dt.ColumnChanged += new DataColumnChangeEventHandler(OnColumnChanged_Handler);
+            dt.ColumnChanged += new DataColumnChangeEventHandler(DataColumnChangeHandler);
             dt.OnColumnChanged_Test();
             // OnColumnChanged Event 2
             Assert.True(_eventRaised);
             // OnColumnChanged Values
             Assert.True(_eventValues);
-            dt.ColumnChanged -= new DataColumnChangeEventHandler(OnColumnChanged_Handler);
-        }
-
-        private void OnColumnChanged_Handler(object sender, DataColumnChangeEventArgs e)
-        {
-            DataTable dt = (DataTable)sender;
-            if ((e.Column.Equals(dt.Columns["Value"])) && (e.Row.Equals(dt.Rows[0])) && (e.ProposedValue.Equals("NewValue")))
-            {
-                _eventValues = true;
-            }
-            else
-            {
-                _eventValues = false;
-            }
-            _eventRaised = true;
+            dt.ColumnChanged -= new DataColumnChangeEventHandler(DataColumnChangeHandler);
         }
 
         [Fact]
@@ -952,16 +910,16 @@ namespace System.Data.Tests
             Assert.False(_eventRaised);
             _eventRaised = false;
             _eventValues = false;
-            dt.ColumnChanging += new DataColumnChangeEventHandler(OnColumnChanging_Handler);
+            dt.ColumnChanging += new DataColumnChangeEventHandler(DataColumnChangeHandler);
             dt.OnColumnChanging_Test();
             // OnColumnChanging Event 2
             Assert.True(_eventRaised);
             // OnColumnChanging Values
             Assert.True(_eventValues);
-            dt.ColumnChanging -= new DataColumnChangeEventHandler(OnColumnChanging_Handler);
+            dt.ColumnChanging -= new DataColumnChangeEventHandler(DataColumnChangeHandler);
         }
 
-        private void OnColumnChanging_Handler(object sender, DataColumnChangeEventArgs e)
+        private void DataColumnChangeHandler(object sender, DataColumnChangeEventArgs e)
         {
             DataTable dt = (DataTable)sender;
             if ((e.Column.Equals(dt.Columns["Value"])) && (e.Row.Equals(dt.Rows[0])) && (e.ProposedValue.Equals("NewValue")))
@@ -1083,34 +1041,34 @@ namespace System.Data.Tests
         {
             DataTable dt = DataProvider.CreateParentDataTable();
 
-            dt.RowChanged += new DataRowChangeEventHandler(Row_Changed);
+            dt.RowChanged += new DataRowChangeEventHandler(RowChangeHandler);
 
-            _EventTriggered = false;
+            _eventTriggered = false;
             // RowChanged - 1
             dt.Rows[0][1] = "NewValue";
-            Assert.True(_EventTriggered);
+            Assert.True(_eventTriggered);
 
-            _EventTriggered = false;
+            _eventTriggered = false;
             // RowChanged - 2
             dt.Rows[0].BeginEdit();
             dt.Rows[0][1] = "NewValue";
-            Assert.False(_EventTriggered);
+            Assert.False(_eventTriggered);
 
-            _EventTriggered = false;
+            _eventTriggered = false;
             // RowChanged - 3
             dt.Rows[0].EndEdit();
-            Assert.True(_EventTriggered);
+            Assert.True(_eventTriggered);
 
-            _EventTriggered = false;
-            dt.RowChanged -= new DataRowChangeEventHandler(Row_Changed);
+            _eventTriggered = false;
+            dt.RowChanged -= new DataRowChangeEventHandler(RowChangeHandler);
             // RowChanged - 4
             dt.Rows[0][1] = "NewValue A";
-            Assert.False(_EventTriggered);
+            Assert.False(_eventTriggered);
         }
 
-        private void Row_Changed(object sender, DataRowChangeEventArgs e)
+        private void RowChangeHandler(object sender, DataRowChangeEventArgs e)
         {
-            _EventTriggered = true;
+            _eventTriggered = true;
         }
 
         [Fact]
@@ -1118,34 +1076,29 @@ namespace System.Data.Tests
         {
             DataTable dt = DataProvider.CreateParentDataTable();
 
-            dt.RowChanging += new DataRowChangeEventHandler(Row_Changing);
+            dt.RowChanging += new DataRowChangeEventHandler(RowChangeHandler);
 
-            _EventTriggered = false;
+            _eventTriggered = false;
             // RowChanging - 1
             dt.Rows[0][1] = "NewValue";
-            Assert.True(_EventTriggered);
+            Assert.True(_eventTriggered);
 
-            _EventTriggered = false;
+            _eventTriggered = false;
             // RowChanging - 2
             dt.Rows[0].BeginEdit();
             dt.Rows[0][1] = "NewValue";
-            Assert.False(_EventTriggered);
+            Assert.False(_eventTriggered);
 
-            _EventTriggered = false;
+            _eventTriggered = false;
             // RowChanging - 3
             dt.Rows[0].EndEdit();
-            Assert.True(_EventTriggered);
+            Assert.True(_eventTriggered);
 
-            _EventTriggered = false;
-            dt.RowChanging -= new DataRowChangeEventHandler(Row_Changing);
+            _eventTriggered = false;
+            dt.RowChanging -= new DataRowChangeEventHandler(RowChangeHandler);
             // RowChanging - 4
             dt.Rows[0][1] = "NewValue A";
-            Assert.False(_EventTriggered);
-        }
-
-        private void Row_Changing(object sender, DataRowChangeEventArgs e)
-        {
-            _EventTriggered = true;
+            Assert.False(_eventTriggered);
         }
 
         [Fact]
@@ -1153,23 +1106,18 @@ namespace System.Data.Tests
         {
             DataTable dt = DataProvider.CreateParentDataTable();
 
-            dt.RowDeleted += new DataRowChangeEventHandler(Row_Deleted);
+            dt.RowDeleted += new DataRowChangeEventHandler(RowChangeHandler);
 
-            _EventTriggered = false;
+            _eventTriggered = false;
             // RowDeleted - 1
             dt.Rows[0].Delete();
-            Assert.True(_EventTriggered);
+            Assert.True(_eventTriggered);
 
-            _EventTriggered = false;
-            dt.RowDeleted -= new DataRowChangeEventHandler(Row_Deleted);
+            _eventTriggered = false;
+            dt.RowDeleted -= new DataRowChangeEventHandler(RowChangeHandler);
             // RowDeleted - 2
             dt.Rows[1].Delete();
-            Assert.False(_EventTriggered);
-        }
-
-        private void Row_Deleted(object sender, DataRowChangeEventArgs e)
-        {
-            _EventTriggered = true;
+            Assert.False(_eventTriggered);
         }
 
         [Fact]
@@ -1177,23 +1125,18 @@ namespace System.Data.Tests
         {
             DataTable dt = DataProvider.CreateParentDataTable();
 
-            dt.RowDeleting += new DataRowChangeEventHandler(Row_Deleting);
+            dt.RowDeleting += new DataRowChangeEventHandler(RowChangeHandler);
 
-            _EventTriggered = false;
+            _eventTriggered = false;
             // RowDeleting - 1
             dt.Rows[0].Delete();
-            Assert.True(_EventTriggered);
+            Assert.True(_eventTriggered);
 
-            _EventTriggered = false;
-            dt.RowDeleting -= new DataRowChangeEventHandler(Row_Deleting);
+            _eventTriggered = false;
+            dt.RowDeleting -= new DataRowChangeEventHandler(RowChangeHandler);
             // RowDeleting - 2
             dt.Rows[1].Delete();
-            Assert.False(_EventTriggered);
-        }
-
-        private void Row_Deleting(object sender, DataRowChangeEventArgs e)
-        {
-            _EventTriggered = true;
+            Assert.False(_eventTriggered);
         }
 
         [Fact]
@@ -1302,7 +1245,7 @@ namespace System.Data.Tests
                     al.Add(dr);
             // Select_S - ChildId+ParentId >= 4
             drSelect = dt.Select("ChildId+ParentId >= 4");
-            CompareUnSorted(drSelect, al.ToArray());
+            CompareUnsorted(drSelect, al.ToArray());
 
             //-------------------------------------------------------------
             al.Clear();
@@ -1313,7 +1256,7 @@ namespace System.Data.Tests
             }
             // Select_S - ChildId-ParentId) * -1  <> 0
             drSelect = dt.Select("(ChildId-ParentId) * -1  <> 0");
-            CompareUnSorted(drSelect, al.ToArray());
+            CompareUnsorted(drSelect, al.ToArray());
 
             //-------------------------------------------------------------
             al.Clear();
@@ -1322,7 +1265,7 @@ namespace System.Data.Tests
                     al.Add(dr);
             // Select_S - ChildDouble < ParentId % 4
             drSelect = dt.Select("ChildDouble < ParentId % 4");
-            CompareUnSorted(drSelect, al.ToArray());
+            CompareUnsorted(drSelect, al.ToArray());
 
             //-------------------------------------------------------------
             al.Clear();
@@ -1331,7 +1274,7 @@ namespace System.Data.Tests
                     al.Add(dr);
             // Select_S - ChildDouble in (10,20,25)
             drSelect = dt.Select("ChildDouble in (10,20,25)");
-            CompareUnSorted(drSelect, al.ToArray());
+            CompareUnsorted(drSelect, al.ToArray());
 
             //-------------------------------------------------------------
             al.Clear();
@@ -1350,7 +1293,7 @@ namespace System.Data.Tests
                     al.Add(dr);
             // Select_S - [Column#] <= 0
             drSelect = dt.Select("[Column#] <= 0 ");
-            CompareUnSorted(drSelect, al.ToArray());
+            CompareUnsorted(drSelect, al.ToArray());
             //-------------------------------------------------------------
             al.Clear();
             foreach (DataRow dr in dt.Rows)
@@ -1358,7 +1301,7 @@ namespace System.Data.Tests
                     al.Add(dr);
             // Select_S - [Column#] <= 0
             drSelect = dt.Select("[Column#] <= 0");
-            CompareUnSorted(drSelect, al.ToArray());
+            CompareUnsorted(drSelect, al.ToArray());
 
             //-------------------------------------------------------------
             al.Clear();
@@ -1367,7 +1310,7 @@ namespace System.Data.Tests
                     al.Add(dr);
             // Select_S - ChildDateTime > #12/12/2000#
             drSelect = dt.Select("ChildDateTime > #12/12/2000# ");
-            CompareUnSorted(drSelect, al.ToArray());
+            CompareUnsorted(drSelect, al.ToArray());
 
             //-------------------------------------------------------------
 
@@ -1377,7 +1320,7 @@ namespace System.Data.Tests
                     al.Add(dr);
             // Select_S - ChildDateTime > #1/12/1999 12:06:30 PM#
             drSelect = dt.Select("ChildDateTime > #1/12/1999 12:06:30 PM#  ");
-            CompareUnSorted(drSelect, al.ToArray());
+            CompareUnsorted(drSelect, al.ToArray());
 
             //-------------------------------------------------------------
 
@@ -1387,8 +1330,8 @@ namespace System.Data.Tests
                     al.Add(dr);
             // Select_S - ChildDateTime >= #12/3/2005 5:06:30 PM# or ChildDateTime <= #11/3/1980#
             drSelect = dt.Select("ChildDateTime >= #12/3/2005 5:06:30 PM# or ChildDateTime <= #11/3/1980#  ");
-            CompareUnSorted(drSelect, al.ToArray());
-
+            CompareUnsorted(drSelect, al.ToArray());
+            //TODO
 #if LATER
             //-------------------------------------------------------------
             al.Clear();
@@ -1407,6 +1350,7 @@ namespace System.Data.Tests
             // Select_S - SubString(Trim(String1),1,2) = '1-'
             drSelect = dt.Select("SubString(Trim(String1),1,2) = '1-'");
             Assert.Equal(al.ToArray(), drSelect);
+            //TODO
             //-------------------------------------------------------------
             /*
             al.Clear();
@@ -1420,18 +1364,10 @@ namespace System.Data.Tests
             //-------------------------------------------------------------
             al.Clear();
             // Select_S - Relation not exists, Exception
-            try
-            {
-                drSelect = dt.Select("Parent.ParentId = ChildId");
-                Assert.False(true);
-            }
-            catch (IndexOutOfRangeException ex)
-            {
-                // Cannot find relation 0
-                Assert.Equal(typeof(IndexOutOfRangeException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-            }
+            IndexOutOfRangeException ex = Assert.Throws<IndexOutOfRangeException>(() => dt.Select("Parent.ParentId = ChildId"));
+            // Cannot find relation 0
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
             //-------------------------------------------------------------
             al.Clear();
             ds.Relations.Add(new DataRelation("ParentChild", ds.Tables[0].Columns[0], ds.Tables[1].Columns[0]));
@@ -1443,20 +1379,11 @@ namespace System.Data.Tests
             Assert.Equal(al.ToArray(), drSelect);
         }
 
-        private void CompareUnSorted(Array a, Array b)
+        private void CompareUnsorted<T>(T[] a, T[] b)
         {
-            string msg = string.Format("Failed while comparing(Array a ={0} ({1}), Array b = {2} ({3}))]", a.ToString(), a.GetType().FullName, b.ToString(), b.GetType().FullName);
-            foreach (object item in a)
-            {
-                if (Array.IndexOf(b, item) < 0) //b does not contain the current item.
-                    Assert.False(true);
-            }
-
-            foreach (object item in b)
-            {
-                if (Array.IndexOf(a, item) < 0) //a does not contain the current item.
-                    Assert.False(true);
-            }
+            IEnumerable<T> union = a.Union(b);
+            IEnumerable<T> intersection = a.Intersect(b);
+            Assert.Equal(union.Count(), intersection.Count());
         }
 
         [Fact]
@@ -1496,7 +1423,7 @@ namespace System.Data.Tests
 
         private DataRow[] GetResultRows(DataTable dt, DataRowState State)
         {
-            ArrayList al = new ArrayList();
+            List<DataRow> al = new List<DataRow>();
             DataRowVersion drVer = DataRowVersion.Current;
 
             //From MSDN -    The row the default version for the current DataRowState.
@@ -1518,7 +1445,7 @@ namespace System.Data.Tests
                 if (dr.HasVersion(drVer) && ((int)dr["ParentId", drVer] == 1) && ((dr.RowState & State) > 0))
                     al.Add(dr);
             }
-            DataRow[] result = (DataRow[])al.ToArray((typeof(DataRow)));
+            DataRow[] result = al.ToArray();
             return result;
         }
 
@@ -1560,20 +1487,17 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public void ctor()
+        public void Ctor()
         {
             DataTable dt = new DataTable();
-            Assert.NotNull(dt);
         }
 
         [Fact]
-        public void ctor_ByName()
+        public void Ctor_ByName()
         {
             string sName = "MyName";
 
             DataTable dt = new DataTable(sName);
-
-            Assert.NotNull(dt);
             Assert.Equal(sName, dt.TableName);
         }
 
@@ -1633,24 +1557,15 @@ namespace System.Data.Tests
             DataTable dt = DataProvider.CreateParentDataTable();
             dt.Columns[0].AllowDBNull = false;
 
-            try
-            {
-                //if BeginLoadData has not been called, an exception will be throw
-                dt.LoadDataRow(new object[] { null, "A", "B" }, false);
-                Assert.False(true);
-            }
-            catch (NoNullAllowedException ex)
-            {
-                // Column 'ParentId' does not allow nulls
-                Assert.Equal(typeof(NoNullAllowedException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-
-                // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
-                // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
-                // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
-                Assert.Matches(@"[\p{Pi}\p{Po}]" + "ParentId" + @"[\p{Pf}\p{Po}]", ex.Message);
-            }
+            //if BeginLoadData has not been called, an exception will be thrown
+            NoNullAllowedException ex = Assert.Throws<NoNullAllowedException>(() => dt.LoadDataRow(new object[] { null, "A", "B" }, false));
+            // Column 'ParentId' does not allow nulls
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+            // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
+            // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
+            // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
+            Assert.Matches(@"[\p{Pi}\p{Po}]" + "ParentId" + @"[\p{Pf}\p{Po}]", ex.Message);
 
             DataTable dt1 = DataProvider.CreateUniqueConstraint();
 
@@ -1660,47 +1575,29 @@ namespace System.Data.Tests
             dr[0] = 3;
             dt1.Rows.Add(dr);
 
-            try
-            {
-                dt1.EndLoadData();
-                Assert.False(true);
-            }
-            catch (ConstraintException ex)
-            {
-                // Failed to enable constraints. One or more rows
-                // contain values violating non-null, unique, or
-                // foreign-key constraints
-                Assert.Equal(typeof(ConstraintException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-
-                Assert.Equal(2, dt1.GetErrors().Length);
-                Assert.True(dt1.GetErrors()[0].RowError.Length > 10);
-                Assert.True(dt1.GetErrors()[1].RowError.Length > 10);
-            }
+            ConstraintException ex2 = Assert.Throws<ConstraintException>(() => dt1.EndLoadData());
+            // Failed to enable constraints. One or more rows
+            // contain values violating non-null, unique, or
+            // foreign-key constraints
+            Assert.Null(ex2.InnerException);
+            Assert.NotNull(ex2.Message);
+            Assert.Equal(2, dt1.GetErrors().Length);
+            Assert.True(dt1.GetErrors()[0].RowError.Length > 10);
+            Assert.True(dt1.GetErrors()[1].RowError.Length > 10);
 
             DataSet ds = DataProvider.CreateForeignConstraint();
             ds.Tables[0].BeginLoadData();
             ds.Tables[0].Rows[0][0] = 10; //Foreign constraint violation
 
-            try
-            {
-                ds.Tables[0].EndLoadData();
-                Assert.False(true);
-            }
-            catch (ConstraintException ex)
-            {
-                // Failed to enable constraints. One or more
-                // rows contain values violating non-null,
-                // unique, or foreign-key constraints
-                Assert.Equal(typeof(ConstraintException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-
-                Assert.Equal(3, ds.Tables[1].GetErrors().Length);
-                for (int index = 0; index < 3; index++)
-                    Assert.True(ds.Tables[1].GetErrors()[index].RowError.Length > 10);
-            }
+            ConstraintException ex3 = Assert.Throws<ConstraintException>(() => ds.Tables[0].EndLoadData());
+            // Failed to enable constraints. One or more
+            // rows contain values violating non-null,
+            // unique, or foreign-key constraints
+            Assert.Null(ex3.InnerException);
+            Assert.NotNull(ex3.Message);
+            Assert.Equal(3, ds.Tables[1].GetErrors().Length);
+            for (int index = 0; index < 3; index++)
+                Assert.True(ds.Tables[1].GetErrors()[index].RowError.Length > 10);
         }
 
         private DataRowAction _drExpectedAction;
@@ -1715,7 +1612,7 @@ namespace System.Data.Tests
 
             Assert.False(_eventRaised);
 
-            dt.RowChanged += new DataRowChangeEventHandler(OnRowChanged_Handler);
+            dt.RowChanged += new DataRowChangeEventHandler(RowChangeHandler2);
             foreach (int i in Enum.GetValues(typeof(DataRowAction)))
             {
                 _eventRaised = false;
@@ -1726,10 +1623,10 @@ namespace System.Data.Tests
                 Assert.True(_eventRaised);
                 Assert.True(_eventValues);
             }
-            dt.RowChanged -= new DataRowChangeEventHandler(OnRowChanged_Handler);
+            dt.RowChanged -= new DataRowChangeEventHandler(RowChangeHandler2);
         }
 
-        private void OnRowChanged_Handler(object sender, DataRowChangeEventArgs e)
+        private void RowChangeHandler2(object sender, DataRowChangeEventArgs e)
         {
             DataTable dt = (DataTable)sender;
             if (dt.Rows[0].Equals(e.Row) && e.Action == _drExpectedAction)
@@ -1747,7 +1644,7 @@ namespace System.Data.Tests
 
             Assert.False(_eventRaised);
 
-            dt.RowChanging += new DataRowChangeEventHandler(OnRowChanging_Handler);
+            dt.RowChanging += new DataRowChangeEventHandler(RowChangeHandler2);
             foreach (int i in Enum.GetValues(typeof(DataRowAction)))
             {
                 _eventRaised = false;
@@ -1758,15 +1655,7 @@ namespace System.Data.Tests
                 Assert.True(_eventRaised);
                 Assert.True(_eventValues);
             }
-            dt.RowChanging -= new DataRowChangeEventHandler(OnRowChanging_Handler);
-        }
-
-        private void OnRowChanging_Handler(object sender, DataRowChangeEventArgs e)
-        {
-            DataTable dt = (DataTable)sender;
-            if (dt.Rows[0].Equals(e.Row) && e.Action == _drExpectedAction)
-                _eventValues = true;
-            _eventRaised = true;
+            dt.RowChanging -= new DataRowChangeEventHandler(RowChangeHandler2);
         }
 
         [Fact]
@@ -1779,7 +1668,7 @@ namespace System.Data.Tests
 
             Assert.False(_eventRaised);
 
-            dt.RowDeleted += new DataRowChangeEventHandler(OnRowDeleted_Handler);
+            dt.RowDeleted += new DataRowChangeEventHandler(RowChangeHandler2);
             foreach (int i in Enum.GetValues(typeof(DataRowAction)))
             {
                 _eventRaised = false;
@@ -1790,16 +1679,9 @@ namespace System.Data.Tests
                 Assert.True(_eventRaised);
                 Assert.True(_eventValues);
             }
-            dt.RowDeleted -= new DataRowChangeEventHandler(OnRowDeleted_Handler);
+            dt.RowDeleted -= new DataRowChangeEventHandler(RowChangeHandler2);
         }
 
-        private void OnRowDeleted_Handler(object sender, DataRowChangeEventArgs e)
-        {
-            DataTable dt = (DataTable)sender;
-            if (dt.Rows[0].Equals(e.Row) && e.Action == _drExpectedAction)
-                _eventValues = true;
-            _eventRaised = true;
-        }
 
         [Fact]
         public void OnRowDeleting()
@@ -1811,7 +1693,7 @@ namespace System.Data.Tests
 
             Assert.False(_eventRaised);
 
-            dt.RowDeleting += new DataRowChangeEventHandler(OnRowDeleting_Handler);
+            dt.RowDeleting += new DataRowChangeEventHandler(RowChangeHandler2);
             foreach (int i in Enum.GetValues(typeof(DataRowAction)))
             {
                 _eventRaised = false;
@@ -1822,7 +1704,7 @@ namespace System.Data.Tests
                 Assert.True(_eventRaised);
                 Assert.True(_eventValues);
             }
-            dt.RowDeleting -= new DataRowChangeEventHandler(OnRowDeleting_Handler);
+            dt.RowDeleting -= new DataRowChangeEventHandler(RowChangeHandler2);
         }
 
         [Fact]
@@ -1858,20 +1740,12 @@ namespace System.Data.Tests
             UniqueConstraint uc = new UniqueConstraint(string.Empty, new string[] { "col1" }, true);
             table.Constraints.AddRange(new Constraint[] { uc });
 
-            try
-            {
-                table.EndInit();
-                Assert.False(true);
-            }
-            catch (ArgumentException ex)
-            {
-                // Cannot add primary key constraint since primary
-                // key is already set for the table
-                Assert.Equal(typeof(ArgumentException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.Null(ex.ParamName);
-            }
+            ArgumentException ex = Assert.Throws<ArgumentException>(() => table.EndInit());
+            // Cannot add primary key constraint since primary
+            // key is already set for the table
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+            Assert.Null(ex.ParamName);
         }
 
         [Fact]
@@ -1898,19 +1772,11 @@ namespace System.Data.Tests
             DataColumn col1 = table.Columns.Add("col1", typeof(int));
             table.PrimaryKey = new DataColumn[] { col1 };
 
-            try
-            {
-                table.PrimaryKey = new DataColumn[] { new DataColumn("col2", typeof(int)) };
-                Assert.False(true);
-            }
-            catch (ArgumentException ex)
-            {
-                //  Column must belong to a table
-                Assert.Equal(typeof(ArgumentException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.Null(ex.ParamName);
-            }
+            ArgumentException ex = Assert.Throws<ArgumentException>(() => table.PrimaryKey = new DataColumn[] { new DataColumn("col2", typeof(int)) });
+            //  Column must belong to a table
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+            Assert.Null(ex.ParamName);
 
             Assert.Equal("col1", table.PrimaryKey[0].ColumnName);
         }
@@ -2056,6 +1922,7 @@ namespace System.Data.Tests
                 if ((int)dr["ChildId"] == 1 && dr["String1"].ToString() == "1-String1")
                     al.Add(dr);
             }
+            //TODO
             //al.Reverse();
             al.Sort(new DataRowsComparer("ParentId", "Desc"));
 
@@ -2070,6 +1937,7 @@ namespace System.Data.Tests
                 if (dr["String1"].ToString().Length < 4)
                     al.Add(dr);
             }
+            //TODO
             //al.Reverse();
             al.Sort(new DataRowsComparer("ParentId", "Desc"));
 
@@ -2082,19 +1950,11 @@ namespace System.Data.Tests
         {
             DataTable dt = DataProvider.CreateParentDataTable();
             //Select - parse sort string checking 1");
-            try
-            {
-                dt.Select(dt.Columns[0].ColumnName, dt.Columns[0].ColumnName + "1");
-                Assert.False(true);
-            }
-            catch (IndexOutOfRangeException ex)
-            {
-                // Cannot find column ParentId1
-                Assert.Equal(typeof(IndexOutOfRangeException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.IndexOf("ParentId1") != -1);
-            }
+            IndexOutOfRangeException ex = Assert.Throws<IndexOutOfRangeException>(() => dt.Select(dt.Columns[0].ColumnName, dt.Columns[0].ColumnName + "1"));
+            // Cannot find column ParentId1
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+            Assert.True(ex.Message.IndexOf("ParentId1") != -1);
         }
 
         [Fact]
@@ -2112,21 +1972,14 @@ namespace System.Data.Tests
             for (int i = 0; i < 5; ++i)
                 table.Rows.Add(new object[] { i });
 
-            try
-            {
-                table.Select("col1*10");
-                Assert.False(true);
-            }
-            catch (EvaluateException ex)
-            {
-                // Filter expression 'col1*10' does not evaluate
-                // to a Boolean term
-                Assert.Equal(typeof(EvaluateException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                //Assert.True (ex.Message.IndexOf ("'col1*10'") != -1);
-                //Assert.True (ex.Message.IndexOf ("Boolean") != -1);
-            }
+            EvaluateException ex = Assert.Throws<EvaluateException>(() => table.Select("col1*10"));
+            // Filter expression 'col1*10' does not evaluate
+            // to a Boolean term
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+            //TODO
+            //Assert.True (ex.Message.IndexOf ("'col1*10'") != -1);
+            //Assert.True (ex.Message.IndexOf ("Boolean") != -1);
         }
 
         [Fact]
@@ -2140,21 +1993,13 @@ namespace System.Data.Tests
                 table.Rows.Add(new object[] { i });
 
             DataRow[] result;
-            try
-            {
-                result = table.Select("col1");
-                Assert.False(true);
-            }
-            catch (EvaluateException ex)
-            {
-                // Filter expression 'col1' does not evaluate to
-                // a Boolean term
-                Assert.Equal(typeof(EvaluateException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                //Assert.True (ex.Message.IndexOf ("'col1'") != -1);
-                //Assert.True (ex.Message.IndexOf ("Boolean") != -1);
-            }
+            EvaluateException ex = Assert.Throws<EvaluateException>(() => table.Select("col1"));
+            // Filter expression 'col1' does not evaluate to
+            // a Boolean term
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+            //Assert.True (ex.Message.IndexOf ("'col1'") != -1);
+            //Assert.True (ex.Message.IndexOf ("Boolean") != -1);
 
             //col2 is a boolean expression, and a null value translates to
             //false.
@@ -2221,8 +2066,9 @@ namespace System.Data.Tests
             table3.Merge(table2, false, MissingSchemaAction.Ignore);
             Assert.Equal(0, table3.Constraints.Count);
 
-            //FIXME : If both source and target have PK, then
-            // shud be the exception raised when schema is merged?
+            //TODO
+            //FIXME : If both source and target have PK, then 
+            // shud be the exception raised when schema is merged? 
             // ms.net throws a nullreference exception.
             // If any data is merged, exception is anyways raised.
             /*
@@ -2243,17 +2089,9 @@ Assert.False(true);
             table1.Columns["col_datetime"].DateTimeMode = DataSetDateTime.Local;
             table2.Columns["col_datetime"].DateTimeMode = DataSetDateTime.Unspecified;
 
-            table3 = table1.Clone();
-            try
-            {
-                table3.Merge(table2);
-                Assert.False(true);
-            }
-            catch (DataException)
-            {
-                // <target>.col_datetime and <source>.col_datetime
-                // have conflicting properties: DataType property mismatch.
-            }
+            // <target>.col_datetime and <source>.col_datetime
+            // have conflicting properties: DataType property mismatch.
+            Assert.Throws<DataException>(() => table3.Merge(table2));
 
             table1.Columns["col_datetime"].DateTimeMode = DataSetDateTime.Unspecified;
             table2.Columns["col_datetime"].DateTimeMode = DataSetDateTime.UnspecifiedLocal;
@@ -2298,13 +2136,13 @@ Assert.False(true);
 
         internal class DataRowsComparer : IComparer<DataRow>
         {
-            private string _columnName;
-            private string _direction;
+            private readonly string _columnName;
+            private readonly string _direction;
 
             public DataRowsComparer(string columnName, string direction)
             {
                 _columnName = columnName;
-                if (direction.ToLower() != "asc" && direction.ToLower() != "desc")
+                if (direction.Equals("asc", StringComparison.OrdinalIgnoreCase) && direction.Equals("desc", StringComparison.OrdinalIgnoreCase))
                     throw new ArgumentException("Direction can only be one of: 'asc' or 'desc'");
                 _direction = direction;
             }
@@ -2317,7 +2155,7 @@ Assert.False(true);
                 int compareResult = Comparer.Default.Compare(objX, objY);
 
                 //If we are comparing desc we need to reverse the result.
-                if (_direction.ToLower() == "desc")
+                if (_direction.Equals("desc", StringComparison.OrdinalIgnoreCase))
                     compareResult = -compareResult;
 
                 return compareResult;

--- a/src/System.Data.Common/tests/System/Data/DataTableTest3.cs
+++ b/src/System.Data.Common/tests/System/Data/DataTableTest3.cs
@@ -645,7 +645,6 @@ namespace System.Data.Tests
             // The URL cannot be empty
             Assert.Null(ex.InnerException);
             Assert.NotNull(ex.Message);
-            //TODO
             //Assert.Equal ("url", ex.ParamName);
         }
 

--- a/src/System.Data.Common/tests/System/Data/DataTableTest3.cs
+++ b/src/System.Data.Common/tests/System/Data/DataTableTest3.cs
@@ -24,7 +24,6 @@
 //
 
 using System.IO;
-using System.Text.RegularExpressions;
 
 using Xunit;
 
@@ -32,7 +31,7 @@ namespace System.Data.Tests
 {
     public class DataTableTest3 : IDisposable
     {
-        private string _tempFile;
+        private readonly string _tempFile;
         private DataSet _dataSet;
         private DataTable _parentTable;
         private DataTable _childTable;
@@ -488,20 +487,10 @@ namespace System.Data.Tests
             _dataSet.Tables.Remove(_parentTable);
             _parentTable.TableName = string.Empty;
 
-            using (FileStream stream = new FileStream(_tempFile, FileMode.Create))
-            {
-                try
-                {
-                    _parentTable.WriteXmlSchema(stream);
-                    Assert.False(true);
-                }
-                catch (InvalidOperationException ex)
-                {
-                    Assert.Equal(typeof(InvalidOperationException), ex.GetType());
-                    Assert.Null(ex.InnerException);
-                    Assert.NotNull(ex.Message);
-                }
-            }
+            using FileStream stream = new FileStream(_tempFile, FileMode.Create);
+            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => _parentTable.WriteXmlSchema(stream));
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
         }
 
         [Fact]
@@ -634,26 +623,16 @@ namespace System.Data.Tests
 
             using (FileStream stream = new FileStream(_tempFile, FileMode.Open))
             {
-                try
-                {
-                    table.ReadXmlSchema(stream);
-                    Assert.False(true);
-                }
-                catch (ArgumentException ex)
-                {
-                    // DataTable 'Table1' does not match
-                    // to any DataTable in source
-                    Assert.Equal(typeof(ArgumentException), ex.GetType());
-                    Assert.Null(ex.InnerException);
-                    Assert.NotNull(ex.Message);
-
-                    // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
-                    // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
-                    // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
-                    Assert.Matches(@"[\p{Pi}\p{Po}]" + "Table1" + @"[\p{Pf}\p{Po}]", ex.Message);
-
-                    Assert.Null(ex.ParamName);
-                }
+                ArgumentException ex = Assert.Throws<ArgumentException>(() => table.ReadXmlSchema(stream));
+                // DataTable 'Table1' does not match
+                // to any DataTable in source
+                Assert.Null(ex.InnerException);
+                Assert.NotNull(ex.Message);
+                // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
+                // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
+                // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
+                Assert.Matches(@"[\p{Pi}\p{Po}]" + "Table1" + @"[\p{Pf}\p{Po}]", ex.Message);
+                Assert.Null(ex.ParamName);
             }
         }
 
@@ -662,19 +641,12 @@ namespace System.Data.Tests
         {
             DataTable table = new DataTable();
 
-            try
-            {
-                table.ReadXmlSchema(string.Empty);
-                Assert.False(true);
-            }
-            catch (ArgumentException ex)
-            {
-                // The URL cannot be empty
-                Assert.Equal(typeof(ArgumentException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-                //Assert.Equal ("url", ex.ParamName);
-            }
+            ArgumentException ex = Assert.Throws<ArgumentException>(() => table.ReadXmlSchema(string.Empty));
+            // The URL cannot be empty
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+            //TODO
+            //Assert.Equal ("url", ex.ParamName);
         }
 
         [Fact]

--- a/src/System.Data.Common/tests/System/Data/DataTableTest4.cs
+++ b/src/System.Data.Common/tests/System/Data/DataTableTest4.cs
@@ -585,20 +585,12 @@ namespace System.Data.Tests
 
             using (FileStream stream = new FileStream(_tempFile, FileMode.Open))
             {
-                try
-                {
-                    table.ReadXml(stream);
-                    //Should throw an exception if the Xml
-                    // File has no schema and target table
-                    // too does not define any schema
-                    Assert.False(true);
-                }
-                catch (InvalidOperationException ex)
-                {
-                    Assert.Equal(typeof(InvalidOperationException), ex.GetType());
-                    Assert.Null(ex.InnerException);
-                    Assert.NotNull(ex.Message);
-                }
+                // Should throw an exception if the Xml
+                // File has no schema and target table
+                // too does not define any schema
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => table.ReadXml(stream));
+                Assert.Null(ex.InnerException);
+                Assert.NotNull(ex.Message);
             }
         }
 
@@ -638,27 +630,17 @@ namespace System.Data.Tests
             _dataSet.Tables.Add(table);
 
             //Read the Xml and the Schema into a table which already belongs to a DataSet
-            //and the table name does not match with the table ion the source XML
-            try
-            {
-                table.ReadXml(_tempFile);
-                Assert.False(true);
-            }
-            catch (ArgumentException ex)
-            {
-                // DataTable 'Table1' does not match to any
-                // DataTable in source
-                Assert.Equal(typeof(ArgumentException), ex.GetType());
-                Assert.Null(ex.InnerException);
-                Assert.NotNull(ex.Message);
-
-                // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
-                // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
-                // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
-                Assert.Matches(@"[\p{Pi}\p{Po}]" + "Table1" + @"[\p{Pf}\p{Po}]", ex.Message);
-
-                Assert.Null(ex.ParamName);
-            }
+            //and the table name does not match with the table ion the source XML 
+            ArgumentException ex = Assert.Throws<ArgumentException>(() => table.ReadXml(_tempFile));
+            // DataTable 'Table1' does not match to any
+            // DataTable in source
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.Message);
+            // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
+            // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
+            // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
+            Assert.Matches(@"[\p{Pi}\p{Po}]" + "Table1" + @"[\p{Pf}\p{Po}]", ex.Message);
+            Assert.Null(ex.ParamName);
         }
 
         [Fact]
@@ -1514,26 +1496,17 @@ namespace System.Data.Tests
                 DataTable table = new DataTable("Table1");
                 table.Columns.Add(new DataColumn("id", typeof(int)));
 
-                try
-                {
-                    table.ReadXml(stream);
-                    Assert.False(true);
-                }
-                catch (ArgumentException ex)
-                {
-                    // DataTable 'Table1' does not match to
-                    // any DataTable in source
-                    Assert.Equal(typeof(ArgumentException), ex.GetType());
-                    Assert.Null(ex.InnerException);
-                    Assert.NotNull(ex.Message);
-
-                    // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
-                    // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
-                    // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
-                    Assert.Matches(@"[\p{Pi}\p{Po}]" + "Table1" + @"[\p{Pf}\p{Po}]", ex.Message);
-
-                    Assert.Null(ex.ParamName);
-                }
+                ArgumentException ex = Assert.Throws<ArgumentException>(() => table.ReadXml(stream));
+                // DataTable 'Table1' does not match to
+                // any DataTable in source
+                Assert.Equal(typeof(ArgumentException), ex.GetType());
+                Assert.Null(ex.InnerException);
+                Assert.NotNull(ex.Message);
+                // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
+                // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
+                // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
+                Assert.Matches(@"[\p{Pi}\p{Po}]" + "Table1" + @"[\p{Pf}\p{Po}]", ex.Message);
+                Assert.Null(ex.ParamName);
             }
         }
 
@@ -1698,26 +1671,17 @@ namespace System.Data.Tests
                 table.Columns.Add(new DataColumn("id", Type.GetType("System.Int32")));
                 ds.Tables.Add(table);
 
-                try
-                {
-                    table.ReadXml(stream);
-                    Assert.False(true);
-                }
-                catch (ArgumentException ex)
-                {
-                    // DataTable 'Table1' does not match to
-                    // any DataTable in source
-                    Assert.Equal(typeof(ArgumentException), ex.GetType());
-                    Assert.Null(ex.InnerException);
-                    Assert.NotNull(ex.Message);
+                ArgumentException ex = Assert.Throws<ArgumentException>(() => table.ReadXml(stream));
+                // DataTable 'Table1' does not match to
+                // any DataTable in sources
+                Assert.Null(ex.InnerException);
+                Assert.NotNull(ex.Message);
+                // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
+                // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
+                // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
+                Assert.Matches(@"[\p{Pi}\p{Po}]" + "Table1" + @"[\p{Pf}\p{Po}]", ex.Message);
+                Assert.Null(ex.ParamName);
 
-                    // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
-                    // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
-                    // \p{Po} any kind of punctuation character that is not a dash, bracket, quote or connector https://www.compart.com/en/unicode/category/Po
-                    Assert.Matches(@"[\p{Pi}\p{Po}]" + "Table1" + @"[\p{Pf}\p{Po}]", ex.Message);
-
-                    Assert.Null(ex.ParamName);
-                }
             }
         }
 
@@ -1781,17 +1745,9 @@ namespace System.Data.Tests
             {
                 DataTable table = new DataTable();
 
-                try
-                {
-                    table.ReadXml(stream);
-                    Assert.False(true);
-                }
-                catch (InvalidOperationException ex)
-                {
-                    Assert.Equal(typeof(InvalidOperationException), ex.GetType());
-                    Assert.Null(ex.InnerException);
-                    Assert.NotNull(ex.Message);
-                }
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => table.ReadXml(stream));
+                Assert.Null(ex.InnerException);
+                Assert.NotNull(ex.Message);
             }
         }
 

--- a/src/System.Data.Common/tests/System/Data/DataViewTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataViewTest.cs
@@ -625,7 +625,7 @@ namespace System.Data.Tests
                 DataView TestView = new DataView(_dataTable);
                 TestView.Delete(0);
                 DataRow r = TestView.Table.Rows[0];
-                Assert.True(!((string)r["itemId"] == "item 1"));
+                Assert.NotEqual("item 1", (string)r["itemId"]);
             });
         }
 

--- a/src/System.Data.Common/tests/System/Data/DataViewTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataViewTest.cs
@@ -107,8 +107,7 @@ namespace System.Data.Tests
             }
             Console.WriteLine();
         }
-        
-        //TODO: what is this for? looks like it's called from nowhere.
+
         public void Dispose()
         {
             _dataTable = null;

--- a/src/System.Data.Common/tests/System/Data/DataViewTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataViewTest.cs
@@ -356,14 +356,8 @@ namespace System.Data.Tests
             Assert.Equal(3, dataView[3][0]);
 
             s = "Ascending sorting 5: ";
-            try
-            {
-                dataView.Sort = "itemId \tASC";
-                Assert.True(false);
-            }
-            catch (IndexOutOfRangeException e)
-            {
-            }
+
+            Assert.Throws<IndexOutOfRangeException>(() => dataView.Sort = "itemId \tASC");
 
             s = "Descending sorting : ";
             dataView.Sort = "itemId DESC";

--- a/src/System.Data.Common/tests/System/Data/DataViewTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataViewTest.cs
@@ -38,7 +38,8 @@ namespace System.Data.Tests
         private DataTable _dataTable;
         private DataView _dataView;
         private Random _rndm;
-        private int _seed,_rowCount;
+        private const int Seed = 123;
+        private int _rowCount;
         private ListChangedEventArgs _listChangedArgs;
         private TextWriter _eventWriter;
 
@@ -60,9 +61,8 @@ namespace System.Data.Tests
             _dataTable.Columns.Add(_dc3);
             _dataTable.Columns.Add(_dc4);
             DataRow dr;
-            _seed = 123;
             _rowCount = 5;
-            _rndm = new Random(_seed);
+            _rndm = new Random(Seed);
             for (int i = 1; i <= _rowCount; i++)
             {
                 dr = _dataTable.NewRow();
@@ -107,7 +107,8 @@ namespace System.Data.Tests
             }
             Console.WriteLine();
         }
-
+        
+        //TODO: what is this for? looks like it's called from nowhere.
         public void Dispose()
         {
             _dataTable = null;

--- a/src/System.Data.Common/tests/System/Data/DataViewTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/DataViewTest2.cs
@@ -640,7 +640,7 @@ namespace System.Data.Tests
             //-------------------------------------------------------------
 
             //-------------------------------------------------------------
-            //Get excpected result 
+            //Get expected result
             list.Clear();
             foreach (DataRow dr in dt.Rows)
                 if ((int)dr["ChildId"] == 1 && dr["String1"].ToString() == "1-String1")

--- a/src/System.Data.Common/tests/System/Data/DataViewTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/DataViewTest2.cs
@@ -351,11 +351,8 @@ namespace System.Data.Tests
             bool succeed = true;
             for (int i = 0; i < dvArr.Length; i++)
             {
-                succeed = (int)dvArr[i]["ChildId"] == (int)drExpected[i]["ChildId"];
-                if (!succeed)
-                    break;
+                Assert.Equal((int)drExpected[i]["ChildId"], (int)dvArr[i]["ChildId"]);
             }
-            Assert.True(succeed);
         }
 
         //Activate This Construntor to log All To Standard output
@@ -1189,17 +1186,8 @@ namespace System.Data.Tests
 
             table.AcceptChanges();
             DataView view = new DataView(table);
-            //TODO
-            //try
-            //{
-            //    DataTable newTable = view.ToTable(false, null);
-            //}
-            //catch (ArgumentNullException e)
-            //{
-            //    // Never premise English.
-            //    //Assert.Equal ("'columnNames' argument cannot be null." + Environment.NewLine + 
-            //    //		"Parameter name: columnNames", e.Message, "#1");
-            //}
+
+            // 'columnNames' argument cannot be null.\r\nParameter name: columnNames
             Assert.Throws<ArgumentNullException>(() => view.ToTable(false, null));
             DataTable newTable1 = view.ToTable(false, new string[] { });
             Assert.Equal(10, newTable1.Rows.Count);

--- a/src/System.Data.Common/tests/System/Data/DataViewTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/DataViewTest2.cs
@@ -67,7 +67,7 @@ namespace System.Data.Tests
             Assert.Equal(dt.Rows.Count, CountTable + 1);
 
             // AddNew - new row != null
-            Assert.True(drv != null);
+            Assert.NotNull(drv);
 
             // AddNew - check table
             Assert.Equal(dt, drv.Row.Table);
@@ -469,7 +469,7 @@ namespace System.Data.Tests
 
             // GetEnumerator != null
             ienm = dv.GetEnumerator();
-            Assert.True(ienm != null);
+            Assert.NotNull(ienm);
 
             int i = 0;
             while (ienm.MoveNext())
@@ -1155,7 +1155,7 @@ namespace System.Data.Tests
             // AutoIncrement state is maintained by ms.net
             Assert.True(table.Columns[2].AutoIncrement);
 
-            Assert.False(ds.Tables[0] == table);
+            Assert.NotEqual(ds.Tables[0], table);
 
             Assert.Equal(ds.Tables[0].TableName, table.TableName);
             Assert.Equal(ds.Tables[0].Columns.Count, table.Columns.Count);

--- a/src/System.Data.Common/tests/System/Data/DataViewTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/DataViewTest2.cs
@@ -26,7 +26,7 @@
 using Xunit;
 using System.Collections;
 using System.ComponentModel;
-
+using System.Collections.Generic;
 
 namespace System.Data.Tests
 {
@@ -302,13 +302,14 @@ namespace System.Data.Tests
             // FindRows - check data
 
             //check that result is ok
-            bool Succeed = true;
+            bool succeed = true;
             for (int i = 0; i < dvArr.Length; i++)
             {
-                Succeed = (int)dvArr[i]["ChildId"] == (int)drExpected[i]["ChildId"];
-                if (!Succeed) break;
+                succeed = (int)dvArr[i]["ChildId"] == (int)drExpected[i]["ChildId"];
+                if (!succeed)
+                    break;
             }
-            Assert.True(Succeed);
+            Assert.True(succeed);
         }
 
         [Fact]
@@ -347,13 +348,14 @@ namespace System.Data.Tests
             // FindRows - check data
 
             //check that result is ok
-            bool Succeed = true;
+            bool succeed = true;
             for (int i = 0; i < dvArr.Length; i++)
             {
-                Succeed = (int)dvArr[i]["ChildId"] == (int)drExpected[i]["ChildId"];
-                if (!Succeed) break;
+                succeed = (int)dvArr[i]["ChildId"] == (int)drExpected[i]["ChildId"];
+                if (!succeed)
+                    break;
             }
-            Assert.True(Succeed);
+            Assert.True(succeed);
         }
 
         //Activate This Construntor to log All To Standard output
@@ -370,7 +372,7 @@ namespace System.Data.Tests
         [Fact]
         public void Find_ByObject()
         {
-            int FindResult, ExpectedResult = -1;
+            int findResult, expectedResult = -1;
 
             //create the source datatable
             DataTable dt = DataProvider.CreateParentDataTable();
@@ -382,7 +384,7 @@ namespace System.Data.Tests
             {
                 if ((int)dt.Rows[i]["ParentId"] == 3)
                 {
-                    ExpectedResult = i;
+                    expectedResult = i;
                     break;
                 }
             }
@@ -390,18 +392,18 @@ namespace System.Data.Tests
             // Find ,no sort - exception
             AssertExtensions.Throws<ArgumentException>(null, () =>
             {
-                FindResult = dv.Find("3");
+                findResult = dv.Find("3");
             });
 
             dv.Sort = "String1";
             // Find = wrong sort, can not find
-            FindResult = dv.Find("3");
-            Assert.Equal(-1, FindResult);
+            findResult = dv.Find("3");
+            Assert.Equal(-1, findResult);
 
             dv.Sort = "ParentId";
-            // Find
-            FindResult = dv.Find("3");
-            Assert.Equal(ExpectedResult, FindResult);
+            // Find 
+            findResult = dv.Find("3");
+            Assert.Equal(expectedResult, findResult);
         }
 
         [Fact]
@@ -512,7 +514,7 @@ namespace System.Data.Tests
             _evProp = null;
             // change value - Event raised
             dv[1]["String1"] = "something";
-            Assert.True(_evProp != null);
+            Assert.NotNull(_evProp);
             // change value - ListChangedType
             Assert.Equal(ListChangedType.ItemChanged, _evProp.lstType);
             // change value - NewIndex
@@ -524,7 +526,7 @@ namespace System.Data.Tests
             _evProp = null;
             // Add New  - Event raised
             dv.AddNew();
-            Assert.True(_evProp != null);
+            Assert.NotNull(_evProp);
             // Add New  - ListChangedType
             Assert.Equal(ListChangedType.ItemAdded, _evProp.lstType);
             // Add New  - NewIndex
@@ -536,7 +538,7 @@ namespace System.Data.Tests
             _evProp = null;
             // sort  - Event raised
             dv.Sort = "ParentId Desc";
-            Assert.True(_evProp != null);
+            Assert.NotNull(_evProp);
             // sort - ListChangedType
             Assert.Equal(ListChangedType.Reset, _evProp.lstType);
             // sort - NewIndex
@@ -564,7 +566,7 @@ namespace System.Data.Tests
             // ListChangedType.Reset
             dt.AcceptChanges();
 
-            Assert.True(_evProp != null);
+            Assert.NotNull(_evProp);
             // AcceptChanges - should emit ListChangedType.Reset
             Assert.Equal(ListChangedType.Reset, _evProp.lstType);
         }
@@ -582,7 +584,7 @@ namespace System.Data.Tests
             // Clears DataTable
             dt.Clear();
 
-            Assert.True(_evProp != null);
+            Assert.NotNull(_evProp);
             // Clear DataTable - should emit ListChangedType.Reset
             Assert.Equal(ListChangedType.Reset, _evProp.lstType);
             // Clear DataTable - should clear view count
@@ -604,7 +606,7 @@ namespace System.Data.Tests
             // this test also check DataView.Count property
 
             DataRowView[] drvResult = null;
-            ArrayList al = new ArrayList();
+            List<DataRow> list = new List<DataRow>();
 
             //create the source datatable
             DataTable dt = DataProvider.CreateChildDataTable();
@@ -613,55 +615,56 @@ namespace System.Data.Tests
             DataView dv = new DataView(dt);
 
             //-------------------------------------------------------------
-            //Get excpected result
-            al.Clear();
+            //Get expected result
             foreach (DataRow dr in dt.Rows)
             {
                 if ((int)dr["ChildId"] == 1)
                 {
-                    al.Add(dr);
+                    list.Add(dr);
                 }
             }
 
             // RowFilter = 'ChildId=1', check count
             dv.RowFilter = "ChildId=1";
-            Assert.Equal(al.Count, dv.Count);
+            Assert.Equal(list.Count, dv.Count);
 
             // RowFilter = 'ChildId=1', check rows
             drvResult = new DataRowView[dv.Count];
             dv.CopyTo(drvResult, 0);
             //check that the filterd rows exists
-            bool Succeed = true;
+            bool succeed = true;
             for (int i = 0; i < drvResult.Length; i++)
             {
-                Succeed = al.Contains(drvResult[i].Row);
-                if (!Succeed) break;
+                succeed = list.Contains(drvResult[i].Row);
+                if (!succeed)
+                    break;
             }
-            Assert.True(Succeed);
+            Assert.True(succeed);
             //-------------------------------------------------------------
 
             //-------------------------------------------------------------
-            //Get excpected result
-            al.Clear();
+            //Get excpected result 
+            list.Clear();
             foreach (DataRow dr in dt.Rows)
                 if ((int)dr["ChildId"] == 1 && dr["String1"].ToString() == "1-String1")
-                    al.Add(dr);
+                    list.Add(dr);
 
             // RowFilter - ChildId=1 and String1='1-String1'
             dv.RowFilter = "ChildId=1 and String1='1-String1'";
-            Assert.Equal(al.Count, dv.Count);
+            Assert.Equal(list.Count, dv.Count);
 
             // RowFilter = ChildId=1 and String1='1-String1', check rows
             drvResult = new DataRowView[dv.Count];
             dv.CopyTo(drvResult, 0);
             //check that the filterd rows exists
-            Succeed = true;
+            succeed = true;
             for (int i = 0; i < drvResult.Length; i++)
             {
-                Succeed = al.Contains(drvResult[i].Row);
-                if (!Succeed) break;
+                succeed = list.Contains(drvResult[i].Row);
+                if (!succeed)
+                    break;
             }
-            Assert.True(Succeed);
+            Assert.True(succeed);
             //-------------------------------------------------------------
 
             //EvaluateException
@@ -699,9 +702,6 @@ namespace System.Data.Tests
                 OriginalRows    Original rows including unchanged and deleted rows. 42
                 Unchanged       An unchanged row. 2
              */
-
-            //DataRowView[] drvResult = null;
-            ArrayList al = new ArrayList();
 
             DataTable dt = DataProvider.CreateParentDataTable();
 
@@ -759,7 +759,7 @@ namespace System.Data.Tests
         private DataRow[] GetResultRows(DataTable dt, DataRowState State)
         {
             //get expected rows
-            ArrayList al = new ArrayList();
+            List<DataRow> al = new List<DataRow>();
             DataRowVersion drVer = DataRowVersion.Current;
 
             //From MSDN -    The row the default version for the current DataRowState.
@@ -784,7 +784,7 @@ namespace System.Data.Tests
                     )
                     al.Add(dr);
             }
-            DataRow[] result = (DataRow[])al.ToArray((typeof(DataRow)));
+            DataRow[] result = al.ToArray();
             return result;
         }
 
@@ -910,22 +910,16 @@ namespace System.Data.Tests
         [Fact]
         public void ctor_Empty()
         {
-            DataView dv;
-            dv = new DataView();
-
+            DataView dv = new DataView();
             // ctor
-            Assert.False(dv == null);
         }
 
         [Fact]
         public void ctor_DataTable()
         {
-            DataView dv = null;
             DataTable dt = new DataTable("myTable");
-
             // ctor
-            dv = new DataView(dt);
-            Assert.False(dv == null);
+            DataView dv = new DataView(dt);
 
             // ctor - table
             Assert.Equal(dt, dv.Table);
@@ -965,7 +959,6 @@ namespace System.Data.Tests
 
             // ctor
             dv = new DataView(dt, "CustomerId > 100", "Age", DataViewRowState.Added);
-            Assert.False(dv == null);
 
             // ctor - table
             Assert.Equal(dt, dv.Table);
@@ -1196,16 +1189,18 @@ namespace System.Data.Tests
 
             table.AcceptChanges();
             DataView view = new DataView(table);
-            try
-            {
-                DataTable newTable = view.ToTable(false, null);
-            }
-            catch (ArgumentNullException e)
-            {
-                // Never premise English.
-                //Assert.Equal ("'columnNames' argument cannot be null." + Environment.NewLine +
-                //        "Parameter name: columnNames", e.Message, "#1");
-            }
+            //TODO
+            //try
+            //{
+            //    DataTable newTable = view.ToTable(false, null);
+            //}
+            //catch (ArgumentNullException e)
+            //{
+            //    // Never premise English.
+            //    //Assert.Equal ("'columnNames' argument cannot be null." + Environment.NewLine + 
+            //    //		"Parameter name: columnNames", e.Message, "#1");
+            //}
+            Assert.Throws<ArgumentNullException>(() => view.ToTable(false, null));
             DataTable newTable1 = view.ToTable(false, new string[] { });
             Assert.Equal(10, newTable1.Rows.Count);
 

--- a/src/System.Data.Common/tests/System/Data/DataViewTest_IBindingList.cs
+++ b/src/System.Data.Common/tests/System/Data/DataViewTest_IBindingList.cs
@@ -25,12 +25,10 @@
 
 
 using System.ComponentModel;
+using Xunit;
 
 namespace System.Data.Tests
 {
-    using Xunit;
-
-
     public class DataViewTest_IBindingList
     {
         private DataTable _dt = new DataTable();

--- a/src/System.Data.Common/tests/System/Data/ForeignKeyConstraintTest.cs
+++ b/src/System.Data.Common/tests/System/Data/ForeignKeyConstraintTest.cs
@@ -197,18 +197,7 @@ namespace System.Data.Tests
             // Create a ForeingKeyConstraint Object using the constructor
             // ForeignKeyConstraint (string, string, string[], string[], AcceptRejectRule, Rule, Rule);
             ForeignKeyConstraint fkc = new ForeignKeyConstraint("hello world", parentTableName, parentColumnNames, childColumnNames, AcceptRejectRule.Cascade, Rule.Cascade, Rule.Cascade);                                                                                                                            // Assert that the Constraint object does not belong to any table yet
-            //TODO
-            //try
-            //{
-            //    DataTable tmp = fkc.Table;
-            //    Assert.False(true);
-            //}
-            //catch (NullReferenceException)
-            //{ // actually .NET throws this (bug)
-            //}
-            //catch (InvalidOperationException)
-            //{
-            //}
+
             Exception ex = Assert.ThrowsAny<Exception>(() => fkc.Table);
             Assert.True(ex is NullReferenceException || ex is InvalidOperationException);
 
@@ -224,51 +213,21 @@ namespace System.Data.Tests
             //    table2.Constraints.Add(fkc);
             //    throw new ApplicationException("An Exception was expected");
             //}
-            //TODO
             // spec says InvalidConstraintException but throws this
             //catch (NullReferenceException)
             //{
             //}
             Assert.Throws<NullReferenceException>(() => table2.Constraints.Add(fkc));
-            //TODO
-#if false // FIXME: Here this test crashes under MS.NET.
-                        // OK - So AddRange() is the only way!
-                        table2.Constraints.AddRange (constraints);
-               // After AddRange(), Check the properties of ForeignKeyConstraint object
-                        Assert.True(fkc.RelatedColumns [0].ColumnName.Equals ("col1"));
-                        Assert.True(fkc.RelatedColumns [1].ColumnName.Equals ("col2"));
-                        Assert.True(fkc.RelatedColumns [2].ColumnName.Equals ("col3"));
-                        Assert.True(fkc.Columns [0].ColumnName.Equals ("col4"));
-                        Assert.True(fkc.Columns [1].ColumnName.Equals ("col5"));
-                        Assert.True(fkc.Columns [2].ColumnName.Equals ("col6"));
-#endif
+
             // Try to add columns with names which do not exist in the table
             parentColumnNames[2] = "noColumn";
             ForeignKeyConstraint foreignKeyConstraint = new ForeignKeyConstraint("hello world", parentTableName, parentColumnNames, childColumnNames, AcceptRejectRule.Cascade, Rule.Cascade, Rule.Cascade);
             constraints[0] = new UniqueConstraint(column1);
             constraints[1] = new UniqueConstraint(column2);
             constraints[2] = foreignKeyConstraint;
-            //TODO
-            //try
-            //{
-            //    table2.Constraints.AddRange(constraints);
-            //    throw new ApplicationException("An Exception was expected");
-            //}
-            //catch (ArgumentException e)
-            //{
-            //}
-            //catch (InvalidConstraintException e)
-            //{ // Could not test on ms.net, as ms.net does not reach here so far.        
-            //}
+
             Exception ex2 = Assert.ThrowsAny<Exception>(() => table2.Constraints.AddRange(constraints));
             Assert.True(ex2 is ArgumentException || ex2 is InvalidConstraintException);
-
-
-            //TODO
-#if false // FIXME: Here this test crashes under MS.NET.
-                        // Check whether the child table really contains the foreign key constraint named "hello world"
-                        Assert.True(table2.Constraints.Contains ("hello world"));
-#endif
         }
 
 
@@ -403,7 +362,6 @@ namespace System.Data.Tests
 
             Assert.False(fkc.Equals(fkcDiff));
 
-            //Assert.True( "Hash Code Assert.True.Failed. 1");
             Assert.NotEqual(fkc.GetHashCode(), fkcDiff.GetHashCode());
         }
 

--- a/src/System.Data.Common/tests/System/Data/ForeignKeyConstraintTest.cs
+++ b/src/System.Data.Common/tests/System/Data/ForeignKeyConstraintTest.cs
@@ -209,7 +209,7 @@ namespace System.Data.Tests
             //catch (InvalidOperationException)
             //{
             //}
-            Exception ex = Assert.Throws<Exception>(() => fkc.Table);
+            Exception ex = Assert.ThrowsAny<Exception>(() => fkc.Table);
             Assert.True(ex is NullReferenceException || ex is InvalidOperationException);
 
 
@@ -260,7 +260,7 @@ namespace System.Data.Tests
             //catch (InvalidConstraintException e)
             //{ // Could not test on ms.net, as ms.net does not reach here so far.        
             //}
-            Exception ex2 = Assert.Throws<Exception>(() => table2.Constraints.AddRange(constraints));
+            Exception ex2 = Assert.ThrowsAny<Exception>(() => table2.Constraints.AddRange(constraints));
             Assert.True(ex2 is ArgumentException || ex2 is InvalidConstraintException);
 
 

--- a/src/System.Data.Common/tests/System/Data/ForeignKeyConstraintTest.cs
+++ b/src/System.Data.Common/tests/System/Data/ForeignKeyConstraintTest.cs
@@ -60,50 +60,50 @@ namespace System.Data.Tests
         [Fact]
         public void Ctor1()
         {
-            DataTable Table = _ds.Tables[0];
+            DataTable table = _ds.Tables[0];
 
-            Assert.Equal(0, Table.Constraints.Count);
-            Table = _ds.Tables[1];
-            Assert.Equal(0, Table.Constraints.Count);
+            Assert.Equal(0, table.Constraints.Count);
+            table = _ds.Tables[1];
+            Assert.Equal(0, table.Constraints.Count);
 
             // ctor (string, DataColumn, DataColumn
             ForeignKeyConstraint Constraint = new ForeignKeyConstraint("test", _ds.Tables[0].Columns[2], _ds.Tables[1].Columns[0]);
-            Table = _ds.Tables[1];
-            Table.Constraints.Add(Constraint);
+            table = _ds.Tables[1];
+            table.Constraints.Add(Constraint);
 
-            Assert.Equal(1, Table.Constraints.Count);
-            Assert.Equal("test", Table.Constraints[0].ConstraintName);
-            Assert.Equal(typeof(ForeignKeyConstraint), Table.Constraints[0].GetType());
+            Assert.Equal(1, table.Constraints.Count);
+            Assert.Equal("test", table.Constraints[0].ConstraintName);
+            Assert.Equal(typeof(ForeignKeyConstraint), table.Constraints[0].GetType());
 
-            Table = _ds.Tables[0];
-            Assert.Equal(1, Table.Constraints.Count);
-            Assert.Equal("Constraint1", Table.Constraints[0].ConstraintName);
-            Assert.Equal(typeof(UniqueConstraint), Table.Constraints[0].GetType());
+            table = _ds.Tables[0];
+            Assert.Equal(1, table.Constraints.Count);
+            Assert.Equal("Constraint1", table.Constraints[0].ConstraintName);
+            Assert.Equal(typeof(UniqueConstraint), table.Constraints[0].GetType());
         }
 
         // Tests ctor (DataColumn, DataColumn)
         [Fact]
         public void Ctor2()
         {
-            DataTable Table = _ds.Tables[0];
+            DataTable table = _ds.Tables[0];
 
-            Assert.Equal(0, Table.Constraints.Count);
-            Table = _ds.Tables[1];
-            Assert.Equal(0, Table.Constraints.Count);
+            Assert.Equal(0, table.Constraints.Count);
+            table = _ds.Tables[1];
+            Assert.Equal(0, table.Constraints.Count);
 
             // ctor (string, DataColumn, DataColumn
             ForeignKeyConstraint Constraint = new ForeignKeyConstraint(_ds.Tables[0].Columns[2], _ds.Tables[1].Columns[0]);
-            Table = _ds.Tables[1];
-            Table.Constraints.Add(Constraint);
+            table = _ds.Tables[1];
+            table.Constraints.Add(Constraint);
 
-            Assert.Equal(1, Table.Constraints.Count);
-            Assert.Equal("Constraint1", Table.Constraints[0].ConstraintName);
-            Assert.Equal(typeof(ForeignKeyConstraint), Table.Constraints[0].GetType());
+            Assert.Equal(1, table.Constraints.Count);
+            Assert.Equal("Constraint1", table.Constraints[0].ConstraintName);
+            Assert.Equal(typeof(ForeignKeyConstraint), table.Constraints[0].GetType());
 
-            Table = _ds.Tables[0];
-            Assert.Equal(1, Table.Constraints.Count);
-            Assert.Equal("Constraint1", Table.Constraints[0].ConstraintName);
-            Assert.Equal(typeof(UniqueConstraint), Table.Constraints[0].GetType());
+            table = _ds.Tables[0];
+            Assert.Equal(1, table.Constraints.Count);
+            Assert.Equal("Constraint1", table.Constraints[0].ConstraintName);
+            Assert.Equal(typeof(UniqueConstraint), table.Constraints[0].GetType());
         }
 
         // Test ctor (DataColumn [], DataColumn [])
@@ -197,17 +197,21 @@ namespace System.Data.Tests
             // Create a ForeingKeyConstraint Object using the constructor
             // ForeignKeyConstraint (string, string, string[], string[], AcceptRejectRule, Rule, Rule);
             ForeignKeyConstraint fkc = new ForeignKeyConstraint("hello world", parentTableName, parentColumnNames, childColumnNames, AcceptRejectRule.Cascade, Rule.Cascade, Rule.Cascade);                                                                                                                            // Assert that the Constraint object does not belong to any table yet
-            try
-            {
-                DataTable tmp = fkc.Table;
-                Assert.False(true);
-            }
-            catch (NullReferenceException)
-            { // actually .NET throws this (bug)
-            }
-            catch (InvalidOperationException)
-            {
-            }
+            //TODO
+            //try
+            //{
+            //    DataTable tmp = fkc.Table;
+            //    Assert.False(true);
+            //}
+            //catch (NullReferenceException)
+            //{ // actually .NET throws this (bug)
+            //}
+            //catch (InvalidOperationException)
+            //{
+            //}
+            Exception ex = Assert.Throws<Exception>(() => fkc.Table);
+            Assert.True(ex is NullReferenceException || ex is InvalidOperationException);
+
 
             Constraint[] constraints = new Constraint[3];
             constraints[0] = new UniqueConstraint(column1);
@@ -215,16 +219,18 @@ namespace System.Data.Tests
             constraints[2] = fkc;
 
             // Try to add the constraint to ConstraintCollection of the DataTable through Add()
-            try
-            {
-                table2.Constraints.Add(fkc);
-                throw new ApplicationException("An Exception was expected");
-            }
+            //try
+            //{
+            //    table2.Constraints.Add(fkc);
+            //    throw new ApplicationException("An Exception was expected");
+            //}
+            //TODO
             // spec says InvalidConstraintException but throws this
-            catch (NullReferenceException)
-            {
-            }
-
+            //catch (NullReferenceException)
+            //{
+            //}
+            Assert.Throws<NullReferenceException>(() => table2.Constraints.Add(fkc));
+            //TODO
 #if false // FIXME: Here this test crashes under MS.NET.
                         // OK - So AddRange() is the only way!
                         table2.Constraints.AddRange (constraints);
@@ -242,18 +248,23 @@ namespace System.Data.Tests
             constraints[0] = new UniqueConstraint(column1);
             constraints[1] = new UniqueConstraint(column2);
             constraints[2] = foreignKeyConstraint;
-            try
-            {
-                table2.Constraints.AddRange(constraints);
-                throw new ApplicationException("An Exception was expected");
-            }
-            catch (ArgumentException e)
-            {
-            }
-            catch (InvalidConstraintException e)
-            { // Could not test on ms.net, as ms.net does not reach here so far.
-            }
+            //TODO
+            //try
+            //{
+            //    table2.Constraints.AddRange(constraints);
+            //    throw new ApplicationException("An Exception was expected");
+            //}
+            //catch (ArgumentException e)
+            //{
+            //}
+            //catch (InvalidConstraintException e)
+            //{ // Could not test on ms.net, as ms.net does not reach here so far.        
+            //}
+            Exception ex2 = Assert.Throws<Exception>(() => table2.Constraints.AddRange(constraints));
+            Assert.True(ex2 is ArgumentException || ex2 is InvalidConstraintException);
 
+
+            //TODO
 #if false // FIXME: Here this test crashes under MS.NET.
                         // Check whether the child table really contains the foreign key constraint named "hello world"
                         Assert.True(table2.Constraints.Contains ("hello world"));
@@ -390,10 +401,10 @@ namespace System.Data.Tests
             Assert.True(fkc2.Equals(fkc));
             Assert.True(fkc.Equals(fkc));
 
-            Assert.True(fkc.Equals(fkcDiff) == false);
+            Assert.False(fkc.Equals(fkcDiff));
 
             //Assert.True( "Hash Code Assert.True.Failed. 1");
-            Assert.True(fkc.GetHashCode() != fkcDiff.GetHashCode());
+            Assert.NotEqual(fkc.GetHashCode(), fkcDiff.GetHashCode());
         }
 
         [Fact]

--- a/src/System.Data.Common/tests/System/Data/ForeignKeyConstraintTest.cs
+++ b/src/System.Data.Common/tests/System/Data/ForeignKeyConstraintTest.cs
@@ -470,7 +470,7 @@ namespace System.Data.Tests
             t2.Rows.Add(new object[] { 10 });
 
             t1.Rows[0][0] = 20;
-            Assert.True((int)t2.Rows[0][0] == 20);
+            Assert.Equal(20, (int)t2.Rows[0][0]);
         }
 
         [Fact]

--- a/src/System.Data.Common/tests/System/Data/ForeignKeyConstraintTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/ForeignKeyConstraintTest2.cs
@@ -137,12 +137,12 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public void acceptRejectRule()
+        public void AcceptRejectRule()
         {
-            DataSet ds = getNewDataSet();
+            DataSet ds = GetNewDataSet();
 
             ForeignKeyConstraint fc = new ForeignKeyConstraint(ds.Tables[0].Columns[0], ds.Tables[1].Columns[0]);
-            fc.AcceptRejectRule = AcceptRejectRule.Cascade;
+            fc.AcceptRejectRule = Data.AcceptRejectRule.Cascade;
             ds.Tables[1].Constraints.Add(fc);
 
             //Update the parent
@@ -152,19 +152,9 @@ namespace System.Data.Tests
             ds.Tables[0].RejectChanges();
             Assert.Equal(0, ds.Tables[1].Select("ParentId=777").Length);
         }
-        private DataSet getNewDataSet()
-        {
-            DataSet ds1 = new DataSet();
-            ds1.Tables.Add(DataProvider.CreateParentDataTable());
-            ds1.Tables.Add(DataProvider.CreateChildDataTable());
-            //    ds1.Tables.Add(DataProvider.CreateChildDataTable());
-            ds1.Tables[0].PrimaryKey = new DataColumn[] { ds1.Tables[0].Columns[0] };
-
-            return ds1;
-        }
 
         [Fact]
-        public void constraintName()
+        public void ConstraintName()
         {
             var ds = new DataSet();
             DataTable dtParent = DataProvider.CreateParentDataTable();
@@ -185,7 +175,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public void ctor_ParentColChildCol()
+        public void Ctor_ParentColChildCol()
         {
             DataTable dtParent = DataProvider.CreateParentDataTable();
             DataTable dtChild = DataProvider.CreateChildDataTable();
@@ -223,7 +213,6 @@ namespace System.Data.Tests
 
             fc = new ForeignKeyConstraint(new DataColumn[] { dtParent.Columns[0] }, new DataColumn[] { dtChild.Columns[0] });
             // Ctor
-            Assert.False(fc == null);
 
             // Child Table Constraints Count
             Assert.Equal(0, dtChild.Constraints.Count);
@@ -275,39 +264,33 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public void ctor_NameParentColChildCol()
+        public void Ctor_NameParentColChildCol()
         {
             DataTable dtParent = DataProvider.CreateParentDataTable();
             DataTable dtChild = DataProvider.CreateChildDataTable();
 
             ForeignKeyConstraint fc = null;
             fc = new ForeignKeyConstraint("myForeignKey", dtParent.Columns[0], dtChild.Columns[0]);
-
             // Ctor
-            Assert.False(fc == null);
 
             // Ctor - name
             Assert.Equal("myForeignKey", fc.ConstraintName);
         }
 
         [Fact]
-        public void ctor_NameParentColsChildCols()
+        public void Ctor_NameParentColsChildCols()
         {
             DataTable dtParent = DataProvider.CreateParentDataTable();
             DataTable dtChild = DataProvider.CreateChildDataTable();
-
-            ForeignKeyConstraint fc = null;
-            fc = new ForeignKeyConstraint("myForeignKey", new DataColumn[] { dtParent.Columns[0] }, new DataColumn[] { dtChild.Columns[0] });
-
+            ForeignKeyConstraint fc = new ForeignKeyConstraint("myForeignKey", new DataColumn[] { dtParent.Columns[0] }, new DataColumn[] { dtChild.Columns[0] });
             // Ctor
-            Assert.False(fc == null);
 
             // Ctor - name
             Assert.Equal("myForeignKey", fc.ConstraintName);
         }
 
         [Fact]
-        public void deleteRule()
+        public void DeleteRule()
         {
             var ds = new DataSet();
             DataTable dtParent = DataProvider.CreateParentDataTable();
@@ -374,7 +357,7 @@ namespace System.Data.Tests
             ds1.Tables[1].AcceptChanges();
 
             DataRow[] arr = ds1.Tables[1].Select("ChildId is null");
-
+            //TODO
             /*foreach (DataRow dr in arr)
                     {
                         Assert.Null(dr["ChildId"]);
@@ -383,6 +366,7 @@ namespace System.Data.Tests
             Assert.Equal(4, arr.Length);
 
             // Rule = SetDefault
+            //TODO
             //fc.DeleteRule = Rule.SetDefault;
             ds1 = new DataSet();
             ds1.Tables.Add(DataProvider.CreateParentDataTable());
@@ -404,7 +388,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public void extendedProperties()
+        public void ExtendedProperties()
         {
             DataTable dtParent = DataProvider.CreateParentDataTable();
             DataTable dtChild = DataProvider.CreateParentDataTable();
@@ -414,26 +398,22 @@ namespace System.Data.Tests
 
             PropertyCollection pc = fc.ExtendedProperties;
 
-            // Checking ExtendedProperties default
-            Assert.True(fc != null);
+            // Checking ExtendedProperties default 
+            Assert.NotNull(pc);
 
             // Checking ExtendedProperties count
             Assert.Equal(0, pc.Count);
         }
 
         [Fact]
-        public void ctor_DclmDclm()
+        public void Ctor_DclmDclm()
         {
             DataTable dtParent = DataProvider.CreateParentDataTable();
             DataTable dtChild = DataProvider.CreateChildDataTable();
             var ds = new DataSet();
             ds.Tables.Add(dtChild);
             ds.Tables.Add(dtParent);
-
-            ForeignKeyConstraint fc = null;
-            fc = new ForeignKeyConstraint(dtParent.Columns[0], dtChild.Columns[0]);
-
-            Assert.False(fc == null);
+            ForeignKeyConstraint fc = new ForeignKeyConstraint(dtParent.Columns[0], dtChild.Columns[0]);
 
             Assert.Equal(0, dtChild.Constraints.Count);
 
@@ -471,7 +451,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public void ctor_DclmDclm1()
+        public void Ctor_DclmDclm1()
         {
             Assert.Throws<NullReferenceException>(() =>
             {
@@ -480,7 +460,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public void ctor_DclmDclm2()
+        public void Ctor_DclmDclm2()
         {
             AssertExtensions.Throws<ArgumentException>(null, () =>
             {
@@ -494,7 +474,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public void ctor_DclmDclm3()
+        public void Ctor_DclmDclm3()
         {
             AssertExtensions.Throws<ArgumentException>(null, () =>
             {
@@ -529,7 +509,7 @@ namespace System.Data.Tests
         [Fact]
         public void UpdateRule2()
         {
-            Assert.Throws<ConstraintException>(() =>
+            Assert.Throws<ConstraintException>((Action)(() =>
             {
                 DataSet ds = GetNewDataSet();
                 ds.Tables[0].PrimaryKey = null;
@@ -540,12 +520,12 @@ namespace System.Data.Tests
                 //Changing parent row
 
                 ds.Tables[0].Rows[0]["ParentId"] = 5;
-
+                //TODO
                 /*ds.Tables[0].AcceptChanges();
                 ds.Tables[1].AcceptChanges();
                 //Checking the table
                 Compare(ds.Tables[1].Select("ParentId=8").Length ,0);*/
-            });
+            }));
         }
 
         [Fact]
@@ -618,13 +598,8 @@ namespace System.Data.Tests
 
             t2.Constraints.Clear();
             t2.Columns[0].DateTimeMode = DataSetDateTime.Local;
-            try
-            {
-                // DataColumn type shud not match, and exception shud be raised
-                t2.Constraints.Add("fk", t1.Columns[0], t2.Columns[0]);
-                Assert.False(true);
-            }
-            catch (InvalidOperationException e) { }
+            // DataColumn type should not match, and exception should be raised
+            Assert.Throws<InvalidOperationException>(() => t2.Constraints.Add("fk", t1.Columns[0], t2.Columns[0]));
         }
 
         [Fact]

--- a/src/System.Data.Common/tests/System/Data/ForeignKeyConstraintTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/ForeignKeyConstraintTest2.cs
@@ -396,7 +396,7 @@ namespace System.Data.Tests
 
             PropertyCollection pc = fc.ExtendedProperties;
 
-            // Checking ExtendedProperties default 
+            // Checking ExtendedProperties default
             Assert.NotNull(pc);
 
             // Checking ExtendedProperties count

--- a/src/System.Data.Common/tests/System/Data/ForeignKeyConstraintTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/ForeignKeyConstraintTest2.cs
@@ -357,7 +357,6 @@ namespace System.Data.Tests
             ds1.Tables[1].AcceptChanges();
 
             DataRow[] arr = ds1.Tables[1].Select("ChildId is null");
-            //TODO
             /*foreach (DataRow dr in arr)
                     {
                         Assert.Null(dr["ChildId"]);
@@ -366,7 +365,6 @@ namespace System.Data.Tests
             Assert.Equal(4, arr.Length);
 
             // Rule = SetDefault
-            //TODO
             //fc.DeleteRule = Rule.SetDefault;
             ds1 = new DataSet();
             ds1.Tables.Add(DataProvider.CreateParentDataTable());
@@ -509,7 +507,7 @@ namespace System.Data.Tests
         [Fact]
         public void UpdateRule2()
         {
-            Assert.Throws<ConstraintException>((Action)(() =>
+            Assert.Throws<ConstraintException>(() =>
             {
                 DataSet ds = GetNewDataSet();
                 ds.Tables[0].PrimaryKey = null;
@@ -520,12 +518,11 @@ namespace System.Data.Tests
                 //Changing parent row
 
                 ds.Tables[0].Rows[0]["ParentId"] = 5;
-                //TODO
                 /*ds.Tables[0].AcceptChanges();
                 ds.Tables[1].AcceptChanges();
                 //Checking the table
                 Compare(ds.Tables[1].Select("ParentId=8").Length ,0);*/
-            }));
+            });
         }
 
         [Fact]

--- a/src/System.Data.Common/tests/System/Data/InRowChangingEventExceptionTest.cs
+++ b/src/System.Data.Common/tests/System/Data/InRowChangingEventExceptionTest.cs
@@ -30,7 +30,7 @@ namespace System.Data.Tests
 {
     public class InRowChangingEventExceptionTest
     {
-        private bool _EventTriggered = false;
+        private bool _eventTriggered = false;
         [Fact]
         public void Generate()
         {
@@ -41,7 +41,7 @@ namespace System.Data.Tests
 
             //this event must be raised in order to test the exception
             // RowChanging - Event raised
-            Assert.True(_EventTriggered);
+            Assert.True(_eventTriggered);
         }
 
         private void Row_Changing(object sender, DataRowChangeEventArgs e)
@@ -51,7 +51,7 @@ namespace System.Data.Tests
             {
                 e.Row.EndEdit(); //can't invoke EndEdit while in ChangingEvent
             });
-            _EventTriggered = true;
+            _eventTriggered = true;
         }
     }
 }

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlBinaryTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlBinaryTest.cs
@@ -39,17 +39,9 @@ namespace System.Data.Tests.SqlTypes
 
         public SqlBinaryTest()
         {
-            byte[] b1 = new byte[2];
-            byte[] b2 = new byte[3];
-            byte[] b3 = new byte[2];
-
-            b1[0] = 240;
-            b1[1] = 15;
-            b2[0] = 10;
-            b2[1] = 10;
-            b2[2] = 10;
-            b3[0] = 240;
-            b3[1] = 15;
+            byte[] b1 = new byte[2] { 240, 15 };
+            byte[] b2 = new byte[3] { 10, 10, 10 };
+            byte[] b3 = new byte[2] { 240, 15 };
 
             _test1 = new SqlBinary(b1);
             _test2 = new SqlBinary(b2);
@@ -61,8 +53,8 @@ namespace System.Data.Tests.SqlTypes
         public void Create()
         {
             byte[] b = new byte[3];
-            SqlBinary Test = new SqlBinary(b);
-            Assert.True(!(Test.IsNull));
+            SqlBinary test = new SqlBinary(b);
+            Assert.False(test.IsNull);
         }
 
         // Test public fields
@@ -76,67 +68,32 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void Properties()
         {
-            byte[] b = new byte[2];
-            b[0] = 64;
-            b[1] = 128;
+            byte[] b = new byte[2] { 64, 128 };
 
-            SqlBinary TestBinary = new SqlBinary(b);
+            SqlBinary testBinary = new SqlBinary(b);
 
             // IsNull
             Assert.True(SqlBinary.Null.IsNull);
 
             // Item
-            Assert.Equal((byte)128, TestBinary[1]);
-            Assert.Equal((byte)64, TestBinary[0]);
+            Assert.Equal((byte)128, testBinary[1]);
+            Assert.Equal((byte)64, testBinary[0]);
 
-            // FIXME: MSDN says that should throw SqlNullValueException
-            // but throws IndexOutOfRangeException
-            try
-            {
-                byte test = TestBinary[TestBinary.Length];
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(IndexOutOfRangeException), e.GetType());
-            }
+            // See https://github.com/dotnet/corefx/issues/39883
+            Assert.Throws<IndexOutOfRangeException>(() => testBinary[testBinary.Length]);
 
-            try
-            {
-                byte test = SqlBinary.Null[2];
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(SqlNullValueException), e.GetType());
-            }
+            Assert.Throws<SqlNullValueException>(() => SqlBinary.Null[2]);
 
             // Length
-            Assert.Equal(2, TestBinary.Length);
+            Assert.Equal(2, testBinary.Length);
 
-            try
-            {
-                int test = SqlBinary.Null.Length;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(SqlNullValueException), e.GetType());
-            }
+            Assert.Throws<SqlNullValueException>(() => SqlBinary.Null.Length);
 
             // Value
-            Assert.Equal((byte)128, TestBinary[1]);
-            Assert.Equal((byte)64, TestBinary[0]);
+            Assert.Equal((byte)128, testBinary[1]);
+            Assert.Equal((byte)64, testBinary[0]);
 
-            try
-            {
-                byte[] test = SqlBinary.Null.Value;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(SqlNullValueException), e.GetType());
-            }
+            Assert.Throws<SqlNullValueException>(() => SqlBinary.Null.Value);
         }
 
         // Methods
@@ -146,86 +103,72 @@ namespace System.Data.Tests.SqlTypes
             // GreaterThan
             Assert.True(SqlBinary.GreaterThan(_test1, _test2).Value);
             Assert.True(SqlBinary.GreaterThan(_test3, _test2).Value);
-            Assert.True(!SqlBinary.GreaterThan(_test2, _test1).Value);
+            Assert.False(SqlBinary.GreaterThan(_test2, _test1).Value);
 
             // GreaterThanOrEqual
             Assert.True(SqlBinary.GreaterThanOrEqual(_test1, _test2).Value);
             Assert.True(SqlBinary.GreaterThanOrEqual(_test1, _test2).Value);
-            Assert.True(!SqlBinary.GreaterThanOrEqual(_test2, _test1).Value);
+            Assert.False(SqlBinary.GreaterThanOrEqual(_test2, _test1).Value);
 
             // LessThan
-            Assert.True(!SqlBinary.LessThan(_test1, _test2).Value);
-            Assert.True(!SqlBinary.LessThan(_test3, _test2).Value);
+            Assert.False(SqlBinary.LessThan(_test1, _test2).Value);
+            Assert.False(SqlBinary.LessThan(_test3, _test2).Value);
             Assert.True(SqlBinary.LessThan(_test2, _test1).Value);
 
             // LessThanOrEqual
-            Assert.True(!SqlBinary.LessThanOrEqual(_test1, _test2).Value);
+            Assert.False(SqlBinary.LessThanOrEqual(_test1, _test2).Value);
             Assert.True(SqlBinary.LessThanOrEqual(_test3, _test1).Value);
             Assert.True(SqlBinary.LessThanOrEqual(_test2, _test1).Value);
 
             // Equals
-            Assert.True(!_test1.Equals(_test2));
-            Assert.True(!_test3.Equals(_test2));
+            Assert.False(_test1.Equals(_test2));
+            Assert.False(_test3.Equals(_test2));
             Assert.True(_test3.Equals(_test1));
 
             // NotEquals
             Assert.True(SqlBinary.NotEquals(_test1, _test2).Value);
-            Assert.True(!SqlBinary.NotEquals(_test3, _test1).Value);
+            Assert.False(SqlBinary.NotEquals(_test3, _test1).Value);
             Assert.True(SqlBinary.NotEquals(_test2, _test1).Value);
         }
 
         [Fact]
         public void CompareTo()
         {
-            SqlString TestString = new SqlString("This is a test");
+            SqlString testString = new SqlString("This is a test");
 
             Assert.True(_test1.CompareTo(_test2) > 0);
             Assert.True(_test2.CompareTo(_test1) < 0);
             Assert.True(_test1.CompareTo(_test3) == 0);
 
-            try
-            {
-                _test1.CompareTo(TestString);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(ArgumentException), e.GetType());
-            }
+            Assert.Throws<ArgumentException>(() => _test1.CompareTo(testString));
         }
 
         [Fact]
         public void GetHashCodeTest()
         {
             Assert.Equal(_test1.GetHashCode(), _test1.GetHashCode());
-            Assert.True(_test2.GetHashCode() != _test1.GetHashCode());
-        }
-
-        [Fact]
-        public void GetTypeTest()
-        {
-            Assert.Equal("System.Data.SqlTypes.SqlBinary", _test1.GetType().ToString());
+            Assert.NotEqual(_test2.GetHashCode(), _test1.GetHashCode());
         }
 
         [Fact]
         public void Concat()
         {
-            SqlBinary TestBinary;
+            SqlBinary testBinary;
 
-            TestBinary = SqlBinary.Concat(_test2, _test3);
-            Assert.Equal((byte)15, TestBinary[4]);
+            testBinary = SqlBinary.Concat(_test2, _test3);
+            Assert.Equal((byte)15, testBinary[4]);
 
-            TestBinary = SqlBinary.Concat(_test1, _test2);
-            Assert.Equal((byte)240, TestBinary[0]);
-            Assert.Equal((byte)15, TestBinary[1]);
+            testBinary = SqlBinary.Concat(_test1, _test2);
+            Assert.Equal((byte)240, testBinary[0]);
+            Assert.Equal((byte)15, testBinary[1]);
         }
 
         [Fact]
         public void ToSqlGuid()
         {
-            SqlBinary TestBinary = new SqlBinary(new byte[16]);
-            SqlGuid TestGuid = TestBinary.ToSqlGuid();
-            Assert.True(!TestGuid.IsNull);
+            SqlBinary testBinary = new SqlBinary(new byte[16]);
+            SqlGuid testGuid = testBinary.ToSqlGuid();
+            Assert.False(testGuid.IsNull);
         }
 
         [Fact]
@@ -239,21 +182,21 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void AdditionOperator()
         {
-            SqlBinary TestBinary = _test1 + _test2;
-            Assert.Equal((byte)240, TestBinary[0]);
-            Assert.Equal((byte)15, TestBinary[1]);
+            SqlBinary testBinary = _test1 + _test2;
+            Assert.Equal((byte)240, testBinary[0]);
+            Assert.Equal((byte)15, testBinary[1]);
         }
 
         [Fact]
         public void ComparisonOperators()
         {
             // Equality
-            Assert.True(!(_test1 == _test2).Value);
+            Assert.False((_test1 == _test2).Value);
             Assert.True((_test3 == _test1).Value);
 
             // Greater than
             Assert.True((_test1 > _test2).Value);
-            Assert.True(!(_test3 > _test1).Value);
+            Assert.False((_test3 > _test1).Value);
 
             // Greater than or equal
             Assert.True((_test1 >= _test2).Value);
@@ -261,44 +204,42 @@ namespace System.Data.Tests.SqlTypes
 
             // Inequality
             Assert.True((_test1 != _test2).Value);
-            Assert.True(!(_test3 != _test1).Value);
+            Assert.False((_test3 != _test1).Value);
 
             // Less than
-            Assert.True(!(_test1 < _test2).Value);
-            Assert.True(!(_test3 < _test2).Value);
+            Assert.False((_test1 < _test2).Value);
+            Assert.False((_test3 < _test2).Value);
 
             // Less than or equal
-            Assert.True(!(_test1 <= _test2).Value);
+            Assert.False((_test1 <= _test2).Value);
             Assert.True((_test3 <= _test1).Value);
         }
 
         [Fact]
         public void SqlBinaryToByteArray()
         {
-            byte[] TestByteArray = (byte[])_test1;
-            Assert.Equal((byte)240, TestByteArray[0]);
+            byte[] testByteArray = (byte[])_test1;
+            Assert.Equal((byte)240, testByteArray[0]);
         }
 
         [Fact]
         public void SqlGuidToSqlBinary()
         {
-            byte[] TestByteArray = new byte[16];
-            TestByteArray[0] = 15;
-            TestByteArray[1] = 200;
-            SqlGuid TestGuid = new SqlGuid(TestByteArray);
+            byte[] testByteArray = new byte[16];
+            testByteArray[0] = 15;
+            testByteArray[1] = 200;
+            SqlGuid testGuid = new SqlGuid(testByteArray);
 
-            SqlBinary TestBinary = (SqlBinary)TestGuid;
-            Assert.Equal((byte)15, TestBinary[0]);
+            SqlBinary testBinary = (SqlBinary)testGuid;
+            Assert.Equal((byte)15, testBinary[0]);
         }
 
         [Fact]
         public void ByteArrayToSqlBinary()
         {
-            byte[] TestByteArray = new byte[2];
-            TestByteArray[0] = 15;
-            TestByteArray[1] = 200;
-            SqlBinary TestBinary = TestByteArray;
-            Assert.Equal((byte)15, TestBinary[0]);
+            byte[] testByteArray = new byte[2] { 15, 200 };
+            SqlBinary testBinary = testByteArray;
+            Assert.Equal((byte)15, testBinary[0]);
         }
         [Fact]
         public void GetXsdTypeTest()

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlBinaryTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlBinaryTest.cs
@@ -138,7 +138,7 @@ namespace System.Data.Tests.SqlTypes
 
             Assert.True(_test1.CompareTo(_test2) > 0);
             Assert.True(_test2.CompareTo(_test1) < 0);
-            Assert.True(_test1.CompareTo(_test3) == 0);
+            Assert.Equal(0, _test1.CompareTo(_test3));
 
             Assert.Throws<ArgumentException>(() => _test1.CompareTo(testString));
         }

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlBooleanTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlBooleanTest.cs
@@ -231,7 +231,7 @@ namespace System.Data.Tests.SqlTypes
             Assert.True((_sqlTrue.CompareTo(SqlBoolean.Null) > 0));
             Assert.True((_sqlTrue.CompareTo(_sqlFalse) > 0));
             Assert.True((_sqlFalse.CompareTo(_sqlTrue) < 0));
-            Assert.True((_sqlFalse.CompareTo(_sqlFalse) == 0));
+            Assert.Equal(0, _sqlFalse.CompareTo(_sqlFalse));
         }
 
         // Equals

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlBooleanTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlBooleanTest.cs
@@ -27,7 +27,6 @@
 using Xunit;
 using System.Xml;
 using System.Data.SqlTypes;
-using System.Globalization;
 
 namespace System.Data.Tests.SqlTypes
 {
@@ -45,13 +44,13 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void Create()
         {
-            SqlBoolean SqlTrue2 = new SqlBoolean(1);
-            SqlBoolean SqlFalse2 = new SqlBoolean(0);
+            SqlBoolean sqlTrue2 = new SqlBoolean(1);
+            SqlBoolean sqlFalse2 = new SqlBoolean(0);
 
             Assert.True(_sqlTrue.Value);
-            Assert.True(SqlTrue2.Value);
-            Assert.True(!_sqlFalse.Value);
-            Assert.True(!SqlFalse2.Value);
+            Assert.True(sqlTrue2.Value);
+            Assert.False(_sqlFalse.Value);
+            Assert.False(sqlFalse2.Value);
         }
 
         ////
@@ -62,103 +61,102 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void And()
         {
-            SqlBoolean SqlTrue2 = new SqlBoolean(true);
-            SqlBoolean SqlFalse2 = new SqlBoolean(false);
+            SqlBoolean sqlTrue2 = new SqlBoolean(true);
+            SqlBoolean sqlFalse2 = new SqlBoolean(false);
 
             // One result value
             SqlBoolean sqlResult;
 
             // true && false
             sqlResult = SqlBoolean.And(_sqlTrue, _sqlFalse);
-            Assert.True(!sqlResult.Value);
+            Assert.False(sqlResult.Value);
             sqlResult = SqlBoolean.And(_sqlFalse, _sqlTrue);
-            Assert.True(!sqlResult.Value);
+            Assert.False(sqlResult.Value);
 
             // true && true
-            sqlResult = SqlBoolean.And(_sqlTrue, SqlTrue2);
+            sqlResult = SqlBoolean.And(_sqlTrue, sqlTrue2);
             Assert.True(sqlResult.Value);
 
             sqlResult = SqlBoolean.And(_sqlTrue, _sqlTrue);
             Assert.True(sqlResult.Value);
 
             // false && false
-            sqlResult = SqlBoolean.And(_sqlFalse, SqlFalse2);
-            Assert.True(!sqlResult.Value);
+            sqlResult = SqlBoolean.And(_sqlFalse, sqlFalse2);
+            Assert.False(sqlResult.Value);
             sqlResult = SqlBoolean.And(_sqlFalse, _sqlFalse);
-            Assert.True(!sqlResult.Value);
+            Assert.False(sqlResult.Value);
         }
 
         // NotEquals
         [Fact]
         public void NotEquals()
         {
-            SqlBoolean SqlTrue2 = new SqlBoolean(true);
-            SqlBoolean SqlFalse2 = new SqlBoolean(false);
+            SqlBoolean sqlTrue2 = new SqlBoolean(true);
 
-            SqlBoolean SqlResult;
+            SqlBoolean sqlResult;
 
             // true != false
-            SqlResult = SqlBoolean.NotEquals(_sqlTrue, _sqlFalse);
-            Assert.True(SqlResult.Value);
-            SqlResult = SqlBoolean.NotEquals(_sqlFalse, _sqlTrue);
-            Assert.True(SqlResult.Value);
+            sqlResult = SqlBoolean.NotEquals(_sqlTrue, _sqlFalse);
+            Assert.True(sqlResult.Value);
+            sqlResult = SqlBoolean.NotEquals(_sqlFalse, _sqlTrue);
+            Assert.True(sqlResult.Value);
 
 
             // true != true
-            SqlResult = SqlBoolean.NotEquals(_sqlTrue, _sqlTrue);
-            Assert.True(!SqlResult.Value);
-            SqlResult = SqlBoolean.NotEquals(_sqlTrue, SqlTrue2);
-            Assert.True(!SqlResult.Value);
+            sqlResult = SqlBoolean.NotEquals(_sqlTrue, _sqlTrue);
+            Assert.False(sqlResult.Value);
+            sqlResult = SqlBoolean.NotEquals(_sqlTrue, sqlTrue2);
+            Assert.False(sqlResult.Value);
             // false != false
-            SqlResult = SqlBoolean.NotEquals(_sqlFalse, _sqlFalse);
-            Assert.True(!SqlResult.Value);
-            SqlResult = SqlBoolean.NotEquals(_sqlTrue, SqlTrue2);
-            Assert.True(!SqlResult.Value);
+            sqlResult = SqlBoolean.NotEquals(_sqlFalse, _sqlFalse);
+            Assert.False(sqlResult.Value);
+            sqlResult = SqlBoolean.NotEquals(_sqlTrue, sqlTrue2);
+            Assert.False(sqlResult.Value);
 
             // If either instance of SqlBoolean is null, the Value of the SqlBoolean will be Null.
-            SqlResult = SqlBoolean.NotEquals(SqlBoolean.Null, _sqlFalse);
-            Assert.True(SqlResult.IsNull);
-            SqlResult = SqlBoolean.NotEquals(_sqlTrue, SqlBoolean.Null);
-            Assert.True(SqlResult.IsNull);
+            sqlResult = SqlBoolean.NotEquals(SqlBoolean.Null, _sqlFalse);
+            Assert.True(sqlResult.IsNull);
+            sqlResult = SqlBoolean.NotEquals(_sqlTrue, SqlBoolean.Null);
+            Assert.True(sqlResult.IsNull);
         }
 
         // OnesComplement
         [Fact]
         public void OnesComplement()
         {
-            SqlBoolean SqlFalse2 = SqlBoolean.OnesComplement(_sqlTrue);
-            Assert.True(!SqlFalse2.Value);
+            SqlBoolean sqlFalse2 = SqlBoolean.OnesComplement(_sqlTrue);
+            Assert.False(sqlFalse2.Value);
 
-            SqlBoolean SqlTrue2 = SqlBoolean.OnesComplement(_sqlFalse);
-            Assert.True(SqlTrue2.Value);
+            SqlBoolean sqlTrue2 = SqlBoolean.OnesComplement(_sqlFalse);
+            Assert.True(sqlTrue2.Value);
         }
 
         // Or
         [Fact]
         public void Or()
         {
-            SqlBoolean SqlTrue2 = new SqlBoolean(true);
-            SqlBoolean SqlFalse2 = new SqlBoolean(false);
+            SqlBoolean sqlTrue2 = new SqlBoolean(true);
+            SqlBoolean sqlFalse2 = new SqlBoolean(false);
 
-            SqlBoolean SqlResult;
+            SqlBoolean sqlResult;
 
             // true || false
-            SqlResult = SqlBoolean.Or(_sqlTrue, _sqlFalse);
-            Assert.True(SqlResult.Value);
-            SqlResult = SqlBoolean.Or(_sqlFalse, _sqlTrue);
-            Assert.True(SqlResult.Value);
+            sqlResult = SqlBoolean.Or(_sqlTrue, _sqlFalse);
+            Assert.True(sqlResult.Value);
+            sqlResult = SqlBoolean.Or(_sqlFalse, _sqlTrue);
+            Assert.True(sqlResult.Value);
 
             // true || true
-            SqlResult = SqlBoolean.Or(_sqlTrue, _sqlTrue);
-            Assert.True(SqlResult.Value);
-            SqlResult = SqlBoolean.Or(_sqlTrue, SqlTrue2);
-            Assert.True(SqlResult.Value);
+            sqlResult = SqlBoolean.Or(_sqlTrue, _sqlTrue);
+            Assert.True(sqlResult.Value);
+            sqlResult = SqlBoolean.Or(_sqlTrue, sqlTrue2);
+            Assert.True(sqlResult.Value);
 
             // false || false
-            SqlResult = SqlBoolean.Or(_sqlFalse, _sqlFalse);
-            Assert.True(!SqlResult.Value);
-            SqlResult = SqlBoolean.Or(_sqlFalse, SqlFalse2);
-            Assert.True(!SqlResult.Value);
+            sqlResult = SqlBoolean.Or(_sqlFalse, _sqlFalse);
+            Assert.False(sqlResult.Value);
+            sqlResult = SqlBoolean.Or(_sqlFalse, sqlFalse2);
+            Assert.False(sqlResult.Value);
         }
 
 
@@ -166,55 +164,52 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void Parse()
         {
-            string error = "Parse method does not work correctly ";
-
             Assert.True(SqlBoolean.Parse("True").Value);
             Assert.True(SqlBoolean.Parse(" True").Value);
             Assert.True(SqlBoolean.Parse("True ").Value);
             Assert.True(SqlBoolean.Parse("tRuE").Value);
-            Assert.True(!SqlBoolean.Parse("False").Value);
-            Assert.True(!SqlBoolean.Parse(" False").Value);
-            Assert.True(!SqlBoolean.Parse("False ").Value);
-            Assert.True(!SqlBoolean.Parse("fAlSe").Value);
+            Assert.False(SqlBoolean.Parse("False").Value);
+            Assert.False(SqlBoolean.Parse(" False").Value);
+            Assert.False(SqlBoolean.Parse("False ").Value);
+            Assert.False(SqlBoolean.Parse("fAlSe").Value);
         }
 
         // Xor
         [Fact]
         public void Xor()
         {
-            SqlBoolean SqlTrue2 = new SqlBoolean(true);
-            SqlBoolean SqlFalse2 = new SqlBoolean(false);
+            SqlBoolean sqlTrue2 = new SqlBoolean(true);
+            SqlBoolean sqlFalse2 = new SqlBoolean(false);
 
-            SqlBoolean SqlResult;
+            SqlBoolean sqlResult;
 
             // true ^ false
-            SqlResult = SqlBoolean.Xor(_sqlTrue, _sqlFalse);
-            Assert.True(SqlResult.Value);
-            SqlResult = SqlBoolean.Xor(_sqlFalse, _sqlTrue);
-            Assert.True(SqlResult.Value);
+            sqlResult = SqlBoolean.Xor(_sqlTrue, _sqlFalse);
+            Assert.True(sqlResult.Value);
+            sqlResult = SqlBoolean.Xor(_sqlFalse, _sqlTrue);
+            Assert.True(sqlResult.Value);
 
             // true ^ true
-            SqlResult = SqlBoolean.Xor(_sqlTrue, SqlTrue2);
-            Assert.True(!SqlResult.Value);
+            sqlResult = SqlBoolean.Xor(_sqlTrue, sqlTrue2);
+            Assert.False(sqlResult.Value);
 
             // false ^ false
-            SqlResult = SqlBoolean.Xor(_sqlFalse, SqlFalse2);
-            Assert.True(!SqlResult.Value);
+            sqlResult = SqlBoolean.Xor(_sqlFalse, sqlFalse2);
+            Assert.False(sqlResult.Value);
         }
 
         // static Equals
         [Fact]
         public void StaticEquals()
         {
-            SqlBoolean SqlTrue2 = new SqlBoolean(true);
-            SqlBoolean SqlFalse2 = new SqlBoolean(false);
-            string error = "Static Equals method does not work correctly ";
+            SqlBoolean sqlTrue2 = new SqlBoolean(true);
+            SqlBoolean sqlFalse2 = new SqlBoolean(false);
 
-            Assert.True(SqlBoolean.Equals(_sqlTrue, SqlTrue2).Value);
-            Assert.True(SqlBoolean.Equals(_sqlFalse, SqlFalse2).Value);
+            Assert.True(SqlBoolean.Equals(_sqlTrue, sqlTrue2).Value);
+            Assert.True(SqlBoolean.Equals(_sqlFalse, sqlFalse2).Value);
 
-            Assert.True(!SqlBoolean.Equals(_sqlTrue, _sqlFalse).Value);
-            Assert.True(!SqlBoolean.Equals(_sqlFalse, _sqlTrue).Value);
+            Assert.False(SqlBoolean.Equals(_sqlTrue, _sqlFalse).Value);
+            Assert.False(SqlBoolean.Equals(_sqlFalse, _sqlTrue).Value);
 
             Assert.Equal(SqlBoolean.Null, SqlBoolean.Equals(SqlBoolean.Null, _sqlFalse));
             Assert.Equal(SqlBoolean.Null, SqlBoolean.Equals(_sqlTrue, SqlBoolean.Null));
@@ -232,7 +227,6 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void CompareTo()
         {
-            string error = "CompareTo method does not work correctly";
 
             Assert.True((_sqlTrue.CompareTo(SqlBoolean.Null) > 0));
             Assert.True((_sqlTrue.CompareTo(_sqlFalse) > 0));
@@ -244,20 +238,19 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void Equals()
         {
-            SqlBoolean SqlTrue2 = new SqlBoolean(true);
-            SqlBoolean SqlFalse2 = new SqlBoolean(false);
+            SqlBoolean sqlTrue2 = new SqlBoolean(true);
+            SqlBoolean sqlFalse2 = new SqlBoolean(false);
 
-            string error = "Equals method does not work correctly ";
-            Assert.True(_sqlTrue.Equals(SqlTrue2));
-            Assert.True(_sqlFalse.Equals(SqlFalse2));
+            Assert.True(_sqlTrue.Equals(sqlTrue2));
+            Assert.True(_sqlFalse.Equals(sqlFalse2));
 
-            Assert.True(!_sqlTrue.Equals(_sqlFalse));
-            Assert.True(!_sqlFalse.Equals(_sqlTrue));
+            Assert.False(_sqlTrue.Equals(_sqlFalse));
+            Assert.False(_sqlFalse.Equals(_sqlTrue));
 
             Assert.False(_sqlTrue.Equals(SqlBoolean.Null));
             Assert.False(_sqlFalse.Equals(SqlBoolean.Null));
 
-            Assert.True(!_sqlTrue.Equals(null));
+            Assert.False(_sqlTrue.Equals(null));
             Assert.True(SqlBoolean.Null.Equals(SqlBoolean.Null));
             Assert.False(SqlBoolean.Null.Equals(_sqlTrue));
             Assert.False(SqlBoolean.Null.Equals(_sqlFalse));
@@ -282,129 +275,118 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void ToSqlByte()
         {
-            SqlByte SqlTestByte;
+            SqlByte sqlTestByte;
 
-            string error = "ToSqlByte method does not work correctly ";
+            sqlTestByte = _sqlTrue.ToSqlByte();
+            Assert.Equal((byte)1, sqlTestByte.Value);
 
-            SqlTestByte = _sqlTrue.ToSqlByte();
-            Assert.Equal((byte)1, SqlTestByte.Value);
-
-            SqlTestByte = _sqlFalse.ToSqlByte();
-            Assert.Equal((byte)0, SqlTestByte.Value);
+            sqlTestByte = _sqlFalse.ToSqlByte();
+            Assert.Equal((byte)0, sqlTestByte.Value);
         }
 
         // ToSqlDecimal
         [Fact]
         public void ToSqlDecimal()
         {
-            SqlDecimal SqlTestDecimal;
+            SqlDecimal sqlTestDecimal;
 
-            string error = "ToSqlDecimal method does not work correctly ";
-            SqlTestDecimal = _sqlTrue.ToSqlDecimal();
+            sqlTestDecimal = _sqlTrue.ToSqlDecimal();
 
-            Assert.Equal(1, SqlTestDecimal.Value);
+            Assert.Equal(1, sqlTestDecimal.Value);
 
-            SqlTestDecimal = _sqlFalse.ToSqlDecimal();
-            Assert.Equal(0, SqlTestDecimal.Value);
+            sqlTestDecimal = _sqlFalse.ToSqlDecimal();
+            Assert.Equal(0, sqlTestDecimal.Value);
         }
 
         // ToSqlDouble
         [Fact]
         public void ToSqlDouble()
         {
-            SqlDouble SqlTestDouble;
+            SqlDouble sqlTestDouble;
 
-            string error = "ToSqlDouble method does not work correctly ";
-            SqlTestDouble = _sqlTrue.ToSqlDouble();
-            Assert.Equal(1, SqlTestDouble.Value);
+            sqlTestDouble = _sqlTrue.ToSqlDouble();
+            Assert.Equal(1, sqlTestDouble.Value);
 
-            SqlTestDouble = _sqlFalse.ToSqlDouble();
-            Assert.Equal(0, SqlTestDouble.Value);
+            sqlTestDouble = _sqlFalse.ToSqlDouble();
+            Assert.Equal(0, sqlTestDouble.Value);
         }
 
         // ToSqlInt16
         [Fact]
         public void ToSqlInt16()
         {
-            SqlInt16 SqlTestInt16;
+            SqlInt16 sqlTestInt16;
 
-            string error = "ToSqlInt16 method does not work correctly ";
-            SqlTestInt16 = _sqlTrue.ToSqlInt16();
-            Assert.Equal((short)1, SqlTestInt16.Value);
+            sqlTestInt16 = _sqlTrue.ToSqlInt16();
+            Assert.Equal((short)1, sqlTestInt16.Value);
 
-            SqlTestInt16 = _sqlFalse.ToSqlInt16();
-            Assert.Equal((short)0, SqlTestInt16.Value);
+            sqlTestInt16 = _sqlFalse.ToSqlInt16();
+            Assert.Equal((short)0, sqlTestInt16.Value);
         }
 
         // ToSqlInt32
         [Fact]
         public void ToSqlInt32()
         {
-            SqlInt32 SqlTestInt32;
+            SqlInt32 sqlTestInt32;
 
-            string error = "ToSqlInt32 method does not work correctly ";
-            SqlTestInt32 = _sqlTrue.ToSqlInt32();
-            Assert.Equal(1, SqlTestInt32.Value);
+            sqlTestInt32 = _sqlTrue.ToSqlInt32();
+            Assert.Equal(1, sqlTestInt32.Value);
 
-            SqlTestInt32 = _sqlFalse.ToSqlInt32();
-            Assert.Equal(0, SqlTestInt32.Value);
+            sqlTestInt32 = _sqlFalse.ToSqlInt32();
+            Assert.Equal(0, sqlTestInt32.Value);
         }
 
         // ToSqlInt64
         [Fact]
         public void ToSqlInt64()
         {
-            SqlInt64 SqlTestInt64;
+            SqlInt64 sqlTestInt64;
 
-            string error = "ToSqlInt64 method does not work correctly ";
+            sqlTestInt64 = _sqlTrue.ToSqlInt64();
+            Assert.Equal(1, sqlTestInt64.Value);
 
-            SqlTestInt64 = _sqlTrue.ToSqlInt64();
-            Assert.Equal(1, SqlTestInt64.Value);
-
-            SqlTestInt64 = _sqlFalse.ToSqlInt64();
-            Assert.Equal(0, SqlTestInt64.Value);
+            sqlTestInt64 = _sqlFalse.ToSqlInt64();
+            Assert.Equal(0, sqlTestInt64.Value);
         }
 
         // ToSqlMoney
         [Fact]
         public void ToSqlMoney()
         {
-            SqlMoney SqlTestMoney;
+            SqlMoney sqlTestMoney;
 
-            string error = "ToSqlMoney method does not work correctly ";
-            SqlTestMoney = _sqlTrue.ToSqlMoney();
-            Assert.Equal(1.0000M, SqlTestMoney.Value);
+            sqlTestMoney = _sqlTrue.ToSqlMoney();
+            Assert.Equal(1M, sqlTestMoney.Value);
 
-            SqlTestMoney = _sqlFalse.ToSqlMoney();
-            Assert.Equal(0, SqlTestMoney.Value);
+            sqlTestMoney = _sqlFalse.ToSqlMoney();
+            Assert.Equal(0, sqlTestMoney.Value);
         }
 
         // ToSqlSingle
         [Fact]
         public void ToSqlsingle()
         {
-            SqlSingle SqlTestSingle;
+            SqlSingle sqlTestSingle;
 
-            string error = "ToSqlSingle method does not work correctly ";
-            SqlTestSingle = _sqlTrue.ToSqlSingle();
-            Assert.Equal(1, SqlTestSingle.Value);
+            sqlTestSingle = _sqlTrue.ToSqlSingle();
+            Assert.Equal(1, sqlTestSingle.Value);
 
-            SqlTestSingle = _sqlFalse.ToSqlSingle();
-            Assert.Equal(0, SqlTestSingle.Value);
+            sqlTestSingle = _sqlFalse.ToSqlSingle();
+            Assert.Equal(0, sqlTestSingle.Value);
         }
 
         // ToSqlString
         [Fact]
         public void ToSqlString()
         {
-            SqlString SqlTestString;
+            SqlString sqlTestString;
 
-            string error = "ToSqlString method does not work correctly ";
-            SqlTestString = _sqlTrue.ToSqlString();
-            Assert.Equal("True", SqlTestString.Value);
+            sqlTestString = _sqlTrue.ToSqlString();
+            Assert.Equal("True", sqlTestString.Value);
 
-            SqlTestString = _sqlFalse.ToSqlString();
-            Assert.Equal("False", SqlTestString.Value);
+            sqlTestString = _sqlFalse.ToSqlString();
+            Assert.Equal("False", sqlTestString.Value);
         }
 
         // ToString
@@ -412,8 +394,6 @@ namespace System.Data.Tests.SqlTypes
         public void ToStringTest()
         {
             SqlString TestString;
-
-            string error = "ToString method does not work correctly ";
 
             TestString = _sqlTrue.ToString();
             Assert.Equal("True", TestString.Value);
@@ -432,119 +412,111 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void BitwiseAndOperator()
         {
-            SqlBoolean SqlTrue2 = new SqlBoolean(true);
-            SqlBoolean SqlFalse2 = new SqlBoolean(false);
+            SqlBoolean sqlTrue2 = new SqlBoolean(true);
+            SqlBoolean sqlFalse2 = new SqlBoolean(false);
 
-            SqlBoolean SqlResult;
-            string error = "BitwiseAnd operator does not work correctly ";
+            SqlBoolean sqlResult;
 
-            SqlResult = _sqlTrue & _sqlFalse;
-            Assert.True(!SqlResult.Value);
-            SqlResult = _sqlFalse & _sqlTrue;
-            Assert.True(!SqlResult.Value);
+            sqlResult = _sqlTrue & _sqlFalse;
+            Assert.False(sqlResult.Value);
+            sqlResult = _sqlFalse & _sqlTrue;
+            Assert.False(sqlResult.Value);
 
-            SqlResult = _sqlTrue & SqlTrue2;
-            Assert.True(SqlResult.Value);
+            sqlResult = _sqlTrue & sqlTrue2;
+            Assert.True(sqlResult.Value);
 
-            SqlResult = _sqlFalse & SqlFalse2;
-            Assert.True(!SqlResult.Value);
+            sqlResult = _sqlFalse & sqlFalse2;
+            Assert.False(sqlResult.Value);
         }
 
         // BitwixeOr operator
         [Fact]
         public void BitwiseOrOperator()
         {
-            SqlBoolean SqlTrue2 = new SqlBoolean(true);
-            SqlBoolean SqlFalse2 = new SqlBoolean(false);
+            SqlBoolean sqlTrue2 = new SqlBoolean(true);
+            SqlBoolean sqlFalse2 = new SqlBoolean(false);
 
-            SqlBoolean SqlResult;
-            string error = "BitwiseOr operator does not work correctly ";
+            SqlBoolean sqlResult;
 
-            SqlResult = _sqlTrue | _sqlFalse;
-            Assert.True(SqlResult.Value);
-            SqlResult = _sqlFalse | _sqlTrue;
+            sqlResult = _sqlTrue | _sqlFalse;
+            Assert.True(sqlResult.Value);
+            sqlResult = _sqlFalse | _sqlTrue;
 
-            Assert.True(SqlResult.Value);
+            Assert.True(sqlResult.Value);
 
-            SqlResult = _sqlTrue | SqlTrue2;
-            Assert.True(SqlResult.Value);
+            sqlResult = _sqlTrue | sqlTrue2;
+            Assert.True(sqlResult.Value);
 
-            SqlResult = _sqlFalse | SqlFalse2;
-            Assert.True(!SqlResult.Value);
+            sqlResult = _sqlFalse | sqlFalse2;
+            Assert.False(sqlResult.Value);
         }
 
         // Equality operator
         [Fact]
         public void EqualityOperator()
         {
-            SqlBoolean SqlTrue2 = new SqlBoolean(true);
-            SqlBoolean SqlFalse2 = new SqlBoolean(false);
+            SqlBoolean sqlTrue2 = new SqlBoolean(true);
+            SqlBoolean sqlFalse2 = new SqlBoolean(false);
 
-            SqlBoolean SqlResult;
-            string error = "Equality operator does not work correctly ";
+            SqlBoolean sqlResult;
 
-            SqlResult = _sqlTrue == _sqlFalse;
-            Assert.True(!SqlResult.Value);
-            SqlResult = _sqlFalse == _sqlTrue;
-            Assert.True(!SqlResult.Value);
+            sqlResult = _sqlTrue == _sqlFalse;
+            Assert.False(sqlResult.Value);
+            sqlResult = _sqlFalse == _sqlTrue;
+            Assert.False(sqlResult.Value);
 
-            SqlResult = _sqlTrue == SqlTrue2;
-            Assert.True(SqlResult.Value);
+            sqlResult = _sqlTrue == sqlTrue2;
+            Assert.True(sqlResult.Value);
 
-            SqlResult = _sqlFalse == SqlFalse2;
-            Assert.True(SqlResult.Value);
+            sqlResult = _sqlFalse == sqlFalse2;
+            Assert.True(sqlResult.Value);
 
-            SqlResult = _sqlFalse == SqlBoolean.Null;
-            Assert.True(SqlResult.IsNull);
-            //SqlResult = SqlBoolean.Null == SqlBoolean.Null;
-            Assert.True(SqlResult.IsNull);
+            sqlResult = _sqlFalse == SqlBoolean.Null;
+            Assert.True(sqlResult.IsNull);
+            //sqlResult = SqlBoolean.Null == SqlBoolean.Null;
+            //Assert.True(sqlResult.IsNull);
         }
 
         // ExlusiveOr operator
         [Fact]
         public void ExlusiveOrOperator()
         {
-            SqlBoolean SqlTrue2 = new SqlBoolean(true);
-            SqlBoolean SqlFalse2 = new SqlBoolean(false);
+            SqlBoolean sqlTrue2 = new SqlBoolean(true);
+            SqlBoolean sqlFalse2 = new SqlBoolean(false);
 
-            SqlBoolean SqlResult;
-            string error = "ExclusiveOr operator does not work correctly ";
+            SqlBoolean sqlResult;
 
-            SqlResult = _sqlTrue ^ _sqlFalse;
-            Assert.True(SqlResult.Value);
-            SqlResult = _sqlFalse | _sqlTrue;
-            Assert.True(SqlResult.Value);
+            sqlResult = _sqlTrue ^ _sqlFalse;
+            Assert.True(sqlResult.Value);
+            sqlResult = _sqlFalse | _sqlTrue;
+            Assert.True(sqlResult.Value);
 
-            SqlResult = _sqlTrue ^ SqlTrue2;
-            Assert.True(!SqlResult.Value);
+            sqlResult = _sqlTrue ^ sqlTrue2;
+            Assert.False(sqlResult.Value);
 
-            SqlResult = _sqlFalse ^ SqlFalse2;
-            Assert.True(!SqlResult.Value);
+            sqlResult = _sqlFalse ^ sqlFalse2;
+            Assert.False(sqlResult.Value);
         }
 
         // false operator
         [Fact]
         public void FalseOperator()
         {
-            string error = "false operator does not work correctly ";
-
-            Assert.Equal(SqlBoolean.False, (!_sqlTrue));
-            Assert.Equal(SqlBoolean.True, (!_sqlFalse));
+            Assert.Equal(SqlBoolean.False, !_sqlTrue);
+            Assert.Equal(SqlBoolean.True, !_sqlFalse);
         }
 
         // Inequality operator
         [Fact]
         public void InequalityOperator()
         {
-            SqlBoolean SqlTrue2 = new SqlBoolean(true);
-            SqlBoolean SqlFalse2 = new SqlBoolean(false);
-
-            string error = "Inequality operator does not work correctly";
+            SqlBoolean sqlTrue2 = new SqlBoolean(true);
+            SqlBoolean sqlFalse2 = new SqlBoolean(false);
 
             Assert.Equal(SqlBoolean.False, _sqlTrue != true);
-            Assert.Equal(SqlBoolean.False, _sqlTrue != SqlTrue2);
+            Assert.Equal(SqlBoolean.False, _sqlTrue != sqlTrue2);
             Assert.Equal(SqlBoolean.False, _sqlFalse != false);
-            Assert.Equal(SqlBoolean.False, _sqlFalse != SqlFalse2);
+            Assert.Equal(SqlBoolean.False, _sqlFalse != sqlFalse2);
             Assert.Equal(SqlBoolean.True, _sqlTrue != _sqlFalse);
             Assert.Equal(SqlBoolean.True, _sqlFalse != _sqlTrue);
             Assert.Equal(SqlBoolean.Null, SqlBoolean.Null != _sqlTrue);
@@ -555,8 +527,6 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void LogicalNotOperator()
         {
-            string error = "Logical Not operator does not work correctly";
-
             Assert.Equal(SqlBoolean.False, !_sqlTrue);
             Assert.Equal(SqlBoolean.True, !_sqlFalse);
         }
@@ -565,14 +535,12 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void OnesComplementOperator()
         {
-            string error = "Ones complement operator does not work correctly";
+            SqlBoolean sqlResult;
 
-            SqlBoolean SqlResult;
-
-            SqlResult = ~_sqlTrue;
-            Assert.True(!SqlResult.Value);
-            SqlResult = ~_sqlFalse;
-            Assert.True(SqlResult.Value);
+            sqlResult = ~_sqlTrue;
+            Assert.False(sqlResult.Value);
+            sqlResult = ~_sqlFalse;
+            Assert.True(sqlResult.Value);
         }
 
 
@@ -580,242 +548,226 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void TrueOperator()
         {
-            string error = "true operator does not work correctly ";
-
-            Assert.Equal(SqlBoolean.True, (_sqlTrue));
-            Assert.Equal(SqlBoolean.False, (_sqlFalse));
+            Assert.Equal(SqlBoolean.True, _sqlTrue);
+            Assert.Equal(SqlBoolean.False, _sqlFalse);
         }
 
         // SqlBoolean to Boolean
         [Fact]
         public void SqlBooleanToBoolean()
         {
-            string error = "SqlBooleanToBoolean operator does not work correctly ";
-
             bool TestBoolean = (bool)_sqlTrue;
             Assert.True(TestBoolean);
             TestBoolean = (bool)_sqlFalse;
-            Assert.True(!TestBoolean);
+            Assert.False(TestBoolean);
         }
 
         // SqlByte to SqlBoolean
         [Fact]
         public void SqlByteToSqlBoolean()
         {
-            SqlByte SqlTestByte;
-            SqlBoolean SqlTestBoolean;
-            string error = "SqlByteToSqlBoolean operator does not work correctly ";
+            SqlByte sqlTestByte;
+            SqlBoolean sqlTestBoolean;
+            sqlTestByte = new SqlByte(1);
+            sqlTestBoolean = (SqlBoolean)sqlTestByte;
+            Assert.True(sqlTestBoolean.Value);
 
-            SqlTestByte = new SqlByte(1);
-            SqlTestBoolean = (SqlBoolean)SqlTestByte;
-            Assert.True(SqlTestBoolean.Value);
+            sqlTestByte = new SqlByte(2);
+            sqlTestBoolean = (SqlBoolean)sqlTestByte;
+            Assert.True(sqlTestBoolean.Value);
 
-            SqlTestByte = new SqlByte(2);
-            SqlTestBoolean = (SqlBoolean)SqlTestByte;
-            Assert.True(SqlTestBoolean.Value);
-
-            SqlTestByte = new SqlByte(0);
-            SqlTestBoolean = (SqlBoolean)SqlTestByte;
-            Assert.True(!SqlTestBoolean.Value);
+            sqlTestByte = new SqlByte(0);
+            sqlTestBoolean = (SqlBoolean)sqlTestByte;
+            Assert.False(sqlTestBoolean.Value);
         }
 
         // SqlDecimal to SqlBoolean
         [Fact]
         public void SqlDecimalToSqlBoolean()
         {
-            SqlDecimal SqlTest;
-            SqlBoolean SqlTestBoolean;
-            string error = "SqlDecimalToSqlBoolean operator does not work correctly ";
+            SqlDecimal sqlTest;
+            SqlBoolean sqlTestBoolean;
 
-            SqlTest = new SqlDecimal(1);
-            SqlTestBoolean = (SqlBoolean)SqlTest;
-            Assert.True(SqlTestBoolean.Value);
+            sqlTest = new SqlDecimal(1);
+            sqlTestBoolean = (SqlBoolean)sqlTest;
+            Assert.True(sqlTestBoolean.Value);
 
-            SqlTest = new SqlDecimal(19);
-            SqlTestBoolean = (SqlBoolean)SqlTest;
-            Assert.True(SqlTestBoolean.Value);
+            sqlTest = new SqlDecimal(19);
+            sqlTestBoolean = (SqlBoolean)sqlTest;
+            Assert.True(sqlTestBoolean.Value);
 
-            SqlTest = new SqlDecimal(0);
-            SqlTestBoolean = (SqlBoolean)SqlTest;
-            Assert.True(!SqlTestBoolean.Value);
+            sqlTest = new SqlDecimal(0);
+            sqlTestBoolean = (SqlBoolean)sqlTest;
+            Assert.False(sqlTestBoolean.Value);
         }
 
         // SqlDouble to SqlBoolean
         [Fact]
         public void SqlDoubleToSqlBoolean()
         {
-            SqlDouble SqlTest;
-            SqlBoolean SqlTestBoolean;
-            string error = "SqlDoubleToSqlBoolean operator does not work correctly ";
+            SqlDouble sqlTest;
+            SqlBoolean sqlTestBoolean;
 
-            SqlTest = new SqlDouble(1);
-            SqlTestBoolean = (SqlBoolean)SqlTest;
-            Assert.True(SqlTestBoolean.Value);
+            sqlTest = new SqlDouble(1);
+            sqlTestBoolean = (SqlBoolean)sqlTest;
+            Assert.True(sqlTestBoolean.Value);
 
-            SqlTest = new SqlDouble(-19.8);
-            SqlTestBoolean = (SqlBoolean)SqlTest;
-            Assert.True(SqlTestBoolean.Value);
+            sqlTest = new SqlDouble(-19.8);
+            sqlTestBoolean = (SqlBoolean)sqlTest;
+            Assert.True(sqlTestBoolean.Value);
 
-            SqlTest = new SqlDouble(0);
-            SqlTestBoolean = (SqlBoolean)SqlTest;
-            Assert.True(!SqlTestBoolean.Value);
+            sqlTest = new SqlDouble(0);
+            sqlTestBoolean = (SqlBoolean)sqlTest;
+            Assert.False(sqlTestBoolean.Value);
         }
 
         // SqlIn16 to SqlBoolean
         [Fact]
         public void SqlInt16ToSqlBoolean()
         {
-            SqlInt16 SqlTest;
-            SqlBoolean SqlTestBoolean;
-            string error = "SqlInt16ToSqlBoolean operator does not work correctly ";
+            SqlInt16 sqlTest;
+            SqlBoolean sqlTestBoolean;
 
-            SqlTest = new SqlInt16(1);
-            SqlTestBoolean = (SqlBoolean)SqlTest;
-            Assert.True(SqlTestBoolean.Value);
+            sqlTest = new SqlInt16(1);
+            sqlTestBoolean = (SqlBoolean)sqlTest;
+            Assert.True(sqlTestBoolean.Value);
 
-            SqlTest = new SqlInt16(-143);
-            SqlTestBoolean = (SqlBoolean)SqlTest;
-            Assert.True(SqlTestBoolean.Value);
+            sqlTest = new SqlInt16(-143);
+            sqlTestBoolean = (SqlBoolean)sqlTest;
+            Assert.True(sqlTestBoolean.Value);
 
-            SqlTest = new SqlInt16(0);
-            SqlTestBoolean = (SqlBoolean)SqlTest;
-            Assert.True(!SqlTestBoolean.Value);
+            sqlTest = new SqlInt16(0);
+            sqlTestBoolean = (SqlBoolean)sqlTest;
+            Assert.False(sqlTestBoolean.Value);
         }
 
         // SqlInt32 to SqlBoolean
         [Fact]
         public void SqlInt32ToSqlBoolean()
         {
-            SqlInt32 SqlTest;
-            SqlBoolean SqlTestBoolean;
-            string error = "SqlInt32ToSqlBoolean operator does not work correctly ";
+            SqlInt32 sqlTest;
+            SqlBoolean sqlTestBoolean;
 
-            SqlTest = new SqlInt32(1);
-            SqlTestBoolean = (SqlBoolean)SqlTest;
-            Assert.True(SqlTestBoolean.Value);
+            sqlTest = new SqlInt32(1);
+            sqlTestBoolean = (SqlBoolean)sqlTest;
+            Assert.True(sqlTestBoolean.Value);
 
-            SqlTest = new SqlInt32(1430);
-            SqlTestBoolean = (SqlBoolean)SqlTest;
-            Assert.True(SqlTestBoolean.Value);
+            sqlTest = new SqlInt32(1430);
+            sqlTestBoolean = (SqlBoolean)sqlTest;
+            Assert.True(sqlTestBoolean.Value);
 
-            SqlTest = new SqlInt32(0);
-            SqlTestBoolean = (SqlBoolean)SqlTest;
-            Assert.True(!SqlTestBoolean.Value);
+            sqlTest = new SqlInt32(0);
+            sqlTestBoolean = (SqlBoolean)sqlTest;
+            Assert.False(sqlTestBoolean.Value);
         }
 
         // SqlInt64 to SqlBoolean
         [Fact]
         public void SqlInt64ToSqlBoolean()
         {
-            SqlInt64 SqlTest;
-            SqlBoolean SqlTestBoolean;
-            string error = "SqlInt64ToSqlBoolean operator does not work correctly ";
+            SqlInt64 sqlTest;
+            SqlBoolean sqlTestBoolean;
 
-            SqlTest = new SqlInt64(1);
-            SqlTestBoolean = (SqlBoolean)SqlTest;
-            Assert.True(SqlTestBoolean.Value);
+            sqlTest = new SqlInt64(1);
+            sqlTestBoolean = (SqlBoolean)sqlTest;
+            Assert.True(sqlTestBoolean.Value);
 
-            SqlTest = new SqlInt64(-14305);
-            SqlTestBoolean = (SqlBoolean)SqlTest;
-            Assert.True(SqlTestBoolean.Value);
+            sqlTest = new SqlInt64(-14305);
+            sqlTestBoolean = (SqlBoolean)sqlTest;
+            Assert.True(sqlTestBoolean.Value);
 
-            SqlTest = new SqlInt64(0);
-            SqlTestBoolean = (SqlBoolean)SqlTest;
-            Assert.True(!SqlTestBoolean.Value);
+            sqlTest = new SqlInt64(0);
+            sqlTestBoolean = (SqlBoolean)sqlTest;
+            Assert.False(sqlTestBoolean.Value);
         }
 
         // SqlMoney to SqlBoolean
         [Fact]
         public void SqlMoneyToSqlBoolean()
         {
-            SqlMoney SqlTest;
-            SqlBoolean SqlTestBoolean;
-            string error = "SqlMoneyToSqlBoolean operator does not work correctly ";
+            SqlMoney sqlTest;
+            SqlBoolean sqlTestBoolean;
 
-            SqlTest = new SqlMoney(1);
-            SqlTestBoolean = (SqlBoolean)SqlTest;
-            Assert.True(SqlTestBoolean.Value);
+            sqlTest = new SqlMoney(1);
+            sqlTestBoolean = (SqlBoolean)sqlTest;
+            Assert.True(sqlTestBoolean.Value);
 
-            SqlTest = new SqlMoney(1305);
-            SqlTestBoolean = (SqlBoolean)SqlTest;
-            Assert.True(SqlTestBoolean.Value);
+            sqlTest = new SqlMoney(1305);
+            sqlTestBoolean = (SqlBoolean)sqlTest;
+            Assert.True(sqlTestBoolean.Value);
 
-            SqlTest = new SqlMoney(0);
-            SqlTestBoolean = (SqlBoolean)SqlTest;
-            Assert.True(!SqlTestBoolean.Value);
+            sqlTest = new SqlMoney(0);
+            sqlTestBoolean = (SqlBoolean)sqlTest;
+            Assert.False(sqlTestBoolean.Value);
         }
 
         // SqlSingle to SqlBoolean
         [Fact]
         public void SqlSingleToSqlBoolean()
         {
-            SqlSingle SqlTest;
-            SqlBoolean SqlTestBoolean;
-            string error = "SqlSingleToSqlBoolean operator does not work correctly ";
+            SqlSingle sqlTest;
+            SqlBoolean sqlTestBoolean;
 
-            SqlTest = new SqlSingle(1);
-            SqlTestBoolean = (SqlBoolean)SqlTest;
-            Assert.True(SqlTestBoolean.Value);
+            sqlTest = new SqlSingle(1);
+            sqlTestBoolean = (SqlBoolean)sqlTest;
+            Assert.True(sqlTestBoolean.Value);
 
-            SqlTest = new SqlSingle(1305);
-            SqlTestBoolean = (SqlBoolean)SqlTest;
-            Assert.True(SqlTestBoolean.Value);
+            sqlTest = new SqlSingle(1305);
+            sqlTestBoolean = (SqlBoolean)sqlTest;
+            Assert.True(sqlTestBoolean.Value);
 
-            SqlTest = new SqlSingle(-305.3);
-            SqlTestBoolean = (SqlBoolean)SqlTest;
-            Assert.True(SqlTestBoolean.Value);
+            sqlTest = new SqlSingle(-305.3);
+            sqlTestBoolean = (SqlBoolean)sqlTest;
+            Assert.True(sqlTestBoolean.Value);
 
-            SqlTest = new SqlSingle(0);
-            SqlTestBoolean = (SqlBoolean)SqlTest;
-            Assert.True(!SqlTestBoolean.Value);
+            sqlTest = new SqlSingle(0);
+            sqlTestBoolean = (SqlBoolean)sqlTest;
+            Assert.False(sqlTestBoolean.Value);
         }
 
         // SqlString to SqlBoolean
         [Fact]
         public void SqlStringToSqlBoolean()
         {
-            SqlString SqlTest;
-            SqlBoolean SqlTestBoolean;
-            string error = "SqlSingleToSqlBoolean operator does not work correctly ";
+            SqlString sqlTest;
+            SqlBoolean sqlTestBoolean;
 
-            SqlTest = new SqlString("true");
-            SqlTestBoolean = (SqlBoolean)SqlTest;
-            Assert.True(SqlTestBoolean.Value);
+            sqlTest = new SqlString("true");
+            sqlTestBoolean = (SqlBoolean)sqlTest;
+            Assert.True(sqlTestBoolean.Value);
 
-            SqlTest = new SqlString("TRUE");
-            SqlTestBoolean = (SqlBoolean)SqlTest;
-            Assert.True(SqlTestBoolean.Value);
+            sqlTest = new SqlString("TRUE");
+            sqlTestBoolean = (SqlBoolean)sqlTest;
+            Assert.True(sqlTestBoolean.Value);
 
-            SqlTest = new SqlString("True");
-            SqlTestBoolean = (SqlBoolean)SqlTest;
-            Assert.True(SqlTestBoolean.Value);
+            sqlTest = new SqlString("True");
+            sqlTestBoolean = (SqlBoolean)sqlTest;
+            Assert.True(sqlTestBoolean.Value);
 
-            SqlTest = new SqlString("false");
-            SqlTestBoolean = (SqlBoolean)SqlTest;
-            Assert.True(!SqlTestBoolean.Value);
+            sqlTest = new SqlString("false");
+            sqlTestBoolean = (SqlBoolean)sqlTest;
+            Assert.False(sqlTestBoolean.Value);
         }
 
         // Boolean to SqlBoolean
         [Fact]
         public void BooleanToSqlBoolean()
         {
-            SqlBoolean SqlTestBoolean;
+            SqlBoolean sqlTestBoolean;
             bool btrue = true;
             bool bfalse = false;
-            string error = "BooleanToSqlBoolean operator does not work correctly ";
 
-            bool SqlTest = true;
-            SqlTestBoolean = SqlTest;
-            Assert.True(SqlTestBoolean.Value);
-            SqlTestBoolean = btrue;
-            Assert.True(SqlTestBoolean.Value);
+            bool sqlTest = true;
+            sqlTestBoolean = sqlTest;
+            Assert.True(sqlTestBoolean.Value);
+            sqlTestBoolean = btrue;
+            Assert.True(sqlTestBoolean.Value);
 
-
-            SqlTest = false;
-            SqlTestBoolean = SqlTest;
-            Assert.True(!SqlTestBoolean.Value);
-            SqlTestBoolean = bfalse;
-            Assert.True(!SqlTestBoolean.Value);
+            sqlTest = false;
+            sqlTestBoolean = sqlTest;
+            Assert.False(sqlTestBoolean.Value);
+            sqlTestBoolean = bfalse;
+            Assert.False(sqlTestBoolean.Value);
         }
 
         // END OF OPERATORS
@@ -828,8 +780,6 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void ByteValueProperty()
         {
-            string error = "ByteValue property does not work correctly ";
-
             Assert.Equal((byte)1, _sqlTrue.ByteValue);
             Assert.Equal((byte)0, _sqlFalse.ByteValue);
         }
@@ -838,9 +788,7 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void IsFalseProperty()
         {
-            string error = "IsFalse property does not work correctly ";
-
-            Assert.True(!_sqlTrue.IsFalse);
+            Assert.False(_sqlTrue.IsFalse);
             Assert.True(_sqlFalse.IsFalse);
         }
 
@@ -848,10 +796,8 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void IsNullProperty()
         {
-            string error = "IsNull property does not work correctly ";
-
-            Assert.True(!_sqlTrue.IsNull);
-            Assert.True(!_sqlFalse.IsNull);
+            Assert.False(_sqlTrue.IsNull);
+            Assert.False(_sqlFalse.IsNull);
             Assert.True(SqlBoolean.Null.IsNull);
         }
 
@@ -859,23 +805,19 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void IsTrueProperty()
         {
-            string error = "IsTrue property does not work correctly ";
-
             Assert.True(_sqlTrue.IsTrue);
-            Assert.True(!_sqlFalse.IsTrue);
+            Assert.False(_sqlFalse.IsTrue);
         }
 
         // Value property
         [Fact]
         public void ValueProperty()
         {
-            string error = "Value property does not work correctly ";
-
             Assert.True(_sqlTrue.Value);
-            Assert.True(!_sqlFalse.Value);
+            Assert.False(_sqlFalse.Value);
         }
 
-        // END OF PROPERTIEs
+        // END OF PROPERTIES
         ////
 
         ////
@@ -884,7 +826,7 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void FalseField()
         {
-            Assert.True(!SqlBoolean.False.Value);
+            Assert.False(SqlBoolean.False.Value);
         }
 
         [Fact]

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlBooleanTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlBooleanTest.cs
@@ -264,13 +264,6 @@ namespace System.Data.Tests.SqlTypes
             Assert.Equal(0, _sqlFalse.GetHashCode());
         }
 
-        // GetType
-        [Fact]
-        public void GetTypeTest()
-        {
-            Assert.Equal("System.Data.SqlTypes.SqlBoolean", _sqlTrue.GetType().ToString());
-        }
-
         // ToSqlByte
         [Fact]
         public void ToSqlByte()

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlByteTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlByteTest.cs
@@ -122,7 +122,7 @@ namespace System.Data.Tests.SqlTypes
 
             Assert.True(testByte13.CompareTo(testByte10) > 0);
             Assert.True(testByte10.CompareTo(testByte13) < 0);
-            Assert.True(testByte10.CompareTo(testByte10II) == 0);
+            Assert.Equal(0, testByte10.CompareTo(testByte10II));
 
             Assert.Throws<ArgumentException>(() => testByte13.CompareTo(testString));
         }

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlByteTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlByteTest.cs
@@ -183,14 +183,6 @@ namespace System.Data.Tests.SqlTypes
         }
 
         [Fact]
-        public void GetTypeTest()
-        {
-            SqlByte testByte = new SqlByte(84);
-
-            Assert.Equal("System.Data.SqlTypes.SqlByte", testByte.GetType().ToString());
-        }
-
-        [Fact]
         public void GreaterThan()
         {
             SqlByte testByte10 = new SqlByte(10);
@@ -461,15 +453,6 @@ namespace System.Data.Tests.SqlTypes
 
             Assert.Equal((SqlByte)88, testByte24 + testByte64);
 
-            try
-            {
-                SqlByte result = testByte64 + testByte255;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
             Assert.Throws<OverflowException>(() => testByte64 + testByte255);
         }
 

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlByteTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlByteTest.cs
@@ -28,21 +28,18 @@
 using Xunit;
 using System.Xml;
 using System.Data.SqlTypes;
-using System.Globalization;
 
 namespace System.Data.Tests.SqlTypes
 {
     public class SqlByteTest
     {
-        private const string Error = " does not work correctly";
-
         // Test constructor
         [Fact]
         public void Create()
         {
             byte b = 29;
-            SqlByte TestByte = new SqlByte(b);
-            Assert.Equal((byte)29, TestByte.Value);
+            SqlByte testByte = new SqlByte(b);
+            Assert.Equal((byte)29, testByte.Value);
         }
 
         // Test public fields
@@ -59,311 +56,254 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void Properties()
         {
-            SqlByte TestByte = new SqlByte(54);
-            SqlByte TestByte2 = new SqlByte(1);
+            SqlByte testByte = new SqlByte(54);
+            SqlByte testByte2 = new SqlByte(1);
 
             Assert.True(SqlByte.Null.IsNull);
-            Assert.Equal((byte)54, TestByte.Value);
-            Assert.Equal((byte)1, TestByte2.Value);
+            Assert.Equal((byte)54, testByte.Value);
+            Assert.Equal((byte)1, testByte2.Value);
         }
 
         // PUBLIC STATIC METHODS
         [Fact]
         public void AddMethod()
         {
-            SqlByte TestByte64 = new SqlByte(64);
-            SqlByte TestByte0 = new SqlByte(0);
-            SqlByte TestByte164 = new SqlByte(164);
-            SqlByte TestByte255 = new SqlByte(255);
+            SqlByte testByte64 = new SqlByte(64);
+            SqlByte testByte0 = new SqlByte(0);
+            SqlByte testByte164 = new SqlByte(164);
+            SqlByte testByte255 = new SqlByte(255);
 
-            Assert.Equal((byte)64, SqlByte.Add(TestByte64, TestByte0).Value);
-            Assert.Equal((byte)228, SqlByte.Add(TestByte64, TestByte164).Value);
-            Assert.Equal((byte)164, SqlByte.Add(TestByte0, TestByte164).Value);
-            Assert.Equal((byte)255, SqlByte.Add(TestByte255, TestByte0).Value);
+            Assert.Equal((byte)64, SqlByte.Add(testByte64, testByte0).Value);
+            Assert.Equal((byte)228, SqlByte.Add(testByte64, testByte164).Value);
+            Assert.Equal((byte)164, SqlByte.Add(testByte0, testByte164).Value);
+            Assert.Equal((byte)255, SqlByte.Add(testByte255, testByte0).Value);
 
-            try
-            {
-                SqlByte.Add(TestByte255, TestByte64);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlByte.Add(testByte255, testByte64));
         }
 
         [Fact]
         public void BitwiseAndMethod()
         {
-            SqlByte TestByte2 = new SqlByte(2);
-            SqlByte TestByte1 = new SqlByte(1);
-            SqlByte TestByte62 = new SqlByte(62);
-            SqlByte TestByte255 = new SqlByte(255);
+            SqlByte testByte2 = new SqlByte(2);
+            SqlByte testByte1 = new SqlByte(1);
+            SqlByte testByte62 = new SqlByte(62);
+            SqlByte testByte255 = new SqlByte(255);
 
-            Assert.Equal((byte)0, SqlByte.BitwiseAnd(TestByte2, TestByte1).Value);
-            Assert.Equal((byte)0, SqlByte.BitwiseAnd(TestByte1, TestByte62).Value);
-            Assert.Equal((byte)2, SqlByte.BitwiseAnd(TestByte62, TestByte2).Value);
-            Assert.Equal((byte)1, SqlByte.BitwiseAnd(TestByte1, TestByte255).Value);
-            Assert.Equal((byte)62, SqlByte.BitwiseAnd(TestByte62, TestByte255).Value);
+            Assert.Equal((byte)0, SqlByte.BitwiseAnd(testByte2, testByte1).Value);
+            Assert.Equal((byte)0, SqlByte.BitwiseAnd(testByte1, testByte62).Value);
+            Assert.Equal((byte)2, SqlByte.BitwiseAnd(testByte62, testByte2).Value);
+            Assert.Equal((byte)1, SqlByte.BitwiseAnd(testByte1, testByte255).Value);
+            Assert.Equal((byte)62, SqlByte.BitwiseAnd(testByte62, testByte255).Value);
         }
 
         [Fact]
         public void BitwiseOrMethod()
         {
-            SqlByte TestByte2 = new SqlByte(2);
-            SqlByte TestByte1 = new SqlByte(1);
-            SqlByte TestByte62 = new SqlByte(62);
-            SqlByte TestByte255 = new SqlByte(255);
+            SqlByte testByte2 = new SqlByte(2);
+            SqlByte testByte1 = new SqlByte(1);
+            SqlByte testByte62 = new SqlByte(62);
+            SqlByte testByte255 = new SqlByte(255);
 
-            Assert.Equal((byte)3, SqlByte.BitwiseOr(TestByte2, TestByte1).Value);
-            Assert.Equal((byte)63, SqlByte.BitwiseOr(TestByte1, TestByte62).Value);
-            Assert.Equal((byte)62, SqlByte.BitwiseOr(TestByte62, TestByte2).Value);
-            Assert.Equal((byte)255, SqlByte.BitwiseOr(TestByte1, TestByte255).Value);
-            Assert.Equal((byte)255, SqlByte.BitwiseOr(TestByte62, TestByte255).Value);
+            Assert.Equal((byte)3, SqlByte.BitwiseOr(testByte2, testByte1).Value);
+            Assert.Equal((byte)63, SqlByte.BitwiseOr(testByte1, testByte62).Value);
+            Assert.Equal((byte)62, SqlByte.BitwiseOr(testByte62, testByte2).Value);
+            Assert.Equal((byte)255, SqlByte.BitwiseOr(testByte1, testByte255).Value);
+            Assert.Equal((byte)255, SqlByte.BitwiseOr(testByte62, testByte255).Value);
         }
 
         [Fact]
         public void CompareTo()
         {
-            SqlByte TestByte13 = new SqlByte(13);
-            SqlByte TestByte10 = new SqlByte(10);
-            SqlByte TestByte10II = new SqlByte(10);
+            SqlByte testByte13 = new SqlByte(13);
+            SqlByte testByte10 = new SqlByte(10);
+            SqlByte testByte10II = new SqlByte(10);
 
-            SqlString TestString = new SqlString("This is a test");
+            SqlString testString = new SqlString("This is a test");
 
-            Assert.True(TestByte13.CompareTo(TestByte10) > 0);
-            Assert.True(TestByte10.CompareTo(TestByte13) < 0);
-            Assert.True(TestByte10.CompareTo(TestByte10II) == 0);
+            Assert.True(testByte13.CompareTo(testByte10) > 0);
+            Assert.True(testByte10.CompareTo(testByte13) < 0);
+            Assert.True(testByte10.CompareTo(testByte10II) == 0);
 
-            try
-            {
-                TestByte13.CompareTo(TestString);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(ArgumentException), e.GetType());
-            }
+            Assert.Throws<ArgumentException>(() => testByte13.CompareTo(testString));
         }
 
         [Fact]
         public void DivideMethod()
         {
-            SqlByte TestByte13 = new SqlByte(13);
-            SqlByte TestByte0 = new SqlByte(0);
+            SqlByte testByte13 = new SqlByte(13);
+            SqlByte testByte0 = new SqlByte(0);
 
-            SqlByte TestByte2 = new SqlByte(2);
-            SqlByte TestByte180 = new SqlByte(180);
-            SqlByte TestByte3 = new SqlByte(3);
+            SqlByte testByte2 = new SqlByte(2);
+            SqlByte testByte180 = new SqlByte(180);
+            SqlByte testByte3 = new SqlByte(3);
 
-            Assert.Equal((byte)6, SqlByte.Divide(TestByte13, TestByte2).Value);
-            Assert.Equal((byte)90, SqlByte.Divide(TestByte180, TestByte2).Value);
-            Assert.Equal((byte)60, SqlByte.Divide(TestByte180, TestByte3).Value);
-            Assert.Equal((byte)0, SqlByte.Divide(TestByte13, TestByte180).Value);
-            Assert.Equal((byte)0, SqlByte.Divide(TestByte13, TestByte180).Value);
+            Assert.Equal((byte)6, SqlByte.Divide(testByte13, testByte2).Value);
+            Assert.Equal((byte)90, SqlByte.Divide(testByte180, testByte2).Value);
+            Assert.Equal((byte)60, SqlByte.Divide(testByte180, testByte3).Value);
+            Assert.Equal((byte)0, SqlByte.Divide(testByte13, testByte180).Value);
+            Assert.Equal((byte)0, SqlByte.Divide(testByte13, testByte180).Value);
 
-            try
-            {
-                SqlByte.Divide(TestByte13, TestByte0);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(DivideByZeroException), e.GetType());
-            }
+            Assert.Throws<DivideByZeroException>(() => SqlByte.Divide(testByte13, testByte0));
         }
 
         [Fact]
         public void EqualsMethod()
         {
-            SqlByte TestByte0 = new SqlByte(0);
-            SqlByte TestByte158 = new SqlByte(158);
-            SqlByte TestByte180 = new SqlByte(180);
-            SqlByte TestByte180II = new SqlByte(180);
+            SqlByte testByte0 = new SqlByte(0);
+            SqlByte testByte158 = new SqlByte(158);
+            SqlByte testByte180 = new SqlByte(180);
+            SqlByte testByte180II = new SqlByte(180);
 
-            Assert.True(!TestByte0.Equals(TestByte158));
-            Assert.True(!TestByte158.Equals(TestByte180));
-            Assert.True(!TestByte180.Equals(new SqlString("TEST")));
-            Assert.True(TestByte180.Equals(TestByte180II));
+            Assert.False(testByte0.Equals(testByte158));
+            Assert.False(testByte158.Equals(testByte180));
+            Assert.False(testByte180.Equals(new SqlString("TEST")));
+            Assert.True(testByte180.Equals(testByte180II));
         }
 
         [Fact]
         public void StaticEqualsMethod()
         {
-            SqlByte TestByte34 = new SqlByte(34);
-            SqlByte TestByte34II = new SqlByte(34);
-            SqlByte TestByte15 = new SqlByte(15);
+            SqlByte testByte34 = new SqlByte(34);
+            SqlByte testByte34II = new SqlByte(34);
+            SqlByte testByte15 = new SqlByte(15);
 
-            Assert.True(SqlByte.Equals(TestByte34, TestByte34II).Value);
-            Assert.True(!SqlByte.Equals(TestByte34, TestByte15).Value);
-            Assert.True(!SqlByte.Equals(TestByte15, TestByte34II).Value);
+            Assert.True(SqlByte.Equals(testByte34, testByte34II).Value);
+            Assert.False(SqlByte.Equals(testByte34, testByte15).Value);
+            Assert.False(SqlByte.Equals(testByte15, testByte34II).Value);
         }
 
         [Fact]
         public void GetHashCodeTest()
         {
-            SqlByte TestByte15 = new SqlByte(15);
-            SqlByte TestByte216 = new SqlByte(216);
+            SqlByte testByte15 = new SqlByte(15);
+            SqlByte testByte216 = new SqlByte(216);
 
-            Assert.Equal(15, TestByte15.GetHashCode());
-            Assert.Equal(216, TestByte216.GetHashCode());
+            Assert.Equal(15, testByte15.GetHashCode());
+            Assert.Equal(216, testByte216.GetHashCode());
         }
 
         [Fact]
         public void GetTypeTest()
         {
-            SqlByte TestByte = new SqlByte(84);
+            SqlByte testByte = new SqlByte(84);
 
-            Assert.Equal("System.Data.SqlTypes.SqlByte", TestByte.GetType().ToString());
+            Assert.Equal("System.Data.SqlTypes.SqlByte", testByte.GetType().ToString());
         }
 
         [Fact]
         public void GreaterThan()
         {
-            SqlByte TestByte10 = new SqlByte(10);
-            SqlByte TestByte10II = new SqlByte(10);
-            SqlByte TestByte110 = new SqlByte(110);
+            SqlByte testByte10 = new SqlByte(10);
+            SqlByte testByte10II = new SqlByte(10);
+            SqlByte testByte110 = new SqlByte(110);
 
-            Assert.True(!SqlByte.GreaterThan(TestByte10, TestByte110).Value);
-            Assert.True(SqlByte.GreaterThan(TestByte110, TestByte10).Value);
-            Assert.True(!SqlByte.GreaterThan(TestByte10II, TestByte10).Value);
+            Assert.False(SqlByte.GreaterThan(testByte10, testByte110).Value);
+            Assert.True(SqlByte.GreaterThan(testByte110, testByte10).Value);
+            Assert.False(SqlByte.GreaterThan(testByte10II, testByte10).Value);
         }
 
         [Fact]
         public void GreaterThanOrEqual()
         {
-            SqlByte TestByte10 = new SqlByte(10);
-            SqlByte TestByte10II = new SqlByte(10);
-            SqlByte TestByte110 = new SqlByte(110);
+            SqlByte testByte10 = new SqlByte(10);
+            SqlByte testByte10II = new SqlByte(10);
+            SqlByte testByte110 = new SqlByte(110);
 
-            Assert.True(!SqlByte.GreaterThanOrEqual(TestByte10, TestByte110).Value);
+            Assert.False(SqlByte.GreaterThanOrEqual(testByte10, testByte110).Value);
 
-            Assert.True(SqlByte.GreaterThanOrEqual(TestByte110, TestByte10).Value);
+            Assert.True(SqlByte.GreaterThanOrEqual(testByte110, testByte10).Value);
 
-            Assert.True(SqlByte.GreaterThanOrEqual(TestByte10II, TestByte10).Value);
+            Assert.True(SqlByte.GreaterThanOrEqual(testByte10II, testByte10).Value);
         }
 
         [Fact]
         public void LessThan()
         {
-            SqlByte TestByte10 = new SqlByte(10);
-            SqlByte TestByte10II = new SqlByte(10);
-            SqlByte TestByte110 = new SqlByte(110);
+            SqlByte testByte10 = new SqlByte(10);
+            SqlByte testByte10II = new SqlByte(10);
+            SqlByte testByte110 = new SqlByte(110);
 
-            Assert.True(SqlByte.LessThan(TestByte10, TestByte110).Value);
+            Assert.True(SqlByte.LessThan(testByte10, testByte110).Value);
 
-            Assert.True(!SqlByte.LessThan(TestByte110, TestByte10).Value);
+            Assert.False(SqlByte.LessThan(testByte110, testByte10).Value);
 
-            Assert.True(!SqlByte.LessThan(TestByte10II, TestByte10).Value);
+            Assert.False(SqlByte.LessThan(testByte10II, testByte10).Value);
         }
 
         [Fact]
         public void LessThanOrEqual()
         {
-            SqlByte TestByte10 = new SqlByte(10);
-            SqlByte TestByte10II = new SqlByte(10);
-            SqlByte TestByte110 = new SqlByte(110);
+            SqlByte testByte10 = new SqlByte(10);
+            SqlByte testByte10II = new SqlByte(10);
+            SqlByte testByte110 = new SqlByte(110);
 
-            Assert.True(SqlByte.LessThanOrEqual(TestByte10, TestByte110).Value);
+            Assert.True(SqlByte.LessThanOrEqual(testByte10, testByte110).Value);
 
-            Assert.True(!SqlByte.LessThanOrEqual(TestByte110, TestByte10).Value);
+            Assert.False(SqlByte.LessThanOrEqual(testByte110, testByte10).Value);
 
-            Assert.True(SqlByte.LessThanOrEqual(TestByte10II, TestByte10).Value);
+            Assert.True(SqlByte.LessThanOrEqual(testByte10II, testByte10).Value);
 
-            Assert.True(SqlByte.LessThanOrEqual(TestByte10II, SqlByte.Null).IsNull);
+            Assert.True(SqlByte.LessThanOrEqual(testByte10II, SqlByte.Null).IsNull);
         }
 
         [Fact]
         public void Mod()
         {
-            SqlByte TestByte132 = new SqlByte(132);
-            SqlByte TestByte10 = new SqlByte(10);
-            SqlByte TestByte200 = new SqlByte(200);
+            SqlByte testByte132 = new SqlByte(132);
+            SqlByte testByte10 = new SqlByte(10);
+            SqlByte testByte200 = new SqlByte(200);
 
-            Assert.Equal((SqlByte)2, SqlByte.Mod(TestByte132, TestByte10));
-            Assert.Equal((SqlByte)10, SqlByte.Mod(TestByte10, TestByte200));
-            Assert.Equal((SqlByte)0, SqlByte.Mod(TestByte200, TestByte10));
-            Assert.Equal((SqlByte)68, SqlByte.Mod(TestByte200, TestByte132));
+            Assert.Equal((SqlByte)2, SqlByte.Mod(testByte132, testByte10));
+            Assert.Equal((SqlByte)10, SqlByte.Mod(testByte10, testByte200));
+            Assert.Equal((SqlByte)0, SqlByte.Mod(testByte200, testByte10));
+            Assert.Equal((SqlByte)68, SqlByte.Mod(testByte200, testByte132));
         }
 
         [Fact]
         public void Multiply()
         {
-            SqlByte TestByte12 = new SqlByte(12);
-            SqlByte TestByte2 = new SqlByte(2);
-            SqlByte TestByte128 = new SqlByte(128);
+            SqlByte testByte12 = new SqlByte(12);
+            SqlByte testByte2 = new SqlByte(2);
+            SqlByte testByte128 = new SqlByte(128);
 
-            Assert.Equal((byte)24, SqlByte.Multiply(TestByte12, TestByte2).Value);
-            Assert.Equal((byte)24, SqlByte.Multiply(TestByte2, TestByte12).Value);
+            Assert.Equal((byte)24, SqlByte.Multiply(testByte12, testByte2).Value);
+            Assert.Equal((byte)24, SqlByte.Multiply(testByte2, testByte12).Value);
 
-            try
-            {
-                SqlByte.Multiply(TestByte128, TestByte2);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlByte.Multiply(testByte128, testByte2));
         }
 
         [Fact]
         public void NotEquals()
         {
-            SqlByte TestByte12 = new SqlByte(12);
-            SqlByte TestByte128 = new SqlByte(128);
-            SqlByte TestByte128II = new SqlByte(128);
+            SqlByte testByte12 = new SqlByte(12);
+            SqlByte testByte128 = new SqlByte(128);
+            SqlByte testByte128II = new SqlByte(128);
 
-            Assert.True(SqlByte.NotEquals(TestByte12, TestByte128).Value);
-            Assert.True(SqlByte.NotEquals(TestByte128, TestByte12).Value);
-            Assert.True(SqlByte.NotEquals(TestByte128II, TestByte12).Value);
-            Assert.True(!SqlByte.NotEquals(TestByte128II, TestByte128).Value);
-            Assert.True(!SqlByte.NotEquals(TestByte128, TestByte128II).Value);
+            Assert.True(SqlByte.NotEquals(testByte12, testByte128).Value);
+            Assert.True(SqlByte.NotEquals(testByte128, testByte12).Value);
+            Assert.True(SqlByte.NotEquals(testByte128II, testByte12).Value);
+            Assert.False(SqlByte.NotEquals(testByte128II, testByte128).Value);
+            Assert.False(SqlByte.NotEquals(testByte128, testByte128II).Value);
         }
 
         [Fact]
         public void OnesComplement()
         {
-            SqlByte TestByte12 = new SqlByte(12);
-            SqlByte TestByte128 = new SqlByte(128);
+            SqlByte testByte12 = new SqlByte(12);
+            SqlByte testByte128 = new SqlByte(128);
 
-            Assert.Equal((SqlByte)243, SqlByte.OnesComplement(TestByte12));
-            Assert.Equal((SqlByte)127, SqlByte.OnesComplement(TestByte128));
+            Assert.Equal((SqlByte)243, SqlByte.OnesComplement(testByte12));
+            Assert.Equal((SqlByte)127, SqlByte.OnesComplement(testByte128));
         }
 
         [Fact]
         public void Parse()
         {
-            try
-            {
-                SqlByte.Parse(null);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(ArgumentNullException), e.GetType());
-            }
+            Assert.Throws<ArgumentNullException>(() => SqlByte.Parse(null));
 
-            try
-            {
-                SqlByte.Parse("not-a-number");
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(FormatException), e.GetType());
-            }
+            Assert.Throws<FormatException>(() => SqlByte.Parse("not-a-number"));
 
-            try
-            {
-                int OverInt = (int)SqlByte.MaxValue + 1;
-                SqlByte.Parse(OverInt.ToString());
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlByte.Parse(((int)SqlByte.MaxValue + 1).ToString()));
 
             Assert.Equal((byte)150, SqlByte.Parse("150").Value);
         }
@@ -371,150 +311,143 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void Subtract()
         {
-            SqlByte TestByte12 = new SqlByte(12);
-            SqlByte TestByte128 = new SqlByte(128);
-            Assert.Equal((byte)116, SqlByte.Subtract(TestByte128, TestByte12).Value);
+            SqlByte testByte12 = new SqlByte(12);
+            SqlByte testByte128 = new SqlByte(128);
+            Assert.Equal((byte)116, SqlByte.Subtract(testByte128, testByte12).Value);
 
-            try
-            {
-                SqlByte.Subtract(TestByte12, TestByte128);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlByte.Subtract(testByte12, testByte128));
         }
 
         [Fact]
         public void ToSqlBoolean()
         {
-            SqlByte TestByte12 = new SqlByte(12);
-            SqlByte TestByte0 = new SqlByte(0);
-            SqlByte TestByteNull = SqlByte.Null;
+            SqlByte testByte12 = new SqlByte(12);
+            SqlByte testByte0 = new SqlByte(0);
+            SqlByte testByteNull = SqlByte.Null;
 
-            Assert.True(TestByte12.ToSqlBoolean().Value);
-            Assert.True(!TestByte0.ToSqlBoolean().Value);
-            Assert.True(TestByteNull.ToSqlBoolean().IsNull);
+            Assert.True(testByte12.ToSqlBoolean().Value);
+            Assert.False(testByte0.ToSqlBoolean().Value);
+            Assert.True(testByteNull.ToSqlBoolean().IsNull);
         }
 
         [Fact]
         public void ToSqlDecimal()
         {
-            SqlByte TestByte12 = new SqlByte(12);
-            SqlByte TestByte0 = new SqlByte(0);
-            SqlByte TestByte228 = new SqlByte(228);
+            SqlByte testByte12 = new SqlByte(12);
+            SqlByte testByte0 = new SqlByte(0);
+            SqlByte testByte228 = new SqlByte(228);
 
-            Assert.Equal(12, TestByte12.ToSqlDecimal().Value);
-            Assert.Equal(0, TestByte0.ToSqlDecimal().Value);
-            Assert.Equal(228, TestByte228.ToSqlDecimal().Value);
+            Assert.Equal(12, testByte12.ToSqlDecimal().Value);
+            Assert.Equal(0, testByte0.ToSqlDecimal().Value);
+            Assert.Equal(228, testByte228.ToSqlDecimal().Value);
         }
 
         [Fact]
         public void ToSqlDouble()
         {
-            SqlByte TestByte12 = new SqlByte(12);
-            SqlByte TestByte0 = new SqlByte(0);
-            SqlByte TestByte228 = new SqlByte(228);
+            SqlByte testByte12 = new SqlByte(12);
+            SqlByte testByte0 = new SqlByte(0);
+            SqlByte testByte228 = new SqlByte(228);
 
-            Assert.Equal(12, TestByte12.ToSqlDouble().Value);
-            Assert.Equal(0, TestByte0.ToSqlDouble().Value);
-            Assert.Equal(228, TestByte228.ToSqlDouble().Value);
+            Assert.Equal(12, testByte12.ToSqlDouble().Value);
+            Assert.Equal(0, testByte0.ToSqlDouble().Value);
+            Assert.Equal(228, testByte228.ToSqlDouble().Value);
         }
 
         [Fact]
         public void ToSqlInt16()
         {
-            SqlByte TestByte12 = new SqlByte(12);
-            SqlByte TestByte0 = new SqlByte(0);
-            SqlByte TestByte228 = new SqlByte(228);
+            SqlByte testByte12 = new SqlByte(12);
+            SqlByte testByte0 = new SqlByte(0);
+            SqlByte testByte228 = new SqlByte(228);
 
-            Assert.Equal((short)12, TestByte12.ToSqlInt16().Value);
-            Assert.Equal((short)0, TestByte0.ToSqlInt16().Value);
-            Assert.Equal((short)228, TestByte228.ToSqlInt16().Value);
+            Assert.Equal((short)12, testByte12.ToSqlInt16().Value);
+            Assert.Equal((short)0, testByte0.ToSqlInt16().Value);
+            Assert.Equal((short)228, testByte228.ToSqlInt16().Value);
         }
 
         [Fact]
         public void ToSqlInt32()
         {
-            SqlByte TestByte12 = new SqlByte(12);
-            SqlByte TestByte0 = new SqlByte(0);
-            SqlByte TestByte228 = new SqlByte(228);
+            SqlByte testByte12 = new SqlByte(12);
+            SqlByte testByte0 = new SqlByte(0);
+            SqlByte testByte228 = new SqlByte(228);
 
-            Assert.Equal(12, TestByte12.ToSqlInt32().Value);
-            Assert.Equal(0, TestByte0.ToSqlInt32().Value);
-            Assert.Equal(228, TestByte228.ToSqlInt32().Value);
+            Assert.Equal(12, testByte12.ToSqlInt32().Value);
+            Assert.Equal(0, testByte0.ToSqlInt32().Value);
+            Assert.Equal(228, testByte228.ToSqlInt32().Value);
         }
 
         [Fact]
         public void ToSqlInt64()
         {
-            SqlByte TestByte12 = new SqlByte(12);
-            SqlByte TestByte0 = new SqlByte(0);
-            SqlByte TestByte228 = new SqlByte(228);
+            SqlByte testByte12 = new SqlByte(12);
+            SqlByte testByte0 = new SqlByte(0);
+            SqlByte testByte228 = new SqlByte(228);
 
-            Assert.Equal(12, TestByte12.ToSqlInt64().Value);
-            Assert.Equal(0, TestByte0.ToSqlInt64().Value);
-            Assert.Equal(228, TestByte228.ToSqlInt64().Value);
+            Assert.Equal(12, testByte12.ToSqlInt64().Value);
+            Assert.Equal(0, testByte0.ToSqlInt64().Value);
+            Assert.Equal(228, testByte228.ToSqlInt64().Value);
         }
 
         [Fact]
         public void ToSqlMoney()
         {
-            SqlByte TestByte12 = new SqlByte(12);
-            SqlByte TestByte0 = new SqlByte(0);
-            SqlByte TestByte228 = new SqlByte(228);
+            SqlByte testByte12 = new SqlByte(12);
+            SqlByte testByte0 = new SqlByte(0);
+            SqlByte testByte228 = new SqlByte(228);
 
-            Assert.Equal(12.0000M, TestByte12.ToSqlMoney().Value);
-            Assert.Equal(0, TestByte0.ToSqlMoney().Value);
-            Assert.Equal(228.0000M, TestByte228.ToSqlMoney().Value);
+            Assert.Equal(12M, testByte12.ToSqlMoney().Value);
+            Assert.Equal(0, testByte0.ToSqlMoney().Value);
+            Assert.Equal(228M, testByte228.ToSqlMoney().Value);
         }
 
         [Fact]
         public void ToSqlSingle()
         {
-            SqlByte TestByte12 = new SqlByte(12);
-            SqlByte TestByte0 = new SqlByte(0);
-            SqlByte TestByte228 = new SqlByte(228);
+            SqlByte testByte12 = new SqlByte(12);
+            SqlByte testByte0 = new SqlByte(0);
+            SqlByte testByte228 = new SqlByte(228);
 
-            Assert.Equal(12, TestByte12.ToSqlSingle().Value);
-            Assert.Equal(0, TestByte0.ToSqlSingle().Value);
-            Assert.Equal(228, TestByte228.ToSqlSingle().Value);
+            Assert.Equal(12, testByte12.ToSqlSingle().Value);
+            Assert.Equal(0, testByte0.ToSqlSingle().Value);
+            Assert.Equal(228, testByte228.ToSqlSingle().Value);
         }
 
         [Fact]
         public void ToSqlString()
         {
-            SqlByte TestByte12 = new SqlByte(12);
-            SqlByte TestByte0 = new SqlByte(0);
-            SqlByte TestByte228 = new SqlByte(228);
+            SqlByte testByte12 = new SqlByte(12);
+            SqlByte testByte0 = new SqlByte(0);
+            SqlByte testByte228 = new SqlByte(228);
 
-            Assert.Equal("12", TestByte12.ToSqlString().Value);
-            Assert.Equal("0", TestByte0.ToSqlString().Value);
-            Assert.Equal("228", TestByte228.ToSqlString().Value);
+            Assert.Equal("12", testByte12.ToSqlString().Value);
+            Assert.Equal("0", testByte0.ToSqlString().Value);
+            Assert.Equal("228", testByte228.ToSqlString().Value);
         }
 
         [Fact]
         public void ToStringTest()
         {
-            SqlByte TestByte12 = new SqlByte(12);
-            SqlByte TestByte0 = new SqlByte(0);
-            SqlByte TestByte228 = new SqlByte(228);
+            SqlByte testByte12 = new SqlByte(12);
+            SqlByte testByte0 = new SqlByte(0);
+            SqlByte testByte228 = new SqlByte(228);
 
-            Assert.Equal("12", TestByte12.ToString());
-            Assert.Equal("0", TestByte0.ToString());
-            Assert.Equal("228", TestByte228.ToString());
+            Assert.Equal("12", testByte12.ToString());
+            Assert.Equal("0", testByte0.ToString());
+            Assert.Equal("228", testByte228.ToString());
         }
 
         [Fact]
         public void TestXor()
         {
-            SqlByte TestByte14 = new SqlByte(14);
-            SqlByte TestByte58 = new SqlByte(58);
-            SqlByte TestByte130 = new SqlByte(130);
+            SqlByte testByte14 = new SqlByte(14);
+            SqlByte testByte58 = new SqlByte(58);
+            SqlByte testByte130 = new SqlByte(130);
 
-            Assert.Equal((byte)52, SqlByte.Xor(TestByte14, TestByte58).Value);
-            Assert.Equal((byte)140, SqlByte.Xor(TestByte14, TestByte130).Value);
-            Assert.Equal((byte)184, SqlByte.Xor(TestByte58, TestByte130).Value);
+            Assert.Equal((byte)52, SqlByte.Xor(testByte14, testByte58).Value);
+            Assert.Equal((byte)140, SqlByte.Xor(testByte14, testByte130).Value);
+            Assert.Equal((byte)184, SqlByte.Xor(testByte58, testByte130).Value);
         }
 
         // OPERATORS
@@ -522,348 +455,248 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void AdditionOperator()
         {
-            SqlByte TestByte24 = new SqlByte(24);
-            SqlByte TestByte64 = new SqlByte(64);
-            SqlByte TestByte255 = new SqlByte(255);
+            SqlByte testByte24 = new SqlByte(24);
+            SqlByte testByte64 = new SqlByte(64);
+            SqlByte testByte255 = new SqlByte(255);
 
-            Assert.Equal((SqlByte)88, TestByte24 + TestByte64);
+            Assert.Equal((SqlByte)88, testByte24 + testByte64);
 
             try
             {
-                SqlByte result = TestByte64 + TestByte255;
+                SqlByte result = testByte64 + testByte255;
                 Assert.False(true);
             }
             catch (Exception e)
             {
                 Assert.Equal(typeof(OverflowException), e.GetType());
             }
+            Assert.Throws<OverflowException>(() => testByte64 + testByte255);
         }
 
         [Fact]
         public void BitwiseAndOperator()
         {
-            SqlByte TestByte2 = new SqlByte(2);
-            SqlByte TestByte4 = new SqlByte(4);
-            SqlByte TestByte255 = new SqlByte(255);
+            SqlByte testByte2 = new SqlByte(2);
+            SqlByte testByte4 = new SqlByte(4);
+            SqlByte testByte255 = new SqlByte(255);
 
-            Assert.Equal((SqlByte)0, TestByte2 & TestByte4);
-            Assert.Equal((SqlByte)2, TestByte2 & TestByte255);
+            Assert.Equal((SqlByte)0, testByte2 & testByte4);
+            Assert.Equal((SqlByte)2, testByte2 & testByte255);
         }
 
         [Fact]
         public void BitwiseOrOperator()
         {
-            SqlByte TestByte2 = new SqlByte(2);
-            SqlByte TestByte4 = new SqlByte(4);
-            SqlByte TestByte255 = new SqlByte(255);
+            SqlByte testByte2 = new SqlByte(2);
+            SqlByte testByte4 = new SqlByte(4);
+            SqlByte testByte255 = new SqlByte(255);
 
-            Assert.Equal((SqlByte)6, TestByte2 | TestByte4);
-            Assert.Equal((SqlByte)255, TestByte2 | TestByte255);
+            Assert.Equal((SqlByte)6, testByte2 | testByte4);
+            Assert.Equal((SqlByte)255, testByte2 | testByte255);
         }
 
         [Fact]
         public void DivisionOperator()
         {
-            SqlByte TestByte2 = new SqlByte(2);
-            SqlByte TestByte4 = new SqlByte(4);
-            SqlByte TestByte255 = new SqlByte(255);
-            SqlByte TestByte0 = new SqlByte(0);
+            SqlByte testByte2 = new SqlByte(2);
+            SqlByte testByte4 = new SqlByte(4);
+            SqlByte testByte255 = new SqlByte(255);
+            SqlByte testByte0 = new SqlByte(0);
 
-            Assert.Equal((SqlByte)2, TestByte4 / TestByte2);
-            Assert.Equal((SqlByte)127, TestByte255 / TestByte2);
+            Assert.Equal((SqlByte)2, testByte4 / testByte2);
+            Assert.Equal((SqlByte)127, testByte255 / testByte2);
 
-            try
-            {
-                TestByte2 = TestByte255 / TestByte0;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(DivideByZeroException), e.GetType());
-            }
+            Assert.Throws<DivideByZeroException>(() => testByte255 / testByte0);
         }
 
         [Fact]
         public void EqualityOperator()
         {
-            SqlByte TestByte15 = new SqlByte(15);
-            SqlByte TestByte15II = new SqlByte(15);
-            SqlByte TestByte255 = new SqlByte(255);
+            SqlByte testByte15 = new SqlByte(15);
+            SqlByte testByte15II = new SqlByte(15);
+            SqlByte testByte255 = new SqlByte(255);
 
-            Assert.True((TestByte15 == TestByte15II).Value);
-            Assert.True(!(TestByte15 == TestByte255).Value);
-            Assert.True(!(TestByte15 != TestByte15II).Value);
-            Assert.True((TestByte15 != TestByte255).Value);
+            Assert.True((testByte15 == testByte15II).Value);
+            Assert.False((testByte15 == testByte255).Value);
+            Assert.False((testByte15 != testByte15II).Value);
+            Assert.True((testByte15 != testByte255).Value);
         }
 
         [Fact]
         public void ExclusiveOrOperator()
         {
-            SqlByte TestByte15 = new SqlByte(15);
-            SqlByte TestByte10 = new SqlByte(10);
-            SqlByte TestByte255 = new SqlByte(255);
+            SqlByte testByte15 = new SqlByte(15);
+            SqlByte testByte10 = new SqlByte(10);
+            SqlByte testByte255 = new SqlByte(255);
 
-            Assert.Equal((SqlByte)5, (TestByte15 ^ TestByte10));
-            Assert.Equal((SqlByte)240, (TestByte15 ^ TestByte255));
+            Assert.Equal((SqlByte)5, (testByte15 ^ testByte10));
+            Assert.Equal((SqlByte)240, (testByte15 ^ testByte255));
         }
 
         [Fact]
         public void ThanOrEqualOperators()
         {
-            SqlByte TestByte165 = new SqlByte(165);
-            SqlByte TestByte100 = new SqlByte(100);
-            SqlByte TestByte100II = new SqlByte(100);
-            SqlByte TestByte255 = new SqlByte(255);
+            SqlByte testByte165 = new SqlByte(165);
+            SqlByte testByte100 = new SqlByte(100);
+            SqlByte testByte100II = new SqlByte(100);
+            SqlByte testByte255 = new SqlByte(255);
 
-            Assert.True((TestByte165 > TestByte100).Value);
-            Assert.True(!(TestByte165 > TestByte255).Value);
-            Assert.True(!(TestByte100 > TestByte100II).Value);
-            Assert.True(!(TestByte165 >= TestByte255).Value);
-            Assert.True((TestByte255 >= TestByte165).Value);
-            Assert.True((TestByte100 >= TestByte100II).Value);
+            Assert.True((testByte165 > testByte100).Value);
+            Assert.False((testByte165 > testByte255).Value);
+            Assert.False((testByte100 > testByte100II).Value);
+            Assert.False((testByte165 >= testByte255).Value);
+            Assert.True((testByte255 >= testByte165).Value);
+            Assert.True((testByte100 >= testByte100II).Value);
 
-            Assert.True(!(TestByte165 < TestByte100).Value);
-            Assert.True((TestByte165 < TestByte255).Value);
-            Assert.True(!(TestByte100 < TestByte100II).Value);
-            Assert.True((TestByte165 <= TestByte255).Value);
-            Assert.True(!(TestByte255 <= TestByte165).Value);
-            Assert.True((TestByte100 <= TestByte100II).Value);
+            Assert.False((testByte165 < testByte100).Value);
+            Assert.True((testByte165 < testByte255).Value);
+            Assert.False((testByte100 < testByte100II).Value);
+            Assert.True((testByte165 <= testByte255).Value);
+            Assert.False((testByte255 <= testByte165).Value);
+            Assert.True((testByte100 <= testByte100II).Value);
         }
 
         [Fact]
         public void MultiplicationOperator()
         {
-            SqlByte TestByte4 = new SqlByte(4);
-            SqlByte TestByte12 = new SqlByte(12);
-            SqlByte TestByte128 = new SqlByte(128);
+            SqlByte testByte4 = new SqlByte(4);
+            SqlByte testByte12 = new SqlByte(12);
+            SqlByte testByte128 = new SqlByte(128);
 
-            Assert.Equal((SqlByte)48, TestByte4 * TestByte12);
-            try
-            {
-                SqlByte test = (TestByte128 * TestByte4);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Equal((SqlByte)48, testByte4 * testByte12);
+            Assert.Throws<OverflowException>(() => testByte128 * testByte4);
         }
 
         [Fact]
         public void OnesComplementOperator()
         {
-            SqlByte TestByte12 = new SqlByte(12);
-            SqlByte TestByte128 = new SqlByte(128);
+            SqlByte testByte12 = new SqlByte(12);
+            SqlByte testByte128 = new SqlByte(128);
 
-            Assert.Equal((SqlByte)243, ~TestByte12);
-            Assert.Equal((SqlByte)127, ~TestByte128);
+            Assert.Equal((SqlByte)243, ~testByte12);
+            Assert.Equal((SqlByte)127, ~testByte128);
         }
 
         [Fact]
         public void SubtractionOperator()
         {
-            SqlByte TestByte4 = new SqlByte(4);
-            SqlByte TestByte12 = new SqlByte(12);
-            SqlByte TestByte128 = new SqlByte(128);
+            SqlByte testByte4 = new SqlByte(4);
+            SqlByte testByte12 = new SqlByte(12);
+            SqlByte testByte128 = new SqlByte(128);
 
-            Assert.Equal((SqlByte)8, TestByte12 - TestByte4);
-            try
-            {
-                SqlByte test = TestByte4 - TestByte128;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Equal((SqlByte)8, testByte12 - testByte4);
+            Assert.Throws<OverflowException>(() => testByte4 - testByte128);
         }
 
         [Fact]
         public void SqlBooleanToSqlByte()
         {
-            SqlBoolean TestBoolean = new SqlBoolean(true);
-            SqlByte TestByte;
+            SqlBoolean testBoolean = new SqlBoolean(true);
+            SqlByte testByte;
 
-            TestByte = (SqlByte)TestBoolean;
+            testByte = (SqlByte)testBoolean;
 
-            Assert.Equal((byte)1, TestByte.Value);
+            Assert.Equal((byte)1, testByte.Value);
         }
 
         [Fact]
         public void SqlByteToByte()
         {
-            SqlByte TestByte = new SqlByte(12);
-            byte test = (byte)TestByte;
+            SqlByte testByte = new SqlByte(12);
+            byte test = (byte)testByte;
             Assert.Equal((byte)12, test);
         }
 
         [Fact]
         public void SqlDecimalToSqlByte()
         {
-            SqlDecimal TestDecimal64 = new SqlDecimal(64);
-            SqlDecimal TestDecimal900 = new SqlDecimal(900);
+            SqlDecimal testDecimal64 = new SqlDecimal(64);
+            SqlDecimal testDecimal900 = new SqlDecimal(900);
 
-            Assert.Equal((byte)64, ((SqlByte)TestDecimal64).Value);
-
-            try
-            {
-                SqlByte test = (SqlByte)TestDecimal900;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Equal((byte)64, ((SqlByte)testDecimal64).Value);
+            Assert.Throws<OverflowException>(() => (SqlByte)testDecimal900);
         }
 
         [Fact]
         public void SqlDoubleToSqlByte()
         {
-            SqlDouble TestDouble64 = new SqlDouble(64);
-            SqlDouble TestDouble900 = new SqlDouble(900);
+            SqlDouble testDouble64 = new SqlDouble(64);
+            SqlDouble testDouble900 = new SqlDouble(900);
 
-            Assert.Equal((byte)64, ((SqlByte)TestDouble64).Value);
-
-            try
-            {
-                SqlByte test = (SqlByte)TestDouble900;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Equal((byte)64, ((SqlByte)testDouble64).Value);
+            Assert.Throws<OverflowException>(() => (SqlByte)testDouble900);
         }
 
         [Fact]
         public void SqlInt16ToSqlByte()
         {
-            SqlInt16 TestInt1664 = new SqlInt16(64);
-            SqlInt16 TestInt16900 = new SqlInt16(900);
+            SqlInt16 testInt1664 = new SqlInt16(64);
+            SqlInt16 testInt16900 = new SqlInt16(900);
 
-            Assert.Equal((byte)64, ((SqlByte)TestInt1664).Value);
+            Assert.Equal((byte)64, ((SqlByte)testInt1664).Value);
 
-            try
-            {
-                SqlByte test = (SqlByte)TestInt16900;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => (SqlByte)testInt16900);
         }
 
         [Fact]
         public void SqlInt32ToSqlByte()
         {
-            SqlInt32 TestInt3264 = new SqlInt32(64);
-            SqlInt32 TestInt32900 = new SqlInt32(900);
+            SqlInt32 testInt3264 = new SqlInt32(64);
+            SqlInt32 testInt32900 = new SqlInt32(900);
 
-            Assert.Equal((byte)64, ((SqlByte)TestInt3264).Value);
-
-            try
-            {
-                SqlByte test = (SqlByte)TestInt32900;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Equal((byte)64, ((SqlByte)testInt3264).Value);
+            Assert.Throws<OverflowException>(() => (SqlByte)testInt32900);
         }
 
         [Fact]
         public void SqlInt64ToSqlByte()
         {
-            SqlInt64 TestInt6464 = new SqlInt64(64);
-            SqlInt64 TestInt64900 = new SqlInt64(900);
+            SqlInt64 testInt6464 = new SqlInt64(64);
+            SqlInt64 testInt64900 = new SqlInt64(900);
 
-            Assert.Equal((byte)64, ((SqlByte)TestInt6464).Value);
-
-            try
-            {
-                SqlByte test = (SqlByte)TestInt64900;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Equal((byte)64, ((SqlByte)testInt6464).Value);
+            Assert.Throws<OverflowException>(() => (SqlByte)testInt64900);
         }
 
         [Fact]
         public void SqlMoneyToSqlByte()
         {
-            SqlMoney TestMoney64 = new SqlMoney(64);
-            SqlMoney TestMoney900 = new SqlMoney(900);
+            SqlMoney testMoney64 = new SqlMoney(64);
+            SqlMoney testMoney900 = new SqlMoney(900);
 
-            Assert.Equal((byte)64, ((SqlByte)TestMoney64).Value);
-
-            try
-            {
-                SqlByte test = (SqlByte)TestMoney900;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Equal((byte)64, ((SqlByte)testMoney64).Value);
+            Assert.Throws<OverflowException>(() => (SqlByte)testMoney900);
         }
 
         [Fact]
         public void SqlSingleToSqlByte()
         {
-            SqlSingle TestSingle64 = new SqlSingle(64);
-            SqlSingle TestSingle900 = new SqlSingle(900);
+            SqlSingle testSingle64 = new SqlSingle(64);
+            SqlSingle testSingle900 = new SqlSingle(900);
 
-            Assert.Equal((byte)64, ((SqlByte)TestSingle64).Value);
-
-            try
-            {
-                SqlByte test = (SqlByte)TestSingle900;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Equal((byte)64, ((SqlByte)testSingle64).Value);
+            Assert.Throws<OverflowException>(() => (SqlByte)testSingle900);
         }
 
         [Fact]
         public void SqlStringToSqlByte()
         {
-            SqlString TestString = new SqlString("Test string");
-            SqlString TestString100 = new SqlString("100");
-            SqlString TestString1000 = new SqlString("1000");
+            SqlString testString = new SqlString("Test string");
+            SqlString testString100 = new SqlString("100");
+            SqlString testString1000 = new SqlString("1000");
 
-            Assert.Equal((byte)100, ((SqlByte)TestString100).Value);
+            Assert.Equal((byte)100, ((SqlByte)testString100).Value);
 
-            try
-            {
-                SqlByte test = (SqlByte)TestString1000;
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => (SqlByte)testString1000);
 
-            try
-            {
-                SqlByte test = (SqlByte)TestString;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(FormatException), e.GetType());
-            }
+            Assert.Throws<FormatException>(() => (SqlByte)testString);
         }
 
         [Fact]
         public void ByteToSqlByte()
         {
-            byte TestByte = 14;
-            Assert.Equal((byte)14, ((SqlByte)TestByte).Value);
+            byte testByte = 14;
+            Assert.Equal((byte)14, ((SqlByte)testByte).Value);
         }
         [Fact]
         public void GetXsdTypeTest()

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlBytesTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlBytesTest.cs
@@ -25,7 +25,6 @@ using Xunit;
 using System.IO;
 using System.Xml;
 using System.Data.SqlTypes;
-using System.Globalization;
 
 namespace System.Data.Tests.SqlTypes
 {
@@ -36,72 +35,28 @@ namespace System.Data.Tests.SqlTypes
         public void SqlBytesItem()
         {
             SqlBytes bytes = new SqlBytes();
-            try
-            {
-                Assert.Equal(0, bytes[0]);
-                Assert.False(true);
-            }
-            catch (Exception ex)
-            {
-                Assert.Equal(typeof(SqlNullValueException), ex.GetType());
-            }
+            Assert.Throws<SqlNullValueException>(() => bytes[0]);
+
             byte[] b = null;
             bytes = new SqlBytes(b);
-            try
-            {
-                Assert.Equal(0, bytes[0]);
-                Assert.False(true);
-            }
-            catch (Exception ex)
-            {
-                Assert.Equal(typeof(SqlNullValueException), ex.GetType());
-            }
+            Assert.Throws<SqlNullValueException>(() => bytes[0]);
+
             b = new byte[10];
             bytes = new SqlBytes(b);
             Assert.Equal(0, bytes[0]);
-            try
-            {
-                Assert.Equal(0, bytes[-1]);
-                Assert.False(true);
-            }
-            catch (Exception ex)
-            {
-                Assert.Equal(typeof(ArgumentOutOfRangeException), ex.GetType());
-            }
-            try
-            {
-                Assert.Equal(0, bytes[10]);
-                Assert.False(true);
-            }
-            catch (Exception ex)
-            {
-                Assert.Equal(typeof(ArgumentOutOfRangeException), ex.GetType());
-            }
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes[-1]);
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes[10]);
         }
         [Fact]
         public void SqlBytesLength()
         {
             byte[] b = null;
             SqlBytes bytes = new SqlBytes();
-            try
-            {
-                Assert.Equal(0, bytes.Length);
-                Assert.False(true);
-            }
-            catch (Exception ex)
-            {
-                Assert.Equal(typeof(SqlNullValueException), ex.GetType());
-            }
+            Assert.Throws<SqlNullValueException>(() => bytes.Length);
+
             bytes = new SqlBytes(b);
-            try
-            {
-                Assert.Equal(0, bytes.Length);
-                Assert.False(true);
-            }
-            catch (Exception ex)
-            {
-                Assert.Equal(typeof(SqlNullValueException), ex.GetType());
-            }
+            Assert.Throws<SqlNullValueException>(() => bytes.Length);
+
             b = new byte[10];
             bytes = new SqlBytes(b);
             Assert.Equal(10, bytes.Length);
@@ -121,7 +76,6 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void SqlBytesNull()
         {
-            byte[] b = null;
             SqlBytes bytes = SqlBytes.Null;
             Assert.True(bytes.IsNull);
         }
@@ -130,39 +84,18 @@ namespace System.Data.Tests.SqlTypes
         {
             byte[] b = null;
             SqlBytes bytes = new SqlBytes();
-            try
-            {
-                Assert.Equal(StorageState.Buffer, bytes.Storage);
-                Assert.False(true);
-            }
-            catch (Exception ex)
-            {
-                Assert.Equal(typeof(SqlNullValueException), ex.GetType());
-            }
+            Assert.Throws<SqlNullValueException>(() => bytes.Storage);
+
             bytes = new SqlBytes(b);
-            try
-            {
-                Assert.Equal(StorageState.Buffer, bytes.Storage);
-                Assert.False(true);
-            }
-            catch (Exception ex)
-            {
-                Assert.Equal(typeof(SqlNullValueException), ex.GetType());
-            }
+            Assert.Throws<SqlNullValueException>(() => bytes.Storage);
+
             b = new byte[10];
             bytes = new SqlBytes(b);
             Assert.Equal(StorageState.Buffer, bytes.Storage);
+
             FileStream fs = null;
             bytes = new SqlBytes(fs);
-            try
-            {
-                Assert.Equal(StorageState.Buffer, bytes.Storage);
-                Assert.False(true);
-            }
-            catch (Exception ex)
-            {
-                Assert.Equal(typeof(SqlNullValueException), ex.GetType());
-            }
+            Assert.Throws<SqlNullValueException>(() => bytes.Storage);
         }
         [Fact]
         public void SqlBytesValue()
@@ -180,35 +113,13 @@ namespace System.Data.Tests.SqlTypes
         {
             byte[] b1 = new byte[10];
             SqlBytes bytes = new SqlBytes();
-            try
-            {
-                bytes.SetLength(20);
-                Assert.False(true);
-            }
-            catch (Exception ex)
-            {
-                Assert.Equal(typeof(SqlTypeException), ex.GetType());
-            }
+            Assert.Throws<SqlTypeException>(() => bytes.SetLength(20));
+
             bytes = new SqlBytes(b1);
             Assert.Equal(10, bytes.Length);
-            try
-            {
-                bytes.SetLength(-1);
-                Assert.False(true);
-            }
-            catch (Exception ex)
-            {
-                Assert.Equal(typeof(ArgumentOutOfRangeException), ex.GetType());
-            }
-            try
-            {
-                bytes.SetLength(11);
-                Assert.False(true);
-            }
-            catch (Exception ex)
-            {
-                Assert.Equal(typeof(ArgumentOutOfRangeException), ex.GetType());
-            }
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.SetLength(-1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bytes.SetLength(11));
+
             bytes.SetLength(2);
             Assert.Equal(2, bytes.Length);
         }
@@ -219,15 +130,7 @@ namespace System.Data.Tests.SqlTypes
             SqlBytes bytes = new SqlBytes(b1);
             Assert.Equal(10, bytes.Length);
             bytes.SetNull();
-            try
-            {
-                Assert.Equal(10, bytes.Length);
-                Assert.False(true);
-            }
-            catch (Exception ex)
-            {
-                Assert.Equal(typeof(SqlNullValueException), ex.GetType());
-            }
+            Assert.Throws<SqlNullValueException>(() => bytes.Length);
             Assert.True(bytes.IsNull);
         }
         [Fact]

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlCharsTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlCharsTest.cs
@@ -39,47 +39,17 @@ namespace System.Data.Tests.SqlTypes
         public void SqlCharsItem()
         {
             SqlChars chars = new SqlChars();
-            try
-            {
-                Assert.Equal(0, chars[0]);
-                Assert.False(true);
-            }
-            catch (Exception ex)
-            {
-                Assert.Equal(typeof(SqlNullValueException), ex.GetType());
-            }
+            Assert.Throws<SqlNullValueException>(() => chars[0]);
+
             char[] b = null;
             chars = new SqlChars(b);
-            try
-            {
-                Assert.Equal(0, chars[0]);
-                Assert.False(true);
-            }
-            catch (Exception ex)
-            {
-                Assert.Equal(typeof(SqlNullValueException), ex.GetType());
-            }
+            Assert.Throws<SqlNullValueException>(() => chars[0]);
+
             b = new char[10];
             chars = new SqlChars(b);
             Assert.Equal(0, chars[0]);
-            try
-            {
-                Assert.Equal(0, chars[-1]);
-                Assert.False(true);
-            }
-            catch (Exception ex)
-            {
-                Assert.Equal(typeof(ArgumentOutOfRangeException), ex.GetType());
-            }
-            try
-            {
-                Assert.Equal(0, chars[10]);
-                Assert.False(true);
-            }
-            catch (Exception ex)
-            {
-                Assert.Equal(typeof(ArgumentOutOfRangeException), ex.GetType());
-            }
+            Assert.Throws<ArgumentOutOfRangeException>(() => chars[-1]);
+            Assert.Throws<ArgumentOutOfRangeException>(() => chars[10]);
         }
 
         [Fact]
@@ -87,25 +57,11 @@ namespace System.Data.Tests.SqlTypes
         {
             char[] b = null;
             SqlChars chars = new SqlChars();
-            try
-            {
-                Assert.Equal(0, chars.Length);
-                Assert.False(true);
-            }
-            catch (Exception ex)
-            {
-                Assert.Equal(typeof(SqlNullValueException), ex.GetType());
-            }
+            Assert.Throws<SqlNullValueException>(() => chars.Length);
+
             chars = new SqlChars(b);
-            try
-            {
-                Assert.Equal(0, chars.Length);
-                Assert.False(true);
-            }
-            catch (Exception ex)
-            {
-                Assert.Equal(typeof(SqlNullValueException), ex.GetType());
-            }
+            Assert.Throws<SqlNullValueException>(() => chars.Length);
+
             b = new char[10];
             chars = new SqlChars(b);
             Assert.Equal(10, chars.Length);
@@ -127,7 +83,6 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void SqlCharsNull()
         {
-            char[] b = null;
             SqlChars chars = SqlChars.Null;
             Assert.True(chars.IsNull);
         }
@@ -137,25 +92,11 @@ namespace System.Data.Tests.SqlTypes
         {
             char[] b = null;
             SqlChars chars = new SqlChars();
-            try
-            {
-                Assert.Equal(StorageState.Buffer, chars.Storage);
-                Assert.False(true);
-            }
-            catch (Exception ex)
-            {
-                Assert.Equal(typeof(SqlNullValueException), ex.GetType());
-            }
+            Assert.Throws<SqlNullValueException>(() => chars.Storage);
+
             chars = new SqlChars(b);
-            try
-            {
-                Assert.Equal(StorageState.Buffer, chars.Storage);
-                Assert.False(true);
-            }
-            catch (Exception ex)
-            {
-                Assert.Equal(typeof(SqlNullValueException), ex.GetType());
-            }
+            Assert.Throws<SqlNullValueException>(() => chars.Storage);
+
             b = new char[10];
             chars = new SqlChars(b);
             Assert.Equal(StorageState.Buffer, chars.Storage);
@@ -178,35 +119,12 @@ namespace System.Data.Tests.SqlTypes
         {
             char[] b1 = new char[10];
             SqlChars chars = new SqlChars();
-            try
-            {
-                chars.SetLength(20);
-                Assert.False(true);
-            }
-            catch (Exception ex)
-            {
-                Assert.Equal(typeof(SqlTypeException), ex.GetType());
-            }
+            Assert.Throws<SqlTypeException>(() => chars.SetLength(20));
+
             chars = new SqlChars(b1);
             Assert.Equal(10, chars.Length);
-            try
-            {
-                chars.SetLength(-1);
-                Assert.False(true);
-            }
-            catch (Exception ex)
-            {
-                Assert.Equal(typeof(ArgumentOutOfRangeException), ex.GetType());
-            }
-            try
-            {
-                chars.SetLength(11);
-                Assert.False(true);
-            }
-            catch (Exception ex)
-            {
-                Assert.Equal(typeof(ArgumentOutOfRangeException), ex.GetType());
-            }
+            Assert.Throws<ArgumentOutOfRangeException>(() => chars.SetLength(-1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => chars.SetLength(11));
             chars.SetLength(2);
             Assert.Equal(2, chars.Length);
         }
@@ -218,15 +136,7 @@ namespace System.Data.Tests.SqlTypes
             SqlChars chars = new SqlChars(b1);
             Assert.Equal(10, chars.Length);
             chars.SetNull();
-            try
-            {
-                Assert.Equal(10, chars.Length);
-                Assert.False(true);
-            }
-            catch (Exception ex)
-            {
-                Assert.Equal(typeof(SqlNullValueException), ex.GetType());
-            }
+            Assert.Throws<SqlNullValueException>(() => chars.Length);
             Assert.True(chars.IsNull);
         }
 

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlDateTimeTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlDateTimeTest.cs
@@ -165,7 +165,7 @@ namespace System.Data.Tests.SqlTypes
 
             Assert.True(_test1.CompareTo(_test3) < 0);
             Assert.True(_test2.CompareTo(_test1) > 0);
-            Assert.True(_test2.CompareTo(_test3) == 0);
+            Assert.Equal(0, _test2.CompareTo(_test3));
             Assert.True(_test1.CompareTo(SqlDateTime.Null) > 0);
 
             Assert.Throws<ArgumentException>(() => _test1.CompareTo(testString));

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlDateTimeTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlDateTimeTest.cs
@@ -192,13 +192,6 @@ namespace System.Data.Tests.SqlTypes
         }
 
         [Fact]
-        public void GetTypeTest()
-        {
-            Assert.Equal("System.Data.SqlTypes.SqlDateTime", _test1.GetType().ToString());
-            Assert.Equal("System.DateTime", _test1.Value.GetType().ToString());
-        }
-
-        [Fact]
         public void Greaters()
         {
             // GreateThan ()

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlDateTimeTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlDateTimeTest.cs
@@ -28,7 +28,6 @@
 using Xunit;
 using System.Xml;
 using System.Data.SqlTypes;
-using System.Globalization;
 
 namespace System.Data.Tests.SqlTypes
 {
@@ -60,53 +59,45 @@ namespace System.Data.Tests.SqlTypes
         public void Create()
         {
             // SqlDateTime (DateTime)
-            SqlDateTime CTest = new SqlDateTime(
+            SqlDateTime cTest = new SqlDateTime(
                 new DateTime(2002, 5, 19, 3, 34, 0));
-            Assert.Equal(2002, CTest.Value.Year);
+            Assert.Equal(2002, cTest.Value.Year);
 
             // SqlDateTime (int, int)
-            CTest = new SqlDateTime(0, 0);
+            cTest = new SqlDateTime(0, 0);
 
             // SqlDateTime (int, int, int)
-            Assert.Equal(1900, CTest.Value.Year);
-            Assert.Equal(1, CTest.Value.Month);
-            Assert.Equal(1, CTest.Value.Day);
-            Assert.Equal(0, CTest.Value.Hour);
+            Assert.Equal(1900, cTest.Value.Year);
+            Assert.Equal(1, cTest.Value.Month);
+            Assert.Equal(1, cTest.Value.Day);
+            Assert.Equal(0, cTest.Value.Hour);
 
             // SqlDateTime (int, int, int, int, int, int)
-            CTest = new SqlDateTime(5000, 12, 31);
-            Assert.Equal(5000, CTest.Value.Year);
-            Assert.Equal(12, CTest.Value.Month);
-            Assert.Equal(31, CTest.Value.Day);
+            cTest = new SqlDateTime(5000, 12, 31);
+            Assert.Equal(5000, cTest.Value.Year);
+            Assert.Equal(12, cTest.Value.Month);
+            Assert.Equal(31, cTest.Value.Day);
 
             // SqlDateTime (int, int, int, int, int, int, double)
-            CTest = new SqlDateTime(1978, 5, 19, 3, 34, 0);
-            Assert.Equal(1978, CTest.Value.Year);
-            Assert.Equal(5, CTest.Value.Month);
-            Assert.Equal(19, CTest.Value.Day);
-            Assert.Equal(3, CTest.Value.Hour);
-            Assert.Equal(34, CTest.Value.Minute);
-            Assert.Equal(0, CTest.Value.Second);
+            cTest = new SqlDateTime(1978, 5, 19, 3, 34, 0);
+            Assert.Equal(1978, cTest.Value.Year);
+            Assert.Equal(5, cTest.Value.Month);
+            Assert.Equal(19, cTest.Value.Day);
+            Assert.Equal(3, cTest.Value.Hour);
+            Assert.Equal(34, cTest.Value.Minute);
+            Assert.Equal(0, cTest.Value.Second);
 
-            try
-            {
-                CTest = new SqlDateTime(10000, 12, 31);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(SqlTypeException), e.GetType());
-            }
+            Assert.Throws<SqlTypeException>(() => new SqlDateTime(10000, 12, 31));
 
             // SqlDateTime (int, int, int, int, int, int, int)
-            CTest = new SqlDateTime(1978, 5, 19, 3, 34, 0, 12);
-            Assert.Equal(1978, CTest.Value.Year);
-            Assert.Equal(5, CTest.Value.Month);
-            Assert.Equal(19, CTest.Value.Day);
-            Assert.Equal(3, CTest.Value.Hour);
-            Assert.Equal(34, CTest.Value.Minute);
-            Assert.Equal(0, CTest.Value.Second);
-            Assert.Equal(0, CTest.Value.Millisecond);
+            cTest = new SqlDateTime(1978, 5, 19, 3, 34, 0, 12);
+            Assert.Equal(1978, cTest.Value.Year);
+            Assert.Equal(5, cTest.Value.Month);
+            Assert.Equal(19, cTest.Value.Day);
+            Assert.Equal(3, cTest.Value.Hour);
+            Assert.Equal(34, cTest.Value.Minute);
+            Assert.Equal(0, cTest.Value.Second);
+            Assert.Equal(0, cTest.Value.Millisecond);
         }
 
         // Test public fields
@@ -149,32 +140,16 @@ namespace System.Data.Tests.SqlTypes
             // DayTicks
             Assert.Equal(37546, _test1.DayTicks);
 
-            try
-            {
-                int test = SqlDateTime.Null.DayTicks;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(SqlNullValueException), e.GetType());
-            }
+            Assert.Throws<SqlNullValueException>(() => SqlDateTime.Null.DayTicks);
 
             // IsNull
             Assert.True(SqlDateTime.Null.IsNull);
-            Assert.True(!_test2.IsNull);
+            Assert.False(_test2.IsNull);
 
             // TimeTicks
             Assert.Equal(10440000, _test1.TimeTicks);
 
-            try
-            {
-                int test = SqlDateTime.Null.TimeTicks;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(SqlNullValueException), e.GetType());
-            }
+            Assert.Throws<SqlNullValueException>(() => SqlDateTime.Null.TimeTicks);
 
             // Value
             Assert.Equal(2003, _test2.Value.Year);
@@ -186,34 +161,26 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void CompareTo()
         {
-            SqlString TestString = new SqlString("This is a test");
+            SqlString testString = new SqlString("This is a test");
 
             Assert.True(_test1.CompareTo(_test3) < 0);
             Assert.True(_test2.CompareTo(_test1) > 0);
             Assert.True(_test2.CompareTo(_test3) == 0);
             Assert.True(_test1.CompareTo(SqlDateTime.Null) > 0);
 
-            try
-            {
-                _test1.CompareTo(TestString);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(ArgumentException), e.GetType());
-            }
+            Assert.Throws<ArgumentException>(() => _test1.CompareTo(testString));
         }
 
         [Fact]
         public void EqualsMethods()
         {
-            Assert.True(!_test1.Equals(_test2));
-            Assert.True(!_test2.Equals(new SqlString("TEST")));
+            Assert.False(_test1.Equals(_test2));
+            Assert.False(_test2.Equals(new SqlString("TEST")));
             Assert.True(_test2.Equals(_test3));
 
             // Static Equals()-method
             Assert.True(SqlDateTime.Equals(_test2, _test3).Value);
-            Assert.True(!SqlDateTime.Equals(_test1, _test2).Value);
+            Assert.False(SqlDateTime.Equals(_test1, _test2).Value);
         }
 
         [Fact]
@@ -221,7 +188,7 @@ namespace System.Data.Tests.SqlTypes
         {
             // FIXME: Better way to test HashCode
             Assert.Equal(_test1.GetHashCode(), _test1.GetHashCode());
-            Assert.True(_test2.GetHashCode() != _test1.GetHashCode());
+            Assert.NotEqual(_test2.GetHashCode(), _test1.GetHashCode());
         }
 
         [Fact]
@@ -235,12 +202,12 @@ namespace System.Data.Tests.SqlTypes
         public void Greaters()
         {
             // GreateThan ()
-            Assert.True(!SqlDateTime.GreaterThan(_test1, _test2).Value);
+            Assert.False(SqlDateTime.GreaterThan(_test1, _test2).Value);
             Assert.True(SqlDateTime.GreaterThan(_test2, _test1).Value);
-            Assert.True(!SqlDateTime.GreaterThan(_test2, _test3).Value);
+            Assert.False(SqlDateTime.GreaterThan(_test2, _test3).Value);
 
             // GreaterTharOrEqual ()
-            Assert.True(!SqlDateTime.GreaterThanOrEqual(_test1, _test2).Value);
+            Assert.False(SqlDateTime.GreaterThanOrEqual(_test1, _test2).Value);
             Assert.True(SqlDateTime.GreaterThanOrEqual(_test2, _test1).Value);
             Assert.True(SqlDateTime.GreaterThanOrEqual(_test2, _test3).Value);
         }
@@ -249,13 +216,13 @@ namespace System.Data.Tests.SqlTypes
         public void Lessers()
         {
             // LessThan()
-            Assert.True(!SqlDateTime.LessThan(_test2, _test3).Value);
-            Assert.True(!SqlDateTime.LessThan(_test2, _test1).Value);
+            Assert.False(SqlDateTime.LessThan(_test2, _test3).Value);
+            Assert.False(SqlDateTime.LessThan(_test2, _test1).Value);
             Assert.True(SqlDateTime.LessThan(_test1, _test3).Value);
 
             // LessThanOrEqual ()
             Assert.True(SqlDateTime.LessThanOrEqual(_test1, _test2).Value);
-            Assert.True(!SqlDateTime.LessThanOrEqual(_test2, _test1).Value);
+            Assert.False(SqlDateTime.LessThanOrEqual(_test2, _test1).Value);
             Assert.True(SqlDateTime.LessThanOrEqual(_test3, _test2).Value);
             Assert.True(SqlDateTime.LessThanOrEqual(_test1, SqlDateTime.Null).IsNull);
         }
@@ -265,46 +232,22 @@ namespace System.Data.Tests.SqlTypes
         {
             Assert.True(SqlDateTime.NotEquals(_test1, _test2).Value);
             Assert.True(SqlDateTime.NotEquals(_test3, _test1).Value);
-            Assert.True(!SqlDateTime.NotEquals(_test2, _test3).Value);
+            Assert.False(SqlDateTime.NotEquals(_test2, _test3).Value);
             Assert.True(SqlDateTime.NotEquals(SqlDateTime.Null, _test2).IsNull);
         }
 
         [Fact]
         public void Parse()
         {
-            try
-            {
-                SqlDateTime.Parse(null);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(ArgumentNullException), e.GetType());
-            }
+            Assert.Throws<ArgumentNullException>(() => SqlDateTime.Parse(null));
 
-            try
-            {
-                SqlDateTime.Parse("not-a-number");
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(FormatException), e.GetType());
-            }
+            Assert.Throws<FormatException>(() => SqlDateTime.Parse("not-a-number"));
 
             SqlDateTime t1 = SqlDateTime.Parse("02/25/2002");
             Assert.Equal(_myTicks[0], t1.Value.Ticks);
 
-            try
-            {
-                t1 = SqlDateTime.Parse("2002-02-25");
-            }
-            catch (Exception e)
-            {
-                Assert.False(true);
-            }
-
             // Thanks for Martin Baulig for these (DateTimeTest.cs)
+            t1 = SqlDateTime.Parse("2002-02-25");
             Assert.Equal(_myTicks[0], t1.Value.Ticks);
             t1 = SqlDateTime.Parse("Monday, 25 February 2002");
             Assert.Equal(_myTicks[0], t1.Value.Ticks);
@@ -371,46 +314,30 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void ArithmeticOperators()
         {
-            TimeSpan TestSpan = new TimeSpan(20, 1, 20, 20);
-            SqlDateTime ResultDateTime;
+            TimeSpan testSpan = new TimeSpan(20, 1, 20, 20);
+            SqlDateTime resultDateTime;
 
             // "+"-operator
-            ResultDateTime = _test1 + TestSpan;
-            Assert.Equal(2002, ResultDateTime.Value.Year);
-            Assert.Equal(8, ResultDateTime.Value.Day);
-            Assert.Equal(11, ResultDateTime.Value.Hour);
-            Assert.Equal(0, ResultDateTime.Value.Minute);
-            Assert.Equal(20, ResultDateTime.Value.Second);
-            Assert.True((SqlDateTime.Null + TestSpan).IsNull);
+            resultDateTime = _test1 + testSpan;
+            Assert.Equal(2002, resultDateTime.Value.Year);
+            Assert.Equal(8, resultDateTime.Value.Day);
+            Assert.Equal(11, resultDateTime.Value.Hour);
+            Assert.Equal(0, resultDateTime.Value.Minute);
+            Assert.Equal(20, resultDateTime.Value.Second);
+            Assert.True((SqlDateTime.Null + testSpan).IsNull);
 
-            try
-            {
-                ResultDateTime = SqlDateTime.MaxValue + TestSpan;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(ArgumentOutOfRangeException), e.GetType());
-            }
+            Assert.Throws<ArgumentOutOfRangeException>(() => SqlDateTime.MaxValue + testSpan);
 
             // "-"-operator
-            ResultDateTime = _test1 - TestSpan;
-            Assert.Equal(2002, ResultDateTime.Value.Year);
-            Assert.Equal(29, ResultDateTime.Value.Day);
-            Assert.Equal(8, ResultDateTime.Value.Hour);
-            Assert.Equal(19, ResultDateTime.Value.Minute);
-            Assert.Equal(40, ResultDateTime.Value.Second);
-            Assert.True((SqlDateTime.Null - TestSpan).IsNull);
+            resultDateTime = _test1 - testSpan;
+            Assert.Equal(2002, resultDateTime.Value.Year);
+            Assert.Equal(29, resultDateTime.Value.Day);
+            Assert.Equal(8, resultDateTime.Value.Hour);
+            Assert.Equal(19, resultDateTime.Value.Minute);
+            Assert.Equal(40, resultDateTime.Value.Second);
+            Assert.True((SqlDateTime.Null - testSpan).IsNull);
 
-            try
-            {
-                ResultDateTime = SqlDateTime.MinValue - TestSpan;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(SqlTypeException), e.GetType());
-            }
+            Assert.Throws<SqlTypeException>(() => SqlDateTime.MinValue - testSpan);
         }
 
         [Fact]
@@ -418,34 +345,34 @@ namespace System.Data.Tests.SqlTypes
         {
             // == -operator
             Assert.True((_test2 == _test3).Value);
-            Assert.True(!(_test1 == _test2).Value);
+            Assert.False((_test1 == _test2).Value);
             Assert.True((_test1 == SqlDateTime.Null).IsNull);
 
             // != -operator
-            Assert.True(!(_test2 != _test3).Value);
+            Assert.False((_test2 != _test3).Value);
             Assert.True((_test1 != _test3).Value);
             Assert.True((_test1 != SqlDateTime.Null).IsNull);
 
             // > -operator
             Assert.True((_test2 > _test1).Value);
-            Assert.True(!(_test3 > _test2).Value);
+            Assert.False((_test3 > _test2).Value);
             Assert.True((_test1 > SqlDateTime.Null).IsNull);
 
             // >=  -operator
-            Assert.True(!(_test1 >= _test3).Value);
+            Assert.False((_test1 >= _test3).Value);
             Assert.True((_test3 >= _test1).Value);
             Assert.True((_test2 >= _test3).Value);
             Assert.True((_test1 >= SqlDateTime.Null).IsNull);
 
             // < -operator
-            Assert.True(!(_test2 < _test1).Value);
+            Assert.False((_test2 < _test1).Value);
             Assert.True((_test1 < _test3).Value);
-            Assert.True(!(_test2 < _test3).Value);
+            Assert.False((_test2 < _test3).Value);
             Assert.True((_test1 < SqlDateTime.Null).IsNull);
 
             // <= -operator
             Assert.True((_test1 <= _test3).Value);
-            Assert.True(!(_test3 <= _test1).Value);
+            Assert.False((_test3 <= _test1).Value);
             Assert.True((_test2 <= _test3).Value);
             Assert.True((_test1 <= SqlDateTime.Null).IsNull);
         }
@@ -465,8 +392,8 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void SqlStringToSqlDateTime()
         {
-            SqlString TestString = new SqlString("02/25/2002");
-            SqlDateTime t1 = (SqlDateTime)TestString;
+            SqlString testString = new SqlString("02/25/2002");
+            SqlDateTime t1 = (SqlDateTime)testString;
 
             Assert.Equal(_myTicks[0], t1.Value.Ticks);
 
@@ -536,14 +463,14 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void DateTimeToSqlDateTime()
         {
-            DateTime DateTimeTest = new DateTime(2002, 10, 19, 11, 53, 4);
-            SqlDateTime Result = DateTimeTest;
-            Assert.Equal(2002, Result.Value.Year);
-            Assert.Equal(10, Result.Value.Month);
-            Assert.Equal(19, Result.Value.Day);
-            Assert.Equal(11, Result.Value.Hour);
-            Assert.Equal(53, Result.Value.Minute);
-            Assert.Equal(4, Result.Value.Second);
+            DateTime dateTimeTest = new DateTime(2002, 10, 19, 11, 53, 4);
+            SqlDateTime result = dateTimeTest;
+            Assert.Equal(2002, result.Value.Year);
+            Assert.Equal(10, result.Value.Month);
+            Assert.Equal(19, result.Value.Day);
+            Assert.Equal(11, result.Value.Hour);
+            Assert.Equal(53, result.Value.Minute);
+            Assert.Equal(4, result.Value.Second);
         }
 
         [Fact]

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlDecimalTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlDecimalTest.cs
@@ -46,8 +46,8 @@ namespace System.Data.Tests.SqlTypes
         public SqlDecimalTest()
         {
             _test1 = new SqlDecimal(6464.6464m);
-            _test2 = new SqlDecimal(10000m);
-            _test3 = new SqlDecimal(10000m);
+            _test2 = new SqlDecimal(10000.00m);
+            _test3 = new SqlDecimal(10000.00m);
             _test4 = new SqlDecimal(-6m);
             _test5 = new SqlDecimal(decimal.MaxValue);
         }
@@ -238,7 +238,7 @@ namespace System.Data.Tests.SqlTypes
             Assert.False(SqlDecimal.NotEquals(_test2, _test3).Value);
             Assert.True(SqlDecimal.NotEquals(SqlDecimal.Null, _test3).IsNull);
         }
-
+        //TODO
         /* Don't do such environment-dependent test. It will never succeed under Portable.NET and MS.NET
         [Fact]
         public void GetHashCodeTest()
@@ -247,13 +247,6 @@ namespace System.Data.Tests.SqlTypes
             Assert.Equal (-1281249885, Test1.GetHashCode ());
         }
         */
-
-        [Fact]
-        public void GetTypeTest()
-        {
-            Assert.Equal("System.Data.SqlTypes.SqlDecimal", _test1.GetType().ToString());
-            Assert.Equal("System.Decimal", _test1.Value.GetType().ToString());
-        }
 
         [Fact]
         public void Greaters()
@@ -369,7 +362,7 @@ namespace System.Data.Tests.SqlTypes
             // "/"-operator => NotWorking
             //Assert.Equal ((SqlDecimal)1.54687501546m, Test2 / Test1);
 
-            Assert.Throws<OverflowException>(() => SqlDecimal.MaxValue / new SqlDecimal(0));
+            Assert.Throws<DivideByZeroException>(() => SqlDecimal.MaxValue / new SqlDecimal(0));
 
             // "*"-operator
             Assert.Equal(64646464.000000m, _test1 * _test2);
@@ -377,15 +370,6 @@ namespace System.Data.Tests.SqlTypes
             SqlDecimal Test = _test5 * (new SqlDecimal(2m));
             Assert.Equal("158456325028528675187087900670", Test.ToString());
 
-            try
-            {
-                SqlDecimal test = SqlDecimal.MaxValue * _test1;
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
             Assert.Throws<OverflowException>(() => SqlDecimal.MaxValue * _test1);
 
             // "-"-operator

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlDecimalTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlDecimalTest.cs
@@ -46,8 +46,8 @@ namespace System.Data.Tests.SqlTypes
         public SqlDecimalTest()
         {
             _test1 = new SqlDecimal(6464.6464m);
-            _test2 = new SqlDecimal(10000.00m);
-            _test3 = new SqlDecimal(10000.00m);
+            _test2 = new SqlDecimal(10000m);
+            _test3 = new SqlDecimal(10000m);
             _test4 = new SqlDecimal(-6m);
             _test5 = new SqlDecimal(decimal.MaxValue);
         }
@@ -57,73 +57,36 @@ namespace System.Data.Tests.SqlTypes
         public void Create()
         {
             // SqlDecimal (decimal)
-            SqlDecimal Test = new SqlDecimal(30.3098m);
-            Assert.Equal((decimal)30.3098, Test.Value);
-
-            try
-            {
-                decimal d = decimal.MaxValue;
-                SqlDecimal test = new SqlDecimal(d + 1);
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            SqlDecimal test = new SqlDecimal(30.3098m);
+            Assert.Equal((decimal)30.3098, test.Value);
 
             // SqlDecimal (double)
-            Test = new SqlDecimal(10E+10d);
-            Assert.Equal(100000000000.00000m, Test.Value);
+            test = new SqlDecimal(1E11d);
+            Assert.Equal(1E11m, test.Value);
 
-            try
-            {
-                SqlDecimal test = new SqlDecimal(10E+200d);
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => new SqlDecimal(1E201d));
 
             // SqlDecimal (int)
-            Test = new SqlDecimal(-1);
-            Assert.Equal(-1m, Test.Value);
+            test = new SqlDecimal(-1);
+            Assert.Equal(-1m, test.Value);
 
             // SqlDecimal (long)
-            Test = new SqlDecimal((long)(-99999));
-            Assert.Equal(-99999m, Test.Value);
+            test = new SqlDecimal((long)-99999);
+            Assert.Equal(-99999m, test.Value);
 
             // SqlDecimal (byte, byte, bool. int[]
-            Test = new SqlDecimal(10, 3, false, new int[4] { 200, 1, 0, 0 });
-            Assert.Equal(-4294967.496m, Test.Value);
+            test = new SqlDecimal(10, 3, false, new int[] { 200, 1, 0, 0 });
+            Assert.Equal(-4294967.496m, test.Value);
 
-            try
-            {
-                Test = new SqlDecimal(100, 100, false,
-                    new int[4] {int.MaxValue,
-                    int.MaxValue, int.MaxValue,
-                    int.MaxValue});
-                Assert.False(true);
-            }
-            catch (SqlTypeException)
-            {
-            }
+            Assert.Throws<SqlTypeException>(() => 
+                new SqlDecimal(100, 100, false, new int[4] { int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue }));
 
-            // sqlDecimal (byte, byte, bool, int, int, int, int)
-            Test = new SqlDecimal(12, 2, true, 100, 100, 0, 0);
-            Assert.Equal(4294967297.00m, Test.Value);
+            // SqlDecimal (byte, byte, bool, int, int, int, int)
+            test = new SqlDecimal(12, 2, true, 100, 100, 0, 0);
+            Assert.Equal(4294967297.00m, test.Value);
 
-            try
-            {
-                Test = new SqlDecimal(100, 100, false,
-                    int.MaxValue,
-                    int.MaxValue, int.MaxValue,
-                    int.MaxValue);
-                Assert.False(true);
-            }
-            catch (SqlTypeException)
-            {
-            }
+            Assert.Throws<SqlTypeException>(() =>
+                new SqlDecimal(100, 100, false, int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue));
         }
 
         // Test public fields
@@ -138,7 +101,7 @@ namespace System.Data.Tests.SqlTypes
 
             Assert.Equal(1262177448, SqlDecimal.MinValue.Data[3]);
             Assert.True(SqlDecimal.Null.IsNull);
-            Assert.True(!_test1.IsNull);
+            Assert.False(_test1.IsNull);
         }
 
         // Test properties
@@ -153,7 +116,7 @@ namespace System.Data.Tests.SqlTypes
 
             Assert.True(SqlDecimal.Null.IsNull);
             Assert.True(_test1.IsPositive);
-            Assert.True(!_test4.IsPositive);
+            Assert.False(_test4.IsPositive);
             Assert.Equal((byte)8, _test1.Precision);
             Assert.Equal((byte)2, _test2.Scale);
             Assert.Equal(6464.6464m, _test1.Value);
@@ -180,53 +143,31 @@ namespace System.Data.Tests.SqlTypes
             Assert.Equal(-2006m, SqlDecimal.Add(_test4, test2));
             Assert.Equal(8000.00m, SqlDecimal.Add(test2, _test3));
 
-            try
-            {
-                SqlDecimal test = SqlDecimal.Add(SqlDecimal.MaxValue, SqlDecimal.MaxValue);
-                Assert.False(true);
-            }
-            catch (OverflowException)
-            {
-            }
+            Assert.Throws<OverflowException>(() => SqlDecimal.Add(SqlDecimal.MaxValue, SqlDecimal.MaxValue));
 
             Assert.Equal(6465m, SqlDecimal.Ceiling(_test1));
             Assert.Equal(SqlDecimal.Null, SqlDecimal.Ceiling(SqlDecimal.Null));
 
-            // Divide() => Notworking
-            /*
-            Assert.Equal ((SqlDecimal)(-1077.441066m), SqlDecimal.Divide (Test1, Test4));
-            Assert.Equal (1.54687501546m, SqlDecimal.Divide (Test2, Test1).Value);
+            // Divide
+            Assert.Equal(-1077.441066m, SqlDecimal.Divide(_test1, _test4));
+            Assert.Equal(1.54687501546m, SqlDecimal.Divide(_test2, _test1).Value, 9);
 
-            try {
-                SqlDecimal test = SqlDecimal.Divide(Test1, new SqlDecimal(0)).Value;
-Assert.False(true);
-            } catch (DivideByZeroException e) {
-                Assert.Equal (typeof (DivideByZeroException), e.GetType ());
-            }
-            */
+            Assert.Throws<DivideByZeroException>(() => SqlDecimal.Divide(_test1, new SqlDecimal(0)));
 
             Assert.Equal(6464m, SqlDecimal.Floor(_test1));
 
             // Multiply()
             SqlDecimal Test;
             SqlDecimal test1 = new SqlDecimal(2m);
-            Assert.Equal(64646464.000000m, SqlDecimal.Multiply(_test1, _test2).Value);
+            Assert.Equal(64646464m, SqlDecimal.Multiply(_test1, _test2).Value);
             Assert.Equal(-38787.8784m, SqlDecimal.Multiply(_test1, _test4).Value);
             Test = SqlDecimal.Multiply(_test5, test1);
             Assert.Equal("158456325028528675187087900670", Test.ToString());
 
-            try
-            {
-                SqlDecimal test = SqlDecimal.Multiply(SqlDecimal.MaxValue, _test1);
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlDecimal.Multiply(SqlDecimal.MaxValue, _test1));
 
-            // Power => NotWorking
-            //Assert.Equal ((SqlDecimal)41791653.0770m, SqlDecimal.Power (Test1, 2));
+            // Power
+            Assert.Equal(41791653.0770m, SqlDecimal.Power(_test1, 2));
 
             // Round
             Assert.Equal(6464.65m, SqlDecimal.Round(_test1, 2));
@@ -236,15 +177,7 @@ Assert.False(true);
             Assert.Equal(10006.00m, SqlDecimal.Subtract(_test3, _test4).Value);
             Assert.Equal("99999999920771837485735662406456049664", SqlDecimal.Subtract(SqlDecimal.MaxValue, decimal.MaxValue).ToString());
 
-            try
-            {
-                SqlDecimal test = SqlDecimal.Subtract(SqlDecimal.MinValue, SqlDecimal.MaxValue);
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlDecimal.Subtract(SqlDecimal.MinValue, SqlDecimal.MaxValue));
 
             Assert.Equal(1, SqlDecimal.Sign(_test1));
             Assert.Equal(new SqlInt32(-1), SqlDecimal.Sign(_test4));
@@ -258,14 +191,8 @@ Assert.False(true);
             Assert.Equal(6464.64.ToString(), SqlDecimal.AdjustScale(_test1, -2, false).Value.ToString());
             Assert.Equal(10000.000000000000m.ToString(), SqlDecimal.AdjustScale(_test2, 10, false).Value.ToString());
             Assert.Equal("79228162514264337593543950335.00", SqlDecimal.AdjustScale(_test5, 2, false).ToString());
-            try
-            {
-                SqlDecimal test = SqlDecimal.AdjustScale(_test1, -5, false);
-                Assert.False(true);
-            }
-            catch (SqlTruncateException)
-            {
-            }
+
+            Assert.Throws<SqlTruncateException>(() => SqlDecimal.AdjustScale(_test1, -5, false));
         }
 
         [Fact]
@@ -273,15 +200,7 @@ Assert.False(true);
         {
             Assert.Equal(new SqlDecimal(6464.6m).Value, SqlDecimal.ConvertToPrecScale(_test1, 5, 1).Value);
 
-            try
-            {
-                SqlDecimal test = SqlDecimal.ConvertToPrecScale(_test1, 6, 4);
-                Assert.False(true);
-            }
-            catch (SqlTruncateException e)
-            {
-                Assert.Equal(typeof(SqlTruncateException), e.GetType());
-            }
+            Assert.Throws<SqlTruncateException>(() => SqlDecimal.ConvertToPrecScale(_test1, 6, 4));
 
             Assert.Equal("10000.00", SqlDecimal.ConvertToPrecScale(_test2, 7, 2).ToSqlString());
 
@@ -299,32 +218,24 @@ Assert.False(true);
             Assert.True(_test2.CompareTo(_test3) == 0);
             Assert.True(_test4.CompareTo(SqlDecimal.Null) > 0);
 
-            try
-            {
-                _test1.CompareTo(TestString);
-                Assert.False(true);
-            }
-            catch (ArgumentException e)
-            {
-                Assert.Equal(typeof(ArgumentException), e.GetType());
-            }
+            Assert.Throws<ArgumentException>(() => _test1.CompareTo(TestString));
         }
 
         [Fact]
         public void EqualsMethods()
         {
-            Assert.True(!_test1.Equals(_test2));
-            Assert.True(!_test2.Equals(new SqlString("TEST")));
+            Assert.False(_test1.Equals(_test2));
+            Assert.False(_test2.Equals(new SqlString("TEST")));
             Assert.True(_test2.Equals(_test3));
 
             // Static Equals()-method
             Assert.True(SqlDecimal.Equals(_test2, _test2).Value);
-            Assert.True(!SqlDecimal.Equals(_test1, _test2).Value);
+            Assert.False(SqlDecimal.Equals(_test1, _test2).Value);
 
             // NotEquals
             Assert.True(SqlDecimal.NotEquals(_test1, _test2).Value);
             Assert.True(SqlDecimal.NotEquals(_test4, _test1).Value);
-            Assert.True(!SqlDecimal.NotEquals(_test2, _test3).Value);
+            Assert.False(SqlDecimal.NotEquals(_test2, _test3).Value);
             Assert.True(SqlDecimal.NotEquals(SqlDecimal.Null, _test3).IsNull);
         }
 
@@ -347,13 +258,13 @@ Assert.False(true);
         [Fact]
         public void Greaters()
         {
-            // GreateThan ()
-            Assert.True(!SqlDecimal.GreaterThan(_test1, _test2).Value);
+            // GreaterThan ()
+            Assert.False(SqlDecimal.GreaterThan(_test1, _test2).Value);
             Assert.True(SqlDecimal.GreaterThan(_test2, _test1).Value);
-            Assert.True(!SqlDecimal.GreaterThan(_test2, _test3).Value);
+            Assert.False(SqlDecimal.GreaterThan(_test2, _test3).Value);
 
-            // GreaterTharOrEqual ()
-            Assert.True(!SqlDecimal.GreaterThanOrEqual(_test1, _test2).Value);
+            // GreaterThanOrEqual ()
+            Assert.False(SqlDecimal.GreaterThanOrEqual(_test1, _test2).Value);
             Assert.True(SqlDecimal.GreaterThanOrEqual(_test2, _test1).Value);
             Assert.True(SqlDecimal.GreaterThanOrEqual(_test2, _test3).Value);
         }
@@ -362,13 +273,13 @@ Assert.False(true);
         public void Lessers()
         {
             // LessThan()
-            Assert.True(!SqlDecimal.LessThan(_test3, _test2).Value);
-            Assert.True(!SqlDecimal.LessThan(_test2, _test1).Value);
+            Assert.False(SqlDecimal.LessThan(_test3, _test2).Value);
+            Assert.False(SqlDecimal.LessThan(_test2, _test1).Value);
             Assert.True(SqlDecimal.LessThan(_test1, _test2).Value);
 
             // LessThanOrEqual ()
             Assert.True(SqlDecimal.LessThanOrEqual(_test1, _test2).Value);
-            Assert.True(!SqlDecimal.LessThanOrEqual(_test2, _test1).Value);
+            Assert.False(SqlDecimal.LessThanOrEqual(_test2, _test1).Value);
             Assert.True(SqlDecimal.LessThanOrEqual(_test2, _test3).Value);
             Assert.True(SqlDecimal.LessThanOrEqual(_test1, SqlDecimal.Null).IsNull);
         }
@@ -382,26 +293,18 @@ Assert.False(true);
             // ToSqlBoolean ()
             Assert.Equal(new SqlBoolean(1), _test1.ToSqlBoolean());
 
-            SqlDecimal Test = new SqlDecimal(0);
-            Assert.True(!Test.ToSqlBoolean().Value);
+            SqlDecimal test = new SqlDecimal(0);
+            Assert.False(test.ToSqlBoolean().Value);
 
-            Test = new SqlDecimal(0);
-            Assert.True(!Test.ToSqlBoolean().Value);
+            test = new SqlDecimal(0);
+            Assert.False(test.ToSqlBoolean().Value);
             Assert.True(SqlDecimal.Null.ToSqlBoolean().IsNull);
 
             // ToSqlByte ()
-            Test = new SqlDecimal(250);
-            Assert.Equal((byte)250, Test.ToSqlByte().Value);
+            test = new SqlDecimal(250);
+            Assert.Equal((byte)250, test.ToSqlByte().Value);
 
-            try
-            {
-                SqlByte b = (byte)_test2.ToSqlByte();
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => (byte)_test2.ToSqlByte());
 
             // ToSqlDouble ()
             Assert.Equal(6464.6464, _test1.ToSqlDouble());
@@ -409,32 +312,15 @@ Assert.False(true);
             // ToSqlInt16 ()
             Assert.Equal((short)1, new SqlDecimal(1).ToSqlInt16().Value);
 
-            try
-            {
-                SqlInt16 test = SqlDecimal.MaxValue.ToSqlInt16().Value;
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
-
-            // ToSqlInt32 ()
+            Assert.Throws<OverflowException>(() => SqlDecimal.MaxValue.ToSqlInt16().Value);
+            // ToSqlInt32 () 
             // 6464.6464 --> 64646464 ??? with windows
             // MS.NET seems to return the first 32 bit integer (i.e.
             // Data [0]) but we don't have to follow such stupidity.
             //            Assert.Equal ((int)64646464, Test1.ToSqlInt32 ().Value);
             //            Assert.Equal ((int)1212, new SqlDecimal(12.12m).ToSqlInt32 ().Value);
 
-            try
-            {
-                SqlInt32 test = SqlDecimal.MaxValue.ToSqlInt32().Value;
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlDecimal.MaxValue.ToSqlInt32().Value);
 
             // ToSqlInt64 ()
             Assert.Equal(6464, _test1.ToSqlInt64().Value);
@@ -442,15 +328,7 @@ Assert.False(true);
             // ToSqlMoney ()
             Assert.Equal((decimal)6464.6464, _test1.ToSqlMoney().Value);
 
-            try
-            {
-                SqlMoney test = SqlDecimal.MaxValue.ToSqlMoney().Value;
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlDecimal.MaxValue.ToSqlMoney().Value);
 
             // ToSqlSingle ()
             Assert.Equal((float)6464.6464, _test1.ToSqlSingle().Value);
@@ -468,7 +346,6 @@ Assert.False(true);
         [Fact]
         public void Truncate()
         {
-            // NOT WORKING
             Assert.Equal(new SqlDecimal(6464.6400m).Value, SqlDecimal.Truncate(_test1, 2).Value);
             Assert.Equal(6464.6400m, SqlDecimal.Truncate(_test1, 2).Value);
         }
@@ -487,25 +364,12 @@ Assert.False(true);
             Assert.Equal(-2006m, _test4 + test2);
             Assert.Equal(8000.00m, test2 + _test3);
 
-            try
-            {
-                SqlDecimal test = SqlDecimal.MaxValue + SqlDecimal.MaxValue;
-                Assert.False(true);
-            }
-            catch (OverflowException) { }
+            Assert.Throws<OverflowException>(() => SqlDecimal.MaxValue + SqlDecimal.MaxValue);
 
             // "/"-operator => NotWorking
             //Assert.Equal ((SqlDecimal)1.54687501546m, Test2 / Test1);
 
-            try
-            {
-                SqlDecimal test = _test3 / new SqlDecimal(0);
-                Assert.False(true);
-            }
-            catch (DivideByZeroException e)
-            {
-                Assert.Equal(typeof(DivideByZeroException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlDecimal.MaxValue / new SqlDecimal(0));
 
             // "*"-operator
             Assert.Equal(64646464.000000m, _test1 * _test2);
@@ -522,20 +386,13 @@ Assert.False(true);
             {
                 Assert.Equal(typeof(OverflowException), e.GetType());
             }
+            Assert.Throws<OverflowException>(() => SqlDecimal.MaxValue * _test1);
 
             // "-"-operator
             Assert.Equal(3535.3536m, _test2 - _test1);
             Assert.Equal(-10006.00m, _test4 - _test3);
 
-            try
-            {
-                SqlDecimal test = SqlDecimal.MinValue - SqlDecimal.MaxValue;
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlDecimal.MinValue - SqlDecimal.MaxValue);
 
             Assert.Equal(SqlDecimal.Null, SqlDecimal.Null + _test1);
         }
@@ -549,12 +406,12 @@ Assert.False(true);
 
             // == -operator
             Assert.True((_test2 == _test3).Value);
-            Assert.True(!(_test1 == _test2).Value);
+            Assert.False((_test1 == _test2).Value);
             Assert.True((_test1 == SqlDecimal.Null).IsNull);
             Assert.False((pval == nval).Value);
 
             // != -operator
-            Assert.True(!(_test2 != _test3).Value);
+            Assert.False((_test2 != _test3).Value);
             Assert.True((_test1 != _test3).Value);
             Assert.True((_test4 != _test3).Value);
             Assert.True((_test1 != SqlDecimal.Null).IsNull);
@@ -562,28 +419,28 @@ Assert.False(true);
 
             // > -operator
             Assert.True((_test2 > _test1).Value);
-            Assert.True(!(_test1 > _test3).Value);
-            Assert.True(!(_test2 > _test3).Value);
+            Assert.False((_test1 > _test3).Value);
+            Assert.False((_test2 > _test3).Value);
             Assert.True((_test1 > SqlDecimal.Null).IsNull);
             Assert.False((nval > val).Value);
 
             // >=  -operator
-            Assert.True(!(_test1 >= _test3).Value);
+            Assert.False((_test1 >= _test3).Value);
             Assert.True((_test3 >= _test1).Value);
             Assert.True((_test2 >= _test3).Value);
             Assert.True((_test1 >= SqlDecimal.Null).IsNull);
             Assert.False((nval > val).Value);
 
             // < -operator
-            Assert.True(!(_test2 < _test1).Value);
+            Assert.False((_test2 < _test1).Value);
             Assert.True((_test1 < _test3).Value);
-            Assert.True(!(_test2 < _test3).Value);
+            Assert.False((_test2 < _test3).Value);
             Assert.True((_test1 < SqlDecimal.Null).IsNull);
             Assert.False((val < nval).Value);
 
             // <= -operator
             Assert.True((_test1 <= _test3).Value);
-            Assert.True(!(_test3 <= _test1).Value);
+            Assert.False((_test3 <= _test1).Value);
             Assert.True((_test2 <= _test3).Value);
             Assert.True((_test1 <= SqlDecimal.Null).IsNull);
             Assert.False((val <= nval).Value);
@@ -600,15 +457,15 @@ Assert.False(true);
         [Fact]
         public void SqlBooleanToSqlDecimal()
         {
-            SqlBoolean TestBoolean = new SqlBoolean(true);
-            SqlDecimal Result;
+            SqlBoolean testBoolean = new SqlBoolean(true);
+            SqlDecimal result;
 
-            Result = (SqlDecimal)TestBoolean;
+            result = (SqlDecimal)testBoolean;
 
-            Assert.Equal(1m, Result.Value);
+            Assert.Equal(1m, result.Value);
 
-            Result = (SqlDecimal)SqlBoolean.Null;
-            Assert.True(Result.IsNull);
+            result = (SqlDecimal)SqlBoolean.Null;
+            Assert.True(result.IsNull);
             Assert.Equal(SqlDecimal.Null, (SqlDecimal)SqlBoolean.Null);
         }
 
@@ -621,25 +478,17 @@ Assert.False(true);
         [Fact]
         public void SqlDoubleToSqlDecimal()
         {
-            SqlDouble Test = new SqlDouble(12E+10);
-            Assert.Equal(120000000000.00000m, ((SqlDecimal)Test).Value);
+            SqlDouble test = new SqlDouble(12E+10);
+            Assert.Equal(120000000000m, ((SqlDecimal)test).Value);
         }
 
         [Fact]
         public void SqlSingleToSqlDecimal()
         {
-            SqlSingle Test = new SqlSingle(1E+9);
-            Assert.Equal(1000000000.0000000m, ((SqlDecimal)Test).Value);
+            SqlSingle test = new SqlSingle(1E+9);
+            Assert.Equal(1000000000m, ((SqlDecimal)test).Value);
 
-            try
-            {
-                SqlDecimal test = (SqlDecimal)SqlSingle.MaxValue;
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => (SqlDecimal)SqlSingle.MaxValue);
         }
 
         [Fact]
@@ -650,25 +499,9 @@ Assert.False(true);
 
             Assert.Equal(100m, ((SqlDecimal)TestString100).Value);
 
-            try
-            {
-                SqlDecimal test = (SqlDecimal)TestString;
-                Assert.False(true);
-            }
-            catch (FormatException e)
-            {
-                Assert.Equal(typeof(FormatException), e.GetType());
-            }
+            Assert.Throws<FormatException>(() => (SqlDecimal)TestString);
 
-            try
-            {
-                SqlDecimal test = (SqlDecimal)new SqlString("9E+100");
-                Assert.False(true);
-            }
-            catch (FormatException e)
-            {
-                Assert.Equal(typeof(FormatException), e.GetType());
-            }
+            Assert.Throws<FormatException>(() => (SqlDecimal)new SqlString("9E+100"));
         }
 
         [Fact]
@@ -768,15 +601,9 @@ Assert.False(true);
             ReadWriteXmlTestInternal(xml1, test1, "BA01");
             ReadWriteXmlTestInternal(xml2, test2, "BA02");
 
-            try
-            {
-                ReadWriteXmlTestInternal(xml3, test3, "BA03");
-                Assert.False(true);
-            }
-            catch (InvalidOperationException e)
-            {
-                Assert.Equal(typeof(FormatException), e.InnerException.GetType());
-            }
+            InvalidOperationException ex =
+                Assert.Throws<InvalidOperationException>(() => ReadWriteXmlTestInternal(xml3, test3, "BA03"));
+            Assert.Equal(typeof(FormatException), ex.InnerException.GetType());
         }
     }
 }

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlDecimalTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlDecimalTest.cs
@@ -238,15 +238,6 @@ namespace System.Data.Tests.SqlTypes
             Assert.False(SqlDecimal.NotEquals(_test2, _test3).Value);
             Assert.True(SqlDecimal.NotEquals(SqlDecimal.Null, _test3).IsNull);
         }
-        //TODO
-        /* Don't do such environment-dependent test. It will never succeed under Portable.NET and MS.NET
-        [Fact]
-        public void GetHashCodeTest()
-        {
-            // FIXME: Better way to test HashCode
-            Assert.Equal (-1281249885, Test1.GetHashCode ());
-        }
-        */
 
         [Fact]
         public void Greaters()

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlDecimalTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlDecimalTest.cs
@@ -215,7 +215,7 @@ namespace System.Data.Tests.SqlTypes
 
             Assert.True(_test1.CompareTo(_test3) < 0);
             Assert.True(_test2.CompareTo(_test1) > 0);
-            Assert.True(_test2.CompareTo(_test3) == 0);
+            Assert.Equal(0, _test2.CompareTo(_test3));
             Assert.True(_test4.CompareTo(SqlDecimal.Null) > 0);
 
             Assert.Throws<ArgumentException>(() => _test1.CompareTo(TestString));

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlDoubleTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlDoubleTest.cs
@@ -42,11 +42,11 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void Create()
         {
-            SqlDouble Test = new SqlDouble(34.87);
-            Assert.Equal(34.87D, Test.Value);
+            SqlDouble test = new SqlDouble(34.87);
+            Assert.Equal(34.87D, test.Value);
 
-            Test = new SqlDouble(-9000.6543);
-            Assert.Equal(-9000.6543D, Test.Value);
+            test = new SqlDouble(-9000.6543);
+            Assert.Equal(-9000.6543D, test.Value);
         }
 
         // Test public fields
@@ -63,12 +63,12 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void Properties()
         {
-            SqlDouble Test5443 = new SqlDouble(5443e12);
-            SqlDouble Test1 = new SqlDouble(1);
+            SqlDouble test5443 = new SqlDouble(5443e12);
+            SqlDouble test1 = new SqlDouble(1);
 
             Assert.True(SqlDouble.Null.IsNull);
-            Assert.Equal(5443e12, Test5443.Value);
-            Assert.Equal(1, Test1.Value);
+            Assert.Equal(5443e12, test5443.Value);
+            Assert.Equal(1, test1.Value);
         }
 
         // PUBLIC METHODS
@@ -76,120 +76,80 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void ArithmeticMethods()
         {
-            SqlDouble Test0 = new SqlDouble(0);
-            SqlDouble Test1 = new SqlDouble(15E+108);
-            SqlDouble Test2 = new SqlDouble(-65E+64);
-            SqlDouble Test3 = new SqlDouble(5E+64);
-            SqlDouble Test4 = new SqlDouble(5E+108);
-            SqlDouble TestMax = new SqlDouble(SqlDouble.MaxValue.Value);
+            SqlDouble test0 = new SqlDouble(0);
+            SqlDouble test1 = new SqlDouble(15E+108);
+            SqlDouble test2 = new SqlDouble(-65E+64);
+            SqlDouble test3 = new SqlDouble(5E+64);
+            SqlDouble test4 = new SqlDouble(5E+108);
+            SqlDouble testMax = new SqlDouble(SqlDouble.MaxValue.Value);
 
             // Add()
-            Assert.Equal(15E+108, SqlDouble.Add(Test1, Test0).Value);
-            Assert.Equal(1.5E+109, SqlDouble.Add(Test1, Test2).Value);
+            Assert.Equal(15E+108, SqlDouble.Add(test1, test0).Value);
+            Assert.Equal(1.5E+109, SqlDouble.Add(test1, test2).Value);
 
-            try
-            {
-                SqlDouble test = SqlDouble.Add(SqlDouble.MaxValue, SqlDouble.MaxValue);
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlDouble.Add(SqlDouble.MaxValue, SqlDouble.MaxValue));
 
             // Divide()
-            Assert.Equal(3, SqlDouble.Divide(Test1, Test4));
-            Assert.Equal(-13d, SqlDouble.Divide(Test2, Test3).Value);
+            Assert.Equal(3, SqlDouble.Divide(test1, test4));
+            Assert.Equal(-13d, SqlDouble.Divide(test2, test3).Value);
 
-            try
-            {
-                SqlDouble test = SqlDouble.Divide(Test1, Test0).Value;
-                Assert.False(true);
-            }
-            catch (DivideByZeroException e)
-            {
-                Assert.Equal(typeof(DivideByZeroException), e.GetType());
-            }
+            Assert.Throws<DivideByZeroException>(() => SqlDouble.Divide(test1, test0).Value);
 
             // Multiply()
-            Assert.Equal(75E+216, SqlDouble.Multiply(Test1, Test4).Value);
-            Assert.Equal(0, SqlDouble.Multiply(Test1, Test0).Value);
+            Assert.Equal(75E+216, SqlDouble.Multiply(test1, test4).Value);
+            Assert.Equal(0, SqlDouble.Multiply(test1, test0).Value);
 
-            try
-            {
-                SqlDouble test = SqlDouble.Multiply(TestMax, Test1);
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlDouble.Multiply(testMax, test1));
 
 
             // Subtract()
-            Assert.Equal(1.5E+109, SqlDouble.Subtract(Test1, Test3).Value);
+            Assert.Equal(1.5E+109, SqlDouble.Subtract(test1, test3).Value);
 
-            try
-            {
-                SqlDouble test = SqlDouble.Subtract(SqlDouble.MinValue, SqlDouble.MaxValue);
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlDouble.Subtract(SqlDouble.MinValue, SqlDouble.MaxValue));
         }
 
         [Fact]
         public void CompareTo()
         {
-            SqlDouble Test1 = new SqlDouble(4e64);
-            SqlDouble Test11 = new SqlDouble(4e64);
-            SqlDouble Test2 = new SqlDouble(-9e34);
-            SqlDouble Test3 = new SqlDouble(10000);
-            SqlString TestString = new SqlString("This is a test");
+            SqlDouble test1 = new SqlDouble(4e64);
+            SqlDouble test11 = new SqlDouble(4e64);
+            SqlDouble test2 = new SqlDouble(-9e34);
+            SqlDouble test3 = new SqlDouble(10000);
+            SqlString testString = new SqlString("This is a test");
 
-            Assert.True(Test1.CompareTo(Test3) > 0);
-            Assert.True(Test2.CompareTo(Test3) < 0);
-            Assert.True(Test1.CompareTo(Test11) == 0);
-            Assert.True(Test11.CompareTo(SqlDouble.Null) > 0);
+            Assert.True(test1.CompareTo(test3) > 0);
+            Assert.True(test2.CompareTo(test3) < 0);
+            Assert.True(test1.CompareTo(test11) == 0);
+            Assert.True(test11.CompareTo(SqlDouble.Null) > 0);
 
-            try
-            {
-                Test1.CompareTo(TestString);
-                Assert.False(true);
-            }
-            catch (ArgumentException e)
-            {
-                Assert.Equal(typeof(ArgumentException), e.GetType());
-            }
+            Assert.Throws<ArgumentException>(() => test1.CompareTo(testString));
         }
 
         [Fact]
         public void EqualsMethods()
         {
-            SqlDouble Test0 = new SqlDouble(0);
-            SqlDouble Test1 = new SqlDouble(1.58e30);
-            SqlDouble Test2 = new SqlDouble(1.8e180);
-            SqlDouble Test22 = new SqlDouble(1.8e180);
+            SqlDouble test0 = new SqlDouble(0);
+            SqlDouble test1 = new SqlDouble(1.58e30);
+            SqlDouble test2 = new SqlDouble(1.8e180);
+            SqlDouble test22 = new SqlDouble(1.8e180);
 
-            Assert.True(!Test0.Equals(Test1));
-            Assert.True(!Test1.Equals(Test2));
-            Assert.True(!Test2.Equals(new SqlString("TEST")));
-            Assert.True(Test2.Equals(Test22));
+            Assert.False(test0.Equals(test1));
+            Assert.False(test1.Equals(test2));
+            Assert.False(test2.Equals(new SqlString("TEST")));
+            Assert.True(test2.Equals(test22));
 
             // Static Equals()-method
-            Assert.True(SqlDouble.Equals(Test2, Test22).Value);
-            Assert.True(!SqlDouble.Equals(Test1, Test2).Value);
+            Assert.True(SqlDouble.Equals(test2, test22).Value);
+            Assert.False(SqlDouble.Equals(test1, test2).Value);
         }
 
         [Fact]
         public void GetHashCodeTest()
         {
-            SqlDouble Test15 = new SqlDouble(15);
+            SqlDouble test15 = new SqlDouble(15);
 
             // FIXME: Better way to test HashCode
-            Assert.Equal(Test15.GetHashCode(), Test15.GetHashCode());
+            Assert.Equal(test15.GetHashCode(), test15.GetHashCode());
         }
 
         [Fact]
@@ -203,213 +163,132 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void Greaters()
         {
-            SqlDouble Test1 = new SqlDouble(1e100);
-            SqlDouble Test11 = new SqlDouble(1e100);
-            SqlDouble Test2 = new SqlDouble(64e164);
+            SqlDouble test1 = new SqlDouble(1e100);
+            SqlDouble test11 = new SqlDouble(1e100);
+            SqlDouble test2 = new SqlDouble(64e164);
 
             // GreateThan ()
-            Assert.True(!SqlDouble.GreaterThan(Test1, Test2).Value);
-            Assert.True(SqlDouble.GreaterThan(Test2, Test1).Value);
-            Assert.True(!SqlDouble.GreaterThan(Test1, Test11).Value);
+            Assert.False(SqlDouble.GreaterThan(test1, test2).Value);
+            Assert.True(SqlDouble.GreaterThan(test2, test1).Value);
+            Assert.False(SqlDouble.GreaterThan(test1, test11).Value);
 
             // GreaterTharOrEqual ()
-            Assert.True(!SqlDouble.GreaterThanOrEqual(Test1, Test2).Value);
-            Assert.True(SqlDouble.GreaterThanOrEqual(Test2, Test1).Value);
-            Assert.True(SqlDouble.GreaterThanOrEqual(Test1, Test11).Value);
+            Assert.False(SqlDouble.GreaterThanOrEqual(test1, test2).Value);
+            Assert.True(SqlDouble.GreaterThanOrEqual(test2, test1).Value);
+            Assert.True(SqlDouble.GreaterThanOrEqual(test1, test11).Value);
         }
 
         [Fact]
         public void Lessers()
         {
-            SqlDouble Test1 = new SqlDouble(1.8e100);
-            SqlDouble Test11 = new SqlDouble(1.8e100);
-            SqlDouble Test2 = new SqlDouble(64e164);
+            SqlDouble test1 = new SqlDouble(1.8e100);
+            SqlDouble test11 = new SqlDouble(1.8e100);
+            SqlDouble test2 = new SqlDouble(64e164);
 
             // LessThan()
-            Assert.True(!SqlDouble.LessThan(Test1, Test11).Value);
-            Assert.True(!SqlDouble.LessThan(Test2, Test1).Value);
-            Assert.True(SqlDouble.LessThan(Test11, Test2).Value);
+            Assert.False(SqlDouble.LessThan(test1, test11).Value);
+            Assert.False(SqlDouble.LessThan(test2, test1).Value);
+            Assert.True(SqlDouble.LessThan(test11, test2).Value);
 
             // LessThanOrEqual ()
-            Assert.True(SqlDouble.LessThanOrEqual(Test1, Test2).Value);
-            Assert.True(!SqlDouble.LessThanOrEqual(Test2, Test1).Value);
-            Assert.True(SqlDouble.LessThanOrEqual(Test11, Test1).Value);
-            Assert.True(SqlDouble.LessThanOrEqual(Test11, SqlDouble.Null).IsNull);
+            Assert.True(SqlDouble.LessThanOrEqual(test1, test2).Value);
+            Assert.False(SqlDouble.LessThanOrEqual(test2, test1).Value);
+            Assert.True(SqlDouble.LessThanOrEqual(test11, test1).Value);
+            Assert.True(SqlDouble.LessThanOrEqual(test11, SqlDouble.Null).IsNull);
         }
 
         [Fact]
         public void NotEquals()
         {
-            SqlDouble Test1 = new SqlDouble(1280000000001);
-            SqlDouble Test2 = new SqlDouble(128e10);
-            SqlDouble Test22 = new SqlDouble(128e10);
+            SqlDouble test1 = new SqlDouble(1280000000001);
+            SqlDouble test2 = new SqlDouble(128e10);
+            SqlDouble test22 = new SqlDouble(128e10);
 
-            Assert.True(SqlDouble.NotEquals(Test1, Test2).Value);
-            Assert.True(SqlDouble.NotEquals(Test2, Test1).Value);
-            Assert.True(SqlDouble.NotEquals(Test22, Test1).Value);
-            Assert.True(!SqlDouble.NotEquals(Test22, Test2).Value);
-            Assert.True(!SqlDouble.NotEquals(Test2, Test22).Value);
-            Assert.True(SqlDouble.NotEquals(SqlDouble.Null, Test22).IsNull);
-            Assert.True(SqlDouble.NotEquals(SqlDouble.Null, Test22).IsNull);
+            Assert.True(SqlDouble.NotEquals(test1, test2).Value);
+            Assert.True(SqlDouble.NotEquals(test2, test1).Value);
+            Assert.True(SqlDouble.NotEquals(test22, test1).Value);
+            Assert.False(SqlDouble.NotEquals(test22, test2).Value);
+            Assert.False(SqlDouble.NotEquals(test2, test22).Value);
+            Assert.True(SqlDouble.NotEquals(SqlDouble.Null, test22).IsNull);
+            Assert.True(SqlDouble.NotEquals(SqlDouble.Null, test22).IsNull);
         }
 
         [Fact]
         public void Parse()
         {
-            try
-            {
-                SqlDouble.Parse(null);
-                Assert.False(true);
-            }
-            catch (ArgumentNullException e)
-            {
-                Assert.Equal(typeof(ArgumentNullException), e.GetType());
-            }
+            Assert.Throws<ArgumentNullException>(() => SqlDouble.Parse(null));
 
-            try
-            {
-                SqlDouble.Parse("not-a-number");
-                Assert.False(true);
-            }
-            catch (FormatException e)
-            {
-                Assert.Equal(typeof(FormatException), e.GetType());
-            }
+            Assert.Throws<FormatException>(() => SqlDouble.Parse("not-a-number"));
 
-            try
-            {
-                SqlDouble.Parse("9e400");
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
-
+            Assert.Throws<OverflowException>(() => SqlDouble.Parse("9e400"));
             Assert.Equal(150, SqlDouble.Parse("150").Value);
         }
 
         [Fact]
         public void Conversions()
         {
-            SqlDouble Test0 = new SqlDouble(0);
-            SqlDouble Test1 = new SqlDouble(250);
-            SqlDouble Test2 = new SqlDouble(64e64);
-            SqlDouble Test3 = new SqlDouble(64e164);
+            SqlDouble test0 = new SqlDouble(0);
+            SqlDouble test1 = new SqlDouble(250);
+            SqlDouble test2 = new SqlDouble(64e64);
+            SqlDouble test3 = new SqlDouble(64e164);
             SqlDouble TestNull = SqlDouble.Null;
 
             // ToSqlBoolean ()
-            Assert.True(Test1.ToSqlBoolean().Value);
-            Assert.True(!Test0.ToSqlBoolean().Value);
+            Assert.True(test1.ToSqlBoolean().Value);
+            Assert.False(test0.ToSqlBoolean().Value);
             Assert.True(TestNull.ToSqlBoolean().IsNull);
 
             // ToSqlByte ()
-            Assert.Equal((byte)250, Test1.ToSqlByte().Value);
-            Assert.Equal((byte)0, Test0.ToSqlByte().Value);
+            Assert.Equal((byte)250, test1.ToSqlByte().Value);
+            Assert.Equal((byte)0, test0.ToSqlByte().Value);
 
-            try
-            {
-                SqlByte b = (byte)Test2.ToSqlByte();
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => test2.ToSqlByte());
 
             // ToSqlDecimal ()
-            Assert.Equal(250.00000000000000M, Test1.ToSqlDecimal().Value);
-            Assert.Equal(0, Test0.ToSqlDecimal().Value);
+            Assert.Equal(250M, test1.ToSqlDecimal().Value);
+            Assert.Equal(0, test0.ToSqlDecimal().Value);
 
-            try
-            {
-                SqlDecimal test = Test3.ToSqlDecimal().Value;
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => test3.ToSqlDecimal());
 
             // ToSqlInt16 ()
-            Assert.Equal((short)250, Test1.ToSqlInt16().Value);
-            Assert.Equal((short)0, Test0.ToSqlInt16().Value);
+            Assert.Equal((short)250, test1.ToSqlInt16().Value);
+            Assert.Equal((short)0, test0.ToSqlInt16().Value);
 
-            try
-            {
-                SqlInt16 test = Test2.ToSqlInt16().Value;
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => test2.ToSqlInt16());
 
             // ToSqlInt32 ()
-            Assert.Equal(250, Test1.ToSqlInt32().Value);
-            Assert.Equal(0, Test0.ToSqlInt32().Value);
+            Assert.Equal(250, test1.ToSqlInt32().Value);
+            Assert.Equal(0, test0.ToSqlInt32().Value);
 
-            try
-            {
-                SqlInt32 test = Test2.ToSqlInt32().Value;
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => test2.ToSqlInt32());
 
             // ToSqlInt64 ()
-            Assert.Equal(250, Test1.ToSqlInt64().Value);
-            Assert.Equal(0, Test0.ToSqlInt64().Value);
+            Assert.Equal(250, test1.ToSqlInt64().Value);
+            Assert.Equal(0, test0.ToSqlInt64().Value);
 
-            try
-            {
-                SqlInt64 test = Test2.ToSqlInt64().Value;
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => test2.ToSqlInt64());
 
             // ToSqlMoney ()
-            Assert.Equal(250.0000M, Test1.ToSqlMoney().Value);
-            Assert.Equal(0, Test0.ToSqlMoney().Value);
+            Assert.Equal(250M, test1.ToSqlMoney().Value);
+            Assert.Equal(0, test0.ToSqlMoney().Value);
 
-            try
-            {
-                SqlMoney test = Test2.ToSqlMoney().Value;
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => test2.ToSqlMoney());
 
             // ToSqlSingle ()
-            Assert.Equal(250, Test1.ToSqlSingle().Value);
-            Assert.Equal(0, Test0.ToSqlSingle().Value);
+            Assert.Equal(250, test1.ToSqlSingle().Value);
+            Assert.Equal(0, test0.ToSqlSingle().Value);
 
-            try
-            {
-                SqlSingle test = Test2.ToSqlSingle().Value;
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => test2.ToSqlSingle());
 
             // ToSqlString ()
-            Assert.Equal(250.ToString(), Test1.ToSqlString().Value);
-            Assert.Equal(0.ToString(), Test0.ToSqlString().Value);
-            Assert.Equal(6.4E+65.ToString(), Test2.ToSqlString().Value);
+            Assert.Equal(250.ToString(), test1.ToSqlString().Value);
+            Assert.Equal(0.ToString(), test0.ToSqlString().Value);
+            Assert.Equal(6.4E+65.ToString(), test2.ToSqlString().Value);
 
             // ToString ()
-            Assert.Equal(250.ToString(), Test1.ToString());
-            Assert.Equal(0.ToString(), Test0.ToString());
-            Assert.Equal(6.4E+65.ToString(), Test2.ToString());
+            Assert.Equal(250.ToString(), test1.ToString());
+            Assert.Equal(0.ToString(), test0.ToString());
+            Assert.Equal(6.4E+65.ToString(), test2.ToString());
         }
 
         // OPERATORS
@@ -417,54 +296,29 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void ArithmeticOperators()
         {
-            SqlDouble Test0 = new SqlDouble(0);
-            SqlDouble Test1 = new SqlDouble(24E+100);
-            SqlDouble Test2 = new SqlDouble(64E+164);
-            SqlDouble Test3 = new SqlDouble(12E+100);
-            SqlDouble Test4 = new SqlDouble(1E+10);
-            SqlDouble Test5 = new SqlDouble(2E+10);
+            SqlDouble test0 = new SqlDouble(0);
+            SqlDouble test1 = new SqlDouble(24E+100);
+            SqlDouble test3 = new SqlDouble(12E+100);
+            SqlDouble test4 = new SqlDouble(1E+10);
+            SqlDouble test5 = new SqlDouble(2E+10);
 
             // "+"-operator
-            Assert.Equal(3E+10, Test4 + Test5);
+            Assert.Equal(3E+10, test4 + test5);
 
-            try
-            {
-                SqlDouble test = SqlDouble.MaxValue + SqlDouble.MaxValue;
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlDouble.MaxValue + SqlDouble.MaxValue);
 
             // "/"-operator
-            Assert.Equal(2, Test1 / Test3);
+            Assert.Equal(2, test1 / test3);
 
-            try
-            {
-                SqlDouble test = Test3 / Test0;
-                Assert.False(true);
-            }
-            catch (DivideByZeroException e)
-            {
-                Assert.Equal(typeof(DivideByZeroException), e.GetType());
-            }
+            Assert.Throws<DivideByZeroException>(() => test3 / test0);
 
             // "*"-operator
-            Assert.Equal(2e20, Test4 * Test5);
+            Assert.Equal(2e20, test4 * test5);
 
-            try
-            {
-                SqlDouble test = SqlDouble.MaxValue * Test1;
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlDouble.MaxValue * test1);
 
             // "-"-operator
-            Assert.Equal(12e100, Test1 - Test3);
+            Assert.Equal(12e100, test1 - test3);
 
             try
             {
@@ -475,112 +329,105 @@ namespace System.Data.Tests.SqlTypes
             {
                 Assert.Equal(typeof(OverflowException), e.GetType());
             }
+            Assert.Throws<OverflowException>(() => SqlDouble.MinValue - SqlDouble.MaxValue);
         }
 
         [Fact]
         public void ThanOrEqualOperators()
         {
-            SqlDouble Test1 = new SqlDouble(1E+164);
-            SqlDouble Test2 = new SqlDouble(9.7E+100);
-            SqlDouble Test22 = new SqlDouble(9.7E+100);
-            SqlDouble Test3 = new SqlDouble(2E+200);
+            SqlDouble test1 = new SqlDouble(1E+164);
+            SqlDouble test2 = new SqlDouble(9.7E+100);
+            SqlDouble test22 = new SqlDouble(9.7E+100);
+            SqlDouble test3 = new SqlDouble(2E+200);
 
             // == -operator
-            Assert.True((Test2 == Test22).Value);
-            Assert.True(!(Test1 == Test2).Value);
-            Assert.True((Test1 == SqlDouble.Null).IsNull);
+            Assert.True((test2 == test22).Value);
+            Assert.False((test1 == test2).Value);
+            Assert.True((test1 == SqlDouble.Null).IsNull);
 
             // != -operator
-            Assert.True(!(Test2 != Test22).Value);
-            Assert.True((Test2 != Test3).Value);
-            Assert.True((Test1 != Test3).Value);
-            Assert.True((Test1 != SqlDouble.Null).IsNull);
+            Assert.False((test2 != test22).Value);
+            Assert.True((test2 != test3).Value);
+            Assert.True((test1 != test3).Value);
+            Assert.True((test1 != SqlDouble.Null).IsNull);
 
             // > -operator
-            Assert.True((Test1 > Test2).Value);
-            Assert.True(!(Test1 > Test3).Value);
-            Assert.True(!(Test2 > Test22).Value);
-            Assert.True((Test1 > SqlDouble.Null).IsNull);
+            Assert.True((test1 > test2).Value);
+            Assert.False((test1 > test3).Value);
+            Assert.False((test2 > test22).Value);
+            Assert.True((test1 > SqlDouble.Null).IsNull);
 
             // >=  -operator
-            Assert.True(!(Test1 >= Test3).Value);
-            Assert.True((Test3 >= Test1).Value);
-            Assert.True((Test2 >= Test22).Value);
-            Assert.True((Test1 >= SqlDouble.Null).IsNull);
+            Assert.False((test1 >= test3).Value);
+            Assert.True((test3 >= test1).Value);
+            Assert.True((test2 >= test22).Value);
+            Assert.True((test1 >= SqlDouble.Null).IsNull);
 
             // < -operator
-            Assert.True(!(Test1 < Test2).Value);
-            Assert.True((Test1 < Test3).Value);
-            Assert.True(!(Test2 < Test22).Value);
-            Assert.True((Test1 < SqlDouble.Null).IsNull);
+            Assert.False((test1 < test2).Value);
+            Assert.True((test1 < test3).Value);
+            Assert.False((test2 < test22).Value);
+            Assert.True((test1 < SqlDouble.Null).IsNull);
 
             // <= -operator
-            Assert.True((Test1 <= Test3).Value);
-            Assert.True(!(Test3 <= Test1).Value);
-            Assert.True((Test2 <= Test22).Value);
-            Assert.True((Test1 <= SqlDouble.Null).IsNull);
+            Assert.True((test1 <= test3).Value);
+            Assert.False((test3 <= test1).Value);
+            Assert.True((test2 <= test22).Value);
+            Assert.True((test1 <= SqlDouble.Null).IsNull);
         }
 
         [Fact]
         public void UnaryNegation()
         {
-            SqlDouble Test = new SqlDouble(2000000001);
-            SqlDouble TestNeg = new SqlDouble(-3000);
+            SqlDouble test = new SqlDouble(2000000001);
+            SqlDouble testNeg = new SqlDouble(-3000);
 
-            SqlDouble Result = -Test;
-            Assert.Equal(-2000000001, Result.Value);
+            SqlDouble result = -test;
+            Assert.Equal(-2000000001, result.Value);
 
-            Result = -TestNeg;
-            Assert.Equal(3000, Result.Value);
+            result = -testNeg;
+            Assert.Equal(3000, result.Value);
         }
 
         [Fact]
         public void SqlBooleanToSqlDouble()
         {
-            SqlBoolean TestBoolean = new SqlBoolean(true);
-            SqlDouble Result;
+            SqlBoolean testBoolean = new SqlBoolean(true);
+            SqlDouble result;
 
-            Result = (SqlDouble)TestBoolean;
+            result = (SqlDouble)testBoolean;
 
-            Assert.Equal(1, Result.Value);
+            Assert.Equal(1, result.Value);
 
-            Result = (SqlDouble)SqlBoolean.Null;
-            Assert.True(Result.IsNull);
+            result = (SqlDouble)SqlBoolean.Null;
+            Assert.True(result.IsNull);
         }
 
         [Fact]
         public void SqlDoubleToDouble()
         {
-            SqlDouble Test = new SqlDouble(12e12);
-            double Result = (double)Test;
-            Assert.Equal(12e12, Result);
+            SqlDouble test = new SqlDouble(12e12);
+            double result = (double)test;
+            Assert.Equal(12e12, result);
         }
 
         [Fact]
         public void SqlStringToSqlDouble()
         {
-            SqlString TestString = new SqlString("Test string");
-            SqlString TestString100 = new SqlString("100");
+            SqlString testString = new SqlString("Test string");
+            SqlString testString100 = new SqlString("100");
 
-            Assert.Equal(100, ((SqlDouble)TestString100).Value);
+            Assert.Equal(100, ((SqlDouble)testString100).Value);
 
-            try
-            {
-                SqlDouble test = (SqlDouble)TestString;
-                Assert.False(true);
-            }
-            catch (FormatException e)
-            {
-                Assert.Equal(typeof(FormatException), e.GetType());
-            }
+            Assert.Throws<FormatException>(() => (SqlDouble)testString);
         }
 
         [Fact]
         public void DoubleToSqlDouble()
         {
-            double Test1 = 5e64;
-            SqlDouble Result = Test1;
-            Assert.Equal(5e64, Result.Value);
+            double test1 = 5e64;
+            SqlDouble result = test1;
+            Assert.Equal(5e64, result.Value);
         }
 
         [Fact]
@@ -672,15 +519,9 @@ namespace System.Data.Tests.SqlTypes
             ReadWriteXmlTestInternal(xml1, test1, "BA01");
             ReadWriteXmlTestInternal(xml2, test2, "BA02");
 
-            try
-            {
-                ReadWriteXmlTestInternal(xml3, test3, "BA03");
-                Assert.False(true);
-            }
-            catch (InvalidOperationException e)
-            {
-                Assert.Equal(typeof(FormatException), e.InnerException.GetType());
-            }
+            InvalidOperationException ex =
+                Assert.Throws<InvalidOperationException>(() => ReadWriteXmlTestInternal(xml3, test3, "BA03"));
+            Assert.Equal(typeof(FormatException), ex.InnerException.GetType());
         }
     }
 }

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlDoubleTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlDoubleTest.cs
@@ -144,15 +144,6 @@ namespace System.Data.Tests.SqlTypes
         }
 
         [Fact]
-        public void GetHashCodeTest()
-        {
-            SqlDouble test15 = new SqlDouble(15);
-
-            // FIXME: Better way to test HashCode
-            Assert.Equal(test15.GetHashCode(), test15.GetHashCode());
-        }
-
-        [Fact]
         public void Greaters()
         {
             SqlDouble test1 = new SqlDouble(1e100);

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlDoubleTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlDoubleTest.cs
@@ -153,14 +153,6 @@ namespace System.Data.Tests.SqlTypes
         }
 
         [Fact]
-        public void GetTypeTest()
-        {
-            SqlDouble Test = new SqlDouble(84);
-            Assert.Equal("System.Data.SqlTypes.SqlDouble", Test.GetType().ToString());
-            Assert.Equal("System.Double", Test.Value.GetType().ToString());
-        }
-
-        [Fact]
         public void Greaters()
         {
             SqlDouble test1 = new SqlDouble(1e100);
@@ -320,15 +312,6 @@ namespace System.Data.Tests.SqlTypes
             // "-"-operator
             Assert.Equal(12e100, test1 - test3);
 
-            try
-            {
-                SqlDouble test = SqlDouble.MinValue - SqlDouble.MaxValue;
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
             Assert.Throws<OverflowException>(() => SqlDouble.MinValue - SqlDouble.MaxValue);
         }
 

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlGuidTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlGuidTest.cs
@@ -144,13 +144,6 @@ namespace System.Data.Tests.SqlTypes
         }
 
         [Fact]
-        public void GetTypeTest()
-        {
-            Assert.Equal("System.Data.SqlTypes.SqlGuid", _test1.GetType().ToString());
-            Assert.Equal("System.Guid", _test3.Value.GetType().ToString());
-        }
-
-        [Fact]
         public void Greaters()
         {
             // GreateThan ()
@@ -193,15 +186,6 @@ namespace System.Data.Tests.SqlTypes
         {
             Assert.Throws<ArgumentNullException>(() => SqlGuid.Parse(null));
 
-            try
-            {
-                SqlGuid.Parse("not-a-number");
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(FormatException), e.GetType());
-            }
             Assert.Throws<FormatException>(() => SqlGuid.Parse("not-a-number"));
 
             Assert.Throws<FormatException>(() => SqlGuid.Parse("9e400"));

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlGuidTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlGuidTest.cs
@@ -114,7 +114,7 @@ namespace System.Data.Tests.SqlTypes
             SqlGuid test3 = new SqlGuid("1AAAAAAA-BBBB-CCCC-DDDD-1EEEEEEEEEEE");
             Assert.True(_test1.CompareTo(_test3) < 0);
             Assert.True(_test4.CompareTo(_test1) > 0);
-            Assert.True(_test3.CompareTo(_test2) == 0);
+            Assert.Equal(0, _test3.CompareTo(_test2));
             Assert.True(_test4.CompareTo(SqlGuid.Null) > 0);
             Assert.True(test1.CompareTo(test2) > 0);
             Assert.True(test3.CompareTo(test2) < 0);
@@ -139,7 +139,7 @@ namespace System.Data.Tests.SqlTypes
         public void GetHashCodeTest()
         {
             Assert.Equal(_test1.GetHashCode(), _test1.GetHashCode());
-            Assert.True(_test1.GetHashCode() != _test2.GetHashCode());
+            Assert.NotEqual(_test1.GetHashCode(), _test2.GetHashCode());
             Assert.Equal(_test3.GetHashCode(), _test2.GetHashCode());
         }
 

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlGuidTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlGuidTest.cs
@@ -74,24 +74,17 @@ namespace System.Data.Tests.SqlTypes
             b[0] = 100;
             b[1] = 200;
 
-            try
-            {
-                SqlGuid Test = new SqlGuid(b);
+            _ =  new SqlGuid(b);
 
-                // SqlGuid (Guid)
-                Guid TestGuid = new Guid(b);
-                Test = new SqlGuid(TestGuid);
+            // SqlGuid (Guid)
+            Guid TestGuid = new Guid(b);
+            _ = new SqlGuid(TestGuid);
 
-                // SqlGuid (string)
-                Test = new SqlGuid("12345678-1234-1234-1234-123456789012");
+            // SqlGuid (string)
+            _ = new SqlGuid("12345678-1234-1234-1234-123456789012");
 
-                // SqlGuid (int, short, short, byte, byte, byte, byte, byte, byte, byte, byte)
-                Test = new SqlGuid(10, 1, 2, 13, 14, 15, 16, 17, 19, 20, 21);
-            }
-            catch (Exception e)
-            {
-                Assert.False(true);
-            }
+            // SqlGuid (int, short, short, byte, byte, byte, byte, byte, byte, byte, byte)
+            _ = new SqlGuid(10, 1, 2, 13, 14, 15, 16, 17, 19, 20, 21);
         }
 
         // Test public fields
@@ -106,7 +99,7 @@ namespace System.Data.Tests.SqlTypes
         public void Properties()
         {
             Guid ResultGuid = new Guid("00000f64-0000-0000-0000-000000000000");
-            Assert.True(!_test1.IsNull);
+            Assert.False(_test1.IsNull);
             Assert.True(SqlGuid.Null.IsNull);
             Assert.Equal(ResultGuid, _test2.Value);
         }
@@ -115,7 +108,7 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void CompareTo()
         {
-            string TestString = "This is a test string";
+            string testString = "This is a test string";
             SqlGuid test1 = new SqlGuid("1AAAAAAA-BBBB-CCCC-DDDD-3EEEEEEEEEEE");
             SqlGuid test2 = new SqlGuid("1AAAAAAA-BBBB-CCCC-DDDD-2EEEEEEEEEEE");
             SqlGuid test3 = new SqlGuid("1AAAAAAA-BBBB-CCCC-DDDD-1EEEEEEEEEEE");
@@ -126,28 +119,20 @@ namespace System.Data.Tests.SqlTypes
             Assert.True(test1.CompareTo(test2) > 0);
             Assert.True(test3.CompareTo(test2) < 0);
 
-            try
-            {
-                _test1.CompareTo(TestString);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(ArgumentException), e.GetType());
-            }
+            Assert.Throws<ArgumentException>(() => _test1.CompareTo(testString));
         }
 
         [Fact]
         public void EqualsMethods()
         {
-            Assert.True(!_test1.Equals(_test2));
-            Assert.True(!_test2.Equals(_test4));
-            Assert.True(!_test2.Equals(new SqlString("TEST")));
+            Assert.False(_test1.Equals(_test2));
+            Assert.False(_test2.Equals(_test4));
+            Assert.False(_test2.Equals(new SqlString("TEST")));
             Assert.True(_test2.Equals(_test3));
 
             // Static Equals()-method
             Assert.True(SqlGuid.Equals(_test2, _test3).Value);
-            Assert.True(!SqlGuid.Equals(_test1, _test2).Value);
+            Assert.False(SqlGuid.Equals(_test1, _test2).Value);
         }
 
         [Fact]
@@ -169,11 +154,11 @@ namespace System.Data.Tests.SqlTypes
         public void Greaters()
         {
             // GreateThan ()
-            Assert.True(!SqlGuid.GreaterThan(_test1, _test2).Value);
+            Assert.False(SqlGuid.GreaterThan(_test1, _test2).Value);
             Assert.True(SqlGuid.GreaterThan(_test2, _test1).Value);
-            Assert.True(!SqlGuid.GreaterThan(_test2, _test3).Value);
+            Assert.False(SqlGuid.GreaterThan(_test2, _test3).Value);
             // GreaterTharOrEqual ()
-            Assert.True(!SqlGuid.GreaterThanOrEqual(_test1, _test2).Value);
+            Assert.False(SqlGuid.GreaterThanOrEqual(_test1, _test2).Value);
             Assert.True(SqlGuid.GreaterThanOrEqual(_test2, _test1).Value);
             Assert.True(SqlGuid.GreaterThanOrEqual(_test2, _test3).Value);
         }
@@ -182,13 +167,13 @@ namespace System.Data.Tests.SqlTypes
         public void Lessers()
         {
             // LessThan()
-            Assert.True(!SqlGuid.LessThan(_test2, _test3).Value);
-            Assert.True(!SqlGuid.LessThan(_test2, _test1).Value);
+            Assert.False(SqlGuid.LessThan(_test2, _test3).Value);
+            Assert.False(SqlGuid.LessThan(_test2, _test1).Value);
             Assert.True(SqlGuid.LessThan(_test1, _test2).Value);
 
             // LessThanOrEqual ()
             Assert.True(SqlGuid.LessThanOrEqual(_test1, _test2).Value);
-            Assert.True(!SqlGuid.LessThanOrEqual(_test2, _test1).Value);
+            Assert.False(SqlGuid.LessThanOrEqual(_test2, _test1).Value);
             Assert.True(SqlGuid.LessThanOrEqual(_test2, _test3).Value);
             Assert.True(SqlGuid.LessThanOrEqual(_test4, SqlGuid.Null).IsNull);
         }
@@ -199,22 +184,14 @@ namespace System.Data.Tests.SqlTypes
             Assert.True(SqlGuid.NotEquals(_test1, _test2).Value);
             Assert.True(SqlGuid.NotEquals(_test2, _test1).Value);
             Assert.True(SqlGuid.NotEquals(_test3, _test1).Value);
-            Assert.True(!SqlGuid.NotEquals(_test3, _test2).Value);
+            Assert.False(SqlGuid.NotEquals(_test3, _test2).Value);
             Assert.True(SqlGuid.NotEquals(SqlGuid.Null, _test2).IsNull);
         }
 
         [Fact]
         public void Parse()
         {
-            try
-            {
-                SqlGuid.Parse(null);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(ArgumentNullException), e.GetType());
-            }
+            Assert.Throws<ArgumentNullException>(() => SqlGuid.Parse(null));
 
             try
             {
@@ -225,16 +202,9 @@ namespace System.Data.Tests.SqlTypes
             {
                 Assert.Equal(typeof(FormatException), e.GetType());
             }
+            Assert.Throws<FormatException>(() => SqlGuid.Parse("not-a-number"));
 
-            try
-            {
-                SqlGuid.Parse("9e400");
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(FormatException), e.GetType());
-            }
+            Assert.Throws<FormatException>(() => SqlGuid.Parse("9e400"));
 
             Assert.Equal(new Guid("87654321-0000-0000-0000-000000000000"), SqlGuid.Parse("87654321-0000-0000-0000-000000000000").Value);
         }
@@ -247,9 +217,7 @@ namespace System.Data.Tests.SqlTypes
             Assert.Equal((byte)15, _test2.ToByteArray()[1]);
 
             // ToSqlBinary ()
-            byte[] b = new byte[2];
-            b[0] = 100;
-            b[1] = 15;
+            byte[] b = new byte[2] { 100, 15 };
 
             Assert.Equal(new SqlBinary(b), _test3.ToSqlBinary());
 
@@ -269,35 +237,35 @@ namespace System.Data.Tests.SqlTypes
         {
             // == -operator
             Assert.True((_test3 == _test2).Value);
-            Assert.True(!(_test1 == _test2).Value);
+            Assert.False((_test1 == _test2).Value);
             Assert.True((_test1 == SqlGuid.Null).IsNull);
 
             // != -operator
-            Assert.True(!(_test2 != _test3).Value);
+            Assert.False((_test2 != _test3).Value);
             Assert.True((_test1 != _test3).Value);
             Assert.True((_test1 != SqlGuid.Null).IsNull);
 
             // > -operator
             Assert.True((_test2 > _test1).Value);
-            Assert.True(!(_test1 > _test3).Value);
-            Assert.True(!(_test3 > _test2).Value);
+            Assert.False((_test1 > _test3).Value);
+            Assert.False((_test3 > _test2).Value);
             Assert.True((_test1 > SqlGuid.Null).IsNull);
 
             // >=  -operator
-            Assert.True(!(_test1 >= _test3).Value);
+            Assert.False((_test1 >= _test3).Value);
             Assert.True((_test3 >= _test1).Value);
             Assert.True((_test3 >= _test2).Value);
             Assert.True((_test1 >= SqlGuid.Null).IsNull);
 
             // < -operator
-            Assert.True(!(_test2 < _test1).Value);
+            Assert.False((_test2 < _test1).Value);
             Assert.True((_test1 < _test3).Value);
-            Assert.True(!(_test2 < _test3).Value);
+            Assert.False((_test2 < _test3).Value);
             Assert.True((_test1 < SqlGuid.Null).IsNull);
 
             // <= -operator
             Assert.True((_test1 <= _test3).Value);
-            Assert.True(!(_test3 <= _test1).Value);
+            Assert.False((_test3 <= _test1).Value);
             Assert.True((_test2 <= _test3).Value);
             Assert.True((_test1 <= SqlGuid.Null).IsNull);
         }
@@ -308,9 +276,9 @@ namespace System.Data.Tests.SqlTypes
             byte[] b = new byte[16];
             b[0] = 100;
             b[1] = 200;
-            SqlBinary TestBinary = new SqlBinary(b);
+            SqlBinary testBinary = new SqlBinary(b);
 
-            Assert.Equal(new Guid("0000c864-0000-0000-0000-000000000000"), ((SqlGuid)TestBinary).Value);
+            Assert.Equal(new Guid("0000c864-0000-0000-0000-000000000000"), ((SqlGuid)testBinary).Value);
         }
 
         [Fact]
@@ -323,27 +291,19 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void SqlStringToSqlGuid()
         {
-            SqlString TestString = new SqlString("Test string");
-            SqlString TestString100 = new SqlString("0000c864-0000-0000-0000-000000000000");
+            SqlString testString = new SqlString("Test string");
+            SqlString testString100 = new SqlString("0000c864-0000-0000-0000-000000000000");
 
-            Assert.Equal(new Guid("0000c864-0000-0000-0000-000000000000"), ((SqlGuid)TestString100).Value);
+            Assert.Equal(new Guid("0000c864-0000-0000-0000-000000000000"), ((SqlGuid)testString100).Value);
 
-            try
-            {
-                SqlGuid test = (SqlGuid)TestString;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(FormatException), e.GetType());
-            }
+            Assert.Throws<FormatException>(() => (SqlGuid)testString);
         }
 
         [Fact]
         public void GuidToSqlGuid()
         {
-            Guid TestGuid = new Guid("0000c864-0000-0000-0000-000007650000");
-            Assert.Equal(new SqlGuid("0000c864-0000-0000-0000-000007650000"), TestGuid);
+            Guid testGuid = new Guid("0000c864-0000-0000-0000-000007650000");
+            Assert.Equal(new SqlGuid("0000c864-0000-0000-0000-000007650000"), testGuid);
         }
         [Fact]
         public void GetXsdTypeTest()

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlInt16Test.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlInt16Test.cs
@@ -184,13 +184,6 @@ namespace System.Data.Tests.SqlTypes
         }
 
         [Fact]
-        public void GetTypeTest()
-        {
-            SqlInt16 Test = new SqlInt16(84);
-            Assert.Equal("System.Data.SqlTypes.SqlInt16", Test.GetType().ToString());
-        }
-
-        [Fact]
         public void Greaters()
         {
             SqlInt16 test10 = new SqlInt16(10);
@@ -565,26 +558,8 @@ namespace System.Data.Tests.SqlTypes
 
             Assert.Equal((short)100, ((SqlInt16)testString100).Value);
 
-            try
-            {
-                SqlInt16 test = (SqlInt16)testString1000;
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
             Assert.Throws<OverflowException>(() => (SqlInt16)testString1000);
 
-            try
-            {
-                SqlInt16 test = (SqlInt16)testString;
-                Assert.False(true);
-            }
-            catch (FormatException e)
-            {
-                Assert.Equal(typeof(FormatException), e.GetType());
-            }
             Assert.Throws<FormatException>(() => (SqlInt16)testString);
         }
 

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlInt16Test.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlInt16Test.cs
@@ -142,7 +142,7 @@ namespace System.Data.Tests.SqlTypes
 
             Assert.True(testInt4000.CompareTo(testInt10) > 0);
             Assert.True(testInt10.CompareTo(testInt4000) < 0);
-            Assert.True(testInt4000II.CompareTo(testInt4000) == 0);
+            Assert.Equal(0, testInt4000II.CompareTo(testInt4000));
             Assert.True(testInt4000II.CompareTo(SqlInt16.Null) > 0);
 
             Assert.Throws<ArgumentException>(() => testInt10.CompareTo(testString));

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlInt16Test.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlInt16Test.cs
@@ -39,11 +39,11 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void Create()
         {
-            SqlInt16 TestShort = new SqlInt16(29);
-            Assert.Equal((short)29, TestShort.Value);
+            SqlInt16 testShort = new SqlInt16(29);
+            Assert.Equal((short)29, testShort.Value);
 
-            TestShort = new SqlInt16(-9000);
-            Assert.Equal((short)-9000, TestShort.Value);
+            testShort = new SqlInt16(-9000);
+            Assert.Equal((short)-9000, testShort.Value);
         }
 
         // Test public fields
@@ -60,11 +60,11 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void Properties()
         {
-            SqlInt16 Test5443 = new SqlInt16(5443);
-            SqlInt16 Test1 = new SqlInt16(1);
+            SqlInt16 test5443 = new SqlInt16(5443);
+            SqlInt16 test1 = new SqlInt16(1);
             Assert.True(SqlInt16.Null.IsNull);
-            Assert.Equal((short)5443, Test5443.Value);
-            Assert.Equal((short)1, Test1.Value);
+            Assert.Equal((short)5443, test5443.Value);
+            Assert.Equal((short)1, test1.Value);
         }
 
         // PUBLIC METHODS
@@ -72,74 +72,43 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void ArithmeticMethods()
         {
-            SqlInt16 Test64 = new SqlInt16(64);
-            SqlInt16 Test0 = new SqlInt16(0);
-            SqlInt16 Test164 = new SqlInt16(164);
-            SqlInt16 TestMax = new SqlInt16(SqlInt16.MaxValue.Value);
+            SqlInt16 test64 = new SqlInt16(64);
+            SqlInt16 test0 = new SqlInt16(0);
+            SqlInt16 test164 = new SqlInt16(164);
+            SqlInt16 testMax = new SqlInt16(SqlInt16.MaxValue.Value);
 
             // Add()
-            Assert.Equal((short)64, SqlInt16.Add(Test64, Test0).Value);
-            Assert.Equal((short)228, SqlInt16.Add(Test64, Test164).Value);
-            Assert.Equal((short)164, SqlInt16.Add(Test0, Test164).Value);
-            Assert.Equal((short)SqlInt16.MaxValue, SqlInt16.Add(TestMax, Test0).Value);
+            Assert.Equal((short)64, SqlInt16.Add(test64, test0).Value);
+            Assert.Equal((short)228, SqlInt16.Add(test64, test164).Value);
+            Assert.Equal((short)164, SqlInt16.Add(test0, test164).Value);
+            Assert.Equal((short)SqlInt16.MaxValue, SqlInt16.Add(testMax, test0).Value);
 
-            try
-            {
-                SqlInt16.Add(TestMax, Test64);
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlInt16.Add(testMax, test64));
 
             // Divide()
-            Assert.Equal((short)2, SqlInt16.Divide(Test164, Test64).Value);
-            Assert.Equal((short)0, SqlInt16.Divide(Test64, Test164).Value);
-            try
-            {
-                SqlInt16.Divide(Test64, Test0);
-                Assert.False(true);
-            }
-            catch (DivideByZeroException e)
-            {
-                Assert.Equal(typeof(DivideByZeroException), e.GetType());
-            }
+            Assert.Equal((short)2, SqlInt16.Divide(test164, test64).Value);
+            Assert.Equal((short)0, SqlInt16.Divide(test64, test164).Value);
+
+            Assert.Throws<DivideByZeroException>(() => SqlInt16.Divide(test64, test0));
 
             // Mod()
-            Assert.Equal((SqlInt16)36, SqlInt16.Mod(Test164, Test64));
-            Assert.Equal((SqlInt16)64, SqlInt16.Mod(Test64, Test164));
+            Assert.Equal((SqlInt16)36, SqlInt16.Mod(test164, test64));
+            Assert.Equal((SqlInt16)64, SqlInt16.Mod(test64, test164));
 
             // Multiply()
-            Assert.Equal((short)10496, SqlInt16.Multiply(Test64, Test164).Value);
-            Assert.Equal((short)0, SqlInt16.Multiply(Test64, Test0).Value);
+            Assert.Equal((short)10496, SqlInt16.Multiply(test64, test164).Value);
+            Assert.Equal((short)0, SqlInt16.Multiply(test64, test0).Value);
 
-            try
-            {
-                SqlInt16.Multiply(TestMax, Test64);
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlInt16.Multiply(testMax, test64));
 
             // Subtract()
-            Assert.Equal((short)100, SqlInt16.Subtract(Test164, Test64).Value);
+            Assert.Equal((short)100, SqlInt16.Subtract(test164, test64).Value);
 
-            try
-            {
-                SqlInt16.Subtract(SqlInt16.MinValue, Test164);
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlInt16.Subtract(SqlInt16.MinValue, test164));
 
             // Modulus ()
-            Assert.Equal((SqlInt16)36, SqlInt16.Modulus(Test164, Test64));
-            Assert.Equal((SqlInt16)64, SqlInt16.Modulus(Test64, Test164));
+            Assert.Equal((SqlInt16)36, SqlInt16.Modulus(test164, test64));
+            Assert.Equal((SqlInt16)64, SqlInt16.Modulus(test64, test164));
         }
 
         [Fact]
@@ -165,61 +134,53 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void CompareTo()
         {
-            SqlInt16 TestInt4000 = new SqlInt16(4000);
-            SqlInt16 TestInt4000II = new SqlInt16(4000);
-            SqlInt16 TestInt10 = new SqlInt16(10);
-            SqlInt16 TestInt10000 = new SqlInt16(10000);
-            SqlString TestString = new SqlString("This is a test");
+            SqlInt16 testInt4000 = new SqlInt16(4000);
+            SqlInt16 testInt4000II = new SqlInt16(4000);
+            SqlInt16 testInt10 = new SqlInt16(10);
+            SqlInt16 testInt10000 = new SqlInt16(10000);
+            SqlString testString = new SqlString("This is a test");
 
-            Assert.True(TestInt4000.CompareTo(TestInt10) > 0);
-            Assert.True(TestInt10.CompareTo(TestInt4000) < 0);
-            Assert.True(TestInt4000II.CompareTo(TestInt4000) == 0);
-            Assert.True(TestInt4000II.CompareTo(SqlInt16.Null) > 0);
+            Assert.True(testInt4000.CompareTo(testInt10) > 0);
+            Assert.True(testInt10.CompareTo(testInt4000) < 0);
+            Assert.True(testInt4000II.CompareTo(testInt4000) == 0);
+            Assert.True(testInt4000II.CompareTo(SqlInt16.Null) > 0);
 
-            try
-            {
-                TestInt10.CompareTo(TestString);
-                Assert.False(true);
-            }
-            catch (ArgumentException e)
-            {
-                Assert.Equal(typeof(ArgumentException), e.GetType());
-            }
+            Assert.Throws<ArgumentException>(() => testInt10.CompareTo(testString));
         }
 
         [Fact]
         public void EqualsMethod()
         {
-            SqlInt16 Test0 = new SqlInt16(0);
-            SqlInt16 Test158 = new SqlInt16(158);
-            SqlInt16 Test180 = new SqlInt16(180);
-            SqlInt16 Test180II = new SqlInt16(180);
+            SqlInt16 test0 = new SqlInt16(0);
+            SqlInt16 test158 = new SqlInt16(158);
+            SqlInt16 test180 = new SqlInt16(180);
+            SqlInt16 test180II = new SqlInt16(180);
 
-            Assert.True(!Test0.Equals(Test158));
-            Assert.True(!Test158.Equals(Test180));
-            Assert.True(!Test180.Equals(new SqlString("TEST")));
-            Assert.True(Test180.Equals(Test180II));
+            Assert.False(test0.Equals(test158));
+            Assert.False(test158.Equals(test180));
+            Assert.False(test180.Equals(new SqlString("TEST")));
+            Assert.True(test180.Equals(test180II));
         }
 
         [Fact]
         public void StaticEqualsMethod()
         {
-            SqlInt16 Test34 = new SqlInt16(34);
-            SqlInt16 Test34II = new SqlInt16(34);
-            SqlInt16 Test15 = new SqlInt16(15);
+            SqlInt16 test34 = new SqlInt16(34);
+            SqlInt16 test34II = new SqlInt16(34);
+            SqlInt16 test15 = new SqlInt16(15);
 
-            Assert.True(SqlInt16.Equals(Test34, Test34II).Value);
-            Assert.True(!SqlInt16.Equals(Test34, Test15).Value);
-            Assert.True(!SqlInt16.Equals(Test15, Test34II).Value);
+            Assert.True(SqlInt16.Equals(test34, test34II).Value);
+            Assert.False(SqlInt16.Equals(test34, test15).Value);
+            Assert.False(SqlInt16.Equals(test15, test34II).Value);
         }
 
         [Fact]
         public void GetHashCodeTest()
         {
-            SqlInt16 Test15 = new SqlInt16(15);
+            SqlInt16 test15 = new SqlInt16(15);
 
             // FIXME: Better way to test GetHashCode()-methods
-            Assert.Equal(Test15.GetHashCode(), Test15.GetHashCode());
+            Assert.Equal(test15.GetHashCode(), test15.GetHashCode());
         }
 
         [Fact]
@@ -232,99 +193,74 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void Greaters()
         {
-            SqlInt16 Test10 = new SqlInt16(10);
-            SqlInt16 Test10II = new SqlInt16(10);
-            SqlInt16 Test110 = new SqlInt16(110);
+            SqlInt16 test10 = new SqlInt16(10);
+            SqlInt16 test10II = new SqlInt16(10);
+            SqlInt16 test110 = new SqlInt16(110);
 
             // GreateThan ()
-            Assert.True(!SqlInt16.GreaterThan(Test10, Test110).Value);
-            Assert.True(SqlInt16.GreaterThan(Test110, Test10).Value);
-            Assert.True(!SqlInt16.GreaterThan(Test10II, Test10).Value);
+            Assert.False(SqlInt16.GreaterThan(test10, test110).Value);
+            Assert.True(SqlInt16.GreaterThan(test110, test10).Value);
+            Assert.False(SqlInt16.GreaterThan(test10II, test10).Value);
 
             // GreaterTharOrEqual ()
-            Assert.True(!SqlInt16.GreaterThanOrEqual(Test10, Test110).Value);
-            Assert.True(SqlInt16.GreaterThanOrEqual(Test110, Test10).Value);
-            Assert.True(SqlInt16.GreaterThanOrEqual(Test10II, Test10).Value);
+            Assert.False(SqlInt16.GreaterThanOrEqual(test10, test110).Value);
+            Assert.True(SqlInt16.GreaterThanOrEqual(test110, test10).Value);
+            Assert.True(SqlInt16.GreaterThanOrEqual(test10II, test10).Value);
         }
 
         [Fact]
         public void Lessers()
         {
-            SqlInt16 Test10 = new SqlInt16(10);
-            SqlInt16 Test10II = new SqlInt16(10);
-            SqlInt16 Test110 = new SqlInt16(110);
+            SqlInt16 test10 = new SqlInt16(10);
+            SqlInt16 test10II = new SqlInt16(10);
+            SqlInt16 test110 = new SqlInt16(110);
 
             // LessThan()
-            Assert.True(SqlInt16.LessThan(Test10, Test110).Value);
-            Assert.True(!SqlInt16.LessThan(Test110, Test10).Value);
-            Assert.True(!SqlInt16.LessThan(Test10II, Test10).Value);
+            Assert.True(SqlInt16.LessThan(test10, test110).Value);
+            Assert.False(SqlInt16.LessThan(test110, test10).Value);
+            Assert.False(SqlInt16.LessThan(test10II, test10).Value);
 
             // LessThanOrEqual ()
-            Assert.True(SqlInt16.LessThanOrEqual(Test10, Test110).Value);
-            Assert.True(!SqlInt16.LessThanOrEqual(Test110, Test10).Value);
-            Assert.True(SqlInt16.LessThanOrEqual(Test10II, Test10).Value);
-            Assert.True(SqlInt16.LessThanOrEqual(Test10II, SqlInt16.Null).IsNull);
+            Assert.True(SqlInt16.LessThanOrEqual(test10, test110).Value);
+            Assert.False(SqlInt16.LessThanOrEqual(test110, test10).Value);
+            Assert.True(SqlInt16.LessThanOrEqual(test10II, test10).Value);
+            Assert.True(SqlInt16.LessThanOrEqual(test10II, SqlInt16.Null).IsNull);
         }
 
         [Fact]
         public void NotEquals()
         {
-            SqlInt16 Test12 = new SqlInt16(12);
-            SqlInt16 Test128 = new SqlInt16(128);
-            SqlInt16 Test128II = new SqlInt16(128);
+            SqlInt16 test12 = new SqlInt16(12);
+            SqlInt16 test128 = new SqlInt16(128);
+            SqlInt16 test128II = new SqlInt16(128);
 
-            Assert.True(SqlInt16.NotEquals(Test12, Test128).Value);
-            Assert.True(SqlInt16.NotEquals(Test128, Test12).Value);
-            Assert.True(SqlInt16.NotEquals(Test128II, Test12).Value);
-            Assert.True(!SqlInt16.NotEquals(Test128II, Test128).Value);
-            Assert.True(!SqlInt16.NotEquals(Test128, Test128II).Value);
-            Assert.True(SqlInt16.NotEquals(SqlInt16.Null, Test128II).IsNull);
-            Assert.True(SqlInt16.NotEquals(SqlInt16.Null, Test128II).IsNull);
+            Assert.True(SqlInt16.NotEquals(test12, test128).Value);
+            Assert.True(SqlInt16.NotEquals(test128, test12).Value);
+            Assert.True(SqlInt16.NotEquals(test128II, test12).Value);
+            Assert.False(SqlInt16.NotEquals(test128II, test128).Value);
+            Assert.False(SqlInt16.NotEquals(test128, test128II).Value);
+            Assert.True(SqlInt16.NotEquals(SqlInt16.Null, test128II).IsNull);
+            Assert.True(SqlInt16.NotEquals(SqlInt16.Null, test128II).IsNull);
         }
 
         [Fact]
         public void OnesComplement()
         {
-            SqlInt16 Test12 = new SqlInt16(12);
-            SqlInt16 Test128 = new SqlInt16(128);
+            SqlInt16 test12 = new SqlInt16(12);
+            SqlInt16 test128 = new SqlInt16(128);
 
-            Assert.Equal((SqlInt16)(-13), SqlInt16.OnesComplement(Test12));
-            Assert.Equal((SqlInt16)(-129), SqlInt16.OnesComplement(Test128));
+            Assert.Equal((SqlInt16)(-13), SqlInt16.OnesComplement(test12));
+            Assert.Equal((SqlInt16)(-129), SqlInt16.OnesComplement(test128));
         }
 
         [Fact]
         public void Parse()
         {
-            try
-            {
-                SqlInt16.Parse(null);
-                Assert.False(true);
-            }
-            catch (ArgumentNullException e)
-            {
-                Assert.Equal(typeof(ArgumentNullException), e.GetType());
-            }
+            Assert.Throws<ArgumentNullException>(() => SqlInt16.Parse(null));
 
-            try
-            {
-                SqlInt16.Parse("not-a-number");
-                Assert.False(true);
-            }
-            catch (FormatException e)
-            {
-                Assert.Equal(typeof(FormatException), e.GetType());
-            }
+            Assert.Throws<FormatException>(() => SqlInt16.Parse("not-a-number"));
 
-            try
-            {
-                int OverInt = (int)SqlInt16.MaxValue + 1;
-                SqlInt16.Parse(OverInt.ToString());
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlInt16.Parse(((int)SqlInt16.MaxValue + 1).ToString()));
 
             Assert.Equal((short)150, SqlInt16.Parse("150").Value);
         }
@@ -332,86 +268,78 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void Conversions()
         {
-            SqlInt16 Test12 = new SqlInt16(12);
-            SqlInt16 Test0 = new SqlInt16(0);
-            SqlInt16 TestNull = SqlInt16.Null;
-            SqlInt16 Test1000 = new SqlInt16(1000);
-            SqlInt16 Test288 = new SqlInt16(288);
+            SqlInt16 test12 = new SqlInt16(12);
+            SqlInt16 test0 = new SqlInt16(0);
+            SqlInt16 testNull = SqlInt16.Null;
+            SqlInt16 test1000 = new SqlInt16(1000);
+            SqlInt16 test288 = new SqlInt16(288);
 
             // ToSqlBoolean ()
-            Assert.True(Test12.ToSqlBoolean().Value);
-            Assert.True(!Test0.ToSqlBoolean().Value);
-            Assert.True(TestNull.ToSqlBoolean().IsNull);
+            Assert.True(test12.ToSqlBoolean().Value);
+            Assert.False(test0.ToSqlBoolean().Value);
+            Assert.True(testNull.ToSqlBoolean().IsNull);
 
             // ToSqlByte ()
-            Assert.Equal((byte)12, Test12.ToSqlByte().Value);
-            Assert.Equal((byte)0, Test0.ToSqlByte().Value);
+            Assert.Equal((byte)12, test12.ToSqlByte().Value);
+            Assert.Equal((byte)0, test0.ToSqlByte().Value);
 
-            try
-            {
-                SqlByte b = (byte)Test1000.ToSqlByte();
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => test1000.ToSqlByte());
 
             // ToSqlDecimal ()
-            Assert.Equal(12, Test12.ToSqlDecimal().Value);
-            Assert.Equal(0, Test0.ToSqlDecimal().Value);
-            Assert.Equal(288, Test288.ToSqlDecimal().Value);
+            Assert.Equal(12, test12.ToSqlDecimal().Value);
+            Assert.Equal(0, test0.ToSqlDecimal().Value);
+            Assert.Equal(288, test288.ToSqlDecimal().Value);
 
             // ToSqlDouble ()
-            Assert.Equal(12, Test12.ToSqlDouble().Value);
-            Assert.Equal(0, Test0.ToSqlDouble().Value);
-            Assert.Equal(1000, Test1000.ToSqlDouble().Value);
+            Assert.Equal(12, test12.ToSqlDouble().Value);
+            Assert.Equal(0, test0.ToSqlDouble().Value);
+            Assert.Equal(1000, test1000.ToSqlDouble().Value);
 
             // ToSqlInt32 ()
-            Assert.Equal(12, Test12.ToSqlInt32().Value);
-            Assert.Equal(0, Test0.ToSqlInt32().Value);
-            Assert.Equal(288, Test288.ToSqlInt32().Value);
+            Assert.Equal(12, test12.ToSqlInt32().Value);
+            Assert.Equal(0, test0.ToSqlInt32().Value);
+            Assert.Equal(288, test288.ToSqlInt32().Value);
 
             // ToSqlInt64 ()
-            Assert.Equal(12, Test12.ToSqlInt64().Value);
-            Assert.Equal(0, Test0.ToSqlInt64().Value);
-            Assert.Equal(288, Test288.ToSqlInt64().Value);
+            Assert.Equal(12, test12.ToSqlInt64().Value);
+            Assert.Equal(0, test0.ToSqlInt64().Value);
+            Assert.Equal(288, test288.ToSqlInt64().Value);
 
             // ToSqlMoney ()
-            Assert.Equal(12.0000M, Test12.ToSqlMoney().Value);
-            Assert.Equal(0, Test0.ToSqlMoney().Value);
-            Assert.Equal(288.0000M, Test288.ToSqlMoney().Value);
+            Assert.Equal(12.0000M, test12.ToSqlMoney().Value);
+            Assert.Equal(0, test0.ToSqlMoney().Value);
+            Assert.Equal(288.0000M, test288.ToSqlMoney().Value);
 
             // ToSqlSingle ()
-            Assert.Equal(12, Test12.ToSqlSingle().Value);
-            Assert.Equal(0, Test0.ToSqlSingle().Value);
-            Assert.Equal(288, Test288.ToSqlSingle().Value);
+            Assert.Equal(12, test12.ToSqlSingle().Value);
+            Assert.Equal(0, test0.ToSqlSingle().Value);
+            Assert.Equal(288, test288.ToSqlSingle().Value);
 
             // ToSqlString ()
-            Assert.Equal("12", Test12.ToSqlString().Value);
-            Assert.Equal("0", Test0.ToSqlString().Value);
-            Assert.Equal("288", Test288.ToSqlString().Value);
+            Assert.Equal("12", test12.ToSqlString().Value);
+            Assert.Equal("0", test0.ToSqlString().Value);
+            Assert.Equal("288", test288.ToSqlString().Value);
 
             // ToString ()
-            Assert.Equal("12", Test12.ToString());
-            Assert.Equal("0", Test0.ToString());
-            Assert.Equal("288", Test288.ToString());
+            Assert.Equal("12", test12.ToString());
+            Assert.Equal("0", test0.ToString());
+            Assert.Equal("288", test288.ToString());
         }
 
         [Fact]
         public void Xor()
         {
-            SqlInt16 Test14 = new SqlInt16(14);
-            SqlInt16 Test58 = new SqlInt16(58);
-            SqlInt16 Test130 = new SqlInt16(130);
-            SqlInt16 TestMax = new SqlInt16(SqlInt16.MaxValue.Value);
-            SqlInt16 Test0 = new SqlInt16(0);
+            SqlInt16 test14 = new SqlInt16(14);
+            SqlInt16 test58 = new SqlInt16(58);
+            SqlInt16 test130 = new SqlInt16(130);
+            SqlInt16 testMax = new SqlInt16(SqlInt16.MaxValue.Value);
+            SqlInt16 test0 = new SqlInt16(0);
 
-            Assert.Equal((short)52, SqlInt16.Xor(Test14, Test58).Value);
-            Assert.Equal((short)140, SqlInt16.Xor(Test14, Test130).Value);
-            Assert.Equal((short)184, SqlInt16.Xor(Test58, Test130).Value);
-            Assert.Equal((short)0, SqlInt16.Xor(TestMax, TestMax).Value);
-            Assert.Equal(TestMax.Value, SqlInt16.Xor(TestMax, Test0).Value);
+            Assert.Equal((short)52, SqlInt16.Xor(test14, test58).Value);
+            Assert.Equal((short)140, SqlInt16.Xor(test14, test130).Value);
+            Assert.Equal((short)184, SqlInt16.Xor(test58, test130).Value);
+            Assert.Equal((short)0, SqlInt16.Xor(testMax, testMax).Value);
+            Assert.Equal(testMax.Value, SqlInt16.Xor(testMax, test0).Value);
         }
 
         // OPERATORS
@@ -419,332 +347,252 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void ArithmeticOperators()
         {
-            SqlInt16 Test24 = new SqlInt16(24);
-            SqlInt16 Test64 = new SqlInt16(64);
-            SqlInt16 Test2550 = new SqlInt16(2550);
-            SqlInt16 Test0 = new SqlInt16(0);
+            SqlInt16 test24 = new SqlInt16(24);
+            SqlInt16 test64 = new SqlInt16(64);
+            SqlInt16 test2550 = new SqlInt16(2550);
+            SqlInt16 test0 = new SqlInt16(0);
 
             // "+"-operator
-            Assert.Equal((SqlInt16)2614, Test2550 + Test64);
-            try
-            {
-                SqlInt16 result = Test64 + SqlInt16.MaxValue;
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Equal((SqlInt16)2614, test2550 + test64);
+            Assert.Throws<OverflowException>(() => test64 + SqlInt16.MaxValue);
 
             // "/"-operator
-            Assert.Equal((SqlInt16)39, Test2550 / Test64);
-            Assert.Equal((SqlInt16)0, Test24 / Test64);
+            Assert.Equal((SqlInt16)39, test2550 / test64);
+            Assert.Equal((SqlInt16)0, test24 / test64);
 
-            try
-            {
-                SqlInt16 result = Test2550 / Test0;
-                Assert.False(true);
-            }
-            catch (DivideByZeroException e)
-            {
-                Assert.Equal(typeof(DivideByZeroException), e.GetType());
-            }
+            Assert.Throws<DivideByZeroException>(() => test2550 / test0);
 
             // "*"-operator
-            Assert.Equal((SqlInt16)1536, Test64 * Test24);
+            Assert.Equal((SqlInt16)1536, test64 * test24);
 
-            try
-            {
-                SqlInt16 test = (SqlInt16.MaxValue * Test64);
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
-
+            Assert.Throws<OverflowException>(() => SqlInt16.MaxValue * test64);
             // "-"-operator
-            Assert.Equal((SqlInt16)2526, Test2550 - Test24);
+            Assert.Equal((SqlInt16)2526, test2550 - test24);
 
-            try
-            {
-                SqlInt16 test = SqlInt16.MinValue - Test64;
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
-
+            Assert.Throws<OverflowException>(() => SqlInt16.MinValue - test64);
             // "%"-operator
-            Assert.Equal((SqlInt16)54, Test2550 % Test64);
-            Assert.Equal((SqlInt16)24, Test24 % Test64);
+            Assert.Equal((SqlInt16)54, test2550 % test64);
+            Assert.Equal((SqlInt16)24, test24 % test64);
             Assert.Equal((SqlInt16)0, new SqlInt16(100) % new SqlInt16(10));
         }
 
         [Fact]
         public void BitwiseOperators()
         {
-            SqlInt16 Test2 = new SqlInt16(2);
-            SqlInt16 Test4 = new SqlInt16(4);
-            SqlInt16 Test2550 = new SqlInt16(2550);
+            SqlInt16 test2 = new SqlInt16(2);
+            SqlInt16 test4 = new SqlInt16(4);
+            SqlInt16 test2550 = new SqlInt16(2550);
 
             // & -operator
-            Assert.Equal((SqlInt16)0, Test2 & Test4);
-            Assert.Equal((SqlInt16)2, Test2 & Test2550);
+            Assert.Equal((SqlInt16)0, test2 & test4);
+            Assert.Equal((SqlInt16)2, test2 & test2550);
             Assert.Equal((SqlInt16)0, SqlInt16.MaxValue & SqlInt16.MinValue);
 
             // | -operator
-            Assert.Equal((SqlInt16)6, Test2 | Test4);
-            Assert.Equal((SqlInt16)2550, Test2 | Test2550);
+            Assert.Equal((SqlInt16)6, test2 | test4);
+            Assert.Equal((SqlInt16)2550, test2 | test2550);
             Assert.Equal((SqlInt16)(-1), SqlInt16.MinValue | SqlInt16.MaxValue);
 
             //  ^ -operator
-            Assert.Equal((SqlInt16)2546, (Test2550 ^ Test4));
-            Assert.Equal((SqlInt16)6, (Test2 ^ Test4));
+            Assert.Equal((SqlInt16)2546, (test2550 ^ test4));
+            Assert.Equal((SqlInt16)6, (test2 ^ test4));
         }
 
         [Fact]
         public void ThanOrEqualOperators()
         {
-            SqlInt16 Test165 = new SqlInt16(165);
-            SqlInt16 Test100 = new SqlInt16(100);
-            SqlInt16 Test100II = new SqlInt16(100);
-            SqlInt16 Test255 = new SqlInt16(2550);
+            SqlInt16 test165 = new SqlInt16(165);
+            SqlInt16 test100 = new SqlInt16(100);
+            SqlInt16 test100II = new SqlInt16(100);
+            SqlInt16 test255 = new SqlInt16(2550);
 
             // == -operator
-            Assert.True((Test100 == Test100II).Value);
-            Assert.True(!(Test165 == Test100).Value);
-            Assert.True((Test165 == SqlInt16.Null).IsNull);
+            Assert.True((test100 == test100II).Value);
+            Assert.False((test165 == test100).Value);
+            Assert.True((test165 == SqlInt16.Null).IsNull);
 
             // != -operator
-            Assert.True(!(Test100 != Test100II).Value);
-            Assert.True((Test100 != Test255).Value);
-            Assert.True((Test165 != Test255).Value);
-            Assert.True((Test165 != SqlInt16.Null).IsNull);
+            Assert.False((test100 != test100II).Value);
+            Assert.True((test100 != test255).Value);
+            Assert.True((test165 != test255).Value);
+            Assert.True((test165 != SqlInt16.Null).IsNull);
 
             // > -operator
-            Assert.True((Test165 > Test100).Value);
-            Assert.True(!(Test165 > Test255).Value);
-            Assert.True(!(Test100 > Test100II).Value);
-            Assert.True((Test165 > SqlInt16.Null).IsNull);
+            Assert.True((test165 > test100).Value);
+            Assert.False((test165 > test255).Value);
+            Assert.False((test100 > test100II).Value);
+            Assert.True((test165 > SqlInt16.Null).IsNull);
 
             // >=  -operator
-            Assert.True(!(Test165 >= Test255).Value);
-            Assert.True((Test255 >= Test165).Value);
-            Assert.True((Test100 >= Test100II).Value);
-            Assert.True((Test165 >= SqlInt16.Null).IsNull);
+            Assert.False((test165 >= test255).Value);
+            Assert.True((test255 >= test165).Value);
+            Assert.True((test100 >= test100II).Value);
+            Assert.True((test165 >= SqlInt16.Null).IsNull);
 
             // < -operator
-            Assert.True(!(Test165 < Test100).Value);
-            Assert.True((Test165 < Test255).Value);
-            Assert.True(!(Test100 < Test100II).Value);
-            Assert.True((Test165 < SqlInt16.Null).IsNull);
+            Assert.False((test165 < test100).Value);
+            Assert.True((test165 < test255).Value);
+            Assert.False((test100 < test100II).Value);
+            Assert.True((test165 < SqlInt16.Null).IsNull);
 
             // <= -operator
-            Assert.True((Test165 <= Test255).Value);
-            Assert.True(!(Test255 <= Test165).Value);
-            Assert.True((Test100 <= Test100II).Value);
-            Assert.True((Test165 <= SqlInt16.Null).IsNull);
+            Assert.True((test165 <= test255).Value);
+            Assert.False((test255 <= test165).Value);
+            Assert.True((test100 <= test100II).Value);
+            Assert.True((test165 <= SqlInt16.Null).IsNull);
         }
 
         [Fact]
         public void OnesComplementOperator()
         {
-            SqlInt16 Test12 = new SqlInt16(12);
-            SqlInt16 Test128 = new SqlInt16(128);
+            SqlInt16 test12 = new SqlInt16(12);
+            SqlInt16 test128 = new SqlInt16(128);
 
-            Assert.Equal((SqlInt16)(-13), ~Test12);
-            Assert.Equal((SqlInt16)(-129), ~Test128);
+            Assert.Equal((SqlInt16)(-13), ~test12);
+            Assert.Equal((SqlInt16)(-129), ~test128);
             Assert.Equal(SqlInt16.Null, ~SqlInt16.Null);
         }
 
         [Fact]
         public void UnaryNegation()
         {
-            SqlInt16 Test = new SqlInt16(2000);
-            SqlInt16 TestNeg = new SqlInt16(-3000);
+            SqlInt16 test = new SqlInt16(2000);
+            SqlInt16 testNeg = new SqlInt16(-3000);
 
-            SqlInt16 Result = -Test;
-            Assert.Equal((short)(-2000), Result.Value);
+            SqlInt16 result = -test;
+            Assert.Equal((short)(-2000), result.Value);
 
-            Result = -TestNeg;
-            Assert.Equal((short)3000, Result.Value);
+            result = -testNeg;
+            Assert.Equal((short)3000, result.Value);
         }
 
         [Fact]
         public void SqlBooleanToSqlInt16()
         {
-            SqlBoolean TestBoolean = new SqlBoolean(true);
-            SqlInt16 Result;
+            SqlBoolean testBoolean = new SqlBoolean(true);
+            SqlInt16 result;
 
-            Result = (SqlInt16)TestBoolean;
+            result = (SqlInt16)testBoolean;
 
-            Assert.Equal((short)1, Result.Value);
+            Assert.Equal((short)1, result.Value);
 
-            Result = (SqlInt16)SqlBoolean.Null;
-            Assert.True(Result.IsNull);
+            result = (SqlInt16)SqlBoolean.Null;
+            Assert.True(result.IsNull);
         }
 
         [Fact]
         public void SqlDecimalToSqlInt16()
         {
-            SqlDecimal TestDecimal64 = new SqlDecimal(64);
-            SqlDecimal TestDecimal900 = new SqlDecimal(90000);
+            SqlDecimal testDecimal64 = new SqlDecimal(64);
+            SqlDecimal testDecimal900 = new SqlDecimal(90000);
 
-            Assert.Equal((short)64, ((SqlInt16)TestDecimal64).Value);
+            Assert.Equal((short)64, ((SqlInt16)testDecimal64).Value);
             Assert.Equal(SqlInt16.Null, ((SqlInt16)SqlDecimal.Null));
 
-            try
-            {
-                SqlInt16 test = (SqlInt16)TestDecimal900;
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => (SqlInt16)testDecimal900);
         }
 
         [Fact]
         public void SqlDoubleToSqlInt16()
         {
-            SqlDouble TestDouble64 = new SqlDouble(64);
-            SqlDouble TestDouble900 = new SqlDouble(90000);
+            SqlDouble testDouble64 = new SqlDouble(64);
+            SqlDouble testDouble900 = new SqlDouble(90000);
 
-            Assert.Equal((short)64, ((SqlInt16)TestDouble64).Value);
+            Assert.Equal((short)64, ((SqlInt16)testDouble64).Value);
             Assert.Equal(SqlInt16.Null, ((SqlInt16)SqlDouble.Null));
 
-            try
-            {
-                SqlInt16 test = (SqlInt16)TestDouble900;
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => (SqlInt16)testDouble900);
         }
 
         [Fact]
         public void SqlIntToInt16()
         {
-            SqlInt16 Test = new SqlInt16(12);
-            short Result = (short)Test;
-            Assert.Equal((short)12, Result);
+            SqlInt16 test = new SqlInt16(12);
+            short result = (short)test;
+            Assert.Equal((short)12, result);
         }
 
         [Fact]
         public void SqlInt32ToSqlInt16()
         {
-            SqlInt32 Test64 = new SqlInt32(64);
-            SqlInt32 Test900 = new SqlInt32(90000);
+            SqlInt32 test64 = new SqlInt32(64);
+            SqlInt32 test900 = new SqlInt32(90000);
 
-            Assert.Equal((short)64, ((SqlInt16)Test64).Value);
+            Assert.Equal((short)64, ((SqlInt16)test64).Value);
 
-            try
-            {
-                SqlInt16 test = (SqlInt16)Test900;
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() =>(SqlInt16)test900);
         }
 
         [Fact]
         public void SqlInt64ToSqlInt16()
         {
-            SqlInt64 Test64 = new SqlInt64(64);
-            SqlInt64 Test900 = new SqlInt64(90000);
+            SqlInt64 test64 = new SqlInt64(64);
+            SqlInt64 test900 = new SqlInt64(90000);
 
-            Assert.Equal((short)64, ((SqlInt16)Test64).Value);
+            Assert.Equal((short)64, ((SqlInt16)test64).Value);
 
-            try
-            {
-                SqlInt16 test = (SqlInt16)Test900;
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => (SqlInt16)test900);
         }
 
         [Fact]
         public void SqlMoneyToSqlInt16()
         {
-            SqlMoney TestMoney64 = new SqlMoney(64);
-            SqlMoney TestMoney900 = new SqlMoney(90000);
+            SqlMoney testMoney64 = new SqlMoney(64);
+            SqlMoney testMoney900 = new SqlMoney(90000);
 
-            Assert.Equal((short)64, ((SqlInt16)TestMoney64).Value);
+            Assert.Equal((short)64, ((SqlInt16)testMoney64).Value);
 
-            try
-            {
-                SqlInt16 test = (SqlInt16)TestMoney900;
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => (SqlInt16)testMoney900);
         }
 
         [Fact]
         public void SqlSingleToSqlInt16()
         {
-            SqlSingle TestSingle64 = new SqlSingle(64);
-            SqlSingle TestSingle900 = new SqlSingle(90000);
+            SqlSingle testSingle64 = new SqlSingle(64);
+            SqlSingle testSingle900 = new SqlSingle(90000);
 
-            Assert.Equal((short)64, ((SqlInt16)TestSingle64).Value);
+            Assert.Equal((short)64, ((SqlInt16)testSingle64).Value);
 
-            try
-            {
-                SqlInt16 test = (SqlInt16)TestSingle900;
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => (SqlInt16)testSingle900);
         }
 
         [Fact]
         public void SqlStringToSqlInt16()
         {
-            SqlString TestString = new SqlString("Test string");
-            SqlString TestString100 = new SqlString("100");
-            SqlString TestString1000 = new SqlString("100000");
+            SqlString testString = new SqlString("Test string");
+            SqlString testString100 = new SqlString("100");
+            SqlString testString1000 = new SqlString("100000");
 
-            Assert.Equal((short)100, ((SqlInt16)TestString100).Value);
+            Assert.Equal((short)100, ((SqlInt16)testString100).Value);
 
             try
             {
-                SqlInt16 test = (SqlInt16)TestString1000;
+                SqlInt16 test = (SqlInt16)testString1000;
                 Assert.False(true);
             }
             catch (OverflowException e)
             {
                 Assert.Equal(typeof(OverflowException), e.GetType());
             }
+            Assert.Throws<OverflowException>(() => (SqlInt16)testString1000);
 
             try
             {
-                SqlInt16 test = (SqlInt16)TestString;
+                SqlInt16 test = (SqlInt16)testString;
                 Assert.False(true);
             }
             catch (FormatException e)
             {
                 Assert.Equal(typeof(FormatException), e.GetType());
             }
+            Assert.Throws<FormatException>(() => (SqlInt16)testString);
         }
 
         [Fact]
         public void ByteToSqlInt16()
         {
-            short TestShort = 14;
-            Assert.Equal((short)14, ((SqlInt16)TestShort).Value);
+            short testShort = 14;
+            Assert.Equal((short)14, ((SqlInt16)testShort).Value);
         }
         [Fact]
         public void GetXsdTypeTest()
@@ -795,15 +643,9 @@ namespace System.Data.Tests.SqlTypes
             ReadWriteXmlTestInternal(xml1, test1, "BA01");
             ReadWriteXmlTestInternal(xml2, test2, "BA02");
 
-            try
-            {
-                ReadWriteXmlTestInternal(xml3, test3, "BA03");
-                Assert.False(true);
-            }
-            catch (InvalidOperationException e)
-            {
-                Assert.Equal(typeof(FormatException), e.InnerException.GetType());
-            }
+            InvalidOperationException ex =
+                Assert.Throws<InvalidOperationException>(() => ReadWriteXmlTestInternal(xml3, test3, "BA03"));
+            Assert.Equal(typeof(FormatException), ex.InnerException.GetType());
         }
     }
 }

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlInt32Test.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlInt32Test.cs
@@ -497,15 +497,9 @@ namespace System.Data.Tests.SqlTypes
             ReadWriteXmlTestInternal(xml1, test1, "BA01");
             ReadWriteXmlTestInternal(xml2, test2, "BA02");
 
-            try
-            {
-                ReadWriteXmlTestInternal(xml3, test3, "#BA03");
-                Assert.False(true);
-            }
-            catch (InvalidOperationException e)
-            {
-                Assert.Equal(typeof(FormatException), e.InnerException.GetType());
-            }
+            InvalidOperationException ex =
+                Assert.Throws<InvalidOperationException>(() => ReadWriteXmlTestInternal(xml3, test3, "#BA03"));
+            Assert.Equal(typeof(FormatException), ex.InnerException.GetType());
         }
     }
 }

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlInt64Test.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlInt64Test.cs
@@ -186,13 +186,6 @@ namespace System.Data.Tests.SqlTypes
         }
 
         [Fact]
-        public void GetTypeTest()
-        {
-            SqlInt64 Test = new SqlInt64(84);
-            Assert.Equal("System.Data.SqlTypes.SqlInt64", Test.GetType().ToString());
-        }
-
-        [Fact]
         public void Greaters()
         {
             SqlInt64 test10 = new SqlInt64(10);
@@ -614,15 +607,6 @@ namespace System.Data.Tests.SqlTypes
             ReadWriteXmlTestInternal(xml1, lngtest1, "BA01");
             ReadWriteXmlTestInternal(xml2, lngtest2, "BA02");
 
-            try
-            {
-                ReadWriteXmlTestInternal(xml3, lngtest3, "BA03");
-                Assert.False(true);
-            }
-            catch (InvalidOperationException e)
-            {
-                Assert.Equal(typeof(FormatException), e.InnerException.GetType());
-            }
             InvalidOperationException ex =
                 Assert.Throws<InvalidOperationException>(() => ReadWriteXmlTestInternal(xml3, lngtest3, "#BA03"));
             Assert.Equal(typeof(FormatException), ex.InnerException.GetType());

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlInt64Test.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlInt64Test.cs
@@ -144,7 +144,7 @@ namespace System.Data.Tests.SqlTypes
 
             Assert.True(testInt4000.CompareTo(testInt10) > 0);
             Assert.True(testInt10.CompareTo(testInt4000) < 0);
-            Assert.True(testInt4000II.CompareTo(testInt4000) == 0);
+            Assert.Equal(0, testInt4000II.CompareTo(testInt4000));
             Assert.True(testInt4000II.CompareTo(SqlInt64.Null) > 0);
 
             Assert.Throws<ArgumentException>(() => testInt10.CompareTo(testString));

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlInt64Test.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlInt64Test.cs
@@ -62,12 +62,12 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void Properties()
         {
-            SqlInt64 Test5443 = new SqlInt64(5443);
-            SqlInt64 Test1 = new SqlInt64(1);
+            SqlInt64 test5443 = new SqlInt64(5443);
+            SqlInt64 test1 = new SqlInt64(1);
 
             Assert.True(SqlInt64.Null.IsNull);
-            Assert.Equal(5443, Test5443.Value);
-            Assert.Equal(1, Test1.Value);
+            Assert.Equal(5443, test5443.Value);
+            Assert.Equal(1, test1.Value);
         }
 
         // PUBLIC METHODS
@@ -75,154 +75,114 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void ArithmeticMethods()
         {
-            SqlInt64 Test64 = new SqlInt64(64);
-            SqlInt64 Test0 = new SqlInt64(0);
-            SqlInt64 Test164 = new SqlInt64(164);
-            SqlInt64 TestMax = new SqlInt64(SqlInt64.MaxValue.Value);
+            SqlInt64 test64 = new SqlInt64(64);
+            SqlInt64 test0 = new SqlInt64(0);
+            SqlInt64 test164 = new SqlInt64(164);
+            SqlInt64 testMax = new SqlInt64(SqlInt64.MaxValue.Value);
 
             // Add()
-            Assert.Equal(64, SqlInt64.Add(Test64, Test0).Value);
-            Assert.Equal(228, SqlInt64.Add(Test64, Test164).Value);
-            Assert.Equal(164, SqlInt64.Add(Test0, Test164).Value);
-            Assert.Equal((long)SqlInt64.MaxValue, SqlInt64.Add(TestMax, Test0).Value);
+            Assert.Equal(64, SqlInt64.Add(test64, test0).Value);
+            Assert.Equal(228, SqlInt64.Add(test64, test164).Value);
+            Assert.Equal(164, SqlInt64.Add(test0, test164).Value);
+            Assert.Equal((long)SqlInt64.MaxValue, SqlInt64.Add(testMax, test0).Value);
 
-            try
-            {
-                SqlInt64.Add(TestMax, Test64);
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlInt64.Add(testMax, test64));
 
             // Divide()
-            Assert.Equal(2, SqlInt64.Divide(Test164, Test64).Value);
-            Assert.Equal(0, SqlInt64.Divide(Test64, Test164).Value);
+            Assert.Equal(2, SqlInt64.Divide(test164, test64).Value);
+            Assert.Equal(0, SqlInt64.Divide(test64, test164).Value);
 
-            try
-            {
-                SqlInt64.Divide(Test64, Test0);
-                Assert.False(true);
-            }
-            catch (DivideByZeroException e)
-            {
-                Assert.Equal(typeof(DivideByZeroException), e.GetType());
-            }
+            Assert.Throws<DivideByZeroException>(() => SqlInt64.Divide(test64, test0));
 
             // Mod()
-            Assert.Equal(36, SqlInt64.Mod(Test164, Test64));
-            Assert.Equal(64, SqlInt64.Mod(Test64, Test164));
+            Assert.Equal(36, SqlInt64.Mod(test164, test64));
+            Assert.Equal(64, SqlInt64.Mod(test64, test164));
 
             // Multiply()
-            Assert.Equal(10496, SqlInt64.Multiply(Test64, Test164).Value);
-            Assert.Equal(0, SqlInt64.Multiply(Test64, Test0).Value);
+            Assert.Equal(10496, SqlInt64.Multiply(test64, test164).Value);
+            Assert.Equal(0, SqlInt64.Multiply(test64, test0).Value);
 
-            try
-            {
-                SqlInt64.Multiply(TestMax, Test64);
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlInt64.Multiply(testMax, test64));
 
             // Subtract()
-            Assert.Equal(100, SqlInt64.Subtract(Test164, Test64).Value);
+            Assert.Equal(100, SqlInt64.Subtract(test164, test64).Value);
 
-            try
-            {
-                SqlInt64.Subtract(SqlInt64.MinValue, Test164);
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlInt64.Subtract(SqlInt64.MinValue, test164));
 
             // Modulus ()
-            Assert.Equal(36, SqlInt64.Modulus(Test164, Test64));
-            Assert.Equal(64, SqlInt64.Modulus(Test64, Test164));
+            Assert.Equal(36, SqlInt64.Modulus(test164, test64));
+            Assert.Equal(64, SqlInt64.Modulus(test64, test164));
         }
 
         [Fact]
         public void BitwiseMethods()
         {
             long MaxValue = SqlInt64.MaxValue.Value;
-            SqlInt64 TestInt = new SqlInt64(0);
-            SqlInt64 TestIntMax = new SqlInt64(MaxValue);
-            SqlInt64 TestInt2 = new SqlInt64(10922);
-            SqlInt64 TestInt3 = new SqlInt64(21845);
+            SqlInt64 testInt = new SqlInt64(0);
+            SqlInt64 testIntMax = new SqlInt64(MaxValue);
+            SqlInt64 testInt2 = new SqlInt64(10922);
+            SqlInt64 testInt3 = new SqlInt64(21845);
 
             // BitwiseAnd
-            Assert.Equal(21845, SqlInt64.BitwiseAnd(TestInt3, TestIntMax).Value);
-            Assert.Equal(0, SqlInt64.BitwiseAnd(TestInt2, TestInt3).Value);
-            Assert.Equal(10922, SqlInt64.BitwiseAnd(TestInt2, TestIntMax).Value);
+            Assert.Equal(21845, SqlInt64.BitwiseAnd(testInt3, testIntMax).Value);
+            Assert.Equal(0, SqlInt64.BitwiseAnd(testInt2, testInt3).Value);
+            Assert.Equal(10922, SqlInt64.BitwiseAnd(testInt2, testIntMax).Value);
 
             //BitwiseOr
-            Assert.Equal(21845, SqlInt64.BitwiseOr(TestInt, TestInt3).Value);
-            Assert.Equal(MaxValue, SqlInt64.BitwiseOr(TestIntMax, TestInt2).Value);
+            Assert.Equal(21845, SqlInt64.BitwiseOr(testInt, testInt3).Value);
+            Assert.Equal(MaxValue, SqlInt64.BitwiseOr(testIntMax, testInt2).Value);
         }
 
         [Fact]
         public void CompareTo()
         {
-            SqlInt64 TestInt4000 = new SqlInt64(4000);
-            SqlInt64 TestInt4000II = new SqlInt64(4000);
-            SqlInt64 TestInt10 = new SqlInt64(10);
-            SqlInt64 TestInt10000 = new SqlInt64(10000);
-            SqlString TestString = new SqlString("This is a test");
+            SqlInt64 testInt4000 = new SqlInt64(4000);
+            SqlInt64 testInt4000II = new SqlInt64(4000);
+            SqlInt64 testInt10 = new SqlInt64(10);
+            SqlInt64 testInt10000 = new SqlInt64(10000);
+            SqlString testString = new SqlString("This is a test");
 
-            Assert.True(TestInt4000.CompareTo(TestInt10) > 0);
-            Assert.True(TestInt10.CompareTo(TestInt4000) < 0);
-            Assert.True(TestInt4000II.CompareTo(TestInt4000) == 0);
-            Assert.True(TestInt4000II.CompareTo(SqlInt64.Null) > 0);
+            Assert.True(testInt4000.CompareTo(testInt10) > 0);
+            Assert.True(testInt10.CompareTo(testInt4000) < 0);
+            Assert.True(testInt4000II.CompareTo(testInt4000) == 0);
+            Assert.True(testInt4000II.CompareTo(SqlInt64.Null) > 0);
 
-            try
-            {
-                TestInt10.CompareTo(TestString);
-                Assert.False(true);
-            }
-            catch (ArgumentException e)
-            {
-                Assert.Equal(typeof(ArgumentException), e.GetType());
-            }
+            Assert.Throws<ArgumentException>(() => testInt10.CompareTo(testString));
         }
 
         [Fact]
         public void EqualsMethod()
         {
-            SqlInt64 Test0 = new SqlInt64(0);
-            SqlInt64 Test158 = new SqlInt64(158);
-            SqlInt64 Test180 = new SqlInt64(180);
-            SqlInt64 Test180II = new SqlInt64(180);
+            SqlInt64 test0 = new SqlInt64(0);
+            SqlInt64 test158 = new SqlInt64(158);
+            SqlInt64 test180 = new SqlInt64(180);
+            SqlInt64 test180II = new SqlInt64(180);
 
-            Assert.True(!Test0.Equals(Test158));
-            Assert.True(!Test158.Equals(Test180));
-            Assert.True(!Test180.Equals(new SqlString("TEST")));
-            Assert.True(Test180.Equals(Test180II));
+            Assert.False(test0.Equals(test158));
+            Assert.False(test158.Equals(test180));
+            Assert.False(test180.Equals(new SqlString("TEST")));
+            Assert.True(test180.Equals(test180II));
         }
 
         [Fact]
         public void StaticEqualsMethod()
         {
-            SqlInt64 Test34 = new SqlInt64(34);
-            SqlInt64 Test34II = new SqlInt64(34);
-            SqlInt64 Test15 = new SqlInt64(15);
+            SqlInt64 test34 = new SqlInt64(34);
+            SqlInt64 test34II = new SqlInt64(34);
+            SqlInt64 test15 = new SqlInt64(15);
 
-            Assert.True(SqlInt64.Equals(Test34, Test34II).Value);
-            Assert.True(!SqlInt64.Equals(Test34, Test15).Value);
-            Assert.True(!SqlInt64.Equals(Test15, Test34II).Value);
+            Assert.True(SqlInt64.Equals(test34, test34II).Value);
+            Assert.False(SqlInt64.Equals(test34, test15).Value);
+            Assert.False(SqlInt64.Equals(test15, test34II).Value);
         }
 
         [Fact]
         public void GetHashCodeTest()
         {
-            SqlInt64 Test15 = new SqlInt64(15);
+            SqlInt64 test15 = new SqlInt64(15);
 
             // FIXME: Better way to test HashCode
-            Assert.Equal(15, Test15.GetHashCode());
+            Assert.Equal(15, test15.GetHashCode());
         }
 
         [Fact]
@@ -235,98 +195,74 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void Greaters()
         {
-            SqlInt64 Test10 = new SqlInt64(10);
-            SqlInt64 Test10II = new SqlInt64(10);
-            SqlInt64 Test110 = new SqlInt64(110);
+            SqlInt64 test10 = new SqlInt64(10);
+            SqlInt64 test10II = new SqlInt64(10);
+            SqlInt64 test110 = new SqlInt64(110);
 
             // GreateThan ()
-            Assert.True(!SqlInt64.GreaterThan(Test10, Test110).Value);
-            Assert.True(SqlInt64.GreaterThan(Test110, Test10).Value);
-            Assert.True(!SqlInt64.GreaterThan(Test10II, Test10).Value);
+            Assert.False(SqlInt64.GreaterThan(test10, test110).Value);
+            Assert.True(SqlInt64.GreaterThan(test110, test10).Value);
+            Assert.False(SqlInt64.GreaterThan(test10II, test10).Value);
 
             // GreaterTharOrEqual ()
-            Assert.True(!SqlInt64.GreaterThanOrEqual(Test10, Test110).Value);
-            Assert.True(SqlInt64.GreaterThanOrEqual(Test110, Test10).Value);
-            Assert.True(SqlInt64.GreaterThanOrEqual(Test10II, Test10).Value);
+            Assert.False(SqlInt64.GreaterThanOrEqual(test10, test110).Value);
+            Assert.True(SqlInt64.GreaterThanOrEqual(test110, test10).Value);
+            Assert.True(SqlInt64.GreaterThanOrEqual(test10II, test10).Value);
         }
 
         [Fact]
         public void Lessers()
         {
-            SqlInt64 Test10 = new SqlInt64(10);
-            SqlInt64 Test10II = new SqlInt64(10);
-            SqlInt64 Test110 = new SqlInt64(110);
+            SqlInt64 test10 = new SqlInt64(10);
+            SqlInt64 test10II = new SqlInt64(10);
+            SqlInt64 test110 = new SqlInt64(110);
 
             // LessThan()
-            Assert.True(SqlInt64.LessThan(Test10, Test110).Value);
-            Assert.True(!SqlInt64.LessThan(Test110, Test10).Value);
-            Assert.True(!SqlInt64.LessThan(Test10II, Test10).Value);
+            Assert.True(SqlInt64.LessThan(test10, test110).Value);
+            Assert.False(SqlInt64.LessThan(test110, test10).Value);
+            Assert.False(SqlInt64.LessThan(test10II, test10).Value);
 
             // LessThanOrEqual ()
-            Assert.True(SqlInt64.LessThanOrEqual(Test10, Test110).Value);
-            Assert.True(!SqlInt64.LessThanOrEqual(Test110, Test10).Value);
-            Assert.True(SqlInt64.LessThanOrEqual(Test10II, Test10).Value);
-            Assert.True(SqlInt64.LessThanOrEqual(Test10II, SqlInt64.Null).IsNull);
+            Assert.True(SqlInt64.LessThanOrEqual(test10, test110).Value);
+            Assert.False(SqlInt64.LessThanOrEqual(test110, test10).Value);
+            Assert.True(SqlInt64.LessThanOrEqual(test10II, test10).Value);
+            Assert.True(SqlInt64.LessThanOrEqual(test10II, SqlInt64.Null).IsNull);
         }
 
         [Fact]
         public void NotEquals()
         {
-            SqlInt64 Test12 = new SqlInt64(12);
-            SqlInt64 Test128 = new SqlInt64(128);
-            SqlInt64 Test128II = new SqlInt64(128);
+            SqlInt64 test12 = new SqlInt64(12);
+            SqlInt64 test128 = new SqlInt64(128);
+            SqlInt64 test128II = new SqlInt64(128);
 
-            Assert.True(SqlInt64.NotEquals(Test12, Test128).Value);
-            Assert.True(SqlInt64.NotEquals(Test128, Test12).Value);
-            Assert.True(SqlInt64.NotEquals(Test128II, Test12).Value);
-            Assert.True(!SqlInt64.NotEquals(Test128II, Test128).Value);
-            Assert.True(!SqlInt64.NotEquals(Test128, Test128II).Value);
-            Assert.True(SqlInt64.NotEquals(SqlInt64.Null, Test128II).IsNull);
-            Assert.True(SqlInt64.NotEquals(SqlInt64.Null, Test128II).IsNull);
+            Assert.True(SqlInt64.NotEquals(test12, test128).Value);
+            Assert.True(SqlInt64.NotEquals(test128, test12).Value);
+            Assert.True(SqlInt64.NotEquals(test128II, test12).Value);
+            Assert.False(SqlInt64.NotEquals(test128II, test128).Value);
+            Assert.False(SqlInt64.NotEquals(test128, test128II).Value);
+            Assert.True(SqlInt64.NotEquals(SqlInt64.Null, test128II).IsNull);
+            Assert.True(SqlInt64.NotEquals(SqlInt64.Null, test128II).IsNull);
         }
 
         [Fact]
         public void OnesComplement()
         {
-            SqlInt64 Test12 = new SqlInt64(12);
-            SqlInt64 Test128 = new SqlInt64(128);
+            SqlInt64 test12 = new SqlInt64(12);
+            SqlInt64 test128 = new SqlInt64(128);
 
-            Assert.Equal(-13, SqlInt64.OnesComplement(Test12));
-            Assert.Equal(-129, SqlInt64.OnesComplement(Test128));
+            Assert.Equal(-13, SqlInt64.OnesComplement(test12));
+            Assert.Equal(-129, SqlInt64.OnesComplement(test128));
         }
 
         [Fact]
         public void Parse()
         {
-            try
-            {
-                SqlInt64.Parse(null);
-                Assert.False(true);
-            }
-            catch (ArgumentNullException e)
-            {
-                Assert.Equal(typeof(ArgumentNullException), e.GetType());
-            }
+            Assert.Throws<ArgumentNullException>(() => SqlInt64.Parse(null));
 
-            try
-            {
-                SqlInt64.Parse("not-a-number");
-                Assert.False(true);
-            }
-            catch (FormatException e)
-            {
-                Assert.Equal(typeof(FormatException), e.GetType());
-            }
+            Assert.Throws<FormatException>(() => SqlInt64.Parse("not-a-number"));
 
-            try
-            {
-                SqlInt64.Parse("1000000000000000000000000000");
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlInt64.Parse("1000000000000000000000000000"));
 
             Assert.Equal(150, SqlInt64.Parse("150").Value);
         }
@@ -334,86 +270,78 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void Conversions()
         {
-            SqlInt64 Test12 = new SqlInt64(12);
-            SqlInt64 Test0 = new SqlInt64(0);
+            SqlInt64 test12 = new SqlInt64(12);
+            SqlInt64 test0 = new SqlInt64(0);
             SqlInt64 TestNull = SqlInt64.Null;
-            SqlInt64 Test1000 = new SqlInt64(1000);
-            SqlInt64 Test288 = new SqlInt64(288);
+            SqlInt64 test1000 = new SqlInt64(1000);
+            SqlInt64 test288 = new SqlInt64(288);
 
             // ToSqlBoolean ()
-            Assert.True(Test12.ToSqlBoolean().Value);
-            Assert.True(!Test0.ToSqlBoolean().Value);
+            Assert.True(test12.ToSqlBoolean().Value);
+            Assert.False(test0.ToSqlBoolean().Value);
             Assert.True(TestNull.ToSqlBoolean().IsNull);
 
             // ToSqlByte ()
-            Assert.Equal((byte)12, Test12.ToSqlByte().Value);
-            Assert.Equal((byte)0, Test0.ToSqlByte().Value);
+            Assert.Equal((byte)12, test12.ToSqlByte().Value);
+            Assert.Equal((byte)0, test0.ToSqlByte().Value);
 
-            try
-            {
-                SqlByte b = (byte)Test1000.ToSqlByte();
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => test1000.ToSqlByte());
 
             // ToSqlDecimal ()
-            Assert.Equal(12, Test12.ToSqlDecimal().Value);
-            Assert.Equal(0, Test0.ToSqlDecimal().Value);
-            Assert.Equal(288, Test288.ToSqlDecimal().Value);
+            Assert.Equal(12, test12.ToSqlDecimal().Value);
+            Assert.Equal(0, test0.ToSqlDecimal().Value);
+            Assert.Equal(288, test288.ToSqlDecimal().Value);
 
             // ToSqlDouble ()
-            Assert.Equal(12, Test12.ToSqlDouble().Value);
-            Assert.Equal(0, Test0.ToSqlDouble().Value);
-            Assert.Equal(1000, Test1000.ToSqlDouble().Value);
+            Assert.Equal(12, test12.ToSqlDouble().Value);
+            Assert.Equal(0, test0.ToSqlDouble().Value);
+            Assert.Equal(1000, test1000.ToSqlDouble().Value);
 
             // ToSqlInt32 ()
-            Assert.Equal(12, Test12.ToSqlInt32().Value);
-            Assert.Equal(0, Test0.ToSqlInt32().Value);
-            Assert.Equal(288, Test288.ToSqlInt32().Value);
+            Assert.Equal(12, test12.ToSqlInt32().Value);
+            Assert.Equal(0, test0.ToSqlInt32().Value);
+            Assert.Equal(288, test288.ToSqlInt32().Value);
 
             // ToSqlInt16 ()
-            Assert.Equal((short)12, Test12.ToSqlInt16().Value);
-            Assert.Equal((short)0, Test0.ToSqlInt16().Value);
-            Assert.Equal((short)288, Test288.ToSqlInt16().Value);
+            Assert.Equal((short)12, test12.ToSqlInt16().Value);
+            Assert.Equal((short)0, test0.ToSqlInt16().Value);
+            Assert.Equal((short)288, test288.ToSqlInt16().Value);
 
             // ToSqlMoney ()
-            Assert.Equal(12.0000M, Test12.ToSqlMoney().Value);
-            Assert.Equal(0, Test0.ToSqlMoney().Value);
-            Assert.Equal(288.0000M, Test288.ToSqlMoney().Value);
+            Assert.Equal(12.0000M, test12.ToSqlMoney().Value);
+            Assert.Equal(0, test0.ToSqlMoney().Value);
+            Assert.Equal(288.0000M, test288.ToSqlMoney().Value);
 
             // ToSqlSingle ()
-            Assert.Equal(12, Test12.ToSqlSingle().Value);
-            Assert.Equal(0, Test0.ToSqlSingle().Value);
-            Assert.Equal(288, Test288.ToSqlSingle().Value);
+            Assert.Equal(12, test12.ToSqlSingle().Value);
+            Assert.Equal(0, test0.ToSqlSingle().Value);
+            Assert.Equal(288, test288.ToSqlSingle().Value);
 
             // ToSqlString ()
-            Assert.Equal("12", Test12.ToSqlString().Value);
-            Assert.Equal("0", Test0.ToSqlString().Value);
-            Assert.Equal("288", Test288.ToSqlString().Value);
+            Assert.Equal("12", test12.ToSqlString().Value);
+            Assert.Equal("0", test0.ToSqlString().Value);
+            Assert.Equal("288", test288.ToSqlString().Value);
 
             // ToString ()
-            Assert.Equal("12", Test12.ToString());
-            Assert.Equal("0", Test0.ToString());
-            Assert.Equal("288", Test288.ToString());
+            Assert.Equal("12", test12.ToString());
+            Assert.Equal("0", test0.ToString());
+            Assert.Equal("288", test288.ToString());
         }
 
         [Fact]
         public void Xor()
         {
-            SqlInt64 Test14 = new SqlInt64(14);
-            SqlInt64 Test58 = new SqlInt64(58);
-            SqlInt64 Test130 = new SqlInt64(130);
-            SqlInt64 TestMax = new SqlInt64(SqlInt64.MaxValue.Value);
-            SqlInt64 Test0 = new SqlInt64(0);
+            SqlInt64 test14 = new SqlInt64(14);
+            SqlInt64 test58 = new SqlInt64(58);
+            SqlInt64 test130 = new SqlInt64(130);
+            SqlInt64 testMax = new SqlInt64(SqlInt64.MaxValue.Value);
+            SqlInt64 test0 = new SqlInt64(0);
 
-            Assert.Equal(52, SqlInt64.Xor(Test14, Test58).Value);
-            Assert.Equal(140, SqlInt64.Xor(Test14, Test130).Value);
-            Assert.Equal(184, SqlInt64.Xor(Test58, Test130).Value);
-            Assert.Equal(0, SqlInt64.Xor(TestMax, TestMax).Value);
-            Assert.Equal(TestMax.Value, SqlInt64.Xor(TestMax, Test0).Value);
+            Assert.Equal(52, SqlInt64.Xor(test14, test58).Value);
+            Assert.Equal(140, SqlInt64.Xor(test14, test130).Value);
+            Assert.Equal(184, SqlInt64.Xor(test58, test130).Value);
+            Assert.Equal(0, SqlInt64.Xor(testMax, testMax).Value);
+            Assert.Equal(testMax.Value, SqlInt64.Xor(testMax, test0).Value);
         }
 
         // OPERATORS
@@ -421,285 +349,221 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void ArithmeticOperators()
         {
-            SqlInt64 Test24 = new SqlInt64(24);
-            SqlInt64 Test64 = new SqlInt64(64);
-            SqlInt64 Test2550 = new SqlInt64(2550);
-            SqlInt64 Test0 = new SqlInt64(0);
+            SqlInt64 test24 = new SqlInt64(24);
+            SqlInt64 test64 = new SqlInt64(64);
+            SqlInt64 test2550 = new SqlInt64(2550);
+            SqlInt64 test0 = new SqlInt64(0);
 
             // "+"-operator
-            Assert.Equal(2614, Test2550 + Test64);
-            try
-            {
-                SqlInt64 result = Test64 + SqlInt64.MaxValue;
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Equal(2614, test2550 + test64);
+            Assert.Throws<OverflowException>(() => test64 + SqlInt64.MaxValue);
+
 
             // "/"-operator
-            Assert.Equal(39, Test2550 / Test64);
-            Assert.Equal(0, Test24 / Test64);
+            Assert.Equal(39, test2550 / test64);
+            Assert.Equal(0, test24 / test64);
 
-            try
-            {
-                SqlInt64 result = Test2550 / Test0;
-                Assert.False(true);
-            }
-            catch (DivideByZeroException e)
-            {
-                Assert.Equal(typeof(DivideByZeroException), e.GetType());
-            }
+            Assert.Throws<DivideByZeroException>(() => test2550 / test0);
 
             // "*"-operator
-            Assert.Equal(1536, Test64 * Test24);
+            Assert.Equal(1536, test64 * test24);
 
-            try
-            {
-                SqlInt64 test = (SqlInt64.MaxValue * Test64);
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlInt64.MaxValue * test64);
 
             // "-"-operator
-            Assert.Equal(2526, Test2550 - Test24);
+            Assert.Equal(2526, test2550 - test24);
 
-            try
-            {
-                SqlInt64 test = SqlInt64.MinValue - Test64;
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlInt64.MinValue - test64);
 
             // "%"-operator
-            Assert.Equal(54, Test2550 % Test64);
-            Assert.Equal(24, Test24 % Test64);
+            Assert.Equal(54, test2550 % test64);
+            Assert.Equal(24, test24 % test64);
             Assert.Equal(0, new SqlInt64(100) % new SqlInt64(10));
         }
 
         [Fact]
         public void BitwiseOperators()
         {
-            SqlInt64 Test2 = new SqlInt64(2);
-            SqlInt64 Test4 = new SqlInt64(4);
+            SqlInt64 test2 = new SqlInt64(2);
+            SqlInt64 test4 = new SqlInt64(4);
 
-            SqlInt64 Test2550 = new SqlInt64(2550);
+            SqlInt64 test2550 = new SqlInt64(2550);
 
             // & -operator
-            Assert.Equal(0, Test2 & Test4);
-            Assert.Equal(2, Test2 & Test2550);
+            Assert.Equal(0, test2 & test4);
+            Assert.Equal(2, test2 & test2550);
             Assert.Equal(0, SqlInt64.MaxValue & SqlInt64.MinValue);
 
             // | -operator
-            Assert.Equal(6, Test2 | Test4);
-            Assert.Equal(2550, Test2 | Test2550);
+            Assert.Equal(6, test2 | test4);
+            Assert.Equal(2550, test2 | test2550);
             Assert.Equal(-1, SqlInt64.MinValue | SqlInt64.MaxValue);
 
             //  ^ -operator
-            Assert.Equal(2546, (Test2550 ^ Test4));
-            Assert.Equal(6, (Test2 ^ Test4));
+            Assert.Equal(2546, (test2550 ^ test4));
+            Assert.Equal(6, (test2 ^ test4));
         }
 
         [Fact]
         public void ThanOrEqualOperators()
         {
-            SqlInt64 Test165 = new SqlInt64(165);
-            SqlInt64 Test100 = new SqlInt64(100);
-            SqlInt64 Test100II = new SqlInt64(100);
-            SqlInt64 Test255 = new SqlInt64(2550);
+            SqlInt64 test165 = new SqlInt64(165);
+            SqlInt64 test100 = new SqlInt64(100);
+            SqlInt64 test100II = new SqlInt64(100);
+            SqlInt64 test255 = new SqlInt64(2550);
 
             // == -operator
-            Assert.True((Test100 == Test100II).Value);
-            Assert.True(!(Test165 == Test100).Value);
-            Assert.True((Test165 == SqlInt64.Null).IsNull);
+            Assert.True((test100 == test100II).Value);
+            Assert.False((test165 == test100).Value);
+            Assert.True((test165 == SqlInt64.Null).IsNull);
 
             // != -operator
-            Assert.True(!(Test100 != Test100II).Value);
-            Assert.True((Test100 != Test255).Value);
-            Assert.True((Test165 != Test255).Value);
-            Assert.True((Test165 != SqlInt64.Null).IsNull);
+            Assert.False((test100 != test100II).Value);
+            Assert.True((test100 != test255).Value);
+            Assert.True((test165 != test255).Value);
+            Assert.True((test165 != SqlInt64.Null).IsNull);
 
             // > -operator
-            Assert.True((Test165 > Test100).Value);
-            Assert.True(!(Test165 > Test255).Value);
-            Assert.True(!(Test100 > Test100II).Value);
-            Assert.True((Test165 > SqlInt64.Null).IsNull);
+            Assert.True((test165 > test100).Value);
+            Assert.False((test165 > test255).Value);
+            Assert.False((test100 > test100II).Value);
+            Assert.True((test165 > SqlInt64.Null).IsNull);
 
             // >=  -operator
-            Assert.True(!(Test165 >= Test255).Value);
-            Assert.True((Test255 >= Test165).Value);
-            Assert.True((Test100 >= Test100II).Value);
-            Assert.True((Test165 >= SqlInt64.Null).IsNull);
+            Assert.False((test165 >= test255).Value);
+            Assert.True((test255 >= test165).Value);
+            Assert.True((test100 >= test100II).Value);
+            Assert.True((test165 >= SqlInt64.Null).IsNull);
 
             // < -operator
-            Assert.True(!(Test165 < Test100).Value);
-            Assert.True((Test165 < Test255).Value);
-            Assert.True(!(Test100 < Test100II).Value);
-            Assert.True((Test165 < SqlInt64.Null).IsNull);
+            Assert.False((test165 < test100).Value);
+            Assert.True((test165 < test255).Value);
+            Assert.False((test100 < test100II).Value);
+            Assert.True((test165 < SqlInt64.Null).IsNull);
 
             // <= -operator
-            Assert.True((Test165 <= Test255).Value);
-            Assert.True(!(Test255 <= Test165).Value);
-            Assert.True((Test100 <= Test100II).Value);
-            Assert.True((Test165 <= SqlInt64.Null).IsNull);
+            Assert.True((test165 <= test255).Value);
+            Assert.False((test255 <= test165).Value);
+            Assert.True((test100 <= test100II).Value);
+            Assert.True((test165 <= SqlInt64.Null).IsNull);
         }
 
         [Fact]
         public void OnesComplementOperator()
         {
-            SqlInt64 Test12 = new SqlInt64(12);
-            SqlInt64 Test128 = new SqlInt64(128);
+            SqlInt64 test12 = new SqlInt64(12);
+            SqlInt64 test128 = new SqlInt64(128);
 
-            Assert.Equal(-13, ~Test12);
-            Assert.Equal(-129, ~Test128);
+            Assert.Equal(-13, ~test12);
+            Assert.Equal(-129, ~test128);
             Assert.Equal(SqlInt64.Null, ~SqlInt64.Null);
         }
 
         [Fact]
         public void UnaryNegation()
         {
-            SqlInt64 Test = new SqlInt64(2000);
-            SqlInt64 TestNeg = new SqlInt64(-3000);
+            SqlInt64 test = new SqlInt64(2000);
+            SqlInt64 testNeg = new SqlInt64(-3000);
 
-            SqlInt64 Result = -Test;
-            Assert.Equal(-2000, Result.Value);
+            SqlInt64 result = -test;
+            Assert.Equal(-2000, result.Value);
 
-            Result = -TestNeg;
-            Assert.Equal(3000, Result.Value);
+            result = -testNeg;
+            Assert.Equal(3000, result.Value);
         }
 
         [Fact]
         public void SqlBooleanToSqlInt64()
         {
-            SqlBoolean TestBoolean = new SqlBoolean(true);
-            SqlInt64 Result;
+            SqlBoolean testBoolean = new SqlBoolean(true);
+            SqlInt64 tesult;
 
-            Result = (SqlInt64)TestBoolean;
+            tesult = (SqlInt64)testBoolean;
 
-            Assert.Equal(1, Result.Value);
+            Assert.Equal(1, tesult.Value);
 
-            Result = (SqlInt64)SqlBoolean.Null;
-            Assert.True(Result.IsNull);
+            tesult = (SqlInt64)SqlBoolean.Null;
+            Assert.True(tesult.IsNull);
         }
 
         [Fact]
         public void SqlDecimalToSqlInt64()
         {
-            SqlDecimal TestDecimal64 = new SqlDecimal(64);
-            SqlDecimal TestDecimal900 = new SqlDecimal(90000);
+            SqlDecimal testDecimal64 = new SqlDecimal(64);
 
-            Assert.Equal(64, ((SqlInt64)TestDecimal64).Value);
+            Assert.Equal(64, ((SqlInt64)testDecimal64).Value);
             Assert.Equal(SqlInt64.Null, ((SqlInt64)SqlDecimal.Null));
 
-            try
-            {
-                SqlInt64 test = (SqlInt64)SqlDecimal.MaxValue;
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => (SqlInt64)SqlDecimal.MaxValue);
         }
 
         [Fact]
         public void SqlDoubleToSqlInt64()
         {
-            SqlDouble TestDouble64 = new SqlDouble(64);
-            SqlDouble TestDouble900 = new SqlDouble(90000);
+            SqlDouble testDouble64 = new SqlDouble(64);
+            SqlDouble testDouble900 = new SqlDouble(90000);
 
-            Assert.Equal(64, ((SqlInt64)TestDouble64).Value);
+            Assert.Equal(64, ((SqlInt64)testDouble64).Value);
             Assert.Equal(SqlInt64.Null, ((SqlInt64)SqlDouble.Null));
 
-            try
-            {
-                SqlInt64 test = (SqlInt64)SqlDouble.MaxValue;
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => (SqlInt64)SqlDouble.MaxValue);
         }
 
         [Fact]
         public void Sql64IntToInt64()
         {
-            SqlInt64 Test = new SqlInt64(12);
-            long Result = (long)Test;
-            Assert.Equal(12, Result);
+            SqlInt64 test = new SqlInt64(12);
+            long result = (long)test;
+            Assert.Equal(12, result);
         }
 
         [Fact]
         public void SqlInt32ToSqlInt64()
         {
-            SqlInt32 Test64 = new SqlInt32(64);
-            Assert.Equal(64, ((SqlInt64)Test64).Value);
+            SqlInt32 test64 = new SqlInt32(64);
+            Assert.Equal(64, ((SqlInt64)test64).Value);
         }
 
         [Fact]
         public void SqlInt16ToSqlInt64()
         {
-            SqlInt16 Test64 = new SqlInt16(64);
-            Assert.Equal(64, ((SqlInt64)Test64).Value);
+            SqlInt16 test64 = new SqlInt16(64);
+            Assert.Equal(64, ((SqlInt64)test64).Value);
         }
 
         [Fact]
         public void SqlMoneyToSqlInt64()
         {
-            SqlMoney TestMoney64 = new SqlMoney(64);
-            Assert.Equal(64, ((SqlInt64)TestMoney64).Value);
+            SqlMoney testMoney64 = new SqlMoney(64);
+            Assert.Equal(64, ((SqlInt64)testMoney64).Value);
         }
 
         [Fact]
         public void SqlSingleToSqlInt64()
         {
-            SqlSingle TestSingle64 = new SqlSingle(64);
-            Assert.Equal(64, ((SqlInt64)TestSingle64).Value);
+            SqlSingle testSingle64 = new SqlSingle(64);
+            Assert.Equal(64, ((SqlInt64)testSingle64).Value);
         }
 
         [Fact]
         public void SqlStringToSqlInt64()
         {
-            SqlString TestString = new SqlString("Test string");
-            SqlString TestString100 = new SqlString("100");
-            SqlString TestString1000 = new SqlString("1000000000000000000000");
+            SqlString testString = new SqlString("Test string");
+            SqlString testString100 = new SqlString("100");
+            SqlString testString1000 = new SqlString("1000000000000000000000");
 
-            Assert.Equal(100, ((SqlInt64)TestString100).Value);
+            Assert.Equal(100, ((SqlInt64)testString100).Value);
 
-            try
-            {
-                SqlInt64 test = (SqlInt64)TestString1000;
-                Assert.False(true);
-            }
-            catch (OverflowException e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => (SqlInt64)testString1000);
 
-            try
-            {
-                SqlInt64 test = (SqlInt64)TestString;
-                Assert.False(true);
-            }
-            catch (FormatException e)
-            {
-                Assert.Equal(typeof(FormatException), e.GetType());
-            }
+            Assert.Throws<FormatException>(() => (SqlInt64)testString);
         }
 
         [Fact]
         public void ByteToSqlInt64()
         {
-            short TestShort = 14;
-            Assert.Equal(14, ((SqlInt64)TestShort).Value);
+            short testShort = 14;
+            Assert.Equal(14, ((SqlInt64)testShort).Value);
         }
         [Fact]
         public void GetXsdTypeTest()
@@ -759,6 +623,9 @@ namespace System.Data.Tests.SqlTypes
             {
                 Assert.Equal(typeof(FormatException), e.InnerException.GetType());
             }
+            InvalidOperationException ex =
+                Assert.Throws<InvalidOperationException>(() => ReadWriteXmlTestInternal(xml3, lngtest3, "#BA03"));
+            Assert.Equal(typeof(FormatException), ex.InnerException.GetType());
         }
     }
 }

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlMoneyTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlMoneyTest.cs
@@ -41,9 +41,9 @@ namespace System.Data.Tests.SqlTypes
         public SqlMoneyTest()
         {
             _test1 = new SqlMoney(6464.6464d);
-            _test2 = new SqlMoney(90000.0m);
-            _test3 = new SqlMoney(90000.0m);
-            _test4 = new SqlMoney(-45000.0m);
+            _test2 = new SqlMoney(90000m);
+            _test3 = new SqlMoney(90000m);
+            _test4 = new SqlMoney(-45000m);
         }
 
         // Test constructor
@@ -53,18 +53,18 @@ namespace System.Data.Tests.SqlTypes
             Assert.Throws<OverflowException>(() => new SqlMoney(1000000000000000m));
 
             SqlMoney CreationTest = new SqlMoney((decimal)913.3);
-            Assert.Equal(913.3000m, CreationTest.Value);
+            Assert.Equal(913.3m, CreationTest.Value);
 
             Assert.Throws<OverflowException>(() => new SqlMoney(1e200));
 
             SqlMoney CreationTest2 = new SqlMoney(913.3);
-            Assert.Equal(913.3000m, CreationTest2.Value);
+            Assert.Equal(913.3m, CreationTest2.Value);
 
             SqlMoney CreationTest3 = new SqlMoney(913);
-            Assert.Equal(913.0000m, CreationTest3.Value);
+            Assert.Equal(913m, CreationTest3.Value);
 
             SqlMoney CreationTest4 = new SqlMoney((long)913.3);
-            Assert.Equal(913.0000m, CreationTest4.Value);
+            Assert.Equal(913m, CreationTest4.Value);
         }
 
         // Test public fields
@@ -84,8 +84,8 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void Properties()
         {
-            Assert.Equal(90000.0000m, _test2.Value);
-            Assert.Equal(-45000.0000m, _test4.Value);
+            Assert.Equal(90000m, _test2.Value);
+            Assert.Equal(-45000m, _test4.Value);
             Assert.True(SqlMoney.Null.IsNull);
         }
 
@@ -141,7 +141,6 @@ namespace System.Data.Tests.SqlTypes
         {
             // FIXME: Better way to test HashCode
             Assert.Equal(_test3.GetHashCode(), _test2.GetHashCode());
-            Assert.NotEqual(_test2.GetHashCode(), _test1.GetHashCode());
         }
 
         [Fact]
@@ -195,7 +194,7 @@ namespace System.Data.Tests.SqlTypes
 
             Assert.Throws<OverflowException>(() => SqlMoney.Parse("1000000000000000"));
 
-            Assert.Equal(150.0000M, SqlMoney.Parse("150").Value);
+            Assert.Equal(150M, SqlMoney.Parse("150").Value);
         }
 
         [Fact]
@@ -229,7 +228,7 @@ namespace System.Data.Tests.SqlTypes
 
             // ToSqlDecimal ()
             Assert.Equal((decimal)6464.6464, _test1.ToSqlDecimal().Value);
-            Assert.Equal(-45000.0000m, _test4.ToSqlDecimal().Value);
+            Assert.Equal(-45000m, _test4.ToSqlDecimal().Value);
 
             // ToSqlInt16 ()
             Assert.Equal((short)6465, _test1.ToSqlInt16().Value);
@@ -326,7 +325,7 @@ namespace System.Data.Tests.SqlTypes
         public void UnaryNegation()
         {
             Assert.Equal((decimal)(-6464.6464), -(_test1).Value);
-            Assert.Equal(45000.0000M, -(_test4).Value);
+            Assert.Equal(45000M, -(_test4).Value);
         }
 
         [Fact]
@@ -334,7 +333,7 @@ namespace System.Data.Tests.SqlTypes
         {
             SqlBoolean TestBoolean = new SqlBoolean(true);
 
-            Assert.Equal(1.0000M, ((SqlMoney)TestBoolean).Value);
+            Assert.Equal(1M, ((SqlMoney)TestBoolean).Value);
             Assert.True(((SqlDecimal)SqlBoolean.Null).IsNull);
         }
 
@@ -345,7 +344,7 @@ namespace System.Data.Tests.SqlTypes
             SqlDecimal testDecimal2 = new SqlDecimal(1E+20);
 
             SqlMoney testMoney = (SqlMoney)testDecimal;
-            Assert.Equal(4000.0000M, testMoney.Value);
+            Assert.Equal(4000M, testMoney.Value);
 
             Assert.Throws<OverflowException>(() => (SqlMoney)testDecimal2);
         }
@@ -357,7 +356,7 @@ namespace System.Data.Tests.SqlTypes
             SqlDouble testDouble2 = new SqlDouble(1E+20);
 
             SqlMoney testMoney = (SqlMoney)testDouble;
-            Assert.Equal(1000000000.0000m, testMoney.Value);
+            Assert.Equal(1000000000m, testMoney.Value);
 
             Assert.Throws<OverflowException>(() => (SqlMoney)testDouble2);
         }
@@ -366,7 +365,7 @@ namespace System.Data.Tests.SqlTypes
         public void SqlMoneyToDecimal()
         {
             Assert.Equal((decimal)6464.6464, (decimal)_test1);
-            Assert.Equal(-45000.0000M, (decimal)_test4);
+            Assert.Equal(-45000M, (decimal)_test4);
         }
 
         [Fact]
@@ -375,7 +374,7 @@ namespace System.Data.Tests.SqlTypes
             SqlSingle testSingle = new SqlSingle(1e10);
             SqlSingle testSingle2 = new SqlSingle(1e20);
 
-            Assert.Equal(10000000000.0000m, ((SqlMoney)testSingle).Value);
+            Assert.Equal(10000000000m, ((SqlMoney)testSingle).Value);
 
             Assert.Throws<OverflowException>(() => (SqlMoney)testSingle2);
         }
@@ -386,7 +385,7 @@ namespace System.Data.Tests.SqlTypes
             SqlString testString = new SqlString("Test string");
             SqlString testString100 = new SqlString("100");
 
-            Assert.Equal(100.0000M, ((SqlMoney)testString100).Value);
+            Assert.Equal(100M, ((SqlMoney)testString100).Value);
 
             Assert.Throws<FormatException>(() => (SqlMoney)testString);
         }
@@ -396,7 +395,7 @@ namespace System.Data.Tests.SqlTypes
         {
             decimal testDecimal = 1e10m;
             decimal testDecimal2 = 1e20m;
-            Assert.Equal(10000000000.0000M, ((SqlMoney)testDecimal).Value);
+            Assert.Equal(10000000000M, ((SqlMoney)testDecimal).Value);
 
             Assert.Throws<OverflowException>(() => (SqlMoney)testDecimal2);
         }
@@ -405,7 +404,7 @@ namespace System.Data.Tests.SqlTypes
         public void SqlByteToSqlMoney()
         {
             SqlByte TestByte = new SqlByte(200);
-            Assert.Equal(200.0000m, ((SqlMoney)TestByte).Value);
+            Assert.Equal(200m, ((SqlMoney)TestByte).Value);
         }
 
         [Fact]
@@ -415,9 +414,9 @@ namespace System.Data.Tests.SqlTypes
             SqlInt32 testInt32 = new SqlInt32(5000);
             SqlInt64 testInt64 = new SqlInt64(5000);
 
-            Assert.Equal(5000.0000m, ((SqlMoney)testInt16).Value);
-            Assert.Equal(5000.0000m, ((SqlMoney)testInt32).Value);
-            Assert.Equal(5000.0000m, ((SqlMoney)testInt64).Value);
+            Assert.Equal(5000m, ((SqlMoney)testInt16).Value);
+            Assert.Equal(5000m, ((SqlMoney)testInt32).Value);
+            Assert.Equal(5000m, ((SqlMoney)testInt64).Value);
 
             Assert.Throws<OverflowException>(() => (SqlMoney)SqlInt64.MaxValue);
         }

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlMoneyTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlMoneyTest.cs
@@ -123,7 +123,7 @@ namespace System.Data.Tests.SqlTypes
         {
             Assert.True(_test1.CompareTo(_test2) < 0);
             Assert.True(_test3.CompareTo(_test1) > 0);
-            Assert.True(_test3.CompareTo(_test2) == 0);
+            Assert.Equal(0, _test3.CompareTo(_test2));
             Assert.True(_test3.CompareTo(SqlMoney.Null) > 0);
         }
 

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlMoneyTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlMoneyTest.cs
@@ -145,12 +145,6 @@ namespace System.Data.Tests.SqlTypes
         }
 
         [Fact]
-        public void GetTypeTest()
-        {
-            Assert.Equal("System.Data.SqlTypes.SqlMoney", _test1.GetType().ToString());
-        }
-
-        [Fact]
         public void Greaters()
         {
             // GreateThan ()

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlMoneyTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlMoneyTest.cs
@@ -28,7 +28,6 @@
 using Xunit;
 using System.Xml;
 using System.Data.SqlTypes;
-using System.Globalization;
 
 namespace System.Data.Tests.SqlTypes
 {
@@ -51,28 +50,12 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void Create()
         {
-            try
-            {
-                SqlMoney Test = new SqlMoney(1000000000000000m);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => new SqlMoney(1000000000000000m));
 
             SqlMoney CreationTest = new SqlMoney((decimal)913.3);
             Assert.Equal(913.3000m, CreationTest.Value);
 
-            try
-            {
-                SqlMoney Test = new SqlMoney(1e200);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => new SqlMoney(1e200));
 
             SqlMoney CreationTest2 = new SqlMoney(913.3);
             Assert.Equal(913.3000m, CreationTest2.Value);
@@ -111,61 +94,28 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void ArithmeticMethods()
         {
-            SqlMoney TestMoney2 = new SqlMoney(2);
+            SqlMoney testMoney2 = new SqlMoney(2);
 
             // Add
             Assert.Equal(96464.6464m, SqlMoney.Add(_test1, _test2));
             Assert.Equal(180000m, SqlMoney.Add(_test2, _test2));
             Assert.Equal(45000m, SqlMoney.Add(_test2, _test4));
 
-            try
-            {
-                SqlMoney test = SqlMoney.Add(SqlMoney.MaxValue, _test2);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlMoney.Add(SqlMoney.MaxValue, _test2));
 
-            // Divide
-            Assert.Equal(45000m, SqlMoney.Divide(_test2, TestMoney2));
-            try
-            {
-                SqlMoney test = SqlMoney.Divide(_test2, SqlMoney.Zero);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(DivideByZeroException), e.GetType());
-            }
+            Assert.Throws<DivideByZeroException>(() => SqlMoney.Divide(_test2, SqlMoney.Zero));
 
             // Multiply
             Assert.Equal(581818176m, SqlMoney.Multiply(_test1, _test2));
             Assert.Equal(-4050000000m, SqlMoney.Multiply(_test3, _test4));
 
-            try
-            {
-                SqlMoney test = SqlMoney.Multiply(SqlMoney.MaxValue, _test2);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlMoney.Multiply(SqlMoney.MaxValue, _test2));
 
             // Subtract
             Assert.Equal(0m, SqlMoney.Subtract(_test2, _test3));
             Assert.Equal(83535.3536m, SqlMoney.Subtract(_test2, _test1));
 
-            try
-            {
-                SqlMoney test = SqlMoney.Subtract(SqlMoney.MinValue, _test2);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlMoney.Subtract(SqlMoney.MinValue, _test2));
         }
 
         [Fact]
@@ -180,9 +130,9 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void EqualsMethods()
         {
-            Assert.True(!_test1.Equals(_test2));
+            Assert.False(_test1.Equals(_test2));
             Assert.True(_test2.Equals(_test3));
-            Assert.True(!SqlMoney.Equals(_test1, _test2).Value);
+            Assert.False(SqlMoney.Equals(_test1, _test2).Value);
             Assert.True(SqlMoney.Equals(_test3, _test2).Value);
         }
 
@@ -191,7 +141,7 @@ namespace System.Data.Tests.SqlTypes
         {
             // FIXME: Better way to test HashCode
             Assert.Equal(_test3.GetHashCode(), _test2.GetHashCode());
-            Assert.True(_test2.GetHashCode() != _test1.GetHashCode());
+            Assert.NotEqual(_test2.GetHashCode(), _test1.GetHashCode());
         }
 
         [Fact]
@@ -204,13 +154,13 @@ namespace System.Data.Tests.SqlTypes
         public void Greaters()
         {
             // GreateThan ()
-            Assert.True(!SqlMoney.GreaterThan(_test1, _test2).Value);
+            Assert.False(SqlMoney.GreaterThan(_test1, _test2).Value);
             Assert.True(SqlMoney.GreaterThan(_test2, _test1).Value);
-            Assert.True(!SqlMoney.GreaterThan(_test2, _test3).Value);
+            Assert.False(SqlMoney.GreaterThan(_test2, _test3).Value);
             Assert.True(SqlMoney.GreaterThan(_test2, SqlMoney.Null).IsNull);
 
             // GreaterTharOrEqual ()
-            Assert.True(!SqlMoney.GreaterThanOrEqual(_test1, _test2).Value);
+            Assert.False(SqlMoney.GreaterThanOrEqual(_test1, _test2).Value);
             Assert.True(SqlMoney.GreaterThanOrEqual(_test2, _test1).Value);
             Assert.True(SqlMoney.GreaterThanOrEqual(_test3, _test2).Value);
             Assert.True(SqlMoney.GreaterThanOrEqual(_test3, SqlMoney.Null).IsNull);
@@ -220,14 +170,14 @@ namespace System.Data.Tests.SqlTypes
         public void Lessers()
         {
             // LessThan()
-            Assert.True(!SqlMoney.LessThan(_test2, _test3).Value);
-            Assert.True(!SqlMoney.LessThan(_test2, _test1).Value);
+            Assert.False(SqlMoney.LessThan(_test2, _test3).Value);
+            Assert.False(SqlMoney.LessThan(_test2, _test1).Value);
             Assert.True(SqlMoney.LessThan(_test1, _test2).Value);
             Assert.True(SqlMoney.LessThan(SqlMoney.Null, _test2).IsNull);
 
             // LessThanOrEqual ()
             Assert.True(SqlMoney.LessThanOrEqual(_test1, _test2).Value);
-            Assert.True(!SqlMoney.LessThanOrEqual(_test2, _test1).Value);
+            Assert.False(SqlMoney.LessThanOrEqual(_test2, _test1).Value);
             Assert.True(SqlMoney.LessThanOrEqual(_test2, _test2).Value);
             Assert.True(SqlMoney.LessThanOrEqual(_test2, SqlMoney.Null).IsNull);
         }
@@ -237,43 +187,19 @@ namespace System.Data.Tests.SqlTypes
         {
             Assert.True(SqlMoney.NotEquals(_test1, _test2).Value);
             Assert.True(SqlMoney.NotEquals(_test2, _test1).Value);
-            Assert.True(!SqlMoney.NotEquals(_test2, _test3).Value);
-            Assert.True(!SqlMoney.NotEquals(_test3, _test2).Value);
+            Assert.False(SqlMoney.NotEquals(_test2, _test3).Value);
+            Assert.False(SqlMoney.NotEquals(_test3, _test2).Value);
             Assert.True(SqlMoney.NotEquals(SqlMoney.Null, _test2).IsNull);
         }
 
         [Fact]
         public void Parse()
         {
-            try
-            {
-                SqlMoney.Parse(null);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(ArgumentNullException), e.GetType());
-            }
+            Assert.Throws<ArgumentNullException>(() => SqlMoney.Parse(null));
 
-            try
-            {
-                SqlMoney.Parse("not-a-number");
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(FormatException), e.GetType());
-            }
+            Assert.Throws<FormatException>(() => SqlMoney.Parse("not-a-number"));
 
-            try
-            {
-                SqlMoney.Parse("1000000000000000");
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlMoney.Parse("1000000000000000"));
 
             Assert.Equal(150.0000M, SqlMoney.Parse("150").Value);
         }
@@ -281,7 +207,7 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void Conversions()
         {
-            SqlMoney TestMoney100 = new SqlMoney(100);
+            SqlMoney testMoney100 = new SqlMoney(100);
 
             // ToDecimal
             Assert.Equal((decimal)6464.6464, _test1.ToDecimal());
@@ -299,21 +225,13 @@ namespace System.Data.Tests.SqlTypes
 
             // ToSqlBoolean ()
             Assert.True(_test1.ToSqlBoolean().Value);
-            Assert.True(!SqlMoney.Zero.ToSqlBoolean().Value);
+            Assert.False(SqlMoney.Zero.ToSqlBoolean().Value);
             Assert.True(SqlMoney.Null.ToSqlBoolean().IsNull);
 
             // ToSqlByte ()
-            Assert.Equal((byte)100, TestMoney100.ToSqlByte().Value);
+            Assert.Equal((byte)100, testMoney100.ToSqlByte().Value);
 
-            try
-            {
-                SqlByte b = (byte)_test2.ToSqlByte();
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => _test2.ToSqlByte());
 
             // ToSqlDecimal ()
             Assert.Equal((decimal)6464.6464, _test1.ToSqlDecimal().Value);
@@ -322,29 +240,13 @@ namespace System.Data.Tests.SqlTypes
             // ToSqlInt16 ()
             Assert.Equal((short)6465, _test1.ToSqlInt16().Value);
 
-            try
-            {
-                SqlInt16 test = SqlMoney.MaxValue.ToSqlInt16().Value;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlMoney.MaxValue.ToSqlInt16());
 
             // ToSqlInt32 ()
             Assert.Equal(6465, _test1.ToSqlInt32().Value);
             Assert.Equal(-45000, _test4.ToSqlInt32().Value);
 
-            try
-            {
-                SqlInt32 test = SqlMoney.MaxValue.ToSqlInt32().Value;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlMoney.MaxValue.ToSqlInt32());
 
             // ToSqlInt64 ()
             Assert.Equal(6465, _test1.ToSqlInt64().Value);
@@ -370,65 +272,33 @@ namespace System.Data.Tests.SqlTypes
             // "+"-operator
             Assert.Equal(96464.6464m, _test1 + _test2);
 
-            try
-            {
-                SqlMoney test = SqlMoney.MaxValue + SqlMoney.MaxValue;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlMoney.MaxValue + SqlMoney.MaxValue);
 
             // "/"-operator
             Assert.Equal(13.9219m, _test2 / _test1);
 
-            try
-            {
-                SqlMoney test = _test3 / SqlMoney.Zero;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(DivideByZeroException), e.GetType());
-            }
+            Assert.Throws<DivideByZeroException>(() => _test3 / SqlMoney.Zero);
 
             // "*"-operator
             Assert.Equal(581818176m, _test1 * _test2);
 
-            try
-            {
-                SqlMoney test = SqlMoney.MaxValue * _test1;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlMoney.MaxValue * _test1);
 
             // "-"-operator
             Assert.Equal(83535.3536m, _test2 - _test1);
 
-            try
-            {
-                SqlMoney test = SqlMoney.MinValue - SqlMoney.MaxValue;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlMoney.MinValue - SqlMoney.MaxValue);
         }
 
         [Fact]
         public void ThanOrEqualOperators()
         {
             // == -operator
-            Assert.True(!(_test1 == _test2).Value);
+            Assert.False((_test1 == _test2).Value);
             Assert.True((_test1 == SqlMoney.Null).IsNull);
 
             // != -operator
-            Assert.True(!(_test2 != _test3).Value);
+            Assert.False((_test2 != _test3).Value);
             Assert.True((_test1 != _test3).Value);
             Assert.True((_test1 != _test4).Value);
             Assert.True((_test1 != SqlMoney.Null).IsNull);
@@ -436,24 +306,24 @@ namespace System.Data.Tests.SqlTypes
             // > -operator
             Assert.True((_test1 > _test4).Value);
             Assert.True((_test2 > _test1).Value);
-            Assert.True(!(_test2 > _test3).Value);
+            Assert.False((_test2 > _test3).Value);
             Assert.True((_test1 > SqlMoney.Null).IsNull);
 
             // >=  -operator
-            Assert.True(!(_test1 >= _test3).Value);
+            Assert.False((_test1 >= _test3).Value);
             Assert.True((_test3 >= _test1).Value);
             Assert.True((_test2 >= _test3).Value);
             Assert.True((_test1 >= SqlMoney.Null).IsNull);
 
             // < -operator
-            Assert.True(!(_test2 < _test1).Value);
+            Assert.False((_test2 < _test1).Value);
             Assert.True((_test1 < _test3).Value);
-            Assert.True(!(_test2 < _test3).Value);
+            Assert.False((_test2 < _test3).Value);
             Assert.True((_test1 < SqlMoney.Null).IsNull);
 
             // <= -operator
             Assert.True((_test1 <= _test3).Value);
-            Assert.True(!(_test3 <= _test1).Value);
+            Assert.False((_test3 <= _test1).Value);
             Assert.True((_test2 <= _test3).Value);
             Assert.True((_test1 <= SqlMoney.Null).IsNull);
         }
@@ -477,41 +347,25 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void SqlDecimalToSqlMoney()
         {
-            SqlDecimal TestDecimal = new SqlDecimal(4000);
-            SqlDecimal TestDecimal2 = new SqlDecimal(1E+20);
+            SqlDecimal testDecimal = new SqlDecimal(4000);
+            SqlDecimal testDecimal2 = new SqlDecimal(1E+20);
 
-            SqlMoney TestMoney = (SqlMoney)TestDecimal;
-            Assert.Equal(4000.0000M, TestMoney.Value);
+            SqlMoney testMoney = (SqlMoney)testDecimal;
+            Assert.Equal(4000.0000M, testMoney.Value);
 
-            try
-            {
-                SqlMoney test = (SqlMoney)TestDecimal2;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => (SqlMoney)testDecimal2);
         }
 
         [Fact]
         public void SqlDoubleToSqlMoney()
         {
-            SqlDouble TestDouble = new SqlDouble(1E+9);
-            SqlDouble TestDouble2 = new SqlDouble(1E+20);
+            SqlDouble testDouble = new SqlDouble(1E+9);
+            SqlDouble testDouble2 = new SqlDouble(1E+20);
 
-            SqlMoney TestMoney = (SqlMoney)TestDouble;
-            Assert.Equal(1000000000.0000m, TestMoney.Value);
+            SqlMoney testMoney = (SqlMoney)testDouble;
+            Assert.Equal(1000000000.0000m, testMoney.Value);
 
-            try
-            {
-                SqlMoney test = (SqlMoney)TestDouble2;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => (SqlMoney)testDouble2);
         }
 
         [Fact]
@@ -524,57 +378,33 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void SqlSingleToSqlMoney()
         {
-            SqlSingle TestSingle = new SqlSingle(1e10);
-            SqlSingle TestSingle2 = new SqlSingle(1e20);
+            SqlSingle testSingle = new SqlSingle(1e10);
+            SqlSingle testSingle2 = new SqlSingle(1e20);
 
-            Assert.Equal(10000000000.0000m, ((SqlMoney)TestSingle).Value);
+            Assert.Equal(10000000000.0000m, ((SqlMoney)testSingle).Value);
 
-            try
-            {
-                SqlMoney test = (SqlMoney)TestSingle2;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => (SqlMoney)testSingle2);
         }
 
         [Fact]
         public void SqlStringToSqlMoney()
         {
-            SqlString TestString = new SqlString("Test string");
-            SqlString TestString100 = new SqlString("100");
+            SqlString testString = new SqlString("Test string");
+            SqlString testString100 = new SqlString("100");
 
-            Assert.Equal(100.0000M, ((SqlMoney)TestString100).Value);
+            Assert.Equal(100.0000M, ((SqlMoney)testString100).Value);
 
-            try
-            {
-                SqlMoney test = (SqlMoney)TestString;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(FormatException), e.GetType());
-            }
+            Assert.Throws<FormatException>(() => (SqlMoney)testString);
         }
 
         [Fact]
         public void DecimalToSqlMoney()
         {
-            decimal TestDecimal = 1e10m;
-            decimal TestDecimal2 = 1e20m;
-            Assert.Equal(10000000000.0000M, ((SqlMoney)TestDecimal).Value);
+            decimal testDecimal = 1e10m;
+            decimal testDecimal2 = 1e20m;
+            Assert.Equal(10000000000.0000M, ((SqlMoney)testDecimal).Value);
 
-            try
-            {
-                SqlMoney test = TestDecimal2;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => (SqlMoney)testDecimal2);
         }
 
         [Fact]
@@ -587,23 +417,15 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void IntsToSqlMoney()
         {
-            SqlInt16 TestInt16 = new SqlInt16(5000);
-            SqlInt32 TestInt32 = new SqlInt32(5000);
-            SqlInt64 TestInt64 = new SqlInt64(5000);
+            SqlInt16 testInt16 = new SqlInt16(5000);
+            SqlInt32 testInt32 = new SqlInt32(5000);
+            SqlInt64 testInt64 = new SqlInt64(5000);
 
-            Assert.Equal(5000.0000m, ((SqlMoney)TestInt16).Value);
-            Assert.Equal(5000.0000m, ((SqlMoney)TestInt32).Value);
-            Assert.Equal(5000.0000m, ((SqlMoney)TestInt64).Value);
+            Assert.Equal(5000.0000m, ((SqlMoney)testInt16).Value);
+            Assert.Equal(5000.0000m, ((SqlMoney)testInt32).Value);
+            Assert.Equal(5000.0000m, ((SqlMoney)testInt64).Value);
 
-            try
-            {
-                SqlMoney test = SqlInt64.MaxValue;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => (SqlMoney)SqlInt64.MaxValue);
         }
         [Fact]
         public void GetXsdTypeTest()

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlSingleTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlSingleTest.cs
@@ -117,7 +117,7 @@ namespace System.Data.Tests.SqlTypes
 
             Assert.True(test1.CompareTo(test3) > 0);
             Assert.True(test2.CompareTo(test3) < 0);
-            Assert.True(test1.CompareTo(test11) == 0);
+            Assert.Equal(0, test1.CompareTo(test11));
             Assert.True(test11.CompareTo(SqlSingle.Null) > 0);
 
             Assert.Throws<ArgumentException>(() => test1.CompareTo(testString));

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlSingleTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlSingleTest.cs
@@ -151,14 +151,6 @@ namespace System.Data.Tests.SqlTypes
         }
 
         [Fact]
-        public void GetTypeTest()
-        {
-            SqlSingle test = new SqlSingle(84);
-            Assert.Equal("System.Data.SqlTypes.SqlSingle", test.GetType().ToString());
-            Assert.Equal("System.Single", test.Value.GetType().ToString());
-        }
-
-        [Fact]
         public void Greaters()
         {
             SqlSingle test1 = new SqlSingle(1e10);
@@ -247,7 +239,7 @@ namespace System.Data.Tests.SqlTypes
             Assert.Equal(250.00000000000000M, test1.ToSqlDecimal().Value);
             Assert.Equal(0, test0.ToSqlDecimal().Value);
 
-            Assert.Throws<OverflowException>(() => test3.ToSqlDecimal());
+            Assert.Throws<OverflowException>(() => test3.ToSqlDecimal().Value);
 
             // ToSqlInt16 ()
             Assert.Equal((short)250, test1.ToSqlInt16().Value);
@@ -265,7 +257,7 @@ namespace System.Data.Tests.SqlTypes
             Assert.Equal(250, test1.ToSqlInt64().Value);
             Assert.Equal(0, test0.ToSqlInt64().Value);
 
-            Assert.Throws<OverflowException>(() => test2.ToSqlInt64());
+            Assert.Throws<OverflowException>(() => test3.ToSqlInt64());
 
             // ToSqlMoney ()
             Assert.Equal(250.0000M, test1.ToSqlMoney().Value);
@@ -412,15 +404,7 @@ namespace System.Data.Tests.SqlTypes
 
             Assert.Equal(100, ((SqlSingle)testString100).Value);
 
-            try
-            {
-                SqlSingle test = (SqlSingle)testString;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(FormatException), e.GetType());
-            }
+            Assert.Throws<FormatException>(() => (SqlSingle)testString);
         }
 
         [Fact]

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlSingleTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlSingleTest.cs
@@ -28,7 +28,6 @@
 using Xunit;
 using System.Xml;
 using System.Data.SqlTypes;
-using System.Globalization;
 
 namespace System.Data.Tests.SqlTypes
 {
@@ -38,14 +37,14 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void Create()
         {
-            SqlSingle Test = new SqlSingle((float)34.87);
-            SqlSingle Test2 = 45.2f;
+            SqlSingle test = new SqlSingle((float)34.87);
+            SqlSingle test2 = 45.2f;
 
-            Assert.Equal(34.87f, Test.Value);
-            Assert.Equal(45.2f, Test2.Value);
+            Assert.Equal(34.87f, test.Value);
+            Assert.Equal(45.2f, test2.Value);
 
-            Test = new SqlSingle(-9000.6543);
-            Assert.Equal(-9000.6543f, Test.Value);
+            test = new SqlSingle(-9000.6543);
+            Assert.Equal(-9000.6543f, test.Value);
         }
 
         // Test public fields
@@ -62,12 +61,12 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void Properties()
         {
-            SqlSingle Test = new SqlSingle(5443e12f);
-            SqlSingle Test1 = new SqlSingle(1);
+            SqlSingle test = new SqlSingle(5443e12f);
+            SqlSingle test1 = new SqlSingle(1);
 
             Assert.True(SqlSingle.Null.IsNull);
-            Assert.Equal(5443e12f, Test.Value);
-            Assert.Equal(1, Test1.Value);
+            Assert.Equal(5443e12f, test.Value);
+            Assert.Equal(1, test1.Value);
         }
 
         // PUBLIC METHODS
@@ -75,217 +74,151 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void ArithmeticMethods()
         {
-            SqlSingle Test0 = new SqlSingle(0);
-            SqlSingle Test1 = new SqlSingle(15E+18);
-            SqlSingle Test2 = new SqlSingle(-65E+6);
-            SqlSingle Test3 = new SqlSingle(5E+30);
-            SqlSingle Test4 = new SqlSingle(5E+18);
-            SqlSingle TestMax = new SqlSingle(SqlSingle.MaxValue.Value);
+            SqlSingle test0 = new SqlSingle(0);
+            SqlSingle test1 = new SqlSingle(15E+18);
+            SqlSingle test2 = new SqlSingle(-65E+6);
+            SqlSingle test3 = new SqlSingle(5E+30);
+            SqlSingle test4 = new SqlSingle(5E+18);
+            SqlSingle testMax = new SqlSingle(SqlSingle.MaxValue.Value);
 
             // Add()
-            Assert.Equal(15E+18f, SqlSingle.Add(Test1, Test0).Value);
-            Assert.Equal(1.5E+19f, SqlSingle.Add(Test1, Test2).Value);
+            Assert.Equal(15E+18f, SqlSingle.Add(test1, test0).Value);
+            Assert.Equal(1.5E+19f, SqlSingle.Add(test1, test2).Value);
 
-            try
-            {
-                SqlSingle test = SqlSingle.Add(SqlSingle.MaxValue,
-             SqlSingle.MaxValue);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlSingle.Add(SqlSingle.MaxValue, SqlSingle.MaxValue));
 
             // Divide()
-            Assert.Equal(3, SqlSingle.Divide(Test1, Test4));
-            Assert.Equal(-1.3E-23f, SqlSingle.Divide(Test2, Test3).Value);
+            Assert.Equal(3, SqlSingle.Divide(test1, test4));
+            Assert.Equal(-1.3E-23f, SqlSingle.Divide(test2, test3).Value);
 
-            try
-            {
-                SqlSingle test = SqlSingle.Divide(Test1, Test0).Value;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(DivideByZeroException), e.GetType());
-            }
+
+            Assert.Throws<DivideByZeroException>(() => SqlSingle.Divide(test1, test0));
 
             // Multiply()
-            Assert.Equal((float)(7.5E+37), SqlSingle.Multiply(Test1, Test4).Value);
-            Assert.Equal(0, SqlSingle.Multiply(Test1, Test0).Value);
+            Assert.Equal((float)(7.5E+37), SqlSingle.Multiply(test1, test4).Value);
+            Assert.Equal(0, SqlSingle.Multiply(test1, test0).Value);
 
-            try
-            {
-                SqlSingle test = SqlSingle.Multiply(TestMax, Test1);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
-
+            Assert.Throws<OverflowException>(() => SqlSingle.Multiply(testMax, test1));
 
             // Subtract()
-            Assert.Equal((float)(-5E+30), SqlSingle.Subtract(Test1, Test3).Value);
+            Assert.Equal((float)(-5E+30), SqlSingle.Subtract(test1, test3).Value);
 
-            try
-            {
-                SqlSingle test = SqlSingle.Subtract(
-    SqlSingle.MinValue, SqlSingle.MaxValue);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlSingle.Subtract(SqlSingle.MinValue, SqlSingle.MaxValue));
         }
 
         [Fact]
         public void CompareTo()
         {
-            SqlSingle Test1 = new SqlSingle(4E+30);
-            SqlSingle Test11 = new SqlSingle(4E+30);
-            SqlSingle Test2 = new SqlSingle(-9E+30);
-            SqlSingle Test3 = new SqlSingle(10000);
-            SqlString TestString = new SqlString("This is a test");
+            SqlSingle test1 = new SqlSingle(4E+30);
+            SqlSingle test11 = new SqlSingle(4E+30);
+            SqlSingle test2 = new SqlSingle(-9E+30);
+            SqlSingle test3 = new SqlSingle(10000);
+            SqlString testString = new SqlString("This is a test");
 
-            Assert.True(Test1.CompareTo(Test3) > 0);
-            Assert.True(Test2.CompareTo(Test3) < 0);
-            Assert.True(Test1.CompareTo(Test11) == 0);
-            Assert.True(Test11.CompareTo(SqlSingle.Null) > 0);
+            Assert.True(test1.CompareTo(test3) > 0);
+            Assert.True(test2.CompareTo(test3) < 0);
+            Assert.True(test1.CompareTo(test11) == 0);
+            Assert.True(test11.CompareTo(SqlSingle.Null) > 0);
 
-            try
-            {
-                Test1.CompareTo(TestString);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(ArgumentException), e.GetType());
-            }
+            Assert.Throws<ArgumentException>(() => test1.CompareTo(testString));
         }
 
         [Fact]
         public void EqualsMethods()
         {
-            SqlSingle Test0 = new SqlSingle(0);
-            SqlSingle Test1 = new SqlSingle(1.58e30);
-            SqlSingle Test2 = new SqlSingle(1.8e32);
-            SqlSingle Test22 = new SqlSingle(1.8e32);
+            SqlSingle test0 = new SqlSingle(0);
+            SqlSingle test1 = new SqlSingle(1.58e30);
+            SqlSingle test2 = new SqlSingle(1.8e32);
+            SqlSingle test22 = new SqlSingle(1.8e32);
 
-            Assert.True(!Test0.Equals(Test1));
-            Assert.True(!Test1.Equals(Test2));
-            Assert.True(!Test2.Equals(new SqlString("TEST")));
-            Assert.True(Test2.Equals(Test22));
+            Assert.False(test0.Equals(test1));
+            Assert.False(test1.Equals(test2));
+            Assert.False(test2.Equals(new SqlString("TEST")));
+            Assert.True(test2.Equals(test22));
 
             // Static Equals()-method
-            Assert.True(SqlSingle.Equals(Test2, Test22).Value);
-            Assert.True(!SqlSingle.Equals(Test1, Test2).Value);
+            Assert.True(SqlSingle.Equals(test2, test22).Value);
+            Assert.False(SqlSingle.Equals(test1, test2).Value);
         }
 
         [Fact]
         public void GetHashCodeTest()
         {
-            SqlSingle Test15 = new SqlSingle(15);
+            SqlSingle test15 = new SqlSingle(15);
 
             // FIXME: Better way to test HashCode
-            Assert.Equal(Test15.GetHashCode(), Test15.GetHashCode());
+            Assert.Equal(test15.GetHashCode(), test15.GetHashCode());
         }
 
         [Fact]
         public void GetTypeTest()
         {
-            SqlSingle Test = new SqlSingle(84);
-            Assert.Equal("System.Data.SqlTypes.SqlSingle", Test.GetType().ToString());
-            Assert.Equal("System.Single", Test.Value.GetType().ToString());
+            SqlSingle test = new SqlSingle(84);
+            Assert.Equal("System.Data.SqlTypes.SqlSingle", test.GetType().ToString());
+            Assert.Equal("System.Single", test.Value.GetType().ToString());
         }
 
         [Fact]
         public void Greaters()
         {
-            SqlSingle Test1 = new SqlSingle(1e10);
-            SqlSingle Test11 = new SqlSingle(1e10);
-            SqlSingle Test2 = new SqlSingle(64e14);
+            SqlSingle test1 = new SqlSingle(1e10);
+            SqlSingle test11 = new SqlSingle(1e10);
+            SqlSingle test2 = new SqlSingle(64e14);
 
             // GreateThan ()
-            Assert.True(!SqlSingle.GreaterThan(Test1, Test2).Value);
-            Assert.True(SqlSingle.GreaterThan(Test2, Test1).Value);
-            Assert.True(!SqlSingle.GreaterThan(Test1, Test11).Value);
+            Assert.False(SqlSingle.GreaterThan(test1, test2).Value);
+            Assert.True(SqlSingle.GreaterThan(test2, test1).Value);
+            Assert.False(SqlSingle.GreaterThan(test1, test11).Value);
 
             // GreaterTharOrEqual ()
-            Assert.True(!SqlSingle.GreaterThanOrEqual(Test1, Test2).Value);
-            Assert.True(SqlSingle.GreaterThanOrEqual(Test2, Test1).Value);
-            Assert.True(SqlSingle.GreaterThanOrEqual(Test1, Test11).Value);
+            Assert.False(SqlSingle.GreaterThanOrEqual(test1, test2).Value);
+            Assert.True(SqlSingle.GreaterThanOrEqual(test2, test1).Value);
+            Assert.True(SqlSingle.GreaterThanOrEqual(test1, test11).Value);
         }
 
         [Fact]
         public void Lessers()
         {
-            SqlSingle Test1 = new SqlSingle(1.8e10);
-            SqlSingle Test11 = new SqlSingle(1.8e10);
-            SqlSingle Test2 = new SqlSingle(64e14);
+            SqlSingle test1 = new SqlSingle(1.8e10);
+            SqlSingle test11 = new SqlSingle(1.8e10);
+            SqlSingle test2 = new SqlSingle(64e14);
 
             // LessThan()
-            Assert.True(!SqlSingle.LessThan(Test1, Test11).Value);
-            Assert.True(!SqlSingle.LessThan(Test2, Test1).Value);
-            Assert.True(SqlSingle.LessThan(Test11, Test2).Value);
+            Assert.False(SqlSingle.LessThan(test1, test11).Value);
+            Assert.False(SqlSingle.LessThan(test2, test1).Value);
+            Assert.True(SqlSingle.LessThan(test11, test2).Value);
 
             // LessThanOrEqual ()
-            Assert.True(SqlSingle.LessThanOrEqual(Test1, Test2).Value);
-            Assert.True(!SqlSingle.LessThanOrEqual(Test2, Test1).Value);
-            Assert.True(SqlSingle.LessThanOrEqual(Test11, Test1).Value);
-            Assert.True(SqlSingle.LessThanOrEqual(Test11, SqlSingle.Null).IsNull);
+            Assert.True(SqlSingle.LessThanOrEqual(test1, test2).Value);
+            Assert.False(SqlSingle.LessThanOrEqual(test2, test1).Value);
+            Assert.True(SqlSingle.LessThanOrEqual(test11, test1).Value);
+            Assert.True(SqlSingle.LessThanOrEqual(test11, SqlSingle.Null).IsNull);
         }
 
         [Fact]
         public void NotEquals()
         {
-            SqlSingle Test1 = new SqlSingle(12800000000001);
-            SqlSingle Test2 = new SqlSingle(128e10);
-            SqlSingle Test22 = new SqlSingle(128e10);
+            SqlSingle test1 = new SqlSingle(12800000000001);
+            SqlSingle test2 = new SqlSingle(128e10);
+            SqlSingle test22 = new SqlSingle(128e10);
 
-            Assert.True(SqlSingle.NotEquals(Test1, Test2).Value);
-            Assert.True(SqlSingle.NotEquals(Test2, Test1).Value);
-            Assert.True(SqlSingle.NotEquals(Test22, Test1).Value);
-            Assert.True(!SqlSingle.NotEquals(Test22, Test2).Value);
-            Assert.True(!SqlSingle.NotEquals(Test2, Test22).Value);
-            Assert.True(SqlSingle.NotEquals(SqlSingle.Null, Test22).IsNull);
-            Assert.True(SqlSingle.NotEquals(SqlSingle.Null, Test22).IsNull);
+            Assert.True(SqlSingle.NotEquals(test1, test2).Value);
+            Assert.True(SqlSingle.NotEquals(test2, test1).Value);
+            Assert.True(SqlSingle.NotEquals(test22, test1).Value);
+            Assert.False(SqlSingle.NotEquals(test22, test2).Value);
+            Assert.False(SqlSingle.NotEquals(test2, test22).Value);
+            Assert.True(SqlSingle.NotEquals(SqlSingle.Null, test22).IsNull);
+            Assert.True(SqlSingle.NotEquals(SqlSingle.Null, test22).IsNull);
         }
 
         [Fact]
         public void Parse()
         {
-            try
-            {
-                SqlSingle.Parse(null);
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(ArgumentNullException), e.GetType());
-            }
+            Assert.Throws<ArgumentNullException>(() => SqlSingle.Parse(null));
 
-            try
-            {
-                SqlSingle.Parse("not-a-number");
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(FormatException), e.GetType());
-            }
+            Assert.Throws<FormatException>(() => SqlSingle.Parse("not-a-number"));
 
-            try
-            {
-                SqlSingle.Parse("9e44");
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlSingle.Parse("9e44"));
 
             Assert.Equal(150, SqlSingle.Parse("150").Value);
         }
@@ -293,111 +226,63 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void Conversions()
         {
-            SqlSingle Test0 = new SqlSingle(0);
-            SqlSingle Test1 = new SqlSingle(250);
-            SqlSingle Test2 = new SqlSingle(64E+16);
-            SqlSingle Test3 = new SqlSingle(64E+30);
+            SqlSingle test0 = new SqlSingle(0);
+            SqlSingle test1 = new SqlSingle(250);
+            SqlSingle test2 = new SqlSingle(64E+16);
+            SqlSingle test3 = new SqlSingle(64E+30);
             SqlSingle TestNull = SqlSingle.Null;
 
             // ToSqlBoolean ()
-            Assert.True(Test1.ToSqlBoolean().Value);
-            Assert.True(!Test0.ToSqlBoolean().Value);
+            Assert.True(test1.ToSqlBoolean().Value);
+            Assert.False(test0.ToSqlBoolean().Value);
             Assert.True(TestNull.ToSqlBoolean().IsNull);
 
             // ToSqlByte ()
-            Assert.Equal((byte)250, Test1.ToSqlByte().Value);
-            Assert.Equal((byte)0, Test0.ToSqlByte().Value);
+            Assert.Equal((byte)250, test1.ToSqlByte().Value);
+            Assert.Equal((byte)0, test0.ToSqlByte().Value);
 
-            try
-            {
-                SqlByte b = (byte)Test2.ToSqlByte();
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => test2.ToSqlByte());
 
             // ToSqlDecimal ()
-            Assert.Equal(250.00000000000000M, Test1.ToSqlDecimal().Value);
-            Assert.Equal(0, Test0.ToSqlDecimal().Value);
+            Assert.Equal(250.00000000000000M, test1.ToSqlDecimal().Value);
+            Assert.Equal(0, test0.ToSqlDecimal().Value);
 
-            try
-            {
-                SqlDecimal test = Test3.ToSqlDecimal().Value;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => test3.ToSqlDecimal());
 
             // ToSqlInt16 ()
-            Assert.Equal((short)250, Test1.ToSqlInt16().Value);
-            Assert.Equal((short)0, Test0.ToSqlInt16().Value);
+            Assert.Equal((short)250, test1.ToSqlInt16().Value);
+            Assert.Equal((short)0, test0.ToSqlInt16().Value);
 
-            try
-            {
-                SqlInt16 test = Test2.ToSqlInt16().Value;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => test2.ToSqlInt16());
 
             // ToSqlInt32 ()
-            Assert.Equal(250, Test1.ToSqlInt32().Value);
-            Assert.Equal(0, Test0.ToSqlInt32().Value);
+            Assert.Equal(250, test1.ToSqlInt32().Value);
+            Assert.Equal(0, test0.ToSqlInt32().Value);
 
-            try
-            {
-                SqlInt32 test = Test2.ToSqlInt32().Value;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => test2.ToSqlInt32());
 
             // ToSqlInt64 ()
-            Assert.Equal(250, Test1.ToSqlInt64().Value);
-            Assert.Equal(0, Test0.ToSqlInt64().Value);
+            Assert.Equal(250, test1.ToSqlInt64().Value);
+            Assert.Equal(0, test0.ToSqlInt64().Value);
 
-            try
-            {
-                SqlInt64 test = Test3.ToSqlInt64().Value;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => test2.ToSqlInt64());
 
             // ToSqlMoney ()
-            Assert.Equal(250.0000M, Test1.ToSqlMoney().Value);
-            Assert.Equal(0, Test0.ToSqlMoney().Value);
+            Assert.Equal(250.0000M, test1.ToSqlMoney().Value);
+            Assert.Equal(0, test0.ToSqlMoney().Value);
 
-            try
-            {
-                SqlMoney test = Test3.ToSqlMoney().Value;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => test2.ToSqlMoney());
 
 
             // ToSqlString ()
-            Assert.Equal(250.ToString(), Test1.ToSqlString().Value);
-            Assert.Equal(0.ToString(), Test0.ToSqlString().Value);
-            Assert.Equal(6.4E+17.ToString(), Test2.ToSqlString().Value);
+            Assert.Equal(250.ToString(), test1.ToSqlString().Value);
+            Assert.Equal(0.ToString(), test0.ToSqlString().Value);
+            Assert.Equal(6.4E+17.ToString(), test2.ToSqlString().Value);
 
             // ToString ()
-            Assert.Equal(250.ToString(), Test1.ToString());
-            Assert.Equal(0.ToString(), Test0.ToString());
-            Assert.Equal(6.4E+17.ToString(), Test2.ToString());
+            Assert.Equal(250.ToString(), test1.ToString());
+            Assert.Equal(0.ToString(), test0.ToString());
+            Assert.Equal(6.4E+17.ToString(), test2.ToString());
         }
 
         // OPERATORS
@@ -405,173 +290,131 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void ArithmeticOperators()
         {
-            SqlSingle Test0 = new SqlSingle(0);
-            SqlSingle Test1 = new SqlSingle(24E+11);
-            SqlSingle Test2 = new SqlSingle(64E+32);
-            SqlSingle Test3 = new SqlSingle(12E+11);
-            SqlSingle Test4 = new SqlSingle(1E+10);
+            SqlSingle test0 = new SqlSingle(0);
+            SqlSingle test1 = new SqlSingle(24E+11);
+            SqlSingle test3 = new SqlSingle(12E+11);
+            SqlSingle test4 = new SqlSingle(1E+10);
             SqlSingle Test5 = new SqlSingle(2E+10);
 
             // "+"-operator
-            Assert.Equal((SqlSingle)3E+10, Test4 + Test5);
+            Assert.Equal((SqlSingle)3E+10, test4 + Test5);
 
-            try
-            {
-                SqlSingle test = SqlSingle.MaxValue + SqlSingle.MaxValue;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
-
-            try
-            {
-                SqlSingle test = SqlSingle.MaxValue + SqlSingle.MaxValue;
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlSingle.MaxValue + SqlSingle.MaxValue);
 
             // "/"-operator
-            Assert.Equal(2, Test1 / Test3);
+            Assert.Equal(2, test1 / test3);
 
-            try
-            {
-                SqlSingle test = Test3 / Test0;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(DivideByZeroException), e.GetType());
-            }
+            Assert.Throws<DivideByZeroException>(() => test3 / test0);
 
             // "*"-operator
-            Assert.Equal((SqlSingle)2E+20, Test4 * Test5);
+            Assert.Equal((SqlSingle)2E+20, test4 * Test5);
 
-            try
-            {
-                SqlSingle test = SqlSingle.MaxValue * Test1;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlSingle.MaxValue * test1);
 
             // "-"-operator
-            Assert.Equal((SqlSingle)12e11, Test1 - Test3);
+            Assert.Equal((SqlSingle)12e11, test1 - test3);
 
-            try
-            {
-                SqlSingle test = SqlSingle.MinValue - SqlSingle.MaxValue;
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(OverflowException), e.GetType());
-            }
+            Assert.Throws<OverflowException>(() => SqlSingle.MinValue - SqlSingle.MaxValue);
         }
 
         [Fact]
         public void ThanOrEqualOperators()
         {
-            SqlSingle Test1 = new SqlSingle(1.0E+14f);
-            SqlSingle Test2 = new SqlSingle(9.7E+11);
-            SqlSingle Test22 = new SqlSingle(9.7E+11);
-            SqlSingle Test3 = new SqlSingle(2.0E+22f);
+            SqlSingle test1 = new SqlSingle(1.0E+14f);
+            SqlSingle test2 = new SqlSingle(9.7E+11);
+            SqlSingle test22 = new SqlSingle(9.7E+11);
+            SqlSingle test3 = new SqlSingle(2.0E+22f);
 
             // == -operator
-            Assert.True((Test2 == Test22).Value);
-            Assert.True(!(Test1 == Test2).Value);
-            Assert.True((Test1 == SqlSingle.Null).IsNull);
+            Assert.True((test2 == test22).Value);
+            Assert.False((test1 == test2).Value);
+            Assert.True((test1 == SqlSingle.Null).IsNull);
 
             // != -operator
-            Assert.True(!(Test2 != Test22).Value);
-            Assert.True((Test2 != Test3).Value);
-            Assert.True((Test1 != Test3).Value);
-            Assert.True((Test1 != SqlSingle.Null).IsNull);
+            Assert.False((test2 != test22).Value);
+            Assert.True((test2 != test3).Value);
+            Assert.True((test1 != test3).Value);
+            Assert.True((test1 != SqlSingle.Null).IsNull);
 
             // > -operator
-            Assert.True((Test1 > Test2).Value);
-            Assert.True(!(Test1 > Test3).Value);
-            Assert.True(!(Test2 > Test22).Value);
-            Assert.True((Test1 > SqlSingle.Null).IsNull);
+            Assert.True((test1 > test2).Value);
+            Assert.False((test1 > test3).Value);
+            Assert.False((test2 > test22).Value);
+            Assert.True((test1 > SqlSingle.Null).IsNull);
 
             // >=  -operator
-            Assert.True(!(Test1 >= Test3).Value);
-            Assert.True((Test3 >= Test1).Value);
-            Assert.True((Test2 >= Test22).Value);
-            Assert.True((Test1 >= SqlSingle.Null).IsNull);
+            Assert.False((test1 >= test3).Value);
+            Assert.True((test3 >= test1).Value);
+            Assert.True((test2 >= test22).Value);
+            Assert.True((test1 >= SqlSingle.Null).IsNull);
 
             // < -operator
-            Assert.True(!(Test1 < Test2).Value);
-            Assert.True((Test1 < Test3).Value);
-            Assert.True(!(Test2 < Test22).Value);
-            Assert.True((Test1 < SqlSingle.Null).IsNull);
+            Assert.False((test1 < test2).Value);
+            Assert.True((test1 < test3).Value);
+            Assert.False((test2 < test22).Value);
+            Assert.True((test1 < SqlSingle.Null).IsNull);
 
             // <= -operator
-            Assert.True((Test1 <= Test3).Value);
-            Assert.True(!(Test3 <= Test1).Value);
-            Assert.True((Test2 <= Test22).Value);
-            Assert.True((Test1 <= SqlSingle.Null).IsNull);
+            Assert.True((test1 <= test3).Value);
+            Assert.False((test3 <= test1).Value);
+            Assert.True((test2 <= test22).Value);
+            Assert.True((test1 <= SqlSingle.Null).IsNull);
         }
 
         [Fact]
         public void UnaryNegation()
         {
-            SqlSingle Test = new SqlSingle(2000000001);
-            SqlSingle TestNeg = new SqlSingle(-3000);
+            SqlSingle test = new SqlSingle(2000000001);
+            SqlSingle testNeg = new SqlSingle(-3000);
 
-            SqlSingle Result = -Test;
-            Assert.Equal(-2000000001, Result.Value);
+            SqlSingle result = -test;
+            Assert.Equal(-2000000001, result.Value);
 
-            Result = -TestNeg;
-            Assert.Equal(3000, Result.Value);
+            result = -testNeg;
+            Assert.Equal(3000, result.Value);
         }
 
         [Fact]
         public void SqlBooleanToSqlSingle()
         {
-            SqlBoolean TestBoolean = new SqlBoolean(true);
-            SqlSingle Result;
+            SqlBoolean testBoolean = new SqlBoolean(true);
+            SqlSingle result;
 
-            Result = (SqlSingle)TestBoolean;
+            result = (SqlSingle)testBoolean;
 
-            Assert.Equal(1, Result.Value);
+            Assert.Equal(1, result.Value);
 
-            Result = (SqlSingle)SqlBoolean.Null;
-            Assert.True(Result.IsNull);
+            result = (SqlSingle)SqlBoolean.Null;
+            Assert.True(result.IsNull);
         }
 
         [Fact]
         public void SqlDoubleToSqlSingle()
         {
-            SqlDouble Test = new SqlDouble(12e12);
-            SqlSingle TestSqlSingle = (SqlSingle)Test;
-            Assert.Equal(12e12f, TestSqlSingle.Value);
+            SqlDouble test = new SqlDouble(12e12);
+            SqlSingle testSqlSingle = (SqlSingle)test;
+            Assert.Equal(12e12f, testSqlSingle.Value);
         }
 
         [Fact]
         public void SqlSingleToSingle()
         {
-            SqlSingle Test = new SqlSingle(12e12);
-            float Result = (float)Test;
-            Assert.Equal(12e12f, Result);
+            SqlSingle test = new SqlSingle(12e12);
+            float result = (float)test;
+            Assert.Equal(12e12f, result);
         }
 
         [Fact]
         public void SqlStringToSqlSingle()
         {
-            SqlString TestString = new SqlString("Test string");
-            SqlString TestString100 = new SqlString("100");
+            SqlString testString = new SqlString("Test string");
+            SqlString testString100 = new SqlString("100");
 
-            Assert.Equal(100, ((SqlSingle)TestString100).Value);
+            Assert.Equal(100, ((SqlSingle)testString100).Value);
 
             try
             {
-                SqlSingle test = (SqlSingle)TestString;
+                SqlSingle test = (SqlSingle)testString;
                 Assert.False(true);
             }
             catch (Exception e)
@@ -583,42 +426,42 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void ByteToSqlSingle()
         {
-            short TestShort = 14;
-            Assert.Equal(14, ((SqlSingle)TestShort).Value);
+            short testShort = 14;
+            Assert.Equal(14, ((SqlSingle)testShort).Value);
         }
 
         [Fact]
         public void SqlDecimalToSqlSingle()
         {
-            SqlDecimal TestDecimal64 = new SqlDecimal(64);
+            SqlDecimal testDecimal64 = new SqlDecimal(64);
 
-            Assert.Equal(64, ((SqlSingle)TestDecimal64).Value);
+            Assert.Equal(64, ((SqlSingle)testDecimal64).Value);
             Assert.Equal(SqlSingle.Null, SqlDecimal.Null);
         }
 
         [Fact]
         public void SqlIntToSqlSingle()
         {
-            SqlInt16 Test64 = new SqlInt16(64);
-            SqlInt32 Test640 = new SqlInt32(640);
-            SqlInt64 Test64000 = new SqlInt64(64000);
-            Assert.Equal(64, ((SqlSingle)Test64).Value);
-            Assert.Equal(640, ((SqlSingle)Test640).Value);
-            Assert.Equal(64000, ((SqlSingle)Test64000).Value);
+            SqlInt16 test64 = new SqlInt16(64);
+            SqlInt32 test640 = new SqlInt32(640);
+            SqlInt64 test64000 = new SqlInt64(64000);
+            Assert.Equal(64, ((SqlSingle)test64).Value);
+            Assert.Equal(640, ((SqlSingle)test640).Value);
+            Assert.Equal(64000, ((SqlSingle)test64000).Value);
         }
 
         [Fact]
         public void SqlMoneyToSqlSingle()
         {
-            SqlMoney TestMoney64 = new SqlMoney(64);
-            Assert.Equal(64, ((SqlSingle)TestMoney64).Value);
+            SqlMoney testMoney64 = new SqlMoney(64);
+            Assert.Equal(64, ((SqlSingle)testMoney64).Value);
         }
 
         [Fact]
         public void SingleToSqlSingle()
         {
-            float TestSingle64 = 64;
-            Assert.Equal(64, ((SqlSingle)TestSingle64).Value);
+            float testSingle64 = 64;
+            Assert.Equal(64, ((SqlSingle)testSingle64).Value);
         }
         [Fact]
         public void GetXsdTypeTest()

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlSingleTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlSingleTest.cs
@@ -236,7 +236,7 @@ namespace System.Data.Tests.SqlTypes
             Assert.Throws<OverflowException>(() => test2.ToSqlByte());
 
             // ToSqlDecimal ()
-            Assert.Equal(250.00000000000000M, test1.ToSqlDecimal().Value);
+            Assert.Equal(250M, test1.ToSqlDecimal().Value);
             Assert.Equal(0, test0.ToSqlDecimal().Value);
 
             Assert.Throws<OverflowException>(() => test3.ToSqlDecimal().Value);
@@ -284,27 +284,27 @@ namespace System.Data.Tests.SqlTypes
         {
             SqlSingle test0 = new SqlSingle(0);
             SqlSingle test1 = new SqlSingle(24E+11);
-            SqlSingle test3 = new SqlSingle(12E+11);
-            SqlSingle test4 = new SqlSingle(1E+10);
-            SqlSingle Test5 = new SqlSingle(2E+10);
+            SqlSingle test2 = new SqlSingle(12E+11);
+            SqlSingle test3 = new SqlSingle(1E+10);
+            SqlSingle test4 = new SqlSingle(2E+10);
 
             // "+"-operator
-            Assert.Equal((SqlSingle)3E+10, test4 + Test5);
+            Assert.Equal((SqlSingle)3E+10, test3 + test4);
 
             Assert.Throws<OverflowException>(() => SqlSingle.MaxValue + SqlSingle.MaxValue);
 
             // "/"-operator
-            Assert.Equal(2, test1 / test3);
+            Assert.Equal(2, test1 / test2);
 
-            Assert.Throws<DivideByZeroException>(() => test3 / test0);
+            Assert.Throws<DivideByZeroException>(() => test2 / test0);
 
             // "*"-operator
-            Assert.Equal((SqlSingle)2E+20, test4 * Test5);
+            Assert.Equal((SqlSingle)2E+20, test3 * test4);
 
             Assert.Throws<OverflowException>(() => SqlSingle.MaxValue * test1);
 
             // "-"-operator
-            Assert.Equal((SqlSingle)12e11, test1 - test3);
+            Assert.Equal((SqlSingle)12e11, test1 - test2);
 
             Assert.Throws<OverflowException>(() => SqlSingle.MinValue - SqlSingle.MaxValue);
         }

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlStringTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlStringTest.cs
@@ -223,13 +223,9 @@ namespace System.Data.Tests.SqlTypes
             Assert.Equal(0, _test2.CompareTo(_test3));
             Assert.True(_test3.CompareTo(SqlString.Null) > 0);
 
-            // TODO: What's this? the values are immediately overwritten.
-            SqlString t1 = new SqlString("test", 2057, SqlCompareOptions.IgnoreCase);
-            SqlString t2 = new SqlString("TEST", 2057, SqlCompareOptions.None);
-
             // IgnoreCase
-            t1 = new SqlString("test", 2057, SqlCompareOptions.IgnoreCase);
-            t2 = new SqlString("TEST", 2057, SqlCompareOptions.IgnoreCase);
+            SqlString t1 = new SqlString("test", 2057, SqlCompareOptions.IgnoreCase);
+            SqlString t2 = new SqlString("TEST", 2057, SqlCompareOptions.IgnoreCase);
             Assert.Equal(0, t2.CompareTo(t1));
 
             t1 = new SqlString("test", 2057);
@@ -270,15 +266,6 @@ namespace System.Data.Tests.SqlTypes
             // Static Equals()-method
             Assert.True(SqlString.Equals(_test2, _test3).Value);
             Assert.False(SqlString.Equals(_test1, _test2).Value);
-        }
-
-        [Fact]
-        public void GetHashCodeTest()
-        {
-            // FIXME: Better way to test HashCode
-            Assert.Equal(_test1.GetHashCode(), _test1.GetHashCode());
-            Assert.NotEqual(_test1.GetHashCode(), _test2.GetHashCode());
-            Assert.Equal(_test2.GetHashCode(), _test2.GetHashCode());
         }
 
         [Fact]

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlStringTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlStringTest.cs
@@ -282,13 +282,6 @@ namespace System.Data.Tests.SqlTypes
         }
 
         [Fact]
-        public void GetTypeTest()
-        {
-            Assert.Equal("System.Data.SqlTypes.SqlString", _test1.GetType().ToString());
-            Assert.Equal("System.String", _test1.Value.GetType().ToString());
-        }
-
-        [Fact]
         public void Greaters()
         {
             // GreateThan ()
@@ -623,7 +616,7 @@ namespace System.Data.Tests.SqlTypes
             SqlByte testByte = new SqlByte(250);
             Assert.Equal("250", ((SqlString)testByte).Value);
 
-            Assert.Throws<SqlNullValueException>(() => (SqlString)SqlByte.Null);
+            Assert.Throws<SqlNullValueException>(() => ((SqlString)SqlByte.Null).Value);
         }
 
         [Fact]
@@ -657,7 +650,7 @@ namespace System.Data.Tests.SqlTypes
 
             Assert.Equal("00004064-0000-0000-0000-000000000000", ((SqlString)testGuid).Value);
 
-            Assert.Throws<SqlNullValueException>(() => (SqlString)SqlGuid.Null);
+            Assert.Throws<SqlNullValueException>(() => ((SqlString)SqlGuid.Null).Value);
         }
 
         [Fact]
@@ -666,7 +659,7 @@ namespace System.Data.Tests.SqlTypes
             SqlInt16 testInt = new SqlInt16(20012);
             Assert.Equal("20012", ((SqlString)testInt).Value);
 
-            Assert.Throws<SqlNullValueException>(() => (SqlString)SqlInt16.Null);
+            Assert.Throws<SqlNullValueException>(() => ((SqlString)SqlInt16.Null).Value);
         }
 
         [Fact]
@@ -675,7 +668,7 @@ namespace System.Data.Tests.SqlTypes
             SqlInt32 testInt = new SqlInt32(-12456);
             Assert.Equal("-12456", ((SqlString)testInt).Value);
 
-            Assert.Throws<SqlNullValueException>(() => (SqlString)SqlInt32.Null);
+            Assert.Throws<SqlNullValueException>(() => ((SqlString)SqlInt32.Null).Value);
         }
 
         [Fact]

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlStringTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlStringTest.cs
@@ -31,7 +31,6 @@ using System.IO;
 using System.Xml;
 using System.Xml.Serialization;
 using System.Text;
-using System.Diagnostics;
 using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
 using System.Tests;
@@ -95,38 +94,38 @@ namespace System.Data.Tests.SqlTypes
         public void Create()
         {
             // SqlString (String)
-            SqlString TestString = new SqlString("Test");
-            Assert.Equal("Test", TestString.Value);
+            SqlString testString = new SqlString("Test");
+            Assert.Equal("Test", testString.Value);
 
             // SqlString (String, int)
-            TestString = new SqlString("Test", 2057);
-            Assert.Equal(2057, TestString.LCID);
+            testString = new SqlString("Test", 2057);
+            Assert.Equal(2057, testString.LCID);
 
             // SqlString (int, SqlCompareOptions, byte[])
-            TestString = new SqlString(2057,
+            testString = new SqlString(2057,
                 SqlCompareOptions.BinarySort | SqlCompareOptions.IgnoreCase,
                 new byte[2] { 123, 221 });
-            Assert.Equal(2057, TestString.CompareInfo.LCID);
+            Assert.Equal(2057, testString.CompareInfo.LCID);
 
             // SqlString(string, int, SqlCompareOptions)
-            TestString = new SqlString("Test", 2057, SqlCompareOptions.IgnoreNonSpace);
-            Assert.True(!TestString.IsNull);
+            testString = new SqlString("Test", 2057, SqlCompareOptions.IgnoreNonSpace);
+            Assert.False(testString.IsNull);
 
             // SqlString (int, SqlCompareOptions, byte[], bool)
-            TestString = new SqlString(2057, SqlCompareOptions.BinarySort, new byte[4] { 100, 100, 200, 45 }, true);
-            Assert.Equal((byte)63, TestString.GetNonUnicodeBytes()[0]);
-            TestString = new SqlString(2057, SqlCompareOptions.BinarySort, new byte[2] { 113, 100 }, false);
-            Assert.Equal("qd", TestString.Value);
+            testString = new SqlString(2057, SqlCompareOptions.BinarySort, new byte[4] { 100, 100, 200, 45 }, true);
+            Assert.Equal((byte)63, testString.GetNonUnicodeBytes()[0]);
+            testString = new SqlString(2057, SqlCompareOptions.BinarySort, new byte[2] { 113, 100 }, false);
+            Assert.Equal("qd", testString.Value);
 
             // SqlString (int, SqlCompareOptions, byte[], int, int)
-            TestString = new SqlString(2057, SqlCompareOptions.BinarySort, new byte[2] { 113, 100 }, 0, 2);
-            Assert.True(!TestString.IsNull);
+            testString = new SqlString(2057, SqlCompareOptions.BinarySort, new byte[2] { 113, 100 }, 0, 2);
+            Assert.False(testString.IsNull);
 
             // SqlString (int, SqlCompareOptions, byte[], int, int, bool)
-            TestString = new SqlString(2057, SqlCompareOptions.IgnoreCase, new byte[3] { 100, 111, 50 }, 1, 2, false);
-            Assert.Equal("o2", TestString.Value);
-            TestString = new SqlString(2057, SqlCompareOptions.IgnoreCase, new byte[3] { 123, 111, 222 }, 1, 2, true);
-            Assert.True(!TestString.IsNull);
+            testString = new SqlString(2057, SqlCompareOptions.IgnoreCase, new byte[3] { 100, 111, 50 }, 1, 2, false);
+            Assert.Equal("o2", testString.Value);
+            testString = new SqlString(2057, SqlCompareOptions.IgnoreCase, new byte[3] { 123, 111, 222 }, 1, 2, true);
+            Assert.False(testString.IsNull);
         }
 
         [Fact]
@@ -188,7 +187,7 @@ namespace System.Data.Tests.SqlTypes
                 Assert.Equal(3081, one.LCID);
 
                 // IsNull
-                Assert.True(!one.IsNull);
+                Assert.False(one.IsNull);
                 Assert.True(SqlString.Null.IsNull);
 
                 // SqlCompareOptions
@@ -204,74 +203,73 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void CompareToArgumentException()
         {
-            SqlByte Test = new SqlByte(1);
-            AssertExtensions.Throws<ArgumentException>(null, () => _test1.CompareTo(Test));
+            SqlByte test = new SqlByte(1);
+            AssertExtensions.Throws<ArgumentException>(null, () => _test1.CompareTo(test));
         }
 
         [Fact]
         public void CompareToSqlTypeException()
         {
-            SqlString T1 = new SqlString("test", 2057, SqlCompareOptions.IgnoreCase);
-            SqlString T2 = new SqlString("TEST", 2057, SqlCompareOptions.None);
-            Assert.Throws<SqlTypeException>(() => T1.CompareTo(T2));
+            SqlString t1 = new SqlString("test", 2057, SqlCompareOptions.IgnoreCase);
+            SqlString t2 = new SqlString("TEST", 2057, SqlCompareOptions.None);
+            Assert.Throws<SqlTypeException>(() => t1.CompareTo(t2));
         }
 
         [Fact]
         public void CompareTo()
         {
-            SqlByte Test = new SqlByte(1);
-
             Assert.True(_test1.CompareTo(_test3) < 0);
             Assert.True(_test2.CompareTo(_test1) > 0);
             Assert.True(_test2.CompareTo(_test3) == 0);
             Assert.True(_test3.CompareTo(SqlString.Null) > 0);
 
-            SqlString T1 = new SqlString("test", 2057, SqlCompareOptions.IgnoreCase);
-            SqlString T2 = new SqlString("TEST", 2057, SqlCompareOptions.None);
+            // TODO: What's this? the values are immediately overwritten.
+            SqlString t1 = new SqlString("test", 2057, SqlCompareOptions.IgnoreCase);
+            SqlString t2 = new SqlString("TEST", 2057, SqlCompareOptions.None);
 
             // IgnoreCase
-            T1 = new SqlString("test", 2057, SqlCompareOptions.IgnoreCase);
-            T2 = new SqlString("TEST", 2057, SqlCompareOptions.IgnoreCase);
-            Assert.True(T2.CompareTo(T1) == 0);
+            t1 = new SqlString("test", 2057, SqlCompareOptions.IgnoreCase);
+            t2 = new SqlString("TEST", 2057, SqlCompareOptions.IgnoreCase);
+            Assert.True(t2.CompareTo(t1) == 0);
 
-            T1 = new SqlString("test", 2057);
-            T2 = new SqlString("TEST", 2057);
-            Assert.True(T2.CompareTo(T1) == 0);
+            t1 = new SqlString("test", 2057);
+            t2 = new SqlString("TEST", 2057);
+            Assert.True(t2.CompareTo(t1) == 0);
 
-            T1 = new SqlString("test", 2057, SqlCompareOptions.None);
-            T2 = new SqlString("TEST", 2057, SqlCompareOptions.None);
-            Assert.True(T2.CompareTo(T1) != 0);
+            t1 = new SqlString("test", 2057, SqlCompareOptions.None);
+            t2 = new SqlString("TEST", 2057, SqlCompareOptions.None);
+            Assert.True(t2.CompareTo(t1) != 0);
 
             // IgnoreNonSpace
-            T1 = new SqlString("TEST\xF1", 2057, SqlCompareOptions.IgnoreNonSpace);
-            T2 = new SqlString("TESTn", 2057, SqlCompareOptions.IgnoreNonSpace);
-            Assert.True(T2.CompareTo(T1) == 0);
+            t1 = new SqlString("TEST\xF1", 2057, SqlCompareOptions.IgnoreNonSpace);
+            t2 = new SqlString("TESTn", 2057, SqlCompareOptions.IgnoreNonSpace);
+            Assert.True(t2.CompareTo(t1) == 0);
 
-            T1 = new SqlString("TEST\u00F1", 2057, SqlCompareOptions.None);
-            T2 = new SqlString("TESTn", 2057, SqlCompareOptions.None);
-            Assert.True(T2.CompareTo(T1) != 0);
+            t1 = new SqlString("TEST\u00F1", 2057, SqlCompareOptions.None);
+            t2 = new SqlString("TESTn", 2057, SqlCompareOptions.None);
+            Assert.True(t2.CompareTo(t1) != 0);
 
             // BinarySort
-            T1 = new SqlString("01_", 2057, SqlCompareOptions.BinarySort);
-            T2 = new SqlString("_01", 2057, SqlCompareOptions.BinarySort);
-            Assert.True(T1.CompareTo(T2) < 0);
+            t1 = new SqlString("01_", 2057, SqlCompareOptions.BinarySort);
+            t2 = new SqlString("_01", 2057, SqlCompareOptions.BinarySort);
+            Assert.True(t1.CompareTo(t2) < 0);
 
-            T1 = new SqlString("01_", 2057, SqlCompareOptions.None);
-            T2 = new SqlString("_01", 2057, SqlCompareOptions.None);
-            Assert.True(T1.CompareTo(T2) > 0);
+            t1 = new SqlString("01_", 2057, SqlCompareOptions.None);
+            t2 = new SqlString("_01", 2057, SqlCompareOptions.None);
+            Assert.True(t1.CompareTo(t2) > 0);
         }
 
         [Fact]
         public void EqualsMethods()
         {
-            Assert.True(!_test1.Equals(_test2));
-            Assert.True(!_test3.Equals(_test1));
-            Assert.True(!_test2.Equals(new SqlString("TEST")));
+            Assert.False(_test1.Equals(_test2));
+            Assert.False(_test3.Equals(_test1));
+            Assert.False(_test2.Equals(new SqlString("TEST")));
             Assert.True(_test2.Equals(_test3));
 
             // Static Equals()-method
             Assert.True(SqlString.Equals(_test2, _test3).Value);
-            Assert.True(!SqlString.Equals(_test1, _test2).Value);
+            Assert.False(SqlString.Equals(_test1, _test2).Value);
         }
 
         [Fact]
@@ -279,8 +277,8 @@ namespace System.Data.Tests.SqlTypes
         {
             // FIXME: Better way to test HashCode
             Assert.Equal(_test1.GetHashCode(), _test1.GetHashCode());
-            Assert.True(_test1.GetHashCode() != _test2.GetHashCode());
-            Assert.True(_test2.GetHashCode() == _test2.GetHashCode());
+            Assert.NotEqual(_test1.GetHashCode(), _test2.GetHashCode());
+            Assert.Equal(_test2.GetHashCode(), _test2.GetHashCode());
         }
 
         [Fact]
@@ -294,12 +292,12 @@ namespace System.Data.Tests.SqlTypes
         public void Greaters()
         {
             // GreateThan ()
-            Assert.True(!SqlString.GreaterThan(_test1, _test2).Value);
+            Assert.False(SqlString.GreaterThan(_test1, _test2).Value);
             Assert.True(SqlString.GreaterThan(_test2, _test1).Value);
-            Assert.True(!SqlString.GreaterThan(_test2, _test3).Value);
+            Assert.False(SqlString.GreaterThan(_test2, _test3).Value);
 
             // GreaterTharOrEqual ()
-            Assert.True(!SqlString.GreaterThanOrEqual(_test1, _test2).Value);
+            Assert.False(SqlString.GreaterThanOrEqual(_test1, _test2).Value);
             Assert.True(SqlString.GreaterThanOrEqual(_test2, _test1).Value);
             Assert.True(SqlString.GreaterThanOrEqual(_test2, _test3).Value);
         }
@@ -308,13 +306,13 @@ namespace System.Data.Tests.SqlTypes
         public void Lessers()
         {
             // LessThan()
-            Assert.True(!SqlString.LessThan(_test2, _test3).Value);
-            Assert.True(!SqlString.LessThan(_test2, _test1).Value);
+            Assert.False(SqlString.LessThan(_test2, _test3).Value);
+            Assert.False(SqlString.LessThan(_test2, _test1).Value);
             Assert.True(SqlString.LessThan(_test1, _test2).Value);
 
             // LessThanOrEqual ()
             Assert.True(SqlString.LessThanOrEqual(_test1, _test2).Value);
-            Assert.True(!SqlString.LessThanOrEqual(_test2, _test1).Value);
+            Assert.False(SqlString.LessThanOrEqual(_test2, _test1).Value);
             Assert.True(SqlString.LessThanOrEqual(_test3, _test2).Value);
             Assert.True(SqlString.LessThanOrEqual(_test2, SqlString.Null).IsNull);
         }
@@ -325,7 +323,7 @@ namespace System.Data.Tests.SqlTypes
             Assert.True(SqlString.NotEquals(_test1, _test2).Value);
             Assert.True(SqlString.NotEquals(_test2, _test1).Value);
             Assert.True(SqlString.NotEquals(_test3, _test1).Value);
-            Assert.True(!SqlString.NotEquals(_test2, _test3).Value);
+            Assert.False(SqlString.NotEquals(_test2, _test3).Value);
             Assert.True(SqlString.NotEquals(SqlString.Null, _test3).IsNull);
         }
 
@@ -343,8 +341,8 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void Clone()
         {
-            SqlString TestSqlString = _test1.Clone();
-            Assert.Equal(_test1, TestSqlString);
+            SqlString testSqlString = _test1.Clone();
+            Assert.Equal(_test1, testSqlString);
         }
 
         [Fact]
@@ -378,15 +376,7 @@ namespace System.Data.Tests.SqlTypes
 
             Assert.Equal((byte)105, _test1.GetUnicodeBytes()[2]);
 
-            try
-            {
-                byte test = _test1.GetUnicodeBytes()[105];
-                Assert.False(true);
-            }
-            catch (Exception e)
-            {
-                Assert.Equal(typeof(IndexOutOfRangeException), e.GetType());
-            }
+            Assert.Throws<IndexOutOfRangeException>(() => _test1.GetUnicodeBytes()[105]);
         }
 
         [Fact]
@@ -516,46 +506,46 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void Conversions()
         {
-            SqlString String250 = new SqlString("250");
-            SqlString String9E300 = new SqlString("9E+300");
+            SqlString string250 = new SqlString("250");
+            SqlString string9E300 = new SqlString("9E+300");
 
             // ToSqlBoolean ()
             Assert.True((new SqlString("1")).ToSqlBoolean().Value);
-            Assert.True(!(new SqlString("0")).ToSqlBoolean().Value);
+            Assert.False((new SqlString("0")).ToSqlBoolean().Value);
             Assert.True((new SqlString("True")).ToSqlBoolean().Value);
-            Assert.True(!(new SqlString("FALSE")).ToSqlBoolean().Value);
+            Assert.False((new SqlString("FALSE")).ToSqlBoolean().Value);
             Assert.True(SqlString.Null.ToSqlBoolean().IsNull);
 
             // ToSqlByte ()
-            Assert.Equal((byte)250, String250.ToSqlByte().Value);
+            Assert.Equal((byte)250, string250.ToSqlByte().Value);
 
             // ToSqlDateTime
             Assert.Equal(10, (new SqlString("2002-10-10")).ToSqlDateTime().Value.Day);
 
             // ToSqlDecimal ()
-            Assert.Equal(250, String250.ToSqlDecimal().Value);
+            Assert.Equal(250, string250.ToSqlDecimal().Value);
 
             // ToSqlDouble
-            Assert.Equal(9E+300, String9E300.ToSqlDouble());
+            Assert.Equal(9E+300, string9E300.ToSqlDouble());
 
             // ToSqlGuid
             SqlString TestGuid = new SqlString("11111111-1111-1111-1111-111111111111");
             Assert.Equal(new SqlGuid("11111111-1111-1111-1111-111111111111"), TestGuid.ToSqlGuid());
 
             // ToSqlInt16 ()
-            Assert.Equal((short)250, String250.ToSqlInt16().Value);
+            Assert.Equal((short)250, string250.ToSqlInt16().Value);
 
             // ToSqlInt32 ()
-            Assert.Equal(250, String250.ToSqlInt32().Value);
+            Assert.Equal(250, string250.ToSqlInt32().Value);
 
             // ToSqlInt64 ()
-            Assert.Equal(250, String250.ToSqlInt64().Value);
+            Assert.Equal(250, string250.ToSqlInt64().Value);
 
             // ToSqlMoney ()
-            Assert.Equal(250.0000M, String250.ToSqlMoney().Value);
+            Assert.Equal(250.0000M, string250.ToSqlMoney().Value);
 
             // ToSqlSingle ()
-            Assert.Equal(250, String250.ToSqlSingle().Value);
+            Assert.Equal(250, string250.ToSqlSingle().Value);
 
             // ToString ()
             Assert.Equal("First TestString", _test1.ToString());
@@ -566,8 +556,8 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void ArithmeticOperators()
         {
-            SqlString TestString = new SqlString("...Testing...");
-            Assert.Equal("First TestString...Testing...", _test1 + TestString);
+            SqlString testString = new SqlString("...Testing...");
+            Assert.Equal("First TestString...Testing...", _test1 + testString);
             Assert.Equal(SqlString.Null, _test1 + SqlString.Null);
         }
 
@@ -576,23 +566,23 @@ namespace System.Data.Tests.SqlTypes
         {
             // == -operator
             Assert.True((_test2 == _test3).Value);
-            Assert.True(!(_test1 == _test2).Value);
+            Assert.False((_test1 == _test2).Value);
             Assert.True((_test1 == SqlString.Null).IsNull);
 
             // != -operator
-            Assert.True(!(_test3 != _test2).Value);
-            Assert.True(!(_test2 != _test3).Value);
+            Assert.False((_test3 != _test2).Value);
+            Assert.False((_test2 != _test3).Value);
             Assert.True((_test1 != _test3).Value);
             Assert.True((_test1 != SqlString.Null).IsNull);
 
             // > -operator
             Assert.True((_test2 > _test1).Value);
-            Assert.True(!(_test1 > _test3).Value);
-            Assert.True(!(_test2 > _test3).Value);
+            Assert.False((_test1 > _test3).Value);
+            Assert.False((_test2 > _test3).Value);
             Assert.True((_test1 > SqlString.Null).IsNull);
 
             // >= -operator
-            Assert.True(!(_test1 >= _test3).Value);
+            Assert.False((_test1 >= _test3).Value);
             Assert.True((_test3 >= _test1).Value);
             Assert.True((_test2 >= _test3).Value);
             Assert.True((_test1 >= SqlString.Null).IsNull);
@@ -600,12 +590,12 @@ namespace System.Data.Tests.SqlTypes
             // < -operator
             Assert.True((_test1 < _test2).Value);
             Assert.True((_test1 < _test3).Value);
-            Assert.True(!(_test2 < _test3).Value);
+            Assert.False((_test2 < _test3).Value);
             Assert.True((_test1 < SqlString.Null).IsNull);
 
             // <= -operator
             Assert.True((_test1 <= _test3).Value);
-            Assert.True(!(_test3 <= _test1).Value);
+            Assert.False((_test3 <= _test1).Value);
             Assert.True((_test2 <= _test3).Value);
             Assert.True((_test1 <= SqlString.Null).IsNull);
         }
@@ -613,55 +603,48 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void SqlBooleanToSqlString()
         {
-            SqlBoolean TestBoolean = new SqlBoolean(true);
-            SqlBoolean TestBoolean2 = new SqlBoolean(false);
-            SqlString Result;
+            SqlBoolean testBoolean = new SqlBoolean(true);
+            SqlBoolean testBoolean2 = new SqlBoolean(false);
+            SqlString result;
 
-            Result = (SqlString)TestBoolean;
-            Assert.Equal("True", Result.Value);
+            result = (SqlString)testBoolean;
+            Assert.Equal("True", result.Value);
 
-            Result = (SqlString)TestBoolean2;
-            Assert.Equal("False", Result.Value);
+            result = (SqlString)testBoolean2;
+            Assert.Equal("False", result.Value);
 
-            Result = (SqlString)SqlBoolean.Null;
-            Assert.True(Result.IsNull);
+            result = (SqlString)SqlBoolean.Null;
+            Assert.True(result.IsNull);
         }
 
         [Fact]
         public void SqlByteToBoolean()
         {
-            SqlByte TestByte = new SqlByte(250);
-            Assert.Equal("250", ((SqlString)TestByte).Value);
-            try
-            {
-                SqlString test = ((SqlString)SqlByte.Null).Value;
-                Assert.False(true);
-            }
-            catch (SqlNullValueException e)
-            {
-                Assert.Equal(typeof(SqlNullValueException), e.GetType());
-            }
+            SqlByte testByte = new SqlByte(250);
+            Assert.Equal("250", ((SqlString)testByte).Value);
+
+            Assert.Throws<SqlNullValueException>(() => (SqlString)SqlByte.Null);
         }
 
         [Fact]
         public void SqlDateTimeToSqlString()
         {
-            SqlDateTime TestTime = new SqlDateTime(2002, 10, 22, 9, 52, 30);
-            Assert.Equal(TestTime.Value.ToString((IFormatProvider)null), ((SqlString)TestTime).Value);
+            SqlDateTime testTime = new SqlDateTime(2002, 10, 22, 9, 52, 30);
+            Assert.Equal(testTime.Value.ToString((IFormatProvider)null), ((SqlString)testTime).Value);
         }
 
         [Fact]
         public void SqlDecimalToSqlString()
         {
-            SqlDecimal TestDecimal = new SqlDecimal(1000.2345);
-            Assert.Equal("1000.2345000000000", ((SqlString)TestDecimal).Value);
+            SqlDecimal testDecimal = new SqlDecimal(1000.2345);
+            Assert.Equal("1000.2345000000000", ((SqlString)testDecimal).Value);
         }
 
         [Fact]
         public void SqlDoubleToSqlString()
         {
-            SqlDouble TestDouble = new SqlDouble(64E+64);
-            Assert.Equal(6.4E+65.ToString(), ((SqlString)TestDouble).Value);
+            SqlDouble testDouble = new SqlDouble(64E+64);
+            Assert.Equal(6.4E+65.ToString(), ((SqlString)testDouble).Value);
         }
 
         [Fact]
@@ -670,64 +653,43 @@ namespace System.Data.Tests.SqlTypes
             byte[] b = new byte[16];
             b[0] = 100;
             b[1] = 64;
-            SqlGuid TestGuid = new SqlGuid(b);
+            SqlGuid testGuid = new SqlGuid(b);
 
-            Assert.Equal("00004064-0000-0000-0000-000000000000", ((SqlString)TestGuid).Value);
-            try
-            {
-                SqlString test = ((SqlString)SqlGuid.Null).Value;
-                Assert.False(true);
-            }
-            catch (SqlNullValueException e)
-            {
-                Assert.Equal(typeof(SqlNullValueException), e.GetType());
-            }
+            Assert.Equal("00004064-0000-0000-0000-000000000000", ((SqlString)testGuid).Value);
+
+            Assert.Throws<SqlNullValueException>(() => (SqlString)SqlGuid.Null);
         }
 
         [Fact]
         public void SqlInt16ToSqlString()
         {
-            SqlInt16 TestInt = new SqlInt16(20012);
-            Assert.Equal("20012", ((SqlString)TestInt).Value);
-            try
-            {
-                SqlString test = ((SqlString)SqlInt16.Null).Value;
-                Assert.False(true);
-            }
-            catch (SqlNullValueException e)
-            {
-                Assert.Equal(typeof(SqlNullValueException), e.GetType());
-            }
+            SqlInt16 testInt = new SqlInt16(20012);
+            Assert.Equal("20012", ((SqlString)testInt).Value);
+
+            Assert.Throws<SqlNullValueException>(() => (SqlString)SqlInt16.Null);
         }
 
         [Fact]
         public void SqlInt32ToSqlString()
         {
-            SqlInt32 TestInt = new SqlInt32(-12456);
-            Assert.Equal("-12456", ((SqlString)TestInt).Value);
-            try
-            {
-                SqlString test = ((SqlString)SqlInt32.Null).Value;
-                Assert.False(true);
-            }
-            catch (SqlNullValueException e)
-            {
-                Assert.Equal(typeof(SqlNullValueException), e.GetType());
-            }
+            SqlInt32 testInt = new SqlInt32(-12456);
+            Assert.Equal("-12456", ((SqlString)testInt).Value);
+
+            Assert.Throws<SqlNullValueException>(() => (SqlString)SqlInt32.Null);
         }
 
         [Fact]
         public void SqlInt64ToSqlString()
         {
-            SqlInt64 TestInt = new SqlInt64(10101010);
-            Assert.Equal("10101010", ((SqlString)TestInt).Value);
+            SqlInt64 testInt = new SqlInt64(10101010);
+            Assert.Equal("10101010", ((SqlString)testInt).Value);
         }
 
         [Fact]
         public void SqlMoneyToSqlString()
         {
-            SqlMoney TestMoney = new SqlMoney(646464.6464);
-            Assert.Equal(646464.6464.ToString(), ((SqlString)TestMoney).Value);
+            SqlMoney testMoney = new SqlMoney(646464.6464);
+            Assert.Equal(646464.6464.ToString(), ((SqlString)testMoney).Value);
         }
 
         [Fact]
@@ -746,8 +708,8 @@ namespace System.Data.Tests.SqlTypes
         [Fact]
         public void StringToSqlString()
         {
-            string TestString = "Test String";
-            Assert.Equal("Test String", ((SqlString)TestString).Value);
+            string testString = "Test String";
+            Assert.Equal("Test String", ((SqlString)testString).Value);
         }
 
         [Fact]

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlStringTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlStringTest.cs
@@ -220,7 +220,7 @@ namespace System.Data.Tests.SqlTypes
         {
             Assert.True(_test1.CompareTo(_test3) < 0);
             Assert.True(_test2.CompareTo(_test1) > 0);
-            Assert.True(_test2.CompareTo(_test3) == 0);
+            Assert.Equal(0, _test2.CompareTo(_test3));
             Assert.True(_test3.CompareTo(SqlString.Null) > 0);
 
             // TODO: What's this? the values are immediately overwritten.
@@ -230,24 +230,24 @@ namespace System.Data.Tests.SqlTypes
             // IgnoreCase
             t1 = new SqlString("test", 2057, SqlCompareOptions.IgnoreCase);
             t2 = new SqlString("TEST", 2057, SqlCompareOptions.IgnoreCase);
-            Assert.True(t2.CompareTo(t1) == 0);
+            Assert.Equal(0, t2.CompareTo(t1));
 
             t1 = new SqlString("test", 2057);
             t2 = new SqlString("TEST", 2057);
-            Assert.True(t2.CompareTo(t1) == 0);
+            Assert.Equal(0, t2.CompareTo(t1));
 
             t1 = new SqlString("test", 2057, SqlCompareOptions.None);
             t2 = new SqlString("TEST", 2057, SqlCompareOptions.None);
-            Assert.True(t2.CompareTo(t1) != 0);
+            Assert.NotEqual(0, t2.CompareTo(t1));
 
             // IgnoreNonSpace
             t1 = new SqlString("TEST\xF1", 2057, SqlCompareOptions.IgnoreNonSpace);
             t2 = new SqlString("TESTn", 2057, SqlCompareOptions.IgnoreNonSpace);
-            Assert.True(t2.CompareTo(t1) == 0);
+            Assert.Equal(0, t2.CompareTo(t1));
 
             t1 = new SqlString("TEST\u00F1", 2057, SqlCompareOptions.None);
             t2 = new SqlString("TESTn", 2057, SqlCompareOptions.None);
-            Assert.True(t2.CompareTo(t1) != 0);
+            Assert.NotEqual(0, t2.CompareTo(t1));
 
             // BinarySort
             t1 = new SqlString("01_", 2057, SqlCompareOptions.BinarySort);

--- a/src/System.Data.Common/tests/System/Data/SqlTypes/SqlXmlTest.cs
+++ b/src/System.Data.Common/tests/System/Data/SqlTypes/SqlXmlTest.cs
@@ -22,7 +22,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System.Data.SqlTypes;
-using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Xml;
@@ -60,14 +59,7 @@ namespace System.Data.Tests.SqlTypes
             SqlXml xmlSql = new SqlXml((Stream)null);
             Assert.True(xmlSql.IsNull);
 
-            try
-            {
-                string value = xmlSql.Value;
-                Assert.False(true);
-            }
-            catch (SqlNullValueException)
-            {
-            }
+            Assert.Throws<SqlNullValueException>(() => xmlSql.Value);
         }
 
         [Fact] // .ctor (XmlReader)
@@ -97,14 +89,7 @@ namespace System.Data.Tests.SqlTypes
             SqlXml xmlSql = new SqlXml((XmlReader)null);
             Assert.True(xmlSql.IsNull);
 
-            try
-            {
-                string value = xmlSql.Value;
-                Assert.False(true);
-            }
-            catch (SqlNullValueException)
-            {
-            }
+            Assert.Throws<SqlNullValueException>(() => xmlSql.Value);
         }
 
         [Fact]
@@ -163,42 +148,24 @@ namespace System.Data.Tests.SqlTypes
         public void SqlXml_fromZeroLengthXmlReader_CreateReaderTest()
         {
             XmlReader rdr = new XmlTextReader(new StringReader(string.Empty));
-            try
-            {
-                new SqlXml(rdr);
-                Assert.False(true);
-            }
-            catch (XmlException)
-            {
-            }
+
+            Assert.Throws<XmlException>(() => new SqlXml(rdr));
         }
 
         [Fact]
         public void CreateReader_Stream_Null()
         {
             SqlXml xmlSql = new SqlXml((Stream)null);
-            try
-            {
-                xmlSql.CreateReader();
-                Assert.False(true);
-            }
-            catch (SqlNullValueException)
-            {
-            }
+
+            Assert.Throws<SqlNullValueException>(() => xmlSql.CreateReader());
         }
 
         [Fact]
         public void CreateReader_XmlReader_Null()
         {
             SqlXml xmlSql = new SqlXml((XmlReader)null);
-            try
-            {
-                xmlSql.CreateReader();
-                Assert.False(true);
-            }
-            catch (SqlNullValueException)
-            {
-            }
+
+            Assert.Throws<SqlNullValueException>(() => xmlSql.CreateReader());
         }
     }
 }

--- a/src/System.Data.Common/tests/System/Data/UniqueConstraintTest.cs
+++ b/src/System.Data.Common/tests/System/Data/UniqueConstraintTest.cs
@@ -108,15 +108,15 @@ namespace System.Data.Tests
         [Fact]
         public void Unique()
         {
-            UniqueConstraint U = new UniqueConstraint(_table.Columns[0]);
+            UniqueConstraint u = new UniqueConstraint(_table.Columns[0]);
             Assert.False(_table.Columns[0].Unique);
 
-            U = new UniqueConstraint(new DataColumn[] { _table.Columns[0], _table.Columns[1] });
+            u = new UniqueConstraint(new DataColumn[] { _table.Columns[0], _table.Columns[1] });
             Assert.False(_table.Columns[0].Unique);
             Assert.False(_table.Columns[1].Unique);
             Assert.False(_table.Columns[2].Unique);
 
-            _table.Constraints.Add(U);
+            _table.Constraints.Add(u);
             Assert.False(_table.Columns[0].Unique);
             Assert.False(_table.Columns[1].Unique);
             Assert.False(_table.Columns[2].Unique);

--- a/src/System.Data.Common/tests/System/Data/UniqueConstraintTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/UniqueConstraintTest2.cs
@@ -322,7 +322,7 @@ namespace System.Data.Tests
             uc = new UniqueConstraint(dtParent.Columns[0]);
             PropertyCollection pc = uc.ExtendedProperties;
 
-            // Checking ExtendedProperties default 
+            // Checking ExtendedProperties default
             Assert.NotNull(pc);
 
             // Checking ExtendedProperties count

--- a/src/System.Data.Common/tests/System/Data/UniqueConstraintTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/UniqueConstraintTest2.cs
@@ -115,7 +115,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public void constraintName()
+        public void ConstraintName()
         {
             DataTable dtParent = DataProvider.CreateParentDataTable();
 
@@ -132,7 +132,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public void ctor_DataColumn()
+        public void Ctor_DataColumn()
         {
             Exception tmpEx = new Exception();
 
@@ -146,10 +146,8 @@ namespace System.Data.Tests
             // DataColumn.Unique - without constraint
             Assert.False(dtParent.Columns[0].Unique);
 
-            uc = new UniqueConstraint(dtParent.Columns[0]);
-
             // Ctor
-            Assert.False(uc == null);
+            uc = new UniqueConstraint(dtParent.Columns[0]);
 
             // DataColumn.Unique - with constraint
             Assert.False(dtParent.Columns[0].Unique);
@@ -185,16 +183,11 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public void ctor_DataColumnNoPrimary()
+        public void Ctor_DataColumnNoPrimary()
         {
             DataTable dtParent = DataProvider.CreateParentDataTable();
-
-            UniqueConstraint uc = null;
-            uc = new UniqueConstraint(dtParent.Columns[0], false);
+            UniqueConstraint uc = new UniqueConstraint(dtParent.Columns[0], false);
             dtParent.Constraints.Add(uc);
-
-            // Ctor
-            Assert.False(uc == null);
 
             // primary key 1
             Assert.Equal(0, dtParent.PrimaryKey.Length);
@@ -208,16 +201,13 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public void ctor_DataColumns()
+        public void Ctor_DataColumns()
         {
             Exception tmpEx = new Exception();
             DataTable dtParent = DataProvider.CreateParentDataTable();
 
-            UniqueConstraint uc = null;
-            uc = new UniqueConstraint(new DataColumn[] { dtParent.Columns[0], dtParent.Columns[1] });
-
             // Ctor - parent
-            Assert.False(uc == null);
+            UniqueConstraint uc = new UniqueConstraint(new DataColumn[] { dtParent.Columns[0], dtParent.Columns[1] });
 
             // Ctor - add existing column
             dtParent.Rows.Add(new object[] { 99, "str1", "str2" });
@@ -228,9 +218,6 @@ namespace System.Data.Tests
             uc = new UniqueConstraint(new DataColumn[] { dtChild.Columns[0], dtChild.Columns[1] });
             dtChild.Constraints.Add(uc);
 
-            // Ctor - child
-            Assert.False(uc == null);
-
             dtChild.Constraints.Clear();
             uc = new UniqueConstraint(new DataColumn[] { dtChild.Columns[1], dtChild.Columns[2] });
 
@@ -240,16 +227,11 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public void ctor_DataColumnPrimary()
+        public void Ctor_DataColumnPrimary()
         {
             DataTable dtParent = DataProvider.CreateParentDataTable();
-
-            UniqueConstraint uc = null;
-            uc = new UniqueConstraint(dtParent.Columns[0], false);
+            UniqueConstraint uc = new UniqueConstraint(dtParent.Columns[0], false);
             dtParent.Constraints.Add(uc);
-
-            // Ctor
-            Assert.False(uc == null);
 
             // primary key 1
             Assert.Equal(0, dtParent.PrimaryKey.Length);
@@ -263,31 +245,21 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public void ctor_NameDataColumn()
+        public void Ctor_NameDataColumn()
         {
             DataTable dtParent = DataProvider.CreateParentDataTable();
-
-            UniqueConstraint uc = null;
-            uc = new UniqueConstraint("myConstraint", dtParent.Columns[0]);
-
-            // Ctor
-            Assert.False(uc == null);
+            UniqueConstraint uc = new UniqueConstraint("myConstraint", dtParent.Columns[0]);
 
             // Ctor name
             Assert.Equal("myConstraint", uc.ConstraintName);
         }
 
         [Fact]
-        public void ctor_NameDataColumnPrimary()
+        public void Ctor_NameDataColumnPrimary()
         {
             DataTable dtParent = DataProvider.CreateParentDataTable();
-
-            UniqueConstraint uc = null;
-            uc = new UniqueConstraint("myConstraint", dtParent.Columns[0], false);
+            UniqueConstraint uc = new UniqueConstraint("myConstraint", dtParent.Columns[0], false);
             dtParent.Constraints.Add(uc);
-
-            // Ctor
-            Assert.False(uc == null);
 
             // primary key 1
             Assert.Equal(0, dtParent.PrimaryKey.Length);
@@ -307,31 +279,22 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public void ctor_NameDataColumns()
+        public void Ctor_NameDataColumns()
         {
             DataTable dtParent = DataProvider.CreateParentDataTable();
 
-            UniqueConstraint uc = null;
-            uc = new UniqueConstraint("myConstraint", new DataColumn[] { dtParent.Columns[0], dtParent.Columns[1] });
-
-            // Ctor
-            Assert.False(uc == null);
+            UniqueConstraint uc = new UniqueConstraint("myConstraint", new DataColumn[] { dtParent.Columns[0], dtParent.Columns[1] });
 
             // Ctor name
             Assert.Equal("myConstraint", uc.ConstraintName);
         }
 
         [Fact]
-        public void ctor_NameDataColumnsPrimary()
+        public void Ctor_NameDataColumnsPrimary()
         {
             DataTable dtParent = DataProvider.CreateParentDataTable();
-
-            UniqueConstraint uc = null;
-            uc = new UniqueConstraint("myConstraint", new DataColumn[] { dtParent.Columns[0] }, false);
+            UniqueConstraint uc = new UniqueConstraint("myConstraint", new DataColumn[] { dtParent.Columns[0] }, false);
             dtParent.Constraints.Add(uc);
-
-            // Ctor
-            Assert.False(uc == null);
 
             // primary key 1
             Assert.Equal(0, dtParent.PrimaryKey.Length);
@@ -351,7 +314,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
-        public void extendedProperties()
+        public void ExtendedProperties()
         {
             DataTable dtParent = DataProvider.CreateParentDataTable();
 
@@ -359,8 +322,8 @@ namespace System.Data.Tests
             uc = new UniqueConstraint(dtParent.Columns[0]);
             PropertyCollection pc = uc.ExtendedProperties;
 
-            // Checking ExtendedProperties default
-            Assert.True(pc != null);
+            // Checking ExtendedProperties default 
+            Assert.NotNull(pc);
 
             // Checking ExtendedProperties count
             Assert.Equal(0, pc.Count);

--- a/src/System.Data.Common/tests/System/Data/XmlDataReaderTest.cs
+++ b/src/System.Data.Common/tests/System/Data/XmlDataReaderTest.cs
@@ -259,8 +259,6 @@ namespace System.Data.Tests
         [Serializable]
         public class CustomTypeXml : IXmlSerializable
         {
-            private XmlNode _mFuncXmlNode;
-
             #region Constructors
             public CustomTypeXml()
             {
@@ -270,45 +268,33 @@ namespace System.Data.Tests
             {
                 XmlDocument doc = new XmlDocument();
                 doc.LoadXml(str);
-                _mFuncXmlNode = doc.DocumentElement;
+                Node = doc.DocumentElement;
             }
 
             public CustomTypeXml(XmlNode xNode)
             {
-                _mFuncXmlNode = xNode;
+                Node = xNode;
             }
             #endregion
 
-            #region Node (set/get)
-            public XmlNode Node
-            {
-                get
-                {
-                    return _mFuncXmlNode;
-                }
-                set
-                {
-                    _mFuncXmlNode = value;
-                }
-            }
-            #endregion
-            #region ToString
+            public XmlNode Node { get; set; }
+
             public override string ToString()
             {
                 return Node.OuterXml;
             }
-            #endregion
 
             /* IXmlSerializable overrides */
             #region WriteXml
             void IXmlSerializable.WriteXml(XmlWriter writer)
             {
                 XmlDocument doc = new XmlDocument();
-                doc.LoadXml(_mFuncXmlNode.OuterXml);
+                doc.LoadXml(Node.OuterXml);
 
                 // On function level
                 if (doc.DocumentElement.Name == "Func")
                 {
+                    //TODO: what
                     try { doc.DocumentElement.Attributes.Remove(doc.DocumentElement.Attributes["ReturnType"]); }
                     catch { }
                     try { doc.DocumentElement.Attributes.Remove(doc.DocumentElement.Attributes["ReturnTId"]); }
@@ -335,6 +321,7 @@ namespace System.Data.Tests
             {
                 XmlDocument doc = new XmlDocument();
                 string str = reader.ReadString();
+                //TODO: what
                 try
                 {
                     doc.LoadXml(str);
@@ -343,7 +330,7 @@ namespace System.Data.Tests
                 {
                     doc.LoadXml(reader.ReadOuterXml());
                 }
-                _mFuncXmlNode = doc.DocumentElement;
+                Node = doc.DocumentElement;
             }
             #endregion
             #region GetSchema
@@ -357,6 +344,7 @@ namespace System.Data.Tests
             #region private UpgradeSchema
             private void UpgradeSchema(XmlNode xNode)
             {
+                //TODO: what
                 // Attribute removals (cleanup)
                 try { xNode.Attributes.Remove(xNode.Attributes["TId"]); }
                 catch { }
@@ -370,6 +358,7 @@ namespace System.Data.Tests
                 catch { }
 
                 // Attribute removals (order)
+                //TODO: what
                 try
                 {
                     XmlAttribute attr = xNode.Attributes["IsExpGetRef"];

--- a/src/System.Data.Common/tests/System/Data/XmlDataReaderTest.cs
+++ b/src/System.Data.Common/tests/System/Data/XmlDataReaderTest.cs
@@ -294,7 +294,6 @@ namespace System.Data.Tests
                 // On function level
                 if (doc.DocumentElement.Name == "Func")
                 {
-                    //TODO: what
                     try { doc.DocumentElement.Attributes.Remove(doc.DocumentElement.Attributes["ReturnType"]); }
                     catch { }
                     try { doc.DocumentElement.Attributes.Remove(doc.DocumentElement.Attributes["ReturnTId"]); }
@@ -321,7 +320,6 @@ namespace System.Data.Tests
             {
                 XmlDocument doc = new XmlDocument();
                 string str = reader.ReadString();
-                //TODO: what
                 try
                 {
                     doc.LoadXml(str);
@@ -344,7 +342,6 @@ namespace System.Data.Tests
             #region private UpgradeSchema
             private void UpgradeSchema(XmlNode xNode)
             {
-                //TODO: what
                 // Attribute removals (cleanup)
                 try { xNode.Attributes.Remove(xNode.Attributes["TId"]); }
                 catch { }
@@ -358,7 +355,6 @@ namespace System.Data.Tests
                 catch { }
 
                 // Attribute removals (order)
-                //TODO: what
                 try
                 {
                     XmlAttribute attr = xNode.Attributes["IsExpGetRef"];

--- a/src/System.Data.Common/tests/System/Xml/XmlDataDocumentTests.cs
+++ b/src/System.Data.Common/tests/System/Xml/XmlDataDocumentTests.cs
@@ -31,7 +31,7 @@ namespace System.Xml.Tests
         public static void XmlDataDocument_CloneNode()
         {
             DataSet ds = Create();
-            DataRow dr = ds.Tables[0].Rows[0];
+            _ = ds.Tables[0].Rows[0];
             XmlDataDocument doc = new XmlDataDocument(ds);
             ds.EnforceConstraints = false;
 


### PR DESCRIPTION
Removing redundant tests, turning try-catches into Assert.Throws, cleaning up comments / using statements, casings and many more!

Left a lot of `//TODO`s to mark where attentions are needed. (Will be removed once I get feedbacks)
Main points:
* Should the exception messages be tested? there were a lot of commented out codes that were comparing the exception messages, which I presume is disabled because of localisations in .NET Framework.
* A few `FIXME` and 'Bug?` comments left here and there, what should we do about it?