### PR TITLE
[release/3.0] Rename OfflineBuild property to DotNetBuildOffline (#39926)

### DIFF
--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <!-- excluded from offline portion of source build -->
-  <ItemGroup Condition="'$(OfflineBuild)' != 'true'">
+  <ItemGroup Condition="'$(DotNetBuildOffline)' != 'true'">
     <!-- arcade -->
     <PackageReference Include="Microsoft.DotNet.GenAPI" Version="$(MicrosoftDotNetGenApiPackageVersion)" />
   </ItemGroup>

--- a/eng/notSupported.SourceBuild.targets
+++ b/eng/notSupported.SourceBuild.targets
@@ -1,24 +1,24 @@
-<Project InitialTargets="_RedefineNotSupportedSourceFile">
-
+<Project>
   <Target Name="_RedefineNotSupportedSourceFile"
+          BeforeTargets="BeforeCompile"
           Condition="'$(DotNetBuildFromSource)' == 'true' and
                      ('$(GeneratePlatformNotSupportedAssembly)' == 'true' or '$(GeneratePlatformNotSupportedAssemblyMessage)' != '')">
                      
     <Error Condition="'$(DotNetSourceBuildIntermediatePath)' == ''" 
            Text="'DotNetSourceBuildIntermediatePath' must be specified when 'DotNetBuildFromSource' is true" />
-           
+
     <PropertyGroup>
       <_notSupportedSourceDirectory>$([MSBuild]::NormalizeDirectory('$(DotNetSourceBuildIntermediatePath)', '$(MSBuildProjectName)', '$(TargetGroup)-$(OSGroup)'))</_notSupportedSourceDirectory>
       <NotSupportedSourceFile>$(_notSupportedSourceDirectory)$(TargetName).notsupported.cs</NotSupportedSourceFile>
     </PropertyGroup>
+
+    <MakeDir Condition="'$(DotNetBuildOffline)' != 'true'" Directories="$(_notSupportedSourceDirectory)" />
     
-    <MakeDir Condition="'$(OfflineBuild)' != 'true'" Directories="$(_notSupportedSourceDirectory)" />
-    
-    <Error Condition="'$(OfflineBuild)' == 'true' AND !Exists('$(NotSupportedSourceFile)')"
+    <Error Condition="'$(DotNetBuildOffline)' == 'true' AND !Exists('$(NotSupportedSourceFile)')"
            Text="Error NotSupportedSourceFile '$(NotSupportedSourceFile)' did not exist under DotNetSourceBuildIntermediatePath." />
-    
-    <!-- OfflineBuild == true, don't use GenAPI and include source from DotNetSourceBuildIntermediatePath -->  
-    <ItemGroup Condition="'$(OfflineBuild)' == 'true'">
+
+    <!-- DotNetBuildOffline == true, don't use GenAPI and include source from DotNetSourceBuildIntermediatePath -->  
+    <ItemGroup Condition="'$(DotNetBuildOffline)' == 'true'">
       <Compile Include="$(NotSupportedSourceFile)" />
     </ItemGroup>
   </Target>


### PR DESCRIPTION
* Rename OfflineBuild property to DotNetBuildOffline

* Change sequencing of _RedefineNotSupportedSourceFile

When running as an initial target _RedefineNotSupportedSourceFile would
run too many times, as currently the config system will evaluate projects
under the parent project's Configuration.