### PR TITLE
Fix DynamicTable.Resize failing when it grows the table.

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/DynamicTable.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/DynamicTable.cs
@@ -98,12 +98,11 @@ namespace System.Net.Http.HPack
             while (_count > 0 && _maxSize - _size < available)
             {
                 ref HeaderField field = ref _buffer[_removeIndex];
-
                 _size -= field.Length;
+                field = default;
+
                 _count--;
                 _removeIndex = (_removeIndex + 1) % _buffer.Length;
-
-                field = default;
             }
         }
     }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/DynamicTable.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/DynamicTable.cs
@@ -75,12 +75,15 @@ namespace System.Net.Http.HPack
             {
                 var newBuffer = new HeaderField[maxSize / HeaderField.RfcOverhead];
 
-                for (var i = 0; i < Count; i++)
-                {
-                    newBuffer[i] = _buffer[i];
-                }
+                int headCount = Math.Min(_buffer.Length - _removeIndex, _count);
+                int tailCount = _count - headCount;
+
+                Array.Copy(_buffer, _removeIndex, newBuffer, 0, headCount);
+                Array.Copy(_buffer, 0, newBuffer, headCount, tailCount);
 
                 _buffer = newBuffer;
+                _removeIndex = 0;
+                _insertIndex = _count;
                 _maxSize = maxSize;
             }
             else
@@ -94,9 +97,13 @@ namespace System.Net.Http.HPack
         {
             while (_count > 0 && _maxSize - _size < available)
             {
-                _size -= _buffer[_removeIndex].Length;
+                ref HeaderField field = ref _buffer[_removeIndex];
+
+                _size -= field.Length;
                 _count--;
                 _removeIndex = (_removeIndex + 1) % _buffer.Length;
+
+                field = default;
             }
         }
     }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HeaderField.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HeaderField.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 // See THIRD-PARTY-NOTICES.TXT in the project root for license information.
 
+using System.Diagnostics;
 using System.Text;
 
 namespace System.Net.Http.HPack
@@ -13,6 +14,8 @@ namespace System.Net.Http.HPack
 
         public HeaderField(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
         {
+            Debug.Assert(name.Length > 0);
+
             // TODO: We're allocating here on every new table entry.
             // That means a poorly-behaved server could cause us to allocate repeatedly.
             // We should revisit our allocation strategy here so we don't need to allocate per entry
@@ -35,9 +38,9 @@ namespace System.Net.Http.HPack
 
         public override string ToString()
         {
-            if (Name?.Length > 0)
+            if (Name != null)
             {
-                return Encoding.ASCII.GetString(Name) + ": " + Encoding.ASCII.GetString(Value ?? Array.Empty<byte>());
+                return Encoding.ASCII.GetString(Name) + ": " + Encoding.ASCII.GetString(Value);
             }
             else
             {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HeaderField.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HeaderField.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0.
 // See THIRD-PARTY-NOTICES.TXT in the project root for license information.
 
+using System.Text;
+
 namespace System.Net.Http.HPack
 {
     internal struct HeaderField
@@ -30,5 +32,17 @@ namespace System.Net.Http.HPack
         public int Length => GetLength(Name.Length, Value.Length);
 
         public static int GetLength(int nameLength, int valueLenth) => nameLength + valueLenth + RfcOverhead;
+
+        public override string ToString()
+        {
+            if (Name?.Length > 0)
+            {
+                return Encoding.ASCII.GetString(Name) + ": " + Encoding.ASCII.GetString(Value ?? Array.Empty<byte>());
+            }
+            else
+            {
+                return "<empty>";
+            }
+        }
     }
 }

--- a/src/System.Net.Http/tests/UnitTests/HPack/DynamicTableTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/HPack/DynamicTableTest.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Net.Http.HPack;
 using System.Reflection;
 using System.Text;
@@ -53,6 +55,58 @@ namespace System.Net.Http.Unit.Tests.HPack
 
                 Assert.True(expectedData.AsSpan().SequenceEqual(dynamicField.Name));
                 Assert.True(expectedData.AsSpan().SequenceEqual(dynamicField.Value));
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(CreateResizeData))]
+        public void DynamicTable_Resize_Success(int initialMaxSize, int finalMaxSize, int insertSize)
+        {
+            // This is purely to make it simple to perfectly reach 256 inserted bytes (our initial maxSize).
+            Debug.Assert((insertSize % 64) == 0, $"{nameof(insertSize)} must be a multiple of 64 ({nameof(HeaderField)}.{nameof(HeaderField.RfcOverhead)} * 2)");
+
+            var dynamicTable = new DynamicTable(maxSize: initialMaxSize);
+            int insertedSize = 0;
+
+            while (insertedSize != insertSize)
+            {
+                byte[] data = Encoding.ASCII.GetBytes($"header-{dynamicTable.Size}".PadRight(16, ' '));
+                Debug.Assert(data.Length == 16);
+
+                dynamicTable.Insert(data, data);
+                insertedSize += data.Length * 2 + HeaderField.RfcOverhead;
+            }
+
+            List<HeaderField> headers = new List<HeaderField>();
+
+            for (int i = 0; i < dynamicTable.Count; ++i)
+            {
+                headers.Add(dynamicTable[i]);
+            }
+
+            dynamicTable.Resize(finalMaxSize);
+
+            int expectedCount = Math.Min(finalMaxSize / 64, headers.Count);
+            Assert.Equal(expectedCount, dynamicTable.Count);
+
+            for (int i = 0; i < dynamicTable.Count; ++i)
+            {
+                Assert.True(headers[i].Name.AsSpan().SequenceEqual(dynamicTable[i].Name));
+                Assert.True(headers[i].Value.AsSpan().SequenceEqual(dynamicTable[i].Value));
+            }
+        }
+
+        public static IEnumerable<object[]> CreateResizeData()
+        {
+            for (int initialMaxSize = 128; initialMaxSize <= 512; initialMaxSize += 128)
+            {
+                for (int finalMaxSize = 128; finalMaxSize <= 512; finalMaxSize += 128)
+                {
+                    for (int insertSize = 128; insertSize <= 512; insertSize += 128)
+                    {
+                        yield return new object[] { initialMaxSize, finalMaxSize, insertSize };
+                    }
+                }
             }
         }
     }

--- a/src/System.Net.Http/tests/UnitTests/HPack/DynamicTableTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/HPack/DynamicTableTest.cs
@@ -62,7 +62,7 @@ namespace System.Net.Http.Unit.Tests.HPack
         [MemberData(nameof(CreateResizeData))]
         public void DynamicTable_Resize_Success(int initialMaxSize, int finalMaxSize, int insertSize)
         {
-            // This is purely to make it simple to perfectly reach 256 inserted bytes (our initial maxSize).
+            // This is purely to make it simple to perfectly reach our initial max size to test growing a full but non-wrapping buffer.
             Debug.Assert((insertSize % 64) == 0, $"{nameof(insertSize)} must be a multiple of 64 ({nameof(HeaderField)}.{nameof(HeaderField.RfcOverhead)} * 2)");
 
             var dynamicTable = new DynamicTable(maxSize: initialMaxSize);

--- a/src/System.Net.Http/tests/UnitTests/HPack/DynamicTableTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/HPack/DynamicTableTest.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Net.Http.HPack;
 using System.Reflection;
 using System.Text;
+using System.Linq;
 using Xunit;
 
 namespace System.Net.Http.Unit.Tests.HPack
@@ -98,16 +99,11 @@ namespace System.Net.Http.Unit.Tests.HPack
 
         public static IEnumerable<object[]> CreateResizeData()
         {
-            for (int initialMaxSize = 128; initialMaxSize <= 512; initialMaxSize += 128)
-            {
-                for (int finalMaxSize = 128; finalMaxSize <= 512; finalMaxSize += 128)
-                {
-                    for (int insertSize = 128; insertSize <= 512; insertSize += 128)
-                    {
-                        yield return new object[] { initialMaxSize, finalMaxSize, insertSize };
-                    }
-                }
-            }
+            var values = new[] { 128, 256, 384, 512 };
+            return from initialMaxSize in values
+                   from finalMaxSize in values
+                   from insertSize in values
+                   select new object[] { initialMaxSize, finalMaxSize, insertSize };
         }
     }
 }


### PR DESCRIPTION
Fixes DynamicTable.Resize failing when it grows. It was not handling the case when the insert index wrapped the ring buffer. Resolves #39967
Updates DynamicTable.EnsureAvailable to null out unused headers. Allows earlier GC, but mainly helps debugging.
Add HeaderField.ToString() to assist with debugging.