### PR TITLE
Update IconCodecTests.cs

### DIFF
--- a/src/System.Drawing.Common/tests/mono/System.Drawing.Imaging/IconCodecTests.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing.Imaging/IconCodecTests.cs
@@ -148,6 +148,7 @@ namespace MonoTests.System.Drawing.Imaging
 
         [PlatformSpecific(TestPlatforms.Windows)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Flaky - ArgumentException")]
         public void Bitmap16Features_Palette_Entries_Windows()
         {
             string sInFile = Helpers.GetTestBitmapPath("48x48_multiple_entries_4bit.ico");


### PR DESCRIPTION
```
Error message
System.ArgumentException : Parameter is not valid.

Stack trace
   at System.Drawing.Bitmap..ctor(String filename)
   at MonoTests.System.Drawing.Imaging.IconCodecTest.Bitmap16Features_Palette_Entries_Windows() in /_/src/System.Drawing.Common/tests/mono/System.Drawing.Imaging/IconCodecTests.cs:line 15
```