### PR TITLE
[release/3.0] HTTP2: Fix exceptions thrown from SendHeadersAsync to be consistent

### DIFF
--- a/src/System.Net.Http/src/Resources/Strings.resx
+++ b/src/System.Net.Http/src/Resources/Strings.resx
@@ -522,4 +522,7 @@
   <data name="net_http_disposed_while_in_use" xml:space="preserve">
     <value>The object was disposed while operations were in progress.</value>
   </data>
+  <data name="net_http_server_shutdown" xml:space="preserve">
+    <value>The server shut down the connection.</value>
+  </data>
 </root>


### PR DESCRIPTION
Port #39985 to 3.0
Fixes #39966

**Description**
This ensures we have consistent and correct exception behavior when the server initiates a shutdown  or the connection fails while we are trying to issue new requests on the connection.

**Customer Impact**
Previously, unprocessed requests could be incorrectly failed in this case; now they will be correctly retried on a new connection.
Previously, customers could see an HttpRequestException with no message in the rare case that shutdown occurs before processing any requests (either server-initiated or caused by failure like a bad HTTP2 handshake). Now customers will receive an appropriate exception message in this case.

**Regression?**
No

**Risk**
Low

@danmosemsft 