### PR TITLE
Validate the algorithmParameters value in Pkcs8PrivateKeyInfo..ctor

### DIFF
--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs8PrivateKeyInfo.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs8PrivateKeyInfo.cs
@@ -25,6 +25,14 @@ namespace System.Security.Cryptography.Pkcs
             if (algorithmId == null)
                 throw new ArgumentNullException(nameof(algorithmId));
 
+            if (algorithmParameters?.Length > 0)
+            {
+                // Read to ensure that there is precisely one legally encoded value.
+                AsnReader reader = new AsnReader(algorithmParameters.Value, AsnEncodingRules.BER);
+                reader.ReadEncodedValue();
+                reader.ThrowIfNotEmpty();
+            }
+
             AlgorithmId = algorithmId;
             AlgorithmParameters = skipCopies ? algorithmParameters : algorithmParameters?.ToArray();
             PrivateKeyBytes = skipCopies ? privateKey : privateKey.ToArray();


### PR DESCRIPTION
If the algorithmParameters value is not null, empty, or a single BER value then
the Encode method will throw an ArgumentException, despite not taking any
arguments.

Rather than let the exception be confusing and run late, catch it in the
constructor (throwing the same CryptographicException as other ctors in this
namespace that expect a single BER value parameter).

Found during docs writing.

(After merge I'll open a 3.0 version of the change to get it as a Preview break instead of a v2v break).