### PR TITLE
Support cyclic types when using collections (#39936)

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/DefaultDerivedDictionaryConverter.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/DefaultDerivedDictionaryConverter.cs
@@ -11,7 +11,7 @@ namespace System.Text.Json.Serialization.Converters
         public override object CreateFromDictionary(ref ReadStack state, IDictionary sourceDictionary, JsonSerializerOptions options)
         {
             JsonPropertyInfo collectionPropertyInfo = state.Current.JsonPropertyInfo;
-            JsonPropertyInfo elementPropertyInfo = options.GetJsonPropertyInfoFromClassInfo(collectionPropertyInfo.ElementClassInfo, options);
+            JsonPropertyInfo elementPropertyInfo = options.GetJsonPropertyInfoFromClassInfo(collectionPropertyInfo.ElementType, options);
             return elementPropertyInfo.CreateDerivedDictionaryInstance(collectionPropertyInfo, sourceDictionary, state.JsonPath, options);
         }
     }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/DefaultDerivedEnumerableConverter.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/DefaultDerivedEnumerableConverter.cs
@@ -11,7 +11,7 @@ namespace System.Text.Json.Serialization.Converters
         public override IEnumerable CreateFromList(ref ReadStack state, IList sourceList, JsonSerializerOptions options)
         {
             JsonPropertyInfo collectionPropertyInfo = state.Current.JsonPropertyInfo;
-            JsonPropertyInfo elementPropertyInfo = options.GetJsonPropertyInfoFromClassInfo(collectionPropertyInfo.ElementClassInfo, options);
+            JsonPropertyInfo elementPropertyInfo = options.GetJsonPropertyInfoFromClassInfo(collectionPropertyInfo.ElementType, options);
             return elementPropertyInfo.CreateDerivedEnumerableInstance(collectionPropertyInfo, sourceList, state.JsonPath, options);
         }
     }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/DefaultICollectionConverter.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/DefaultICollectionConverter.cs
@@ -11,8 +11,8 @@ namespace System.Text.Json.Serialization.Converters
         public override IEnumerable CreateFromList(ref ReadStack state, IList sourceList, JsonSerializerOptions options)
         {
             Type enumerableType = state.Current.JsonPropertyInfo.RuntimePropertyType;
-            JsonClassInfo elementClassInfo = state.Current.JsonPropertyInfo.ElementClassInfo;
-            JsonPropertyInfo propertyInfo = options.GetJsonPropertyInfoFromClassInfo(elementClassInfo, options);
+            Type elementType = state.Current.JsonPropertyInfo.ElementType;
+            JsonPropertyInfo propertyInfo = options.GetJsonPropertyInfoFromClassInfo(elementType, options);
             return propertyInfo.CreateIEnumerableInstance(enumerableType, sourceList, state.JsonPath, options);
         }
     }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/DefaultIDictionaryConverter.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/DefaultIDictionaryConverter.cs
@@ -11,8 +11,8 @@ namespace System.Text.Json.Serialization.Converters
         public override object CreateFromDictionary(ref ReadStack state, IDictionary sourceDictionary, JsonSerializerOptions options)
         {
             Type dictionaryType = state.Current.JsonPropertyInfo.RuntimePropertyType;
-            JsonClassInfo elementClassInfo = state.Current.JsonPropertyInfo.ElementClassInfo;
-            JsonPropertyInfo propertyInfo = options.GetJsonPropertyInfoFromClassInfo(elementClassInfo, options);
+            Type elementType = state.Current.JsonPropertyInfo.ElementType;
+            JsonPropertyInfo propertyInfo = options.GetJsonPropertyInfoFromClassInfo(elementType, options);
             return propertyInfo.CreateIDictionaryInstance(dictionaryType, sourceDictionary, state.JsonPath, options);
         }
     }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/DefaultImmutableDictionaryConverter.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/DefaultImmutableDictionaryConverter.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections;
+using System.Diagnostics;
 
 namespace System.Text.Json.Serialization.Converters
 {
@@ -62,8 +63,7 @@ namespace System.Text.Json.Serialization.Converters
 
             string delegateKey = DefaultImmutableEnumerableConverter.GetDelegateKey(immutableCollectionType, elementType, out _, out _);
 
-            JsonClassInfo elementClassInfo = state.Current.JsonPropertyInfo.ElementClassInfo;
-            JsonPropertyInfo propertyInfo = options.GetJsonPropertyInfoFromClassInfo(elementClassInfo, options);
+            JsonPropertyInfo propertyInfo = options.GetJsonPropertyInfoFromClassInfo(elementType, options);
             return propertyInfo.CreateImmutableDictionaryInstance(immutableCollectionType, delegateKey, sourceDictionary, state.JsonPath, options);
         }
     }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/DefaultImmutableEnumerableConverter.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/DefaultImmutableEnumerableConverter.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections;
+using System.Diagnostics;
 
 namespace System.Text.Json.Serialization.Converters
 {
@@ -108,8 +109,7 @@ namespace System.Text.Json.Serialization.Converters
 
             string delegateKey = GetDelegateKey(immutableCollectionType, elementType, out _, out _);
 
-            JsonClassInfo elementClassInfo = state.Current.JsonPropertyInfo.ElementClassInfo;
-            JsonPropertyInfo propertyInfo = options.GetJsonPropertyInfoFromClassInfo(elementClassInfo, options);
+            JsonPropertyInfo propertyInfo = options.GetJsonPropertyInfoFromClassInfo(elementType, options);
             return propertyInfo.CreateImmutableCollectionInstance(immutableCollectionType, delegateKey, sourceList, state.JsonPath, options);
         }
     }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.AddProperty.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.AddProperty.cs
@@ -43,8 +43,7 @@ namespace System.Text.Json
             // Convert non-immutable dictionary interfaces to concrete types.
             if (IsNativelySupportedCollection(propertyType) && implementedType.IsInterface && jsonInfo.ClassType == ClassType.Dictionary)
             {
-                JsonClassInfo elementClassInfo = jsonInfo.ElementClassInfo;
-                JsonPropertyInfo elementPropertyInfo = options.GetJsonPropertyInfoFromClassInfo(elementClassInfo, options);
+                JsonPropertyInfo elementPropertyInfo = options.GetJsonPropertyInfoFromClassInfo(jsonInfo.ElementType, options);
 
                 Type newPropertyType = elementPropertyInfo.GetDictionaryConcreteType();
                 if (implementedType != newPropertyType)
@@ -60,8 +59,7 @@ namespace System.Text.Json
                 !implementedType.IsArray &&
                 ((IsDeserializedByAssigningFromList(implementedType) && IsNativelySupportedCollection(propertyType)) || IsSetInterface(implementedType)))
             {
-                JsonClassInfo elementClassInfo = jsonInfo.ElementClassInfo;
-                JsonPropertyInfo elementPropertyInfo = options.GetJsonPropertyInfoFromClassInfo(elementClassInfo, options);
+                JsonPropertyInfo elementPropertyInfo = options.GetJsonPropertyInfoFromClassInfo(jsonInfo.ElementType, options);
 
                 // Get a runtime type for the implemented property. e.g. ISet<T> -> HashSet<T>, ICollection -> List<object>
                 // We use the element's JsonPropertyInfo so we can utilize the generic support.

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -351,10 +351,8 @@ namespace System.Text.Json
             };
         }
 
-        internal JsonPropertyInfo GetJsonPropertyInfoFromClassInfo(JsonClassInfo classInfo, JsonSerializerOptions options)
+        internal JsonPropertyInfo GetJsonPropertyInfoFromClassInfo(Type objectType, JsonSerializerOptions options)
         {
-            Type objectType = classInfo.Type;
-
             if (!_objectJsonProperties.TryGetValue(objectType, out JsonPropertyInfo propertyInfo))
             {
                 propertyInfo = JsonClassInfo.CreateProperty(objectType, objectType, objectType, null, typeof(object), options);

--- a/src/System.Text.Json/tests/Serialization/CustomConverterTests.BadConverters.cs
+++ b/src/System.Text.Json/tests/Serialization/CustomConverterTests.BadConverters.cs
@@ -101,7 +101,7 @@ namespace System.Text.Json.Serialization.Tests
             InvalidOperationException ex;
 
             ex = Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(new InvalidTypeConverterClass()));
-            // Message should be in the form "The converter specified on 'System.Text.Json.Serialization.Tests.CustomConverterTests+InvalidTypeConverterClass.MyEnumValues' is not compatible with the type 'System.Collections.Generic.ICollection`1[System.Text.Json.Serialization.Tests.ExceptionTests+InvalidTypeConverterEnum]'."
+            // Message should be in the form "The converter specified on 'System.Text.Json.Serialization.Tests.CustomConverterTests+InvalidTypeConverterClass.MyEnumValues' is not compatible with the type 'System.Collections.Generic.ICollection`1[System.Text.Json.Serialization.Tests.CustomConverterTests+InvalidTypeConverterEnum]'."
             Assert.Contains("'System.Text.Json.Serialization.Tests.CustomConverterTests+InvalidTypeConverterClass.MyEnumValues'", ex.Message);
 
             ex = Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<InvalidTypeConverterClass>("{}"));


### PR DESCRIPTION
Port https://github.com/dotnet/corefx/commit/69df8abea7bd02fcaa47befb6f9722bf2908e6ac to 3.0

Issue https://github.com/dotnet/corefx/issues/39769.

cc: @ericstj, @danmosemsft

## Description

Prevents a `StackOverflowException` from occurring when serializing or deserializing an object graph that has type cycles in collection references, such as `IList<MyDependency>`.

Changes the behavior to not call `JsonSerializerOptions.JsonClassInfo GetOrAddClass(Type classType)` during the "warm-up" phase where metadata is being obtained for use with (de)serialization. Previously this was protected against `StackOverflowException` due to circular type references but not for collections (only for properties that returned an object directly).

## Customer Impact

This was _reported by a customer;_ unable to serialize circular object graphs in certain cases.

## Regression?

No; the code is new in 3.0.

## Risk

Low. The original repro was verified and additional tests added with no known issues.