### PR TITLE
Error out clearly when trying to use COM objects with the DLR.

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/BinderHelper.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/BinderHelper.cs
@@ -182,7 +182,6 @@ namespace Microsoft.CSharp.RuntimeBinder
             return obj != null && Marshal.IsComObject(obj);
         }
 
-#if ENABLECOMBINDER
         /////////////////////////////////////////////////////////////////////////////////
 
         // Try to determine if this object represents a WindowsRuntime object - i.e. it either
@@ -210,7 +209,7 @@ namespace Microsoft.CSharp.RuntimeBinder
 
             return false;
         }
-#endif
+
         /////////////////////////////////////////////////////////////////////////////////
 
         private static bool IsTransparentProxy(object obj)

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/BinderHelper.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/BinderHelper.cs
@@ -548,5 +548,15 @@ namespace Microsoft.CSharp.RuntimeBinder
 
             return true;
         }
+
+#if !ENABLECOMBINDER
+        internal static void ThrowIfUsingDynamicCom(DynamicMetaObject target)
+        {
+            if (!BinderHelper.IsWindowsRuntimeObject(target) && target.LimitType.IsCOMObject)
+            {
+                throw ErrorHandling.Error(ErrorCode.ERR_DynamicBindingComUnsupported);
+            }
+        }
+#endif
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/BinderHelper.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/BinderHelper.cs
@@ -11,6 +11,7 @@ using System.Linq.Expressions;
 using System.Runtime.InteropServices;
 using System.Reflection;
 using System.Numerics.Hashing;
+using Microsoft.CSharp.RuntimeBinder.Errors;
 
 namespace Microsoft.CSharp.RuntimeBinder
 {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpConvertBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpConvertBinder.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Dynamic;
 using System.Numerics.Hashing;
+using Microsoft.CSharp.RuntimeBinder.Errors;
 using Microsoft.CSharp.RuntimeBinder.Semantics;
 
 namespace Microsoft.CSharp.RuntimeBinder
@@ -121,7 +122,13 @@ namespace Microsoft.CSharp.RuntimeBinder
             {
                 return com;
             }
+#else
+            if (!BinderHelper.IsWindowsRuntimeObject(target) && target.LimitType.IsCOMObject)
+            {
+                throw ErrorHandling.Error(ErrorCode.ERR_DynamicBindingComUnsupported);
+            }
 #endif
+
             BinderHelper.ValidateBindArgument(target, nameof(target));
             return BinderHelper.Bind(this, _binder, new[] { target }, null, errorSuggestion);
         }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpConvertBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpConvertBinder.cs
@@ -123,10 +123,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                 return com;
             }
 #else
-            if (!BinderHelper.IsWindowsRuntimeObject(target) && target.LimitType.IsCOMObject)
-            {
-                throw ErrorHandling.Error(ErrorCode.ERR_DynamicBindingComUnsupported);
-            }
+            BinderHelper.ThrowIfUsingDynamicCom(target);
 #endif
 
             BinderHelper.ValidateBindArgument(target, nameof(target));

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpGetIndexBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpGetIndexBinder.cs
@@ -95,10 +95,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                 return com;
             }
 #else
-            if (!BinderHelper.IsWindowsRuntimeObject(target) && target.LimitType.IsCOMObject)
-            {
-                throw ErrorHandling.Error(ErrorCode.ERR_DynamicBindingComUnsupported);
-            }
+            BinderHelper.ThrowIfUsingDynamicCom(target);
 #endif
 
             BinderHelper.ValidateBindArgument(target, nameof(target));

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpGetIndexBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpGetIndexBinder.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Dynamic;
+using Microsoft.CSharp.RuntimeBinder.Errors;
 using Microsoft.CSharp.RuntimeBinder.Semantics;
 
 namespace Microsoft.CSharp.RuntimeBinder
@@ -89,11 +90,17 @@ namespace Microsoft.CSharp.RuntimeBinder
         {
 #if ENABLECOMBINDER
             DynamicMetaObject com;
-            if (!BinderHelper.IsWindowsRuntimeObject(target) && ComBinder.TryBindGetIndex(this, target, indexes, out com))
+            if (!BinderHelper.IsWindowsRuntimeObject(target) && ComBinder.TryConvert(this, target, out com))
             {
                 return com;
             }
+#else
+            if (!BinderHelper.IsWindowsRuntimeObject(target) && target.LimitType.IsCOMObject)
+            {
+                throw ErrorHandling.Error(ErrorCode.ERR_DynamicBindingComUnsupported);
+            }
 #endif
+
             BinderHelper.ValidateBindArgument(target, nameof(target));
             BinderHelper.ValidateBindArgument(indexes, nameof(indexes));
             return BinderHelper.Bind(this, _binder, BinderHelper.Cons(target, indexes), _argumentInfo, errorSuggestion);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpGetMemberBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpGetMemberBinder.cs
@@ -110,10 +110,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                 return com;
             }
 #else
-            if (!BinderHelper.IsWindowsRuntimeObject(target) && target.LimitType.IsCOMObject)
-            {
-                throw ErrorHandling.Error(ErrorCode.ERR_DynamicBindingComUnsupported);
-            }
+            BinderHelper.ThrowIfUsingDynamicCom(target);
 #endif
 
             BinderHelper.ValidateBindArgument(target, nameof(target));

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpGetMemberBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpGetMemberBinder.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Dynamic;
 using System.Numerics.Hashing;
+using Microsoft.CSharp.RuntimeBinder.Errors;
 using Microsoft.CSharp.RuntimeBinder.Semantics;
 
 namespace Microsoft.CSharp.RuntimeBinder
@@ -104,11 +105,17 @@ namespace Microsoft.CSharp.RuntimeBinder
         {
 #if ENABLECOMBINDER
             DynamicMetaObject com;
-            if (!BinderHelper.IsWindowsRuntimeObject(target) && ComBinder.TryBindGetMember(this, target, out com, ResultIndexed))
+            if (!BinderHelper.IsWindowsRuntimeObject(target) && ComBinder.TryConvert(this, target, out com))
             {
                 return com;
             }
+#else
+            if (!BinderHelper.IsWindowsRuntimeObject(target) && target.LimitType.IsCOMObject)
+            {
+                throw ErrorHandling.Error(ErrorCode.ERR_DynamicBindingComUnsupported);
+            }
 #endif
+
             BinderHelper.ValidateBindArgument(target, nameof(target));
             return BinderHelper.Bind(this, _binder, new[] { target }, _argumentInfo, errorSuggestion);
         }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpInvokeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpInvokeBinder.cs
@@ -108,10 +108,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                 return com;
             }
 #else
-            if (!BinderHelper.IsWindowsRuntimeObject(target) && target.LimitType.IsCOMObject)
-            {
-                throw ErrorHandling.Error(ErrorCode.ERR_DynamicBindingComUnsupported);
-            }
+            BinderHelper.ThrowIfUsingDynamicCom(target);
 #endif
 
             BinderHelper.ValidateBindArgument(target, nameof(target));

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpInvokeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpInvokeBinder.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Dynamic;
 using System.Numerics.Hashing;
+using Microsoft.CSharp.RuntimeBinder.Errors;
 using Microsoft.CSharp.RuntimeBinder.Semantics;
 
 namespace Microsoft.CSharp.RuntimeBinder
@@ -101,13 +102,18 @@ namespace Microsoft.CSharp.RuntimeBinder
         public override DynamicMetaObject FallbackInvoke(DynamicMetaObject target, DynamicMetaObject[] args, DynamicMetaObject errorSuggestion)
         {
 #if ENABLECOMBINDER
-
             DynamicMetaObject com;
-            if (!BinderHelper.IsWindowsRuntimeObject(target) && ComBinder.TryBindInvoke(this, target, args, out com))
+            if (!BinderHelper.IsWindowsRuntimeObject(target) && ComBinder.TryConvert(this, target, out com))
             {
                 return com;
             }
+#else
+            if (!BinderHelper.IsWindowsRuntimeObject(target) && target.LimitType.IsCOMObject)
+            {
+                throw ErrorHandling.Error(ErrorCode.ERR_DynamicBindingComUnsupported);
+            }
 #endif
+
             BinderHelper.ValidateBindArgument(target, nameof(target));
             BinderHelper.ValidateBindArgument(args, nameof(args));
             return BinderHelper.Bind(this, _binder, BinderHelper.Cons(target, args), _argumentInfo, errorSuggestion);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpInvokeMemberBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpInvokeMemberBinder.cs
@@ -121,10 +121,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                 return com;
             }
 #else
-            if (!BinderHelper.IsWindowsRuntimeObject(target) && target.LimitType.IsCOMObject)
-            {
-                throw ErrorHandling.Error(ErrorCode.ERR_DynamicBindingComUnsupported);
-            }
+            BinderHelper.ThrowIfUsingDynamicCom(target);
 #endif
 
             BinderHelper.ValidateBindArgument(target, nameof(target));

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpInvokeMemberBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpInvokeMemberBinder.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Dynamic;
 using System.Numerics.Hashing;
+using Microsoft.CSharp.RuntimeBinder.Errors;
 using Microsoft.CSharp.RuntimeBinder.Semantics;
 
 namespace Microsoft.CSharp.RuntimeBinder
@@ -115,11 +116,17 @@ namespace Microsoft.CSharp.RuntimeBinder
         {
 #if ENABLECOMBINDER
             DynamicMetaObject com;
-            if (!BinderHelper.IsWindowsRuntimeObject(target) && ComBinder.TryBindInvokeMember(this, target, args, out com))
+            if (!BinderHelper.IsWindowsRuntimeObject(target) && ComBinder.TryConvert(this, target, out com))
             {
                 return com;
             }
+#else
+            if (!BinderHelper.IsWindowsRuntimeObject(target) && target.LimitType.IsCOMObject)
+            {
+                throw ErrorHandling.Error(ErrorCode.ERR_DynamicBindingComUnsupported);
+            }
 #endif
+
             BinderHelper.ValidateBindArgument(target, nameof(target));
             BinderHelper.ValidateBindArgument(args, nameof(args));
             return BinderHelper.Bind(this, _binder, BinderHelper.Cons(target, args), _argumentInfo, errorSuggestion);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpSetIndexBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpSetIndexBinder.cs
@@ -115,10 +115,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                 return com;
             }
 #else
-            if (!BinderHelper.IsWindowsRuntimeObject(target) && target.LimitType.IsCOMObject)
-            {
-                throw ErrorHandling.Error(ErrorCode.ERR_DynamicBindingComUnsupported);
-            }
+            BinderHelper.ThrowIfUsingDynamicCom(target);
 #endif
 
             BinderHelper.ValidateBindArgument(target, nameof(target));

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpSetIndexBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpSetIndexBinder.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Dynamic;
 using System.Numerics.Hashing;
+using Microsoft.CSharp.RuntimeBinder.Errors;
 using Microsoft.CSharp.RuntimeBinder.Semantics;
 
 namespace Microsoft.CSharp.RuntimeBinder
@@ -109,11 +110,17 @@ namespace Microsoft.CSharp.RuntimeBinder
         {
 #if ENABLECOMBINDER
             DynamicMetaObject com;
-            if (!BinderHelper.IsWindowsRuntimeObject(target) && ComBinder.TryBindSetIndex(this, target, indexes, value, out com))
+            if (!BinderHelper.IsWindowsRuntimeObject(target) && ComBinder.TryConvert(this, target, out com))
             {
                 return com;
             }
+#else
+            if (!BinderHelper.IsWindowsRuntimeObject(target) && target.LimitType.IsCOMObject)
+            {
+                throw ErrorHandling.Error(ErrorCode.ERR_DynamicBindingComUnsupported);
+            }
 #endif
+
             BinderHelper.ValidateBindArgument(target, nameof(target));
             BinderHelper.ValidateBindArgument(indexes, nameof(indexes));
             BinderHelper.ValidateBindArgument(value, nameof(value));

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpSetMemberBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpSetMemberBinder.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Dynamic;
 using System.Numerics.Hashing;
+using Microsoft.CSharp.RuntimeBinder.Errors;
 using Microsoft.CSharp.RuntimeBinder.Semantics;
 
 namespace Microsoft.CSharp.RuntimeBinder
@@ -109,11 +110,17 @@ namespace Microsoft.CSharp.RuntimeBinder
         {
 #if ENABLECOMBINDER
             DynamicMetaObject com;
-            if (!BinderHelper.IsWindowsRuntimeObject(target) && ComBinder.TryBindSetMember(this, target, value, out com))
+            if (!BinderHelper.IsWindowsRuntimeObject(target) && ComBinder.TryConvert(this, target, out com))
             {
                 return com;
             }
+#else
+            if (!BinderHelper.IsWindowsRuntimeObject(target) && target.LimitType.IsCOMObject)
+            {
+                throw ErrorHandling.Error(ErrorCode.ERR_DynamicBindingComUnsupported);
+            }
 #endif
+
             BinderHelper.ValidateBindArgument(target, nameof(target));
             BinderHelper.ValidateBindArgument(value, nameof(value));
             return BinderHelper.Bind(this, _binder, new[] { target, value }, _argumentInfo, errorSuggestion);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpSetMemberBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpSetMemberBinder.cs
@@ -115,10 +115,7 @@ namespace Microsoft.CSharp.RuntimeBinder
                 return com;
             }
 #else
-            if (!BinderHelper.IsWindowsRuntimeObject(target) && target.LimitType.IsCOMObject)
-            {
-                throw ErrorHandling.Error(ErrorCode.ERR_DynamicBindingComUnsupported);
-            }
+            BinderHelper.ThrowIfUsingDynamicCom(target);
 #endif
 
             BinderHelper.ValidateBindArgument(target, nameof(target));

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorCode.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorCode.cs
@@ -65,6 +65,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
         ERR_BadNamedArgumentForDelegateInvoke = 1746,
         ERR_NonInvocableMemberCalled = 1955,
         ERR_BadNonTrailingNamedArgument = 8323,
-        ERR_DynamicBindingComUnsupported,
+        ERR_DynamicBindingComUnsupported = 8365
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorCode.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorCode.cs
@@ -64,6 +64,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
         ERR_NamedArgumentUsedInPositional = 1744,
         ERR_BadNamedArgumentForDelegateInvoke = 1746,
         ERR_NonInvocableMemberCalled = 1955,
-        ERR_BadNonTrailingNamedArgument = 8323
+        ERR_BadNonTrailingNamedArgument = 8323,
+        ERR_DynamicBindingComUnsupported,
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorFacts.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorFacts.cs
@@ -191,7 +191,9 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
                 case ErrorCode.ERR_BadNonTrailingNamedArgument:
                     codeStr = SR.BadNonTrailingNamedArgument;
                     break;
-
+                case ErrorCode.ERR_DynamicBindingComUnsupported:
+                    codeStr = SR.DynamicBindingComUnsupported;
+                    break;
                 default:
                     // means missing resources match the code entry
                     Debug.Fail("Missing resources for the error " + code.ToString());

--- a/src/Microsoft.CSharp/src/Resources/Strings.resx
+++ b/src/Microsoft.CSharp/src/Resources/Strings.resx
@@ -329,6 +329,9 @@
   <data name="AnonMethod" xml:space="preserve">
     <value>anonymous method</value>
   </data>
+  <data name="DynamicBindingComUnsupported" xml:space="preserve">
+    <value>The C# runtime binder cannot dynamically resolve members on COM Runtime Callable Wrappers.</value>
+  </data>
   <data name="ERRORSYM" xml:space="preserve">
     <value>&lt;error&gt;</value>
   </data>


### PR DESCRIPTION
Since .NET Core doesn't support using `dynamic` with COM objects, add in exception throws with a standardized message that explains that the dynamic binder doesn't work with COM objects outside of .NET Framework.

Initially we thought that the `RuntimeBinderException` that was being thrown for not finding a member on `System.__ComObject` would cover all of our cases, but we learned in #40053, .NET constructs that are valid in COM but not in C# can cause other exceptions with poor error messages to leak out of the binder.

This PR changes the C# binders to throw an exception in the dynamic binder when trying to dynamically resolve a COM object without an enabled COM binder.

cc: @jaredpar @jkotas @davidwrighton 
