### PR TITLE
[release/3.0] HTTP/2 - fix HPACK decoder failing inconsistently with 0-length header names

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackDecoder.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackDecoder.cs
@@ -249,6 +249,11 @@ namespace System.Net.Http.HPack
 
                         if (_integerDecoder.StartDecode((byte)(b & ~HuffmanMask), StringLengthPrefix))
                         {
+                            if (_integerDecoder.Value == 0)
+                            {
+                                throw new HPackDecodingException(SR.Format(SR.net_http_invalid_response_header_name, ""));
+                            }
+
                             OnStringLength(_integerDecoder.Value, nextState: State.HeaderName);
                         }
                         else

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Headers.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Headers.cs
@@ -265,5 +265,23 @@ namespace System.Net.Http.Functional.Tests
                 await Assert.ThrowsAsync<HttpRequestException>(() => client.SendAsync(m));
             }
         }
+
+        [Fact]
+        public async Task SendAsync_WithZeroLengthHeaderName_Throws()
+        {
+            await LoopbackServerFactory.CreateClientAndServerAsync(
+                async uri =>
+                {
+                    using HttpClient client = CreateHttpClient();
+                    await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(uri));
+                },
+                async server =>
+                {
+                    await server.HandleRequestAsync(headers: new[]
+                    {
+                        new HttpHeaderData("", "foo")
+                    });
+                });
+        }
     }
 }


### PR DESCRIPTION
This is port of #39907 to 3.0 release branch.
fixes #39873

## Description

A server sending 0-length header names will cause the client to read up to around MaxResponseHeadersLength bytes from header blocks, eventually ending with an exception when it reads too much data or reaches end of headers.
Fix is to throw an exception immediately rather than waiting for it to domino into one of those other failures.

## Customer Impact

A user explicitly increasing MaxResponseHeadersLength against an incorrectly implemented server may read more data than necessary before closing with a protocol error.

No demonstrated vulnerability without the fix, but uneasy enough about it that we want it in.

## Regression?

No

## Risk

The scope is specific to HTTP2 and covers specific invalid behavior. A single `if` added to check for invalid input.