### PR TITLE
Disable some tests for Mono

### DIFF
--- a/src/System.Diagnostics.TraceSource/tests/SwitchClassTests.cs
+++ b/src/System.Diagnostics.TraceSource/tests/SwitchClassTests.cs
@@ -43,7 +43,7 @@ namespace System.Diagnostics.TraceSourceTests
             return new WeakReference(new TestSwitch());
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPreciseGcSupported))]
         public void PruneTest()
         {
             var strongSwitch = new TestSwitch();

--- a/src/System.IO.FileSystem/tests/FileStream/Dispose.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/Dispose.cs
@@ -150,7 +150,7 @@ namespace System.IO.Tests
             }).Dispose();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPreciseGcSupported))]
         public void Dispose_CallsVirtualDispose_TrueArg()
         {
             bool disposeInvoked = false;

--- a/src/System.Net.Sockets/tests/FunctionalTests/DisposedSocketTests.netcoreapp.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DisposedSocketTests.netcoreapp.cs
@@ -12,7 +12,7 @@ namespace System.Net.Sockets.Tests
 {
     public partial class DisposedSocket
     {
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsPreciseGcSupported))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task NonDisposedSocket_SafeHandlesCollected(bool clientAsync)

--- a/src/System.Threading.Overlapped/tests/OverlappedTests.cs
+++ b/src/System.Threading.Overlapped/tests/OverlappedTests.cs
@@ -43,7 +43,7 @@ public static partial class OverlappedTests
         Assert.Equal(0, obj.OffsetLow);
     }
 
-    [Fact]
+    [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.Is32BitProcess))]
     public static void PropertyTest2()
     {
         IAsyncResult asyncResult = new Task(() => Console.WriteLine("this is a dummy task"));


### PR DESCRIPTION
A few precise GC related (similar to https://github.com/dotnet/corefx/pull/39176)
And `PropertyTest2` uses a 32 bit ctor (fails on mono with OverflowException due to 64bit pointer in MRE.Handle + ToInt32)