### PR TITLE
Enable partial package build during source build

### DIFF
--- a/eng/Packaging.props
+++ b/eng/Packaging.props
@@ -31,6 +31,19 @@
     <SkipGenerationCheck>true</SkipGenerationCheck>
     <SkipIndexCheck>true</SkipIndexCheck>
   </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
+    <!-- Don't build referenced projects -->
+    <BuildPackageLibraryReferences>false</BuildPackageLibraryReferences>
+    <!-- Omit any files that were not built -->
+    <AllowPartialPackages>true</AllowPartialPackages>
+    <!-- Don't permit harvesting since this requires pre-builts -->
+    <HarvestStablePackage>false</HarvestStablePackage>
+    <!-- Validation will fail in case we were relying on harvested assets or assets not built to satisfy stated support -->
+    <SkipValidatePackage>true</SkipValidatePackage>
+    <!-- Include All BuildConfigurations in package, so that whatever we're building for source build is included -->
+    <PackageConfigurations>$(BuildConfigurations)</PackageConfigurations>
+  </PropertyGroup>
 
   <Import Condition="Exists('../pkg/baseline/baseline.props') AND '$(MSBuildProjectExtension)' == '.pkgproj'" Project="../pkg/baseline/baseline.props" />
 

--- a/eng/Packaging.targets
+++ b/eng/Packaging.targets
@@ -20,7 +20,11 @@
     </ItemGroup>    
   </Target>
 
-  <Target Name="ValidateExcludeCompileDesktop" AfterTargets="GetPackageDependencies" Inputs="%(Dependency.Identity);%(Dependency.TargetFramework)" Outputs="unused">
+  <Target Name="ValidateExcludeCompileDesktop"
+          AfterTargets="GetPackageDependencies"
+          Inputs="%(Dependency.Identity);%(Dependency.TargetFramework)" 
+          Outputs="unused"
+          Condition="'$(SkipValidatePackage)' != 'true'">
     <PropertyGroup>
       <_excludeCompile Condition="@(Dependency->WithMetadataValue('Exclude', 'Compile')->Count()) == @(Dependency->Count())">true</_excludeCompile>
     </PropertyGroup>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -1,11 +1,15 @@
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
 
-  <ItemGroup>
-    <Project Include="$(MSBuildThisFileDirectory)..\pkg\*\*.builds" Condition="'$(SkipManagedPackageBuild)' != 'true'">
+  <PropertyGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
+    <AdditionalBuildConfigurations>$(AdditionalBuildConfigurations);package-$(ConfigurationGroup)</AdditionalBuildConfigurations>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(SkipManagedPackageBuild)' != 'true'">
+    <Project Include="$(MSBuildThisFileDirectory)..\pkg\*\*.builds" >
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
-    <Project Include="*\pkg\**\*.pkgproj" Condition="'$(SkipManagedPackageBuild)' != 'true' AND '$(BuildAllConfigurations)' == 'true'">
+    <Project Include="*\pkg\**\*.pkgproj" Condition="'$(BuildAllConfigurations)' == 'true' OR '$(DotNetBuildFromSource)' == 'true'">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
   </ItemGroup>

--- a/src/src.builds
+++ b/src/src.builds
@@ -1,6 +1,10 @@
 <Project DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
 
+  <PropertyGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
+    <AdditionalBuildConfigurations>$(AdditionalBuildConfigurations);netstandard-$(ConfigurationGroup)</AdditionalBuildConfigurations>
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(DirectoryToBuild)' == ''">
     <Project Include="$(MSBuildThisFileDirectory)*\src\*.csproj" Exclude="@(ProjectExclusions)" />
     <Project Include="$(MSBuildThisFileDirectory)*\src\*.ilproj" Exclude="@(ProjectExclusions)" />


### PR DESCRIPTION
This turns on package build during source build and builds all the library packages.

Packages omit any library build that wasn't part of source build, and do so in a way that won't change nuget resolution.  We also include assets that might only build during source build (eg: a netcoreapp3.0 targeting library when the package might only contain a netcoreapp2.0 targeting version).

This should satisfy all up-stack dependencies for netcoreapp3.0 on corefx produced packages.

The SDK also has some dependencies on desktop assets that are not covered by this, due to the packages shipping a netstandard2.0 asset but having a "better" netcoreapp3.0 specific asset that will be built.  To ensure we build the netstandard asset I made sure that we build the best configurations for both netcoreapp and netstandard for all src projects.

Fixes #39787 #39793 