### PR TITLE
Port Microsoft.VisualBasic.MyServices.Internal.ContextValue(Of T)

### DIFF
--- a/src/Microsoft.VisualBasic.Core/ref/Microsoft.VisualBasic.Core.cs
+++ b/src/Microsoft.VisualBasic.Core/ref/Microsoft.VisualBasic.Core.cs
@@ -1470,3 +1470,12 @@ namespace Microsoft.VisualBasic.MyServices
         public string Temp { get { throw null; } }
     }
 }
+namespace Microsoft.VisualBasic.MyServices.Internal
+{
+    [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+    public partial class ContextValue<T>
+    {
+        public ContextValue() { }
+        public T Value { get { throw null; } set { } }
+    }
+}

--- a/src/Microsoft.VisualBasic.Core/src/Microsoft.VisualBasic.Core.vbproj
+++ b/src/Microsoft.VisualBasic.Core/src/Microsoft.VisualBasic.Core.vbproj
@@ -112,6 +112,7 @@
     <Compile Include="Microsoft\VisualBasic\MyGroupCollectionAttribute.vb" />
     <Compile Include="Microsoft\VisualBasic\MyServices\ClipboardProxy.vb" />
     <Compile Include="Microsoft\VisualBasic\MyServices\FileSystemProxy.vb" />
+    <Compile Include="Microsoft\VisualBasic\MyServices\Internal\ContextValue.vb" />
     <Compile Include="Microsoft\VisualBasic\MyServices\RegistryProxy.vb" />
     <Compile Include="Microsoft\VisualBasic\MyServices\SpecialDirectoriesProxy.vb" />
     <Compile Include="Microsoft\VisualBasic\Strings.vb" />

--- a/src/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/MyServices/Internal/ContextValue.vb
+++ b/src/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/MyServices/Internal/ContextValue.vb
@@ -1,0 +1,115 @@
+' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Option Explicit On
+Option Strict Off
+
+Imports System.Collections
+Imports System.Collections.Generic
+Imports System.Threading
+
+Namespace Microsoft.VisualBasic.MyServices.Internal
+
+    '''**************************************************************************
+    ''' ;SkuSafeHttpContext
+    ''' <summary>
+    ''' Returns the current HTTPContext or nothing if we are not running in a 
+    ''' web context.
+    ''' </summary>
+    ''' <remarks>
+    ''' With the FX dividing into Client and Full skus, we may not always have
+    ''' access to the System.Web types.  So we have to test for the presence
+    ''' of System.Web.Httpcontext before trying to access it.
+    ''' </remarks>
+    <Global.System.ComponentModel.EditorBrowsableAttribute(Global.System.ComponentModel.EditorBrowsableState.Never)>
+    Friend Class SkuSafeHttpContext
+        Public Shared ReadOnly Property Current() As Object
+            Get
+                'Return the equivalent of System.Web.HttpContext.Current
+                If m_HttpContextCurrent IsNot Nothing Then
+                    Return m_HttpContextCurrent.GetValue(Nothing, Nothing)
+                Else
+                    Return Nothing
+                End If
+            End Get
+        End Property
+
+        '''**************************************************************************
+        ''' ;InitContext
+        ''' <summary>
+        ''' Initialize the field that holds the type that allows us to access
+        ''' System.Web.HttpContext
+        ''' </summary>
+        Private Shared Function InitContext() As System.Reflection.PropertyInfo
+            Dim HttpContextType As System.Type
+            HttpContextType = System.Type.GetType("System.Web.HttpContext,System.Web,Version=0.0.0.0,Culture=neutral,PublicKeyToken=B03F5F7F11D50A3A")
+
+            If HttpContextType IsNot Nothing Then
+                Return HttpContextType.GetProperty("Current")
+            Else
+                Return Nothing
+            End If
+        End Function
+
+        'This class isn't meant to be constructed.
+        Private Sub New()
+        End Sub
+
+        Private Shared m_HttpContextCurrent As System.Reflection.PropertyInfo = InitContext()
+    End Class
+
+    '''**************************************************************************
+    ''' ;ContextValue
+    ''' <summary>
+    ''' Stores an object in a context appropriate for the environment we are 
+    ''' running in (web/windows)
+    ''' </summary>
+    ''' <typeparam name="T"></typeparam>
+    ''' <remarks>
+    ''' "Thread appropriate" means that if we are running on ASP.Net the object will be stored in the 
+    ''' context of the current request (meaning the object is stored per request on the web).  Otherwise, 
+    ''' the object is stored per CallContext.  Note that an instance of this class can only be associated
+    ''' with the one item to be stored/retrieved at a time.
+    ''' </remarks>
+    <Global.System.ComponentModel.EditorBrowsableAttribute(Global.System.ComponentModel.EditorBrowsableState.Never)>
+    Public Class ContextValue(Of T)
+        Public Sub New()
+            m_ContextKey = System.Guid.NewGuid.ToString
+        End Sub
+
+        '''**************************************************************************
+        ''' ;Value
+        ''' <summary>
+        ''' Get the object from the correct thread-appropriate location
+        ''' </summary>
+        ''' <value></value>
+        Public Property Value() As T 'No Synclocks required because we are operating upon instance data and the object is not shared across threads
+            Get
+                Dim items As IDictionary = GetDictionary()
+                Return DirectCast(items(m_ContextKey), T) 'Note, IDictionary(key) can return Nothing and that's ok
+            End Get
+            Set(ByVal value As T)
+                Dim items As IDictionary = GetDictionary()
+                items(m_ContextKey) = value
+            End Set
+        End Property
+
+        Private Shared Function GetDictionary() As IDictionary
+            Dim context = SkuSafeHttpContext.Current()
+            If context IsNot Nothing Then
+                Return context.Items
+            End If
+            If s_ThreadLocal Is Nothing Then
+                Interlocked.CompareExchange(s_ThreadLocal, New ThreadLocal(Of IDictionary)(Function() New Dictionary(Of String, T)), Nothing)
+            End If
+            Return s_ThreadLocal.Value
+        End Function
+
+        Private ReadOnly m_ContextKey As String 'An item is stored in the dictionary by a guid which this string maintains
+
+        Private Shared s_ThreadLocal As ThreadLocal(Of IDictionary)
+
+    End Class 'ContextValue
+
+End Namespace

--- a/src/Microsoft.VisualBasic.Core/tests/Microsoft.VisualBasic.Core.Tests.csproj
+++ b/src/Microsoft.VisualBasic.Core/tests/Microsoft.VisualBasic.Core.Tests.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Microsoft\VisualBasic\HideModuleNameAttributeTests.cs" />
     <Compile Include="Microsoft\VisualBasic\MyGroupCollectionAttributeTests.cs" />
     <Compile Include="Microsoft\VisualBasic\MyServices\FileSystemProxyTests.cs" />
+    <Compile Include="Microsoft\VisualBasic\MyServices\Internal\ContextValueTests.cs" />
     <Compile Include="Microsoft\VisualBasic\MyServices\SpecialDirectoriesProxyTests.cs" />
     <Compile Include="Microsoft\VisualBasic\VBFixedArrayAttributeTests.cs" />
     <Compile Include="Microsoft\VisualBasic\VBFixedStringAttributeTests.cs" />

--- a/src/Microsoft.VisualBasic.Core/tests/Microsoft/VisualBasic/MyServices/Internal/ContextValueTests.cs
+++ b/src/Microsoft.VisualBasic.Core/tests/Microsoft/VisualBasic/MyServices/Internal/ContextValueTests.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.VisualBasic.MyServices.Internal;
+using System;
+using System.Threading;
+using Xunit;
+
+namespace Microsoft.VisualBasic.MyServices.Internal.Tests
+{
+    public class ContextValueTests
+    {
+        [Fact]
+        public void NoValue()
+        {
+            Assert.Equal(null, (new ContextValue<string>()).Value);
+            Assert.Throws<NullReferenceException>(() => (new ContextValue<int>()).Value);
+        }
+
+        [Fact]
+        public void MultipleInstances()
+        {
+            var context1 = new ContextValue<int>();
+            context1.Value = 1;
+            var context2 = new ContextValue<int>();
+            context2.Value = 2;
+            Assert.Equal(1, context1.Value);
+            Assert.Equal(2, context2.Value);
+        }
+
+        [Fact]
+        public void MultipleThreads()
+        {
+            var context = new ContextValue<string>();
+            context.Value = "Hello";
+            var thread = new Thread(() =>
+            {
+                Assert.Equal(null, context.Value);
+                context.Value = "World";
+                Assert.Equal("World", context.Value);
+            });
+            thread.Start();
+            thread.Join();
+            Assert.Equal("Hello", context.Value);
+        }
+    }
+}


### PR DESCRIPTION
Port Microsoft.VisualBasic.MyServices.Internal.ContextValue(Of T) from https://github.com/Microsoft/referencesource/tree/master/Microsoft.VisualBasic/runtime/msvbalib.

Note: The implementation here uses `ThreadLocal(Of IDictionary)` rather than `System.Runtime.Remoting.Messaging.CallContext` when not executing in ASP.NET because `System.Runtime.Remoting` is not available on .NET Core.

Fixes #40012
