### PR TITLE
Use non-virtual IsAuthenticated internal to SslStream

### DIFF
--- a/src/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -452,22 +452,31 @@ namespace System.Net.Security
                 this);
         #endregion
 
-        public override bool IsAuthenticated => _context != null && _context.IsValidContext && _exception == null && _handshakeCompleted;
+        private bool IsAuthenticatedCore
+        {
+            get
+            {
+                SecureChannel context = _context;
+                return context != null && context.IsValidContext && _exception == null && _handshakeCompleted;
+            }
+        }
+
+        public override bool IsAuthenticated => IsAuthenticatedCore;
 
         public override bool IsMutuallyAuthenticated
         {
             get
             {
                 return
-                    IsAuthenticated &&
+                    IsAuthenticatedCore &&
                     (_context.IsServer ? _context.LocalServerCertificate : _context.LocalClientCertificate) != null &&
                     _context.IsRemoteCertificateAvailable; /* does not work: Context.IsMutualAuthFlag;*/
             }
         }
 
-        public override bool IsEncrypted => IsAuthenticated;
+        public override bool IsEncrypted => IsAuthenticatedCore;
 
-        public override bool IsSigned => IsAuthenticated;
+        public override bool IsSigned => IsAuthenticatedCore;
 
         public override bool IsServer => _context != null && _context.IsServer;
 
@@ -649,11 +658,11 @@ namespace System.Net.Security
         //
         public override bool CanSeek => false;
 
-        public override bool CanRead => IsAuthenticated && InnerStream.CanRead;
+        public override bool CanRead => IsAuthenticatedCore && InnerStream.CanRead;
 
         public override bool CanTimeout => InnerStream.CanTimeout;
 
-        public override bool CanWrite => IsAuthenticated && InnerStream.CanWrite && !_shutdown;
+        public override bool CanWrite => IsAuthenticatedCore && InnerStream.CanWrite && !_shutdown;
 
         public override int ReadTimeout
         {
@@ -849,7 +858,7 @@ namespace System.Net.Security
         {
             ThrowIfExceptional();
 
-            if (!IsAuthenticated)
+            if (!IsAuthenticatedCore)
             {
                 ThrowNotAuthenticated();
             }
@@ -860,7 +869,7 @@ namespace System.Net.Security
         {
             ThrowIfExceptional();
 
-            if (!IsAuthenticated)
+            if (!IsAuthenticatedCore)
             {
                 ThrowNotAuthenticated();
             }


### PR DESCRIPTION
It gets called a lot

![image](https://user-images.githubusercontent.com/1142958/62402685-cd850900-b580-11e9-92a2-cdd47aa96908.png)

I was trying to workout why it didn't inline, and its because its an virtual override. So use a concrete method internal to SslStream rather than virtual method so improve the performance of the high number of calls.

/cc @stephentoub @davidsh 