### PR TITLE
Add Encode(Span<char>) API (#39900)

### DIFF
--- a/src/System.Text.Encodings.Web/ref/System.Text.Encodings.Web.cs
+++ b/src/System.Text.Encodings.Web/ref/System.Text.Encodings.Web.cs
@@ -32,6 +32,7 @@ namespace System.Text.Encodings.Web
         public virtual void Encode(System.IO.TextWriter output, char[] value, int startIndex, int characterCount) { }
         public void Encode(System.IO.TextWriter output, string value) { }
         public virtual void Encode(System.IO.TextWriter output, string value, int startIndex, int characterCount) { }
+        public virtual System.Buffers.OperationStatus Encode(System.ReadOnlySpan<char> source, System.Span<char> destination, out int charsConsumed, out int charsWritten, bool isFinalBlock = true) { throw null; }
         public virtual string Encode(string value) { throw null; }
         public virtual System.Buffers.OperationStatus EncodeUtf8(System.ReadOnlySpan<byte> utf8Source, System.Span<byte> utf8Destination, out int bytesConsumed, out int bytesWritten, bool isFinalBlock = true) { throw null; }
         [System.CLSCompliantAttribute(false)]

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/JavaScriptEncoder.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/JavaScriptEncoder.cs
@@ -119,6 +119,7 @@ namespace System.Text.Encodings.Web
             {
                 throw new ArgumentNullException(nameof(text));
             }
+
             return _allowedCharacters.FindFirstCharacterToEncode(text, textLength);
         }
 
@@ -160,7 +161,7 @@ namespace System.Text.Encodings.Web
 
             if (!WillEncode(unicodeScalar)) { return TryWriteScalarAsChar(unicodeScalar, buffer, bufferLength, out numberOfCharactersWritten); }
 
-            char[] toCopy = null;
+            char[] toCopy;
             switch (unicodeScalar)
             {
                 case '\b': toCopy = s_b; break;

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/TextEncoder.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/TextEncoder.cs
@@ -22,9 +22,12 @@ namespace System.Text.Encodings.Web
     public abstract class TextEncoder
     {
         // Fast cache for Ascii
-        private static readonly byte[] s_noEscape = new byte[] { }; // Should not be Array.Empty<byte> since used as a singleton for comparison.
         private byte[][] _asciiEscape = new byte[0x80][];
-        
+
+        // Keep a reference to Array.Empty<byte> as this is used as a singleton for comparisons
+        // and there is no guarantee that Array.Empty<byte>() will always be the same instance.
+        private static readonly byte[] s_noEscape = Array.Empty<byte>();
+
         // The following pragma disables a warning complaining about non-CLS compliant members being abstract, 
         // and wants me to mark the type as non-CLS compliant. 
         // It is true that this type cannot be extended by all CLS compliant languages. 
@@ -109,7 +112,12 @@ namespace System.Text.Encodings.Web
                     if (bufferSize < 1024)
                     {
                         char* wholebuffer = stackalloc char[bufferSize];
-                        int totalWritten = EncodeIntoBuffer(wholebuffer, bufferSize, valuePointer, value.Length, firstCharacterToEncode);
+                        OperationStatus status = EncodeIntoBuffer(wholebuffer, bufferSize, valuePointer, value.Length, out int _, out int totalWritten, firstCharacterToEncode);
+                        if (status != OperationStatus.Done)
+                        {
+                            ThrowArgumentException_MaxOutputCharsPerInputChar();
+                        }
+
                         result = new string(wholebuffer, 0, totalWritten);
                     }
                     else
@@ -117,7 +125,12 @@ namespace System.Text.Encodings.Web
                         char[] wholebuffer = new char[bufferSize];
                         fixed (char* buffer = &wholebuffer[0])
                         {
-                            int totalWritten = EncodeIntoBuffer(buffer, bufferSize, valuePointer, value.Length, firstCharacterToEncode);
+                            OperationStatus status = EncodeIntoBuffer(buffer, bufferSize, valuePointer, value.Length, out int _, out int totalWritten, firstCharacterToEncode);
+                            if (status != OperationStatus.Done)
+                            {
+                                ThrowArgumentException_MaxOutputCharsPerInputChar();
+                            }
+
                             result = new string(wholebuffer, 0, totalWritten);
                         }
                     }
@@ -127,12 +140,21 @@ namespace System.Text.Encodings.Web
             }
         }
 
-        // NOTE: The order of the parameters to this method is a work around for https://github.com/dotnet/corefx/issues/4455
-        // and the underlying Mono bug: https://bugzilla.xamarin.com/show_bug.cgi?id=36052.
-        // If changing the signature of this method, ensure this issue isn't regressing on Mono.
-        private unsafe int EncodeIntoBuffer(char* buffer, int bufferLength, char* value, int valueLength, int firstCharacterToEncode)
+        private unsafe OperationStatus EncodeIntoBuffer(
+            char* buffer,
+            int bufferLength,
+            char* value,
+            int valueLength,
+            out int charsConsumed,
+            out int charsWritten,
+            int firstCharacterToEncode,
+            bool isFinalBlock = true)
         {
-            int totalWritten = 0;
+            Debug.Assert(value != null);
+            Debug.Assert(firstCharacterToEncode >= 0);
+
+            char* originalBuffer = buffer;
+            charsWritten = 0;
 
             if (firstCharacterToEncode > 0)
             {
@@ -142,7 +164,7 @@ namespace System.Text.Encodings.Web
                     destinationSizeInBytes: sizeof(char) * bufferLength,
                     sourceBytesToCopy: sizeof(char) * firstCharacterToEncode);
 
-                totalWritten += firstCharacterToEncode;
+                charsWritten += firstCharacterToEncode;
                 bufferLength -= firstCharacterToEncode;
                 buffer += firstCharacterToEncode;
             }
@@ -152,7 +174,6 @@ namespace System.Text.Encodings.Web
             char firstChar = value[valueIndex];
             char secondChar = firstChar;
             bool wasSurrogatePair = false;
-            int charsWritten;
 
             // this loop processes character pairs (in case they are surrogates).
             // there is an if block below to process single last character.
@@ -167,6 +188,7 @@ namespace System.Text.Encodings.Web
                 {
                     firstChar = value[secondCharIndex - 1];
                 }
+
                 secondChar = value[secondCharIndex];
 
                 if (!WillEncode(firstChar))
@@ -175,41 +197,52 @@ namespace System.Text.Encodings.Web
                     *buffer = firstChar;
                     buffer++;
                     bufferLength--;
-                    totalWritten++;
+                    charsWritten++;
                 }
                 else
                 {
-                    int nextScalar = UnicodeHelpers.GetScalarValueFromUtf16(firstChar, secondChar, out wasSurrogatePair);
-                    if (!TryEncodeUnicodeScalar(nextScalar, buffer, bufferLength, out charsWritten))
+                    int nextScalar = UnicodeHelpers.GetScalarValueFromUtf16(firstChar, secondChar, out wasSurrogatePair, out bool _);
+                    if (!TryEncodeUnicodeScalar(nextScalar, buffer, bufferLength, out int charsWrittenThisTime))
                     {
-                        throw new ArgumentException("Argument encoder does not implement MaxOutputCharsPerInputChar correctly.");
+                        charsConsumed = (int)(originalBuffer - buffer);
+                        return OperationStatus.DestinationTooSmall;
                     }
 
-                    buffer += charsWritten;
-                    bufferLength -= charsWritten;
-                    totalWritten += charsWritten;
                     if (wasSurrogatePair)
                     {
                         secondCharIndex++;
                     }
+
+                    buffer += charsWrittenThisTime;
+                    bufferLength -= charsWrittenThisTime;
+                    charsWritten += charsWrittenThisTime;
                 }
             }
 
             if (secondCharIndex == valueLength)
             {
                 firstChar = value[valueLength - 1];
-                int nextScalar = UnicodeHelpers.GetScalarValueFromUtf16(firstChar, null, out wasSurrogatePair);
-                if (!TryEncodeUnicodeScalar(nextScalar, buffer, bufferLength, out charsWritten))
+                int nextScalar = UnicodeHelpers.GetScalarValueFromUtf16(firstChar, null, out wasSurrogatePair, out bool needMoreData);
+                if (!isFinalBlock && needMoreData)
                 {
-                    throw new ArgumentException("Argument encoder does not implement MaxOutputCharsPerInputChar correctly.");
+                    Debug.Assert(wasSurrogatePair == false);
+                    charsConsumed = (int)(buffer - originalBuffer);
+                    return OperationStatus.NeedMoreData;
                 }
 
-                buffer += charsWritten;
-                bufferLength -= charsWritten;
-                totalWritten += charsWritten;
+                if (!TryEncodeUnicodeScalar(nextScalar, buffer, bufferLength, out int charsWrittenThisTime))
+                {
+                    charsConsumed = (int)(buffer - originalBuffer);
+                    return OperationStatus.DestinationTooSmall;
+                }
+
+                buffer += charsWrittenThisTime;
+                bufferLength -= charsWrittenThisTime;
+                charsWritten += charsWrittenThisTime;
             }
 
-            return totalWritten;
+            charsConsumed = valueLength;
+            return OperationStatus.Done;
         }
 
         /// <summary>
@@ -248,7 +281,7 @@ namespace System.Text.Encodings.Web
                     char* substring = valuePointer + startIndex;
                     int firstIndexToEncode = FindFirstCharacterToEncode(substring, characterCount);
 
-                    if (firstIndexToEncode == -1) // nothing to encode; 
+                    if (firstIndexToEncode == -1) // nothing to encode;
                     {
                         if (startIndex == 0 && characterCount == value.Length) // write whole string
                         {
@@ -301,7 +334,7 @@ namespace System.Text.Encodings.Web
                     char* substring = valuePointer + startIndex;
                     int firstIndexToEncode = FindFirstCharacterToEncode(substring, characterCount);
 
-                    if (firstIndexToEncode == -1) // nothing to encode; 
+                    if (firstIndexToEncode == -1) // nothing to encode;
                     {
                         if (startIndex == 0 && characterCount == value.Length) // write whole string
                         {
@@ -340,7 +373,12 @@ namespace System.Text.Encodings.Web
         /// <see langword="false"/> if there is no further source data that needs to be encoded.</param>
         /// <returns>An <see cref="OperationStatus"/> describing the result of the encoding operation.</returns>
         /// <remarks>The buffers <paramref name="utf8Source"/> and <paramref name="utf8Destination"/> must not overlap.</remarks>
-        public unsafe virtual OperationStatus EncodeUtf8(ReadOnlySpan<byte> utf8Source, Span<byte> utf8Destination, out int bytesConsumed, out int bytesWritten, bool isFinalBlock = true)
+        public unsafe virtual OperationStatus EncodeUtf8(
+            ReadOnlySpan<byte> utf8Source,
+            Span<byte> utf8Destination,
+            out int bytesConsumed,
+            out int bytesWritten,
+            bool isFinalBlock = true)
         {
             int originalUtf8SourceLength = utf8Source.Length;
             int originalUtf8DestinationLength = utf8Destination.Length;
@@ -462,6 +500,7 @@ namespace System.Text.Encodings.Web
                             bytesWritten = originalUtf8DestinationLength - utf8Destination.Length;
                             return OperationStatus.NeedMoreData;
                         }
+                        // else treat this as a normal invalid subsequence.
                     }
                     else if (opStatus == OperationStatus.DestinationTooSmall)
                     {
@@ -522,6 +561,59 @@ namespace System.Text.Encodings.Web
             return encoder.EncodeUtf8(utf8Source, utf8Destination, out bytesConsumed, out bytesWritten, isFinalBlock);
         }
 
+        /// <summary>
+        /// Encodes the supplied characters.
+        /// </summary>
+        /// <param name="source">A source buffer containing the characters to encode.</param>
+        /// <param name="destination">The destination buffer to which the encoded form of <paramref name="source"/>
+        /// will be written.</param>
+        /// <param name="charsConsumed">The number of characters consumed from the <paramref name="source"/> buffer.</param>
+        /// <param name="charsWritten">The number of characters written to the <paramref name="destination"/> buffer.</param>
+        /// <param name="isFinalBlock"><see langword="true"/> if there is further source data that needs to be encoded;
+        /// <see langword="false"/> if there is no further source data that needs to be encoded.</param>
+        /// <returns>An <see cref="OperationStatus"/> describing the result of the encoding operation.</returns>
+        /// <remarks>The buffers <paramref name="source"/> and <paramref name="destination"/> must not overlap.</remarks>
+        public virtual OperationStatus Encode(
+            ReadOnlySpan<char> source,
+            Span<char> destination,
+            out int charsConsumed,
+            out int charsWritten,
+            bool isFinalBlock = true)
+        {
+            unsafe
+            {
+                fixed (char* sourcePtr = source)
+                {
+                    int firstCharacterToEncode;
+                    if (source.IsEmpty || (firstCharacterToEncode = FindFirstCharacterToEncode(sourcePtr, source.Length)) == -1)
+                    {
+                        if (source.TryCopyTo(destination))
+                        {
+                            charsConsumed = source.Length;
+                            charsWritten = source.Length;
+                            return OperationStatus.Done;
+                        }
+
+                        charsConsumed = 0;
+                        charsWritten = 0;
+                        return OperationStatus.DestinationTooSmall;
+                    }
+                    else if (destination.IsEmpty)
+                    {
+                        // Guards against passing a null destinationPtr to EncodeIntoBuffer (pinning an empty Span will return a null pointer).
+                        charsConsumed = 0;
+                        charsWritten = 0;
+                        return OperationStatus.DestinationTooSmall;
+                    }
+
+                    fixed (char* destinationPtr = destination)
+                    {
+                        return EncodeIntoBuffer(destinationPtr, destination.Length, sourcePtr, source.Length, out charsConsumed, out charsWritten, firstCharacterToEncode, isFinalBlock);
+                    }
+                }
+            }
+        }
+
         private unsafe void EncodeCore(TextWriter output, char* value, int valueLength)
         {
             Debug.Assert(value != null & output != null);
@@ -557,10 +649,10 @@ namespace System.Text.Encodings.Web
                 }
                 else
                 {
-                    int nextScalar = UnicodeHelpers.GetScalarValueFromUtf16(firstChar, secondChar, out wasSurrogatePair);
+                    int nextScalar = UnicodeHelpers.GetScalarValueFromUtf16(firstChar, secondChar, out wasSurrogatePair, out bool _);
                     if (!TryEncodeUnicodeScalar(nextScalar, buffer, bufferLength, out charsWritten))
                     {
-                        throw new ArgumentException("Argument encoder does not implement MaxOutputCharsPerInputChar correctly.");
+                        ThrowArgumentException_MaxOutputCharsPerInputChar();
                     }
                     Write(output, buffer, charsWritten);
 
@@ -574,10 +666,10 @@ namespace System.Text.Encodings.Web
             if (!wasSurrogatePair || (secondCharIndex == valueLength))
             {
                 firstChar = value[valueLength - 1];
-                int nextScalar = UnicodeHelpers.GetScalarValueFromUtf16(firstChar, null, out wasSurrogatePair);
+                int nextScalar = UnicodeHelpers.GetScalarValueFromUtf16(firstChar, null, out wasSurrogatePair, out bool _);
                 if (!TryEncodeUnicodeScalar(nextScalar, buffer, bufferLength, out charsWritten))
                 {
-                    throw new ArgumentException("Argument encoder does not implement MaxOutputCharsPerInputChar correctly.");
+                    ThrowArgumentException_MaxOutputCharsPerInputChar();
                 }
                 Write(output, buffer, charsWritten);
             }
@@ -717,12 +809,17 @@ namespace System.Text.Encodings.Web
             {
                 if (!WillEncode(value))
                 {
-                    _asciiEscape[value] = s_noEscape;
-                    return s_noEscape;
+                    encoding = s_noEscape;
+                    _asciiEscape[value] = encoding;
                 }
             }
 
             return encoding;
+        }
+
+        private static void ThrowArgumentException_MaxOutputCharsPerInputChar()
+        {
+            throw new ArgumentException("Argument encoder does not implement MaxOutputCharsPerInputChar correctly.");
         }
     }
 }

--- a/src/System.Text.Encodings.Web/src/System/Text/Unicode/UnicodeHelpers.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Unicode/UnicodeHelpers.cs
@@ -48,71 +48,6 @@ namespace System.Text.Unicode
         }
 
         /// <summary>
-        /// A copy of the logic in Rune.DecodeFromUtf16.
-        /// </summary>
-        public static OperationStatus DecodeScalarValueFromUtf16(ReadOnlySpan<char> source, out uint result, out int charsConsumed)
-        {
-            const char ReplacementChar = '\uFFFD';
-
-            if (!source.IsEmpty)
-            {
-                // First, check for the common case of a BMP scalar value.
-                // If this is correct, return immediately.
-
-                uint firstChar = source[0];
-                if (!UnicodeUtility.IsSurrogateCodePoint(firstChar))
-                {
-                    result = firstChar;
-                    charsConsumed = 1;
-                    return OperationStatus.Done;
-                }
-
-                // First thing we saw was a UTF-16 surrogate code point.
-                // Let's optimistically assume for now it's a high surrogate and hope
-                // that combining it with the next char yields useful results.
-
-                if (1 < (uint)source.Length)
-                {
-                    uint secondChar = source[1];
-                    if (UnicodeUtility.IsHighSurrogateCodePoint(firstChar) && UnicodeUtility.IsLowSurrogateCodePoint(secondChar))
-                    {
-                        // Success! Formed a supplementary scalar value.
-                        result = UnicodeUtility.GetScalarFromUtf16SurrogatePair(firstChar, secondChar);
-                        charsConsumed = 2;
-                        return OperationStatus.Done;
-                    }
-                    else
-                    {
-                        // Either the first character was a low surrogate, or the second
-                        // character was not a low surrogate. This is an error.
-                        goto InvalidData;
-                    }
-                }
-                else if (!UnicodeUtility.IsHighSurrogateCodePoint(firstChar))
-                {
-                    // Quick check to make sure we're not going to report NeedMoreData for
-                    // a single-element buffer where the data is a standalone low surrogate
-                    // character. Since no additional data will ever make this valid, we'll
-                    // report an error immediately.
-                    goto InvalidData;
-                }
-            }
-
-            // If we got to this point, the input buffer was empty, or the buffer
-            // was a single element in length and that element was a high surrogate char.
-
-            charsConsumed = source.Length;
-            result = ReplacementChar;
-            return OperationStatus.NeedMoreData;
-
-        InvalidData:
-
-            charsConsumed = 1; // maximal invalid subsequence for UTF-16 is always a single code unit in length
-            result = ReplacementChar;
-            return OperationStatus.InvalidData;
-        }
-
-        /// <summary>
         /// A copy of the logic in Rune.DecodeFromUtf8.
         /// </summary>
         public static OperationStatus DecodeScalarValueFromUtf8(ReadOnlySpan<byte> source, out uint result, out int bytesConsumed)
@@ -309,23 +244,26 @@ namespace System.Text.Unicode
         /// Set 'endOfString' to true if 'pChar' points to the last character in the stream.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static int GetScalarValueFromUtf16(char first, char? second, out bool wasSurrogatePair)
+        internal static int GetScalarValueFromUtf16(char first, char? second, out bool wasSurrogatePair, out bool needsMoreData)
         {
             if (!char.IsSurrogate(first))
             {
                 wasSurrogatePair = false;
+                needsMoreData = false;
                 return first;
             }
-            return GetScalarValueFromUtf16Slow(first, second, out wasSurrogatePair);
+
+            return GetScalarValueFromUtf16Slow(first, second, out wasSurrogatePair, out needsMoreData);
         }
 
-        private static int GetScalarValueFromUtf16Slow(char first, char? second, out bool wasSurrogatePair)
+        private static int GetScalarValueFromUtf16Slow(char first, char? second, out bool wasSurrogatePair, out bool needMoreData)
         {
 #if DEBUG
             if (!Char.IsSurrogate(first))
             {
                 Debug.Assert(false, "This case should've been handled by the fast path.");
                 wasSurrogatePair = false;
+                needMoreData = false;
                 return first;
             }
 #endif
@@ -337,12 +275,14 @@ namespace System.Text.Unicode
                     {
                         // valid surrogate pair - extract codepoint
                         wasSurrogatePair = true;
+                        needMoreData = false;
                         return GetScalarValueFromUtf16SurrogatePair(first, second.Value);
                     }
                     else
                     {
                         // unmatched surrogate - substitute
                         wasSurrogatePair = false;
+                        needMoreData = false;
                         return UNICODE_REPLACEMENT_CHAR;
                     }
                 }
@@ -350,6 +290,7 @@ namespace System.Text.Unicode
                 {
                     // unmatched surrogate - substitute
                     wasSurrogatePair = false;
+                    needMoreData = true; // Last character was high surrogate; we need more data.
                     return UNICODE_REPLACEMENT_CHAR;
                 }
             }
@@ -358,6 +299,7 @@ namespace System.Text.Unicode
                 // unmatched surrogate - substitute
                 Debug.Assert(char.IsLowSurrogate(first));
                 wasSurrogatePair = false;
+                needMoreData = false;
                 return UNICODE_REPLACEMENT_CHAR;
             }
         }

--- a/src/System.Text.Json/src/System/Text/Json/JsonHelpers.cs
+++ b/src/System.Text.Json/src/System/Text/Json/JsonHelpers.cs
@@ -9,6 +9,7 @@ namespace System.Text.Json
 {
     internal static partial class JsonHelpers
     {
+#if !BUILDING_INBOX_LIBRARY
         /// <summary>
         /// Returns <see langword="true"/> if <paramref name="value"/> is a valid Unicode scalar
         /// value, i.e., is in [ U+0000..U+D7FF ], inclusive; or [ U+E000..U+10FFFF ], inclusive.
@@ -23,6 +24,7 @@ namespace System.Text.Json
 
             return IsInRangeInclusive(value ^ 0xD800U, 0x800U, 0x10FFFFU);
         }
+#endif
 
         /// <summary>
         /// Returns <see langword="true"/> if <paramref name="value"/> is between
@@ -31,14 +33,6 @@ namespace System.Text.Json
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsInRangeInclusive(uint value, uint lowerBound, uint upperBound)
             => (value - lowerBound) <= (upperBound - lowerBound);
-
-        /// <summary>
-        /// Returns <see langword="true"/> if <paramref name="value"/> is between
-        /// <paramref name="lowerBound"/> and <paramref name="upperBound"/>, inclusive.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsInRangeInclusive(byte value, byte lowerBound, byte upperBound)
-            => ((byte)(value - lowerBound) <= (byte)(upperBound - lowerBound));
 
         /// <summary>
         /// Returns <see langword="true"/> if <paramref name="value"/> is between

--- a/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Escaping.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Escaping.cs
@@ -8,7 +8,6 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text.Encodings.Web;
-using System.Text.Unicode;
 
 namespace System.Text.Json
 {
@@ -21,7 +20,8 @@ namespace System.Text.Json
         //
         // non-zero = allowed, 0 = disallowed
         public const int LastAsciiCharacter = 0x7F;
-        private static ReadOnlySpan<byte> AllowList => new byte[LastAsciiCharacter + 1] {
+        private static ReadOnlySpan<byte> AllowList => new byte[byte.MaxValue + 1]
+        {
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // U+0000..U+000F
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // U+0010..U+001F
             1, 1, 0, 1, 1, 1, 0, 0, 1, 1, 1, 0, 1, 1, 1, 1, // U+0020..U+002F
@@ -30,38 +30,41 @@ namespace System.Text.Json
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, // U+0050..U+005F
             0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // U+0060..U+006F
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, // U+0070..U+007F
+
+            // Also include the ranges from U+0080 to U+00FF for performance to avoid UTF8 code from checking boundary.
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // U+00F0..U+00FF
         };
 
+#if BUILDING_INBOX_LIBRARY
         private const string HexFormatString = "X4";
+#endif
+
         private static readonly StandardFormat s_hexStandardFormat = new StandardFormat('X', 4);
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool NeedsEscapingNoBoundsCheck(byte value)
-        {
-            Debug.Assert(value <= LastAsciiCharacter);
-            return AllowList[value] == 0;
-        }
+        private static bool NeedsEscaping(byte value) => AllowList[value] == 0;
 
-        private static bool NeedsEscapingNoBoundsCheck(char value)
-        {
-            Debug.Assert(value <= LastAsciiCharacter);
-            return AllowList[value] == 0;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool NeedsEscaping(byte value) => value > LastAsciiCharacter || AllowList[value] == 0;
+        private static bool NeedsEscapingNoBoundsCheck(char value) => AllowList[value] == 0;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool NeedsEscaping(char value) => value > LastAsciiCharacter || AllowList[value] == 0;
 
         public static int NeedsEscaping(ReadOnlySpan<byte> value, JavaScriptEncoder encoder)
         {
+            int idx;
+
             if (encoder != null)
             {
-                return encoder.FindFirstCharacterToEncodeUtf8(value);
+                idx = encoder.FindFirstCharacterToEncodeUtf8(value);
+                goto Return;
             }
 
-            int idx;
             for (idx = 0; idx < value.Length; idx++)
             {
                 if (NeedsEscaping(value[idx]))
@@ -78,12 +81,14 @@ namespace System.Text.Json
 
         public static int NeedsEscaping(ReadOnlySpan<char> value, JavaScriptEncoder encoder)
         {
+            int idx;
+
             if (encoder != null)
             {
-                return encoder.FindFirstCharacterToEncodeUtf8(MemoryMarshal.Cast<char, byte>(value));
+                idx = encoder.FindFirstCharacterToEncodeUtf8(MemoryMarshal.Cast<char, byte>(value));
+                goto Return;
             }
 
-            int idx;
             for (idx = 0; idx < value.Length; idx++)
             {
                 if (NeedsEscaping(value[idx]))
@@ -113,12 +118,13 @@ namespace System.Text.Json
 
             Debug.Assert(result != OperationStatus.DestinationTooSmall);
             Debug.Assert(result != OperationStatus.NeedMoreData);
-            Debug.Assert(encoderBytesConsumed == value.Length);
 
             if (result != OperationStatus.Done)
             {
                 ThrowHelper.ThrowArgumentException_InvalidUTF8(value.Slice(encoderBytesWritten));
             }
+
+            Debug.Assert(encoderBytesConsumed == value.Length);
 
             written += encoderBytesWritten;
         }
@@ -129,7 +135,6 @@ namespace System.Text.Json
 
             value.Slice(0, indexOfFirstByteToEscape).CopyTo(destination);
             written = indexOfFirstByteToEscape;
-            int consumed = indexOfFirstByteToEscape;
 
             if (encoder != null)
             {
@@ -141,28 +146,28 @@ namespace System.Text.Json
             {
                 // For performance when no encoder is specified, perform escaping here for Ascii and on the
                 // first occurrence of a non-Ascii character, then call into the default encoder.
-                while (consumed < value.Length)
+                while (indexOfFirstByteToEscape < value.Length)
                 {
-                    byte val = value[consumed];
+                    byte val = value[indexOfFirstByteToEscape];
                     if (IsAsciiValue(val))
                     {
-                        if (NeedsEscapingNoBoundsCheck(val))
+                        if (NeedsEscaping(val))
                         {
                             EscapeNextBytes(val, destination, ref written);
-                            consumed++;
+                            indexOfFirstByteToEscape++;
                         }
                         else
                         {
                             destination[written] = val;
                             written++;
-                            consumed++;
+                            indexOfFirstByteToEscape++;
                         }
                     }
                     else
                     {
                         // Fall back to default encoder.
                         destination = destination.Slice(written);
-                        value = value.Slice(consumed);
+                        value = value.Slice(indexOfFirstByteToEscape);
                         EscapeString(value, destination, JavaScriptEncoder.Default, ref written);
                         break;
                     }
@@ -216,300 +221,23 @@ namespace System.Text.Json
 
         private static bool IsAsciiValue(char value) => value <= LastAsciiCharacter;
 
-        /// <summary>
-        /// Returns <see langword="true"/> if <paramref name="value"/> is a UTF-8 continuation byte.
-        /// A UTF-8 continuation byte is a byte whose value is in the range 0x80-0xBF, inclusive.
-        /// </summary>
-        private static bool IsUtf8ContinuationByte(byte value) => (value & 0xC0) == 0x80;
-
-        /// <summary>
-        /// Returns <see langword="true"/> if the low word of <paramref name="char"/> is a UTF-16 surrogate.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool IsLowWordSurrogate(uint @char)
-            => (@char & 0xF800U) == 0xD800U;
-
-        // We can't use the type Rune since it is not available on netstandard2.0
-        // To avoid extensive ifdefs and for simplicity, just using an int to reprepsent the scalar value, instead.
-        public static SequenceValidity PeekFirstSequence(ReadOnlySpan<byte> data, out int numBytesConsumed, out int rune)
-        {
-            // This method is implemented to match the behavior of System.Text.Encoding.UTF8 in terms of
-            // how many bytes it consumes when reporting invalid sequences. The behavior is as follows:
-            //
-            // - Some bytes are *always* invalid (ranges [ C0..C1 ] and [ F5..FF ]), and when these
-            //   are encountered it's an invalid sequence of length 1.
-            //
-            // - Multi-byte sequences which are overlong are reported as an invalid sequence of length 2,
-            //   since per the Unicode Standard Table 3-7 it's always possible to tell these by the second byte.
-            //   Exception: Sequences which begin with [ C0..C1 ] are covered by the above case, thus length 1.
-            //
-            // - Multi-byte sequences which are improperly terminated (no continuation byte when one is
-            //   expected) are reported as invalid sequences up to and including the last seen continuation byte.
-
-            Debug.Assert(JsonHelpers.IsValidUnicodeScalar(ReplacementChar));
-            rune = ReplacementChar;
-
-            if (data.IsEmpty)
-            {
-                // No data to peek at
-                numBytesConsumed = 0;
-                return SequenceValidity.Empty;
-            }
-
-            byte firstByte = data[0];
-
-            if (IsAsciiValue(firstByte))
-            {
-                // ASCII byte = well-formed one-byte sequence.
-                Debug.Assert(JsonHelpers.IsValidUnicodeScalar(firstByte));
-                rune = firstByte;
-                numBytesConsumed = 1;
-                return SequenceValidity.WellFormed;
-            }
-
-            if (!JsonHelpers.IsInRangeInclusive(firstByte, (byte)0xC2U, (byte)0xF4U))
-            {
-                // Standalone continuation byte or "always invalid" byte = ill-formed one-byte sequence.
-                goto InvalidOneByteSequence;
-            }
-
-            // At this point, we know we're working with a multi-byte sequence,
-            // and we know that at least the first byte is potentially valid.
-
-            if (data.Length < 2)
-            {
-                // One byte of an incomplete multi-byte sequence.
-                goto OneByteOfIncompleteMultiByteSequence;
-            }
-
-            byte secondByte = data[1];
-
-            if (!IsUtf8ContinuationByte(secondByte))
-            {
-                // One byte of an improperly terminated multi-byte sequence.
-                goto InvalidOneByteSequence;
-            }
-
-            if (firstByte < (byte)0xE0U)
-            {
-                // Well-formed two-byte sequence.
-                uint scalar = (((uint)firstByte & 0x1FU) << 6) | ((uint)secondByte & 0x3FU);
-                Debug.Assert(JsonHelpers.IsValidUnicodeScalar(scalar));
-                rune = (int)scalar;
-                numBytesConsumed = 2;
-                return SequenceValidity.WellFormed;
-            }
-
-            if (firstByte < (byte)0xF0U)
-            {
-                // Start of a three-byte sequence.
-                // Need to check for overlong or surrogate sequences.
-
-                uint scalar = (((uint)firstByte & 0x0FU) << 12) | (((uint)secondByte & 0x3FU) << 6);
-                if (scalar < 0x800U || IsLowWordSurrogate(scalar))
-                {
-                    goto OverlongOutOfRangeOrSurrogateSequence;
-                }
-
-                // At this point, we have a valid two-byte start of a three-byte sequence.
-
-                if (data.Length < 3)
-                {
-                    // Two bytes of an incomplete three-byte sequence.
-                    goto TwoBytesOfIncompleteMultiByteSequence;
-                }
-                else
-                {
-                    byte thirdByte = data[2];
-                    if (IsUtf8ContinuationByte(thirdByte))
-                    {
-                        // Well-formed three-byte sequence.
-                        scalar |= (uint)thirdByte & 0x3FU;
-                        Debug.Assert(JsonHelpers.IsValidUnicodeScalar(scalar));
-                        rune = (int)scalar;
-                        numBytesConsumed = 3;
-                        return SequenceValidity.WellFormed;
-                    }
-                    else
-                    {
-                        // Two bytes of improperly terminated multi-byte sequence.
-                        goto InvalidTwoByteSequence;
-                    }
-                }
-            }
-
-            {
-                // Start of four-byte sequence.
-                // Need to check for overlong or out-of-range sequences.
-
-                uint scalar = (((uint)firstByte & 0x07U) << 18) | (((uint)secondByte & 0x3FU) << 12);
-                Debug.Assert(JsonHelpers.IsValidUnicodeScalar(scalar));
-                if (!JsonHelpers.IsInRangeInclusive(scalar, 0x10000U, 0x10FFFFU))
-                {
-                    goto OverlongOutOfRangeOrSurrogateSequence;
-                }
-
-                // At this point, we have a valid two-byte start of a four-byte sequence.
-
-                if (data.Length < 3)
-                {
-                    // Two bytes of an incomplete four-byte sequence.
-                    goto TwoBytesOfIncompleteMultiByteSequence;
-                }
-                else
-                {
-                    byte thirdByte = data[2];
-                    if (IsUtf8ContinuationByte(thirdByte))
-                    {
-                        // Valid three-byte start of a four-byte sequence.
-
-                        if (data.Length < 4)
-                        {
-                            // Three bytes of an incomplete four-byte sequence.
-                            goto ThreeBytesOfIncompleteMultiByteSequence;
-                        }
-                        else
-                        {
-                            byte fourthByte = data[3];
-                            if (IsUtf8ContinuationByte(fourthByte))
-                            {
-                                // Well-formed four-byte sequence.
-                                scalar |= (((uint)thirdByte & 0x3FU) << 6) | ((uint)fourthByte & 0x3FU);
-                                Debug.Assert(JsonHelpers.IsValidUnicodeScalar(scalar));
-                                rune = (int)scalar;
-                                numBytesConsumed = 4;
-                                return SequenceValidity.WellFormed;
-                            }
-                            else
-                            {
-                                // Three bytes of an improperly terminated multi-byte sequence.
-                                goto InvalidThreeByteSequence;
-                            }
-                        }
-                    }
-                    else
-                    {
-                        // Two bytes of improperly terminated multi-byte sequence.
-                        goto InvalidTwoByteSequence;
-                    }
-                }
-            }
-
-        // Everything below here is error handling.
-
-        InvalidOneByteSequence:
-            numBytesConsumed = 1;
-            return SequenceValidity.Invalid;
-
-        InvalidTwoByteSequence:
-        OverlongOutOfRangeOrSurrogateSequence:
-            numBytesConsumed = 2;
-            return SequenceValidity.Invalid;
-
-        InvalidThreeByteSequence:
-            numBytesConsumed = 3;
-            return SequenceValidity.Invalid;
-
-        OneByteOfIncompleteMultiByteSequence:
-            numBytesConsumed = 1;
-            return SequenceValidity.Incomplete;
-
-        TwoBytesOfIncompleteMultiByteSequence:
-            numBytesConsumed = 2;
-            return SequenceValidity.Incomplete;
-
-        ThreeBytesOfIncompleteMultiByteSequence:
-            numBytesConsumed = 3;
-            return SequenceValidity.Incomplete;
-        }
-
         private static void EscapeString(ReadOnlySpan<char> value, Span<char> destination, JavaScriptEncoder encoder, ref int written)
         {
-            // todo: issue #39523: add an Encode(ReadOnlySpan<char>) decode API to System.Text.Encodings.Web.TextEncoding to avoid utf16->utf8->utf16 conversion.
-
             Debug.Assert(encoder != null);
 
-            // Convert char to byte.
-            byte[] utf8DestinationArray = null;
-            Span<byte> utf8Destination;
-            int length = checked((value.Length) * JsonConstants.MaxExpansionFactorWhileTranscoding);
-            if (length > JsonConstants.StackallocThreshold)
+            OperationStatus result = encoder.Encode(value, destination, out int encoderBytesConsumed, out int encoderCharsWritten);
+
+            Debug.Assert(result != OperationStatus.DestinationTooSmall);
+            Debug.Assert(result != OperationStatus.NeedMoreData);
+
+            if (result != OperationStatus.Done)
             {
-                utf8DestinationArray = ArrayPool<byte>.Shared.Rent(length);
-                utf8Destination = utf8DestinationArray;
-            }
-            else
-            {
-                unsafe
-                {
-                    byte* ptr = stackalloc byte[JsonConstants.StackallocThreshold];
-                    utf8Destination = new Span<byte>(ptr, JsonConstants.StackallocThreshold);
-                }
+                ThrowHelper.ThrowArgumentException_InvalidUTF16(value[encoderCharsWritten]);
             }
 
-            ReadOnlySpan<byte> utf16Value = MemoryMarshal.AsBytes(value);
-            OperationStatus toUtf8Status = ToUtf8(utf16Value, utf8Destination, out int bytesConsumed, out int bytesWritten);
+            Debug.Assert(encoderBytesConsumed == value.Length);
 
-            Debug.Assert(toUtf8Status != OperationStatus.DestinationTooSmall);
-            Debug.Assert(toUtf8Status != OperationStatus.NeedMoreData);
-
-            if (toUtf8Status != OperationStatus.Done)
-            {
-                if (utf8DestinationArray != null)
-                {
-                    utf8Destination.Slice(0, bytesWritten).Clear();
-                    ArrayPool<byte>.Shared.Return(utf8DestinationArray);
-                }
-
-                ThrowHelper.ThrowArgumentException_InvalidUTF8(utf16Value.Slice(bytesWritten));
-            }
-
-            Debug.Assert(toUtf8Status == OperationStatus.Done);
-            Debug.Assert(bytesConsumed == utf16Value.Length);
-
-            // Escape the bytes.
-            byte[] utf8ConvertedDestinationArray = null;
-            Span<byte> utf8ConvertedDestination;
-            length = checked(bytesWritten * JsonConstants.MaxExpansionFactorWhileEscaping);
-            if (length > JsonConstants.StackallocThreshold)
-            {
-                utf8ConvertedDestinationArray = ArrayPool<byte>.Shared.Rent(length);
-                utf8ConvertedDestination = utf8ConvertedDestinationArray;
-            }
-            else
-            {
-                unsafe
-                {
-                    byte* ptr = stackalloc byte[JsonConstants.StackallocThreshold];
-                    utf8ConvertedDestination = new Span<byte>(ptr, JsonConstants.StackallocThreshold);
-                }
-            }
-
-            EscapeString(utf8Destination.Slice(0, bytesWritten), utf8ConvertedDestination, indexOfFirstByteToEscape: 0, encoder, out int convertedBytesWritten);
-
-            if (utf8DestinationArray != null)
-            {
-                utf8Destination.Slice(0, bytesWritten).Clear();
-                ArrayPool<byte>.Shared.Return(utf8DestinationArray);
-            }
-
-            // Convert byte to char.
-#if BUILDING_INBOX_LIBRARY
-            OperationStatus toUtf16Status = Utf8.ToUtf16(utf8ConvertedDestination.Slice(0, convertedBytesWritten), destination, out int bytesRead, out int charsWritten);
-            Debug.Assert(toUtf16Status == OperationStatus.Done);
-            Debug.Assert(bytesRead == convertedBytesWritten);
-#else
-            string utf16 = JsonReaderHelper.GetTextFromUtf8(utf8ConvertedDestination.Slice(0, convertedBytesWritten));
-            utf16.AsSpan().CopyTo(destination);
-            int charsWritten = utf16.Length;
-#endif
-            written += charsWritten;
-
-            if (utf8ConvertedDestinationArray != null)
-            {
-                utf8ConvertedDestination.Slice(0, written).Clear();
-                ArrayPool<byte>.Shared.Return(utf8ConvertedDestinationArray);
-            }
+            written += encoderCharsWritten;
         }
 
         public static void EscapeString(ReadOnlySpan<char> value, Span<char> destination, int indexOfFirstByteToEscape, JavaScriptEncoder encoder, out int written)
@@ -518,7 +246,6 @@ namespace System.Text.Json
 
             value.Slice(0, indexOfFirstByteToEscape).CopyTo(destination);
             written = indexOfFirstByteToEscape;
-            int consumed = indexOfFirstByteToEscape;
 
             if (encoder != null)
             {
@@ -530,28 +257,28 @@ namespace System.Text.Json
             {
                 // For performance when no encoder is specified, perform escaping here for Ascii and on the
                 // first occurrence of a non-Ascii character, then call into the default encoder.
-                while (consumed < value.Length)
+                while (indexOfFirstByteToEscape < value.Length)
                 {
-                    char val = value[consumed];
+                    char val = value[indexOfFirstByteToEscape];
                     if (IsAsciiValue(val))
                     {
                         if (NeedsEscapingNoBoundsCheck(val))
                         {
                             EscapeNextChars(val, destination, ref written);
-                            consumed++;
+                            indexOfFirstByteToEscape++;
                         }
                         else
                         {
                             destination[written] = val;
                             written++;
-                            consumed++;
+                            indexOfFirstByteToEscape++;
                         }
                     }
                     else
                     {
                         // Fall back to default encoder.
                         destination = destination.Slice(written);
-                        value = value.Slice(consumed);
+                        value = value.Slice(indexOfFirstByteToEscape);
                         EscapeString(value, destination, JavaScriptEncoder.Default, ref written);
                         break;
                     }
@@ -606,11 +333,6 @@ namespace System.Text.Json
             }
         }
 
-        /// <summary>
-        /// A scalar that represents the Unicode replacement character U+FFFD.
-        /// </summary>
-        private const int ReplacementChar = 0xFFFD;
-
 #if !BUILDING_INBOX_LIBRARY
         private static int WriteHex(int value, Span<char> destination, int written)
         {
@@ -622,13 +344,13 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Converts a number 0 - 15 to its associated hex character '0' - 'f' as byte.
+        /// Converts a number 0 - 15 to its associated hex character '0' - 'F' as byte.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static byte Int32LsbToHexDigit(int value)
         {
             Debug.Assert(value < 16);
-            return (byte)((value < 10) ? ('0' + value) : ('a' + (value - 10)));
+            return (byte)((value < 10) ? ('0' + value) : ('A' + (value - 10)));
         }
 #endif
     }

--- a/src/System.Text.Json/tests/JsonTestHelper.cs
+++ b/src/System.Text.Json/tests/JsonTestHelper.cs
@@ -683,6 +683,7 @@ namespace System.Text.Json
                     );
 
             // Temporary hack until we can use the same escape algorithm on both sides and make sure we want uppercase hex.
+            // Todo: create new AssertContentsAgainJsonNet to avoid calling NormalizeToJsonNetFormat when not necessary.
             Assert.Equal(expectedValue.NormalizeToJsonNetFormat(), value.NormalizeToJsonNetFormat());
         }
 
@@ -696,6 +697,7 @@ namespace System.Text.Json
                     );
 
             // Temporary hack until we can use the same escape algorithm on both sides and make sure we want uppercase hex.
+            // Todo: create new AssertContentsNotEqualAgainJsonNet to avoid calling NormalizeToJsonNetFormat when not necessary.
             Assert.NotEqual(expectedValue.NormalizeToJsonNetFormat(), value.NormalizeToJsonNetFormat());
         }
 

--- a/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
@@ -3522,7 +3522,7 @@ namespace System.Text.Json.Tests
         [InlineData(true, false)]
         [InlineData(false, true)]
         [InlineData(false, false)]
-        public void EscapeSurrogatePairs(bool formatted, bool skipValidation)
+        public void HighSurrogateMissingGetsReplaced(bool formatted, bool skipValidation)
         {
             var propertyArray = new char[10] { 'a', (char)0xD800, (char)0xDC00, (char)0xD803, (char)0xDE6D, (char)0xD834, (char)0xDD1E, (char)0xDBFF, (char)0xDFFF, 'a' };
 
@@ -3572,118 +3572,179 @@ namespace System.Text.Json.Tests
         }
 
         [Fact]
-        public void EscapeSurrogatePairsThrowsHighSurrogateMissing()
+        public void EscapeSurrogatePairs()
         {
             string propertyName = "a \uD800\uDC00\uDE6D a";
             string value = propertyName;
             var output = new ArrayBufferWriter<byte>(12);
-            using var jsonUtf8 = new Utf8JsonWriter(output);
-
-            Assert.Throws<ArgumentException>(() => jsonUtf8.WriteString(propertyName, value));
-        }
-
-        private const string InvalidUtf8 = "\"\\uFFFD(\"";
-        private const string ValidUtf8 = "\"\\u00F1\"";
-
-        // todo: verify that we should be using replacement char and not throwing here if skipValidation=true
-        [Theory]
-        [InlineData(true,
-            "{" + InvalidUtf8 + ":" + InvalidUtf8 + "}",
-            "{" + InvalidUtf8 + ":" + ValidUtf8 + "}",
-            "{" + ValidUtf8 + ":" + InvalidUtf8 + "}",
-            "{" + ValidUtf8 + ":" + ValidUtf8 + "}")]
-        [InlineData(false,
-            "{" + InvalidUtf8 + ":" + InvalidUtf8 + "}",
-            "{" + InvalidUtf8 + ":" + ValidUtf8 + "}",
-            "{" + ValidUtf8 + ":" + InvalidUtf8 + "}",
-            "{" + ValidUtf8 + ":" + ValidUtf8 + "}")]
-        public void UTF8ReplacementCharacters(bool skipValidation, string expected0, string expected1, string expected2, string expected3)
-        {
-            var options = new JsonWriterOptions { SkipValidation = skipValidation };
-
-            var validUtf8 = new byte[2] { 0xc3, 0xb1 }; // 0xF1
-            var invalidUtf8 = new byte[2] { 0xc3, 0x28 };
-
-            string WriteProperty(byte[] propertyName, byte[] value)
+            using (var jsonUtf8 = new Utf8JsonWriter(output))
             {
-                var output = new ArrayBufferWriter<byte>(1024);
-                using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 jsonUtf8.WriteStartObject();
                 jsonUtf8.WriteString(propertyName, value);
                 jsonUtf8.WriteEndObject();
-                jsonUtf8.Flush();
-                string result = Encoding.UTF8.GetString(
-                        output.WrittenSpan
-#if netfx
-                        .ToArray()
-#endif
-                    );
-                output.Clear();
-                return result;
             }
 
-            string result;
-            result = WriteProperty(invalidUtf8, invalidUtf8);
-            Assert.Equal(expected0, result);
+            JsonTestHelper.AssertContents("{\"a \\uD800\\uDC00\\uFFFD a\":\"a \\uD800\\uDC00\\uFFFD a\"}", output);
+        }
 
-            result = WriteProperty(invalidUtf8, validUtf8);
-            Assert.Equal(expected1, result);
+        private static readonly byte[] s_InvalidUtf8Input = new byte[2] { 0xc3, 0x28 };
+        private const string InvalidUtf8Expected = "\"\\uFFFD(\"";
 
-            result = WriteProperty(validUtf8, invalidUtf8);
-            Assert.Equal(expected2, result);
+        private static readonly byte[] s_ValidUtf8Input = new byte[2] { 0xc3, 0xb1 }; // 0xF1
+        private const string ValidUtf8Expected = "\"\\u00F1\"";
 
-            result = WriteProperty(validUtf8, validUtf8);
-            Assert.Equal(expected3, result);
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Utf8SurrogatePairReplacement_InvalidPropertyName_InvalidValue(bool skipValidation)
+        {
+            // SkipValidation does not affect whether we write the replacement character or not (we always do, unless we add a new option to control).
+            // Comment also applies to other Utf8SurrogatePairReplacement* tests below.
+            var options = new JsonWriterOptions { SkipValidation = skipValidation };
+
+            var output = new ArrayBufferWriter<byte>(1024);
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartObject();
+                jsonUtf8.WriteString(s_InvalidUtf8Input, s_InvalidUtf8Input);
+                jsonUtf8.WriteEndObject();
+            }
+
+            JsonTestHelper.AssertContents("{" + InvalidUtf8Expected + ":" + InvalidUtf8Expected + "}", output);
         }
 
         [Theory]
-        [InlineData(true, true)]
-        [InlineData(true, false)]
-        [InlineData(false, true)]
-        [InlineData(false, false)]
-        public void InvalidUTF16(bool formatted, bool skipValidation)
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Utf8SurrogatePairReplacement_InvalidPropertyName_ValidValue(bool skipValidation)
         {
-            var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
+            var options = new JsonWriterOptions { SkipValidation = skipValidation };
 
             var output = new ArrayBufferWriter<byte>(1024);
-            using var jsonUtf8 = new Utf8JsonWriter(output, options);
-
-            var validUtf16 = new char[2] { (char)0xD801, (char)0xDC37 }; // 0x10437
-            var invalidUtf16 = new char[2] { (char)0xD801, 'a' };
-
-            jsonUtf8.WriteStartObject();
-            for (int i = 0; i < 7; i++)
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                switch (i)
-                {
-                    case 0:
-                        Assert.Throws<ArgumentException>(() => jsonUtf8.WriteString(invalidUtf16, invalidUtf16));
-                        break;
-                    case 1:
-                        Assert.Throws<ArgumentException>(() => jsonUtf8.WriteString(invalidUtf16, validUtf16));
-                        break;
-                    case 2:
-                        Assert.Throws<ArgumentException>(() => jsonUtf8.WriteString(validUtf16, invalidUtf16));
-                        break;
-                    case 3:
-                        jsonUtf8.WriteString(validUtf16, validUtf16);
-                        break;
-                    case 4:
-                        Assert.Throws<ArgumentException>(() => jsonUtf8.WritePropertyName(invalidUtf16));
-                        break;
-                    case 5:
-                        jsonUtf8.WritePropertyName(validUtf16);
-                        Assert.Throws<ArgumentException>(() => jsonUtf8.WriteStringValue(invalidUtf16));
-                        jsonUtf8.WriteStringValue(validUtf16);
-                        break;
-                    case 6:
-                        jsonUtf8.WritePropertyName(validUtf16);
-                        jsonUtf8.WriteStringValue(validUtf16);
-                        break;
-                }
+                jsonUtf8.WriteStartObject();
+                jsonUtf8.WriteString(s_InvalidUtf8Input, s_ValidUtf8Input);
+                jsonUtf8.WriteEndObject();
             }
-            jsonUtf8.WriteEndObject();
-            jsonUtf8.Flush();
+
+            JsonTestHelper.AssertContents("{" + InvalidUtf8Expected + ":" + ValidUtf8Expected + "}", output);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Utf8SurrogatePairReplacement_ValidPropertyName_InvalidValue(bool skipValidation)
+        {
+            var options = new JsonWriterOptions { SkipValidation = skipValidation };
+
+            var output = new ArrayBufferWriter<byte>(1024);
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartObject();
+                jsonUtf8.WriteString(s_ValidUtf8Input, s_InvalidUtf8Input);
+                jsonUtf8.WriteEndObject();
+            }
+
+            JsonTestHelper.AssertContents("{" + ValidUtf8Expected + ":" + InvalidUtf8Expected + "}", output);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Utf8SurrogatePairReplacement_ValidPropertyName_ValidValue(bool skipValidation)
+        {
+            var options = new JsonWriterOptions { SkipValidation = skipValidation };
+
+            var output = new ArrayBufferWriter<byte>(1024);
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartObject();
+                jsonUtf8.WriteString(s_ValidUtf8Input, s_ValidUtf8Input);
+                jsonUtf8.WriteEndObject();
+            }
+
+            JsonTestHelper.AssertContents("{" + ValidUtf8Expected + ":" + ValidUtf8Expected + "}", output);
+        }
+
+        private static readonly string s_InvalidUtf16Input = new string (new char[2] { (char)0xD801, 'a' });
+        private const string InvalidUtf16Expected = "\"\\uFFFDa\"";
+
+        private static readonly string s_ValidUtf16Input = new string(new char[2] { (char)0xD801, (char)0xDC37 }); // 0x10437
+        private const string ValidUtf16Expected = "\"\\uD801\\uDC37\"";
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Utf16SurrogatePairReplacement_InvalidPropertyName_InvalidValue(bool skipValidation)
+        {
+            // SkipValidation does not affect whether we write the replacement character or not (we always do, unless we add a new option to control).
+            // Comment also applies to other Utf16SurrogatePairReplacement* tests below.
+            var options = new JsonWriterOptions { SkipValidation = skipValidation };
+
+            var output = new ArrayBufferWriter<byte>(1024);
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartObject();
+                jsonUtf8.WriteString(s_InvalidUtf16Input, s_InvalidUtf16Input);
+                jsonUtf8.WriteEndObject();
+            }
+
+            JsonTestHelper.AssertContents("{" + InvalidUtf16Expected + ":" + InvalidUtf16Expected + "}", output);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Utf16SurrogatePairReplacement_InvalidPropertyName_ValidValue(bool skipValidation)
+        {
+            var options = new JsonWriterOptions { SkipValidation = skipValidation };
+
+            var output = new ArrayBufferWriter<byte>(1024);
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartObject();
+                jsonUtf8.WriteString(s_InvalidUtf16Input, s_ValidUtf16Input);
+                jsonUtf8.WriteEndObject();
+            }
+
+            JsonTestHelper.AssertContents("{" + InvalidUtf16Expected + ":" + ValidUtf16Expected + "}", output);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Utf16SurrogatePairReplacement_ValidPropertyName_InvalidValue(bool skipValidation)
+        {
+            var options = new JsonWriterOptions { SkipValidation = skipValidation };
+
+            var output = new ArrayBufferWriter<byte>(1024);
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartObject();
+                jsonUtf8.WriteString(s_ValidUtf16Input, s_InvalidUtf16Input);
+                jsonUtf8.WriteEndObject();
+            }
+
+            JsonTestHelper.AssertContents("{" + ValidUtf16Expected + ":" + InvalidUtf16Expected + "}", output);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Utf16SurrogatePairReplacement_ValidPropertyName_ValidValue(bool skipValidation)
+        {
+            var options = new JsonWriterOptions { SkipValidation = skipValidation };
+
+            var output = new ArrayBufferWriter<byte>(1024);
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartObject();
+                jsonUtf8.WriteString(s_ValidUtf16Input, s_ValidUtf16Input);
+                jsonUtf8.WriteEndObject();
+            }
+
+            JsonTestHelper.AssertContents("{" + ValidUtf16Expected + ":" + ValidUtf16Expected + "}", output);
         }
 
         public static IEnumerable<object[]> JsonEncodedTextStringsCustomAll


### PR DESCRIPTION
Port https://github.com/dotnet/corefx/pull/39900 to 3.0

cc: @ericstj, @danmosemsft, @GrabYourPitchforks, @ahsonkhan 

## Description

- Adds a new [API ](https://github.com/dotnet/corefx/issues/39523)to System.Text.Encoding.Web for encoding Utf16\char when dealing with `Span<char>`.
- System.Text.Json uptake of this API. This is for both performance and consistency:
  - Performance: previously the code in System.Text.Json had a workaround that converted Utf16 to Utf8, then performed the encoding, and then converted back to Utf16. The new API avoids this workaround and gains a performance improvement of ~25%.
  - Consistency: the new API replaces unpaired surrogates with the "replacement character" `0xFFFD`. Previously the code in System.Text.Json would throw. Using replacement characters makes the semantics consistent with Utf8 behavior and with similar APIs in System.Text.Encoding.Web.
- Addresses a performance regression for Utf8 (byte) encoding when there is no encoding necessary, or encoding occurs later in the string. The performance is improved ~15% in Utf8JsonWriter cases.

## Customer Impact

Improved performance when encoding with System.Text.Json and prevents unwanted exceptions when encoding unpaired surrogates.

Ability for others to call an `Encode(Span<char>)` method in System.Text.Encoding.Web for ease-of-use and performance. This new API matches the equivalent Utf8 API (already existing) in signature , except `char` is used instead of `byte`.

## Regression?

No; the code is new in 3.0.

## Risk

Low. Several tests added to both System.Text.Encoding.Web and System.Text.Json covering the scenarios.

