### PR TITLE
Re-enable xunit warning 1026 (unused theory arguments)

### DIFF
--- a/src/CodeAnalysis.ruleset
+++ b/src/CodeAnalysis.ruleset
@@ -213,7 +213,6 @@
   <Rules AnalyzerId="xunit.analyzers" RuleNamespace="xunit.analyzers">
     <Rule Id="xUnit1019" Action="None" /> <!-- MemberData must reference a member providing a valid data type -->
     <Rule Id="xUnit1024" Action="None" /> <!-- Test methods cannot have overloads -->
-    <Rule Id="xUnit1026" Action="None" /> <!-- Theory methods should use all of their parameters -->
     <Rule Id="xUnit2013" Action="None" /> <!-- Do not use equality check to check for collection size. -->
     <Rule Id="xUnit2017" Action="None" /> <!-- Do not use Contains() to check if a value exists in a collection -->
   </Rules>

--- a/src/Common/tests/System/Collections/ICollectionTest.cs
+++ b/src/Common/tests/System/Collections/ICollectionTest.cs
@@ -263,7 +263,7 @@ namespace Tests.Collections
             if (arrayLowerBound != 0 && !PlatformDetection.IsNonZeroLowerBoundArraySupported)
                 return;
 
-            object[] items = GenerateItems(16);
+            object[] items = GenerateItems(size);
             ICollection collection = GetCollection(items);
             Array itemArray = Array.CreateInstance(
                 typeof (object),

--- a/src/Common/tests/System/Net/WebSockets/WebSocketCreateTest.cs
+++ b/src/Common/tests/System/Net/WebSockets/WebSocketCreateTest.cs
@@ -31,12 +31,8 @@ namespace System.Net.WebSockets.Tests
             AssertExtensions.Throws<ArgumentOutOfRangeException>("keepAliveInterval", () => CreateFromStream(new MemoryStream(), true, "subProtocol", TimeSpan.FromSeconds(-2)));
         }
 
-        [Theory]
-        [InlineData(0)]
-        [InlineData(1)]
-        [InlineData(14)]
-        [InlineData(4096)]
-        public void CreateFromStream_ValidBufferSizes_CreatesWebSocket(int bufferSize)
+        [Fact]
+        public void CreateFromStream_ValidBufferSizes_CreatesWebSocket()
         {
             Assert.NotNull(CreateFromStream(new MemoryStream(), false, null, Timeout.InfiniteTimeSpan));
             Assert.NotNull(CreateFromStream(new MemoryStream(), true, null, Timeout.InfiniteTimeSpan));

--- a/src/Common/tests/Tests/System/Net/HttpDateParserTests.cs
+++ b/src/Common/tests/Tests/System/Net/HttpDateParserTests.cs
@@ -57,7 +57,8 @@ namespace Tests.System.Net.Http
         [InlineData(",Sun, 06 Nov 1994 08:49:37 GMT")]
         public static void TryStringToDate_UseInvalidDateTimeString(string invalid)
         {
-            Assert.False(HttpDateParser.TryStringToDate(",Sun, 06 Nov 1994 08:49:37 GMT", out var result));
+            Assert.False(HttpDateParser.TryStringToDate(invalid, out var result));
+            Assert.Equal(default, result);
         }
 
         [Fact]

--- a/src/Common/tests/Tests/System/StringTests.cs
+++ b/src/Common/tests/Tests/System/StringTests.cs
@@ -82,6 +82,7 @@ namespace System.Tests
         [InlineData(new char[] { 'a', 'b', 'c' }, 1, 0, "")]
         public static unsafe void Ctor_CharPtr_Int_Int(char[] valueArray, int startIndex, int length, string expected)
         {
+            _ = valueArray; // xunit analyzer bug: https://github.com/xunit/xunit/issues/1969
             fixed (char* value = valueArray)
             {
                 Assert.Equal(expected, new string(value, startIndex, length));
@@ -288,31 +289,31 @@ namespace System.Tests
         [MemberData(nameof(Concat_Strings_LessThan2_GreaterThan4_TestData))]
         public static void Concat_String(string[] values, string expected)
         {
-            Action<string> validate = result =>
+            void Validate(string result)
             {
                 Assert.Equal(expected, result);
                 if (result.Length == 0)
                 {
                     Assert.Same(string.Empty, result);
                 }
-            };
+            }
 
             if (values.Length == 2)
             {
-                validate(string.Concat(values[0], values[1]));
+                Validate(string.Concat(values[0], values[1]));
             }
             else if (values.Length == 3)
             {
-                validate(string.Concat(values[0], values[1], values[2]));
+                Validate(string.Concat(values[0], values[1], values[2]));
             }
             else if (values.Length == 4)
             {
-                validate(string.Concat(values[0], values[1], values[2], values[3]));
+                Validate(string.Concat(values[0], values[1], values[2], values[3]));
             }
 
-            validate(string.Concat(values));
-            validate(string.Concat((IEnumerable<string>)values));
-            validate(string.Concat<string>((IEnumerable<string>)values)); // Call the generic IEnumerable<T>-based overload
+            Validate(string.Concat(values));
+            Validate(string.Concat((IEnumerable<string>)values));
+            Validate(string.Concat<string>((IEnumerable<string>)values)); // Call the generic IEnumerable<T>-based overload
         }
 
         [Fact]

--- a/src/Microsoft.VisualBasic.Core/tests/ByteTypeTests.cs
+++ b/src/Microsoft.VisualBasic.Core/tests/ByteTypeTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
         // The following conversions are not supported.
         [Theory]
         [MemberData(nameof(FromObject_NotSupported_TestData))]
-        public void FromObject_NotSupported(object value, byte expected)
+        public void FromObject_NotSupported(object value)
         {
             Assert.Throws<InvalidCastException>(() => ByteType.FromObject(value));
         }
@@ -46,14 +46,6 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
         public void FromString(string value, byte expected)
         {
             Assert.Equal(expected, ByteType.FromString(value));
-        }
-
-        // The following conversions are not supported.
-        [Theory]
-        [MemberData(nameof(FromString_NotSupported_TestData))]
-        public void FromString_NotSupported(string value, byte expected)
-        {
-            Assert.Throws<InvalidCastException>(() => ByteType.FromString(value));
         }
 
         [Theory]
@@ -121,30 +113,30 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
         public static IEnumerable<object[]> FromObject_NotSupported_TestData()
         {
             // sbyte.
-            yield return new object[] { (sbyte)0, byte.MinValue };
-            yield return new object[] { (sbyte)1, (byte)1 };
-            yield return new object[] { sbyte.MaxValue, (byte)127 };
-            yield return new object[] { (SByteEnum)0, byte.MinValue };
-            yield return new object[] { (SByteEnum)1, (byte)1 };
-            yield return new object[] { (SByteEnum)sbyte.MaxValue, (byte)127 };
+            yield return new object[] { (sbyte)0 };
+            yield return new object[] { (sbyte)1 };
+            yield return new object[] { sbyte.MaxValue };
+            yield return new object[] { (SByteEnum)0 };
+            yield return new object[] { (SByteEnum)1 };
+            yield return new object[] { (SByteEnum)sbyte.MaxValue };
 
             // ushort.
-            yield return new object[] { ushort.MinValue, byte.MinValue };
-            yield return new object[] { (ushort)1, (byte)1 };
-            yield return new object[] { (UShortEnum)ushort.MinValue, byte.MinValue };
-            yield return new object[] { (UShortEnum)1, (byte)1 };
+            yield return new object[] { ushort.MinValue };
+            yield return new object[] { (ushort)1 };
+            yield return new object[] { (UShortEnum)ushort.MinValue };
+            yield return new object[] { (UShortEnum)1 };
 
             // uint.
-            yield return new object[] { uint.MinValue, byte.MinValue };
-            yield return new object[] { (uint)1, (byte)1 };
-            yield return new object[] { (UIntEnum)uint.MinValue, byte.MinValue };
-            yield return new object[] { (UIntEnum)1, (byte)1 };
+            yield return new object[] { uint.MinValue };
+            yield return new object[] { (uint)1 };
+            yield return new object[] { (UIntEnum)uint.MinValue };
+            yield return new object[] { (UIntEnum)1 };
 
             // ulong.
-            yield return new object[] { ulong.MinValue, byte.MinValue };
-            yield return new object[] { (ulong)1, (byte)1 };
-            yield return new object[] { (ULongEnum)ulong.MinValue, byte.MinValue };
-            yield return new object[] { (ULongEnum)1, (byte)1 };
+            yield return new object[] { ulong.MinValue };
+            yield return new object[] { (ulong)1 };
+            yield return new object[] { (ULongEnum)ulong.MinValue };
+            yield return new object[] { (ULongEnum)1 };
         }
 
         public static IEnumerable<object[]> FromObject_Invalid_TestData()
@@ -182,11 +174,6 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
             yield return new object[] { " &o5", (byte)5 };
             yield return new object[] { "&o0", byte.MinValue };
             yield return new object[] { 1.1.ToString(), (byte)1 };
-        }
-
-        public static IEnumerable<object[]> FromString_NotSupported_TestData()
-        {
-            yield break;
         }
 
         public static IEnumerable<object[]> FromString_Invalid_TestData()

--- a/src/Microsoft.VisualBasic.Core/tests/CharTypeTests.cs
+++ b/src/Microsoft.VisualBasic.Core/tests/CharTypeTests.cs
@@ -19,14 +19,6 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
             Assert.Equal(expected, CharType.FromObject(value));
         }
 
-        // The following conversions are not supported.
-        [Theory]
-        [MemberData(nameof(FromObject_NotSupported_TestData))]
-        public void FromObject_NotSupported(object value, char expected)
-        {
-            Assert.Throws<InvalidCastException>(() => CharType.FromObject(value));
-        }
-
         [Theory]
         [MemberData(nameof(FromObject_Invalid_TestData))]
         public void FromObject_ThrowsInvalidCastException(object value)
@@ -46,14 +38,6 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
         public void FromString(string value, char expected)
         {
             Assert.Equal(expected, CharType.FromString(value));
-        }
-
-        // The following conversions are not supported.
-        [Theory]
-        [MemberData(nameof(FromString_NotSupported_TestData))]
-        public void FromString_NotSupported(string value, char expected)
-        {
-            Assert.Throws<InvalidCastException>(() => CharType.FromString(value));
         }
 
         [Theory]
@@ -79,11 +63,6 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
 
             // null.
             yield return new object[] { null, char.MinValue };
-        }
-
-        public static IEnumerable<object[]> FromObject_NotSupported_TestData()
-        {
-            yield break;
         }
 
         public static IEnumerable<object[]> FromObject_Invalid_TestData()
@@ -207,11 +186,6 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
             yield return new object[] { "invalid", 'i' };
             yield return new object[] { "18446744073709551616", '1' };
             yield return new object[] { "1844674407370955161618446744073709551616", '1' };
-        }
-
-        public static IEnumerable<object[]> FromString_NotSupported_TestData()
-        {
-            yield break;
         }
 
         public static IEnumerable<object[]> FromString_Invalid_TestData()

--- a/src/Microsoft.VisualBasic.Core/tests/DateTypeTests.cs
+++ b/src/Microsoft.VisualBasic.Core/tests/DateTypeTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
         // The following conversions are not supported.
         [Theory]
         [MemberData(nameof(FromObject_NotSupported_TestData))]
-        public void FromObject_NotSupported(object value, DateTime expected)
+        public void FromObject_NotSupported(object value)
         {
             Assert.Throws<InvalidCastException>(() => DateType.FromObject(value));
         }
@@ -52,7 +52,7 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
         // The following conversions are not supported.
         [Theory]
         [MemberData(nameof(FromString_NotSupported_TestData))]
-        public void FromString_NotSupported(string value, DateTime expected)
+        public void FromString_NotSupported(string value)
         {
             Assert.Throws<InvalidCastException>(() => DateType.FromString(value));
         }
@@ -80,95 +80,95 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
         public static IEnumerable<object[]> FromObject_NotSupported_TestData()
         {
             // byte.
-            yield return new object[] { byte.MinValue, default(DateTime) };
-            yield return new object[] { (byte)1, default(DateTime) };
-            yield return new object[] { byte.MaxValue, default(DateTime) };
-            yield return new object[] { (ByteEnum)byte.MinValue, default(DateTime) };
-            yield return new object[] { (ByteEnum)1, default(DateTime) };
-            yield return new object[] { (ByteEnum)byte.MaxValue, default(DateTime) };
+            yield return new object[] { byte.MinValue };
+            yield return new object[] { (byte)1 };
+            yield return new object[] { byte.MaxValue };
+            yield return new object[] { (ByteEnum)byte.MinValue };
+            yield return new object[] { (ByteEnum)1 };
+            yield return new object[] { (ByteEnum)byte.MaxValue };
 
             // sbyte.
-            yield return new object[] { sbyte.MinValue, default(DateTime) };
-            yield return new object[] { (sbyte)(-1), default(DateTime) };
-            yield return new object[] { (sbyte)0, default(DateTime) };
-            yield return new object[] { (sbyte)1, default(DateTime) };
-            yield return new object[] { sbyte.MaxValue, default(DateTime) };
-            yield return new object[] { (SByteEnum)sbyte.MinValue, default(DateTime) };
-            yield return new object[] { (SByteEnum)(-1), default(DateTime) };
-            yield return new object[] { (SByteEnum)0, default(DateTime) };
-            yield return new object[] { (SByteEnum)1, default(DateTime) };
-            yield return new object[] { (SByteEnum)sbyte.MaxValue, default(DateTime) };
+            yield return new object[] { sbyte.MinValue };
+            yield return new object[] { (sbyte)(-1) };
+            yield return new object[] { (sbyte)0 };
+            yield return new object[] { (sbyte)1 };
+            yield return new object[] { sbyte.MaxValue };
+            yield return new object[] { (SByteEnum)sbyte.MinValue };
+            yield return new object[] { (SByteEnum)(-1) };
+            yield return new object[] { (SByteEnum)0 };
+            yield return new object[] { (SByteEnum)1 };
+            yield return new object[] { (SByteEnum)sbyte.MaxValue };
 
             // ushort.
-            yield return new object[] { ushort.MinValue, default(DateTime) };
-            yield return new object[] { (ushort)1, default(DateTime) };
-            yield return new object[] { ushort.MaxValue, default(DateTime) };
-            yield return new object[] { (UShortEnum)ushort.MinValue, default(DateTime) };
-            yield return new object[] { (UShortEnum)1, default(DateTime) };
-            yield return new object[] { (UShortEnum)ushort.MaxValue, default(DateTime) };
+            yield return new object[] { ushort.MinValue };
+            yield return new object[] { (ushort)1 };
+            yield return new object[] { ushort.MaxValue };
+            yield return new object[] { (UShortEnum)ushort.MinValue };
+            yield return new object[] { (UShortEnum)1 };
+            yield return new object[] { (UShortEnum)ushort.MaxValue };
 
             // short.
-            yield return new object[] { short.MinValue, default(DateTime) };
-            yield return new object[] { (short)(-1), default(DateTime) };
-            yield return new object[] { (short)0, default(DateTime) };
-            yield return new object[] { (short)1, default(DateTime) };
-            yield return new object[] { short.MaxValue, default(DateTime) };
-            yield return new object[] { (ShortEnum)short.MinValue, default(DateTime) };
-            yield return new object[] { (ShortEnum)(-1), default(DateTime) };
-            yield return new object[] { (ShortEnum)0, default(DateTime) };
-            yield return new object[] { (ShortEnum)1, default(DateTime) };
-            yield return new object[] { (ShortEnum)short.MaxValue, default(DateTime) };
+            yield return new object[] { short.MinValue };
+            yield return new object[] { (short)(-1) };
+            yield return new object[] { (short)0 };
+            yield return new object[] { (short)1 };
+            yield return new object[] { short.MaxValue };
+            yield return new object[] { (ShortEnum)short.MinValue };
+            yield return new object[] { (ShortEnum)(-1) };
+            yield return new object[] { (ShortEnum)0 };
+            yield return new object[] { (ShortEnum)1 };
+            yield return new object[] { (ShortEnum)short.MaxValue };
 
             // uint.
-            yield return new object[] { uint.MinValue, default(DateTime) };
-            yield return new object[] { (uint)1, default(DateTime) };
-            yield return new object[] { (UIntEnum)uint.MinValue, default(DateTime) };
-            yield return new object[] { (UIntEnum)1, default(DateTime) };
+            yield return new object[] { uint.MinValue };
+            yield return new object[] { (uint)1 };
+            yield return new object[] { (UIntEnum)uint.MinValue };
+            yield return new object[] { (UIntEnum)1 };
 
             // int.
-            yield return new object[] { int.MinValue, default(DateTime) };
-            yield return new object[] { -1, default(DateTime) };
-            yield return new object[] { 0, default(DateTime) };
-            yield return new object[] { 1, default(DateTime) };
-            yield return new object[] { int.MaxValue, default(DateTime) };
-            yield return new object[] { (IntEnum)int.MinValue, default(DateTime) };
-            yield return new object[] { (IntEnum)(-1), default(DateTime) };
-            yield return new object[] { (IntEnum)0, default(DateTime) };
-            yield return new object[] { (IntEnum)1, default(DateTime) };
-            yield return new object[] { (IntEnum)int.MaxValue, default(DateTime) };
+            yield return new object[] { int.MinValue };
+            yield return new object[] { -1 };
+            yield return new object[] { 0 };
+            yield return new object[] { 1 };
+            yield return new object[] { int.MaxValue };
+            yield return new object[] { (IntEnum)int.MinValue };
+            yield return new object[] { (IntEnum)(-1) };
+            yield return new object[] { (IntEnum)0 };
+            yield return new object[] { (IntEnum)1 };
+            yield return new object[] { (IntEnum)int.MaxValue };
 
             // ulong.
-            yield return new object[] { ulong.MinValue, default(DateTime) };
-            yield return new object[] { (ulong)1, default(DateTime) };
-            yield return new object[] { (ULongEnum)ulong.MinValue, default(DateTime) };
-            yield return new object[] { (ULongEnum)1, default(DateTime) };
+            yield return new object[] { ulong.MinValue };
+            yield return new object[] { (ulong)1 };
+            yield return new object[] { (ULongEnum)ulong.MinValue };
+            yield return new object[] { (ULongEnum)1 };
 
             // long.
-            yield return new object[] { (long)(-1), default(DateTime) };
-            yield return new object[] { (long)0, default(DateTime) };
-            yield return new object[] { (long)1, default(DateTime) };
-            yield return new object[] { (LongEnum)(-1), default(DateTime) };
-            yield return new object[] { (LongEnum)0, default(DateTime) };
-            yield return new object[] { (LongEnum)1, default(DateTime) };
+            yield return new object[] { (long)(-1) };
+            yield return new object[] { (long)0 };
+            yield return new object[] { (long)1 };
+            yield return new object[] { (LongEnum)(-1) };
+            yield return new object[] { (LongEnum)0 };
+            yield return new object[] { (LongEnum)1 };
 
             // float.
-            yield return new object[] { (float)(-1), default(DateTime) };
-            yield return new object[] { (float)0, default(DateTime) };
-            yield return new object[] { (float)1, default(DateTime) };
+            yield return new object[] { (float)(-1) };
+            yield return new object[] { (float)0 };
+            yield return new object[] { (float)1 };
 
             // double.
-            yield return new object[] { (double)(-1), default(DateTime) };
-            yield return new object[] { (double)0, default(DateTime) };
-            yield return new object[] { (double)1, default(DateTime) };
+            yield return new object[] { (double)(-1) };
+            yield return new object[] { (double)0 };
+            yield return new object[] { (double)1 };
 
             // decimal.
-            yield return new object[] { (decimal)(-1), default(DateTime) };
-            yield return new object[] { (decimal)0, default(DateTime) };
-            yield return new object[] { (decimal)1, default(DateTime) };
+            yield return new object[] { (decimal)(-1) };
+            yield return new object[] { (decimal)0 };
+            yield return new object[] { (decimal)1 };
 
             // bool.
-            yield return new object[] { true, default(DateTime) };
-            yield return new object[] { false, default(DateTime) };
+            yield return new object[] { true };
+            yield return new object[] { false };
         }
 
         public static IEnumerable<object[]> FromObject_Invalid_TestData()
@@ -188,15 +188,15 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
 
         public static IEnumerable<object[]> FromString_NotSupported_TestData()
         {
-            yield return new object[] { null, default(DateTime) };
-            yield return new object[] { "-1", default(DateTime) };
-            yield return new object[] { "0", default(DateTime) };
-            yield return new object[] { "1", default(DateTime) };
-            yield return new object[] { "&h5", default(DateTime) };
-            yield return new object[] { "&h0", default(DateTime) };
-            yield return new object[] { "&o5", default(DateTime) };
-            yield return new object[] { " &o5", default(DateTime) };
-            yield return new object[] { "&o0", default(DateTime) };
+            yield return new object[] { null };
+            yield return new object[] { "-1" };
+            yield return new object[] { "0" };
+            yield return new object[] { "1" };
+            yield return new object[] { "&h5" };
+            yield return new object[] { "&h0" };
+            yield return new object[] { "&o5" };
+            yield return new object[] { " &o5" };
+            yield return new object[] { "&o0" };
         }
 
         public static IEnumerable<object[]> FromString_Invalid_TestData()

--- a/src/Microsoft.VisualBasic.Core/tests/IntegerTypeTests.cs
+++ b/src/Microsoft.VisualBasic.Core/tests/IntegerTypeTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
         // The following conversions are not supported.
         [Theory]
         [MemberData(nameof(FromObject_NotSupported_TestData))]
-        public void FromObject_NotSupported(object value, int expected)
+        public void FromObject_NotSupported(object value)
         {
             Assert.Throws<InvalidCastException>(() => IntegerType.FromObject(value));
         }
@@ -46,14 +46,6 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
         public void FromString(string value, int expected)
         {
             Assert.Equal(expected, IntegerType.FromString(value));
-        }
-
-        // The following conversions are not supported.
-        [Theory]
-        [MemberData(nameof(FromString_NotSupported_TestData))]
-        public void FromString_NotSupported(string value, int expected)
-        {
-            Assert.Throws<InvalidCastException>(() => IntegerType.FromString(value));
         }
 
         [Theory]
@@ -138,36 +130,36 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
         public static IEnumerable<object[]> FromObject_NotSupported_TestData()
         {
             // sbyte.
-            yield return new object[] { sbyte.MinValue, -128 };
-            yield return new object[] { (sbyte)(-1), -1 };
-            yield return new object[] { (sbyte)0, 0 };
-            yield return new object[] { (sbyte)1, 1 };
-            yield return new object[] { sbyte.MaxValue, 127 };
-            yield return new object[] { (SByteEnum)sbyte.MinValue, -128 };
-            yield return new object[] { (SByteEnum)(-1), -1 };
-            yield return new object[] { (SByteEnum)0, 0 };
-            yield return new object[] { (SByteEnum)1, 1 };
-            yield return new object[] { (SByteEnum)sbyte.MaxValue, 127 };
+            yield return new object[] { sbyte.MinValue };
+            yield return new object[] { (sbyte)(-1) };
+            yield return new object[] { (sbyte)0 };
+            yield return new object[] { (sbyte)1 };
+            yield return new object[] { sbyte.MaxValue };
+            yield return new object[] { (SByteEnum)sbyte.MinValue };
+            yield return new object[] { (SByteEnum)(-1) };
+            yield return new object[] { (SByteEnum)0 };
+            yield return new object[] { (SByteEnum)1 };
+            yield return new object[] { (SByteEnum)sbyte.MaxValue };
 
             // ushort.
-            yield return new object[] { ushort.MinValue, 0 };
-            yield return new object[] { (ushort)1, 1 };
-            yield return new object[] { ushort.MaxValue, 65535 };
-            yield return new object[] { (UShortEnum)ushort.MinValue, 0 };
-            yield return new object[] { (UShortEnum)1, 1 };
-            yield return new object[] { (UShortEnum)ushort.MaxValue, 65535 };
+            yield return new object[] { ushort.MinValue };
+            yield return new object[] { (ushort)1 };
+            yield return new object[] { ushort.MaxValue };
+            yield return new object[] { (UShortEnum)ushort.MinValue };
+            yield return new object[] { (UShortEnum)1 };
+            yield return new object[] { (UShortEnum)ushort.MaxValue };
 
             // uint.
-            yield return new object[] { uint.MinValue, 0 };
-            yield return new object[] { (uint)1, 1 };
-            yield return new object[] { (UIntEnum)uint.MinValue, 0 };
-            yield return new object[] { (UIntEnum)1, 1 };
+            yield return new object[] { uint.MinValue };
+            yield return new object[] { (uint)1 };
+            yield return new object[] { (UIntEnum)uint.MinValue };
+            yield return new object[] { (UIntEnum)1 };
 
             // ulong.
-            yield return new object[] { ulong.MinValue, 0 };
-            yield return new object[] { (ulong)1, 1 };
-            yield return new object[] { (ULongEnum)ulong.MinValue, 0 };
-            yield return new object[] { (ULongEnum)1, 1 };
+            yield return new object[] { ulong.MinValue };
+            yield return new object[] { (ulong)1 };
+            yield return new object[] { (ULongEnum)ulong.MinValue };
+            yield return new object[] { (ULongEnum)1 };
         }
 
         public static IEnumerable<object[]> FromObject_Invalid_TestData()
@@ -208,11 +200,6 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
             yield return new object[] { " &o5", 5 };
             yield return new object[] { "&o0", 0 };
             yield return new object[] { 1.1.ToString(), 1 };
-        }
-
-        public static IEnumerable<object[]> FromString_NotSupported_TestData()
-        {
-            yield break;
         }
 
         public static IEnumerable<object[]> FromString_Invalid_TestData()

--- a/src/Microsoft.VisualBasic.Core/tests/LongTypeTests.cs
+++ b/src/Microsoft.VisualBasic.Core/tests/LongTypeTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
         // The following conversions are not supported.
         [Theory]
         [MemberData(nameof(FromObject_NotSupported_TestData))]
-        public void FromObject_NotSupported(object value, long expected)
+        public void FromObject_NotSupported(object value)
         {
             Assert.Throws<InvalidCastException>(() => LongType.FromObject(value));
         }
@@ -46,14 +46,6 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
         public void FromString(string value, long expected)
         {
             Assert.Equal(expected, LongType.FromString(value));
-        }
-
-        // The following conversions are not supported.
-        [Theory]
-        [MemberData(nameof(FromString_NotSupported_TestData))]
-        public void FromString_NotSupported(string value, long expected)
-        {
-            Assert.Throws<InvalidCastException>(() => LongType.FromString(value));
         }
 
         [Theory]
@@ -142,38 +134,38 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
         public static IEnumerable<object[]> FromObject_NotSupported_TestData()
         {
             // sbyte.
-            yield return new object[] { sbyte.MinValue, (long)(-128) };
-            yield return new object[] { (sbyte)(-1), (long)(-1) };
-            yield return new object[] { (sbyte)0, (long)0 };
-            yield return new object[] { (sbyte)1, (long)1 };
-            yield return new object[] { sbyte.MaxValue, (long)127 };
-            yield return new object[] { (SByteEnum)sbyte.MinValue, (long)(-128) };
-            yield return new object[] { (SByteEnum)(-1), (long)(-1) };
-            yield return new object[] { (SByteEnum)0, (long)0 };
-            yield return new object[] { (SByteEnum)1, (long)1 };
-            yield return new object[] { (SByteEnum)sbyte.MaxValue, (long)127 };
+            yield return new object[] { sbyte.MinValue };
+            yield return new object[] { (sbyte)(-1) };
+            yield return new object[] { (sbyte)0 };
+            yield return new object[] { (sbyte)1 };
+            yield return new object[] { sbyte.MaxValue };
+            yield return new object[] { (SByteEnum)sbyte.MinValue };
+            yield return new object[] { (SByteEnum)(-1) };
+            yield return new object[] { (SByteEnum)0 };
+            yield return new object[] { (SByteEnum)1 };
+            yield return new object[] { (SByteEnum)sbyte.MaxValue };
 
             // ushort.
-            yield return new object[] { ushort.MinValue, (long)0 };
-            yield return new object[] { (ushort)1, (long)1 };
-            yield return new object[] { ushort.MaxValue, (long)65535 };
-            yield return new object[] { (UShortEnum)ushort.MinValue, (long)0 };
-            yield return new object[] { (UShortEnum)1, (long)1 };
-            yield return new object[] { (UShortEnum)ushort.MaxValue, (long)65535 };
+            yield return new object[] { ushort.MinValue };
+            yield return new object[] { (ushort)1 };
+            yield return new object[] { ushort.MaxValue };
+            yield return new object[] { (UShortEnum)ushort.MinValue };
+            yield return new object[] { (UShortEnum)1 };
+            yield return new object[] { (UShortEnum)ushort.MaxValue };
 
             // uint.
-            yield return new object[] { uint.MinValue, (long)0 };
-            yield return new object[] { (uint)1, (long)1 };
-            yield return new object[] { uint.MaxValue, (long)4294967295 };
-            yield return new object[] { (UIntEnum)uint.MinValue, (long)0 };
-            yield return new object[] { (UIntEnum)1, (long)1 };
-            yield return new object[] { (UIntEnum)uint.MaxValue, (long)4294967295 };
+            yield return new object[] { uint.MinValue };
+            yield return new object[] { (uint)1 };
+            yield return new object[] { uint.MaxValue };
+            yield return new object[] { (UIntEnum)uint.MinValue };
+            yield return new object[] { (UIntEnum)1 };
+            yield return new object[] { (UIntEnum)uint.MaxValue };
 
             // ulong.
-            yield return new object[] { ulong.MinValue, (long)0 };
-            yield return new object[] { (ulong)1, (long)1 };
-            yield return new object[] { (ULongEnum)ulong.MinValue, (long)0 };
-            yield return new object[] { (ULongEnum)1, (long)1 };
+            yield return new object[] { ulong.MinValue };
+            yield return new object[] { (ulong)1 };
+            yield return new object[] { (ULongEnum)ulong.MinValue };
+            yield return new object[] { (ULongEnum)1 };
         }
 
         public static IEnumerable<object[]> FromObject_Invalid_TestData()
@@ -222,11 +214,6 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
             yield return new object[] { " &o5", (long)5 };
             yield return new object[] { "&o0", (long)0 };
             yield return new object[] { 1.1.ToString(), (long)1 };
-        }
-
-        public static IEnumerable<object[]> FromString_NotSupported_TestData()
-        {
-            yield break;
         }
 
         public static IEnumerable<object[]> FromString_Invalid_TestData()

--- a/src/Microsoft.VisualBasic.Core/tests/OperatorsTests.Comparison.cs
+++ b/src/Microsoft.VisualBasic.Core/tests/OperatorsTests.Comparison.cs
@@ -1112,6 +1112,8 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
         [MemberData(nameof(Compare_Primitives_TestData))]
         public void CompareObjectEqual_Invoke_ReturnsExpected(object left, object right, bool greater, bool equal, bool less)
         {
+            _ = greater;
+            _ = less;
              Assert.Equal(equal, Operators.CompareObjectEqual(left, right, true));
              Assert.Equal(equal, Operators.CompareObjectEqual(left, right, false));
         }
@@ -1174,7 +1176,9 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
         [MemberData(nameof(Compare_Primitives_TestData))]
         public void CompareObjectGreater_Invoke_ReturnsExpected(object left, object right, bool greater, bool equal, bool less)
         {
-             Assert.Equal(greater, Operators.CompareObjectGreater(left, right, true));
+            _ = equal;
+            _ = less;
+            Assert.Equal(greater, Operators.CompareObjectGreater(left, right, true));
              Assert.Equal(greater, Operators.CompareObjectGreater(left, right, false));
         }
 
@@ -1236,7 +1240,8 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
         [MemberData(nameof(Compare_Primitives_TestData))]
         public void CompareObjectGreaterEqual_Invoke_ReturnsExpected(object left, object right, bool greater, bool equal, bool less)
         {
-             Assert.Equal(greater || equal, Operators.CompareObjectGreaterEqual(left, right, true));
+            _ = less;
+            Assert.Equal(greater || equal, Operators.CompareObjectGreaterEqual(left, right, true));
              Assert.Equal(greater || equal, Operators.CompareObjectGreaterEqual(left, right, false));
         }
 
@@ -1298,6 +1303,8 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
         [MemberData(nameof(Compare_Primitives_TestData))]
         public void CompareObjectLess_Invoke_ReturnsExpected(object left, object right, bool greater, bool equal, bool less)
         {
+            _ = greater;
+            _ = equal;
              Assert.Equal(less, Operators.CompareObjectLess(left, right, true));
              Assert.Equal(less, Operators.CompareObjectLess(left, right, false));
         }
@@ -1360,7 +1367,8 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
         [MemberData(nameof(Compare_Primitives_TestData))]
         public void CompareObjectLessEqual_Invoke_ReturnsExpected(object left, object right, bool greater, bool equal, bool less)
         {
-             Assert.Equal(less || equal, Operators.CompareObjectLessEqual(left, right, true));
+            _ = greater;
+            Assert.Equal(less || equal, Operators.CompareObjectLessEqual(left, right, true));
              Assert.Equal(less || equal, Operators.CompareObjectLessEqual(left, right, false));
         }
 
@@ -1422,7 +1430,9 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
         [MemberData(nameof(Compare_Primitives_TestData))]
         public void CompareObjectNotEqual_Invoke_ReturnsExpected(object left, object right, bool greater, bool equal, bool less)
         {
-             Assert.Equal(!equal, Operators.CompareObjectNotEqual(left, right, true));
+            _ = greater;
+            _ = less;
+            Assert.Equal(!equal, Operators.CompareObjectNotEqual(left, right, true));
              Assert.Equal(!equal, Operators.CompareObjectNotEqual(left, right, false));
         }
 
@@ -1485,7 +1495,9 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
         [MemberData(nameof(Compare_Primitives_TestData))]
         public void ConditionalCompareObjectEqual_Invoke_ReturnsExpected(object left, object right, bool greater, bool equal, bool less)
         {
-             Assert.Equal(equal, Operators.ConditionalCompareObjectEqual(left, right, true));
+            _ = greater;
+            _ = less;
+            Assert.Equal(equal, Operators.ConditionalCompareObjectEqual(left, right, true));
              Assert.Equal(equal, Operators.ConditionalCompareObjectEqual(left, right, false));
         }
 
@@ -1547,7 +1559,9 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
         [MemberData(nameof(Compare_Primitives_TestData))]
         public void ConditionalCompareObjectGreater_Invoke_ReturnsExpected(object left, object right, bool greater, bool equal, bool less)
         {
-             Assert.Equal(greater, Operators.ConditionalCompareObjectGreater(left, right, true));
+            _ = equal;
+            _ = less;
+            Assert.Equal(greater, Operators.ConditionalCompareObjectGreater(left, right, true));
              Assert.Equal(greater, Operators.ConditionalCompareObjectGreater(left, right, false));
         }
 
@@ -1609,7 +1623,8 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
         [MemberData(nameof(Compare_Primitives_TestData))]
         public void ConditionalCompareObjectGreaterEqual_Invoke_ReturnsExpected(object left, object right, bool greater, bool equal, bool less)
         {
-             Assert.Equal(greater || equal, Operators.ConditionalCompareObjectGreaterEqual(left, right, true));
+            _ = less;
+            Assert.Equal(greater || equal, Operators.ConditionalCompareObjectGreaterEqual(left, right, true));
              Assert.Equal(greater || equal, Operators.ConditionalCompareObjectGreaterEqual(left, right, false));
         }
 
@@ -1671,6 +1686,8 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
         [MemberData(nameof(Compare_Primitives_TestData))]
         public void ConditionalCompareObjectLess_Invoke_ReturnsExpected(object left, object right, bool greater, bool equal, bool less)
         {
+            _ = greater;
+            _ = equal;
              Assert.Equal(less, Operators.ConditionalCompareObjectLess(left, right, true));
              Assert.Equal(less, Operators.ConditionalCompareObjectLess(left, right, false));
         }
@@ -1733,7 +1750,8 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
         [MemberData(nameof(Compare_Primitives_TestData))]
         public void ConditionalCompareObjectLessEqual_Invoke_ReturnsExpected(object left, object right, bool greater, bool equal, bool less)
         {
-             Assert.Equal(less || equal, Operators.ConditionalCompareObjectLessEqual(left, right, true));
+            _ = greater;
+            Assert.Equal(less || equal, Operators.ConditionalCompareObjectLessEqual(left, right, true));
              Assert.Equal(less || equal, Operators.ConditionalCompareObjectLessEqual(left, right, false));
         }
 
@@ -1795,6 +1813,8 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
         [MemberData(nameof(Compare_Primitives_TestData))]
         public void ConditionalCompareObjectNotEqual_Invoke_ReturnsExpected(object left, object right, bool greater, bool equal, bool less)
         {
+            _ = greater;
+            _ = less;
              Assert.Equal(!equal, Operators.ConditionalCompareObjectNotEqual(left, right, true));
              Assert.Equal(!equal, Operators.ConditionalCompareObjectNotEqual(left, right, false));
         }

--- a/src/Microsoft.VisualBasic.Core/tests/ShortTypeTests.cs
+++ b/src/Microsoft.VisualBasic.Core/tests/ShortTypeTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
         // The following conversions are not supported.
         [Theory]
         [MemberData(nameof(FromObject_NotSupported_TestData))]
-        public void FromObject_NotSupported(object value, short expected)
+        public void FromObject_NotSupported(object value)
         {
             Assert.Throws<InvalidCastException>(() => ShortType.FromObject(value));
         }
@@ -46,14 +46,6 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
         public void FromString(string value, short expected)
         {
             Assert.Equal(expected, ShortType.FromString(value));
-        }
-
-        // The following conversions are not supported.
-        [Theory]
-        [MemberData(nameof(FromString_NotSupported_TestData))]
-        public void FromString_NotSupported(string value, short expected)
-        {
-            Assert.Throws<InvalidCastException>(() => ShortType.FromString(value));
         }
 
         [Theory]
@@ -134,34 +126,34 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
         public static IEnumerable<object[]> FromObject_NotSupported_TestData()
         {
             // sbyte.
-            yield return new object[] { sbyte.MinValue, (short)(-128) };
-            yield return new object[] { (sbyte)(-1), (short)(-1) };
-            yield return new object[] { (sbyte)0, (short)0 };
-            yield return new object[] { (sbyte)1, (short)1 };
-            yield return new object[] { sbyte.MaxValue, (short)127 };
-            yield return new object[] { (SByteEnum)sbyte.MinValue, (short)(-128) };
-            yield return new object[] { (SByteEnum)(-1), (short)(-1) };
-            yield return new object[] { (SByteEnum)0, (short)0 };
-            yield return new object[] { (SByteEnum)1, (short)1 };
-            yield return new object[] { (SByteEnum)sbyte.MaxValue, (short)127 };
+            yield return new object[] { sbyte.MinValue };
+            yield return new object[] { (sbyte)(-1) };
+            yield return new object[] { (sbyte)0 };
+            yield return new object[] { (sbyte)1 };
+            yield return new object[] { sbyte.MaxValue };
+            yield return new object[] { (SByteEnum)sbyte.MinValue };
+            yield return new object[] { (SByteEnum)(-1) };
+            yield return new object[] { (SByteEnum)0 };
+            yield return new object[] { (SByteEnum)1 };
+            yield return new object[] { (SByteEnum)sbyte.MaxValue };
 
             // ushort.
-            yield return new object[] { ushort.MinValue, (short)0 };
-            yield return new object[] { (ushort)1, (short)1 };
-            yield return new object[] { (UShortEnum)ushort.MinValue, (short)0 };
-            yield return new object[] { (UShortEnum)1, (short)1 };
+            yield return new object[] { ushort.MinValue };
+            yield return new object[] { (ushort)1 };
+            yield return new object[] { (UShortEnum)ushort.MinValue };
+            yield return new object[] { (UShortEnum)1 };
 
             // uint.
-            yield return new object[] { uint.MinValue, (short)0 };
-            yield return new object[] { (uint)1, (short)1 };
-            yield return new object[] { (UIntEnum)uint.MinValue, (short)0 };
-            yield return new object[] { (UIntEnum)1, (short)1 };
+            yield return new object[] { uint.MinValue };
+            yield return new object[] { (uint)1 };
+            yield return new object[] { (UIntEnum)uint.MinValue };
+            yield return new object[] { (UIntEnum)1 };
 
             // ulong.
-            yield return new object[] { ulong.MinValue, (short)0 };
-            yield return new object[] { (ulong)1, (short)1 };
-            yield return new object[] { (ULongEnum)ulong.MinValue, (short)0 };
-            yield return new object[] { (ULongEnum)1, (short)1 };
+            yield return new object[] { ulong.MinValue };
+            yield return new object[] { (ulong)1 };
+            yield return new object[] { (ULongEnum)ulong.MinValue };
+            yield return new object[] { (ULongEnum)1 };
         }
 
         public static IEnumerable<object[]> FromObject_Invalid_TestData()
@@ -202,11 +194,6 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
             yield return new object[] { " &o5", (short)5 };
             yield return new object[] { "&o0", (short)0 };
             yield return new object[] { 1.1.ToString(), (short)1 };
-        }
-
-        public static IEnumerable<object[]> FromString_NotSupported_TestData()
-        {
-            yield break;
         }
 
         public static IEnumerable<object[]> FromString_Invalid_TestData()

--- a/src/Microsoft.VisualBasic.Core/tests/SingleTypeTests.cs
+++ b/src/Microsoft.VisualBasic.Core/tests/SingleTypeTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
         // The following conversions are not supported.
         [Theory]
         [MemberData(nameof(FromObject_NotSupported_TestData))]
-        public void FromObject_NotSupported(object value, float expected)
+        public void FromObject_NotSupported(object value)
         {
             Assert.Throws<InvalidCastException>(() => SingleType.FromObject(value));
         }
@@ -62,14 +62,6 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
         public void FromString_Other(string value, float expected)
         {
             Assert.Equal(expected, SingleType.FromString(value));
-        }
-
-        // The following conversions are not supported.
-        [Theory]
-        [MemberData(nameof(FromString_NotSupported_TestData))]
-        public void FromString_NotSupported(string value, float expected)
-        {
-            Assert.Throws<InvalidCastException>(() => SingleType.FromString(value));
         }
 
         [Theory]
@@ -170,40 +162,40 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
         public static IEnumerable<object[]> FromObject_NotSupported_TestData()
         {
             // sbyte.
-            yield return new object[] { sbyte.MinValue, (float)(-128) };
-            yield return new object[] { (sbyte)(-1), (float)(-1) };
-            yield return new object[] { (sbyte)0, (float)0 };
-            yield return new object[] { (sbyte)1, (float)1 };
-            yield return new object[] { sbyte.MaxValue, (float)127 };
-            yield return new object[] { (SByteEnum)sbyte.MinValue, (float)(-128) };
-            yield return new object[] { (SByteEnum)(-1), (float)(-1) };
-            yield return new object[] { (SByteEnum)0, (float)0 };
-            yield return new object[] { (SByteEnum)1, (float)1 };
-            yield return new object[] { (SByteEnum)sbyte.MaxValue, (float)127 };
+            yield return new object[] { sbyte.MinValue };
+            yield return new object[] { (sbyte)(-1) };
+            yield return new object[] { (sbyte)0 };
+            yield return new object[] { (sbyte)1 };
+            yield return new object[] { sbyte.MaxValue };
+            yield return new object[] { (SByteEnum)sbyte.MinValue };
+            yield return new object[] { (SByteEnum)(-1) };
+            yield return new object[] { (SByteEnum)0 };
+            yield return new object[] { (SByteEnum)1 };
+            yield return new object[] { (SByteEnum)sbyte.MaxValue };
 
             // ushort.
-            yield return new object[] { ushort.MinValue, (float)0 };
-            yield return new object[] { (ushort)1, (float)1 };
-            yield return new object[] { ushort.MaxValue, (float)65535 };
-            yield return new object[] { (UShortEnum)ushort.MinValue, (float)0 };
-            yield return new object[] { (UShortEnum)1, (float)1 };
-            yield return new object[] { (UShortEnum)ushort.MaxValue, (float)65535 };
+            yield return new object[] { ushort.MinValue };
+            yield return new object[] { (ushort)1, };
+            yield return new object[] { ushort.MaxValue };
+            yield return new object[] { (UShortEnum)ushort.MinValue };
+            yield return new object[] { (UShortEnum)1 };
+            yield return new object[] { (UShortEnum)ushort.MaxValue };
 
             // uint.
-            yield return new object[] { uint.MinValue, (float)0 };
-            yield return new object[] { (uint)1, (float)1 };
-            yield return new object[] { uint.MaxValue, (float)uint.MaxValue };
-            yield return new object[] { (UIntEnum)uint.MinValue, (float)0 };
-            yield return new object[] { (UIntEnum)1, (float)1 };
-            yield return new object[] { (UIntEnum)uint.MaxValue, (float)uint.MaxValue };
+            yield return new object[] { uint.MinValue };
+            yield return new object[] { (uint)1 };
+            yield return new object[] { uint.MaxValue };
+            yield return new object[] { (UIntEnum)uint.MinValue };
+            yield return new object[] { (UIntEnum)1 };
+            yield return new object[] { (UIntEnum)uint.MaxValue };
 
             // ulong.
-            yield return new object[] { ulong.MinValue, (float)0 };
-            yield return new object[] { (ulong)1, (float)1 };
-            yield return new object[] { ulong.MaxValue, (float)ulong.MaxValue };
-            yield return new object[] { (ULongEnum)ulong.MinValue, (float)0 };
-            yield return new object[] { (ULongEnum)1, (float)1 };
-            yield return new object[] { (ULongEnum)ulong.MaxValue, (float)ulong.MaxValue };
+            yield return new object[] { ulong.MinValue };
+            yield return new object[] { (ulong)1 };
+            yield return new object[] { ulong.MaxValue };
+            yield return new object[] { (ULongEnum)ulong.MinValue };
+            yield return new object[] { (ULongEnum)1 };
+            yield return new object[] { (ULongEnum)ulong.MaxValue };
         }
 
         public static IEnumerable<object[]> FromObject_Invalid_TestData()
@@ -244,11 +236,6 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
         {
             yield return new object[] { double.PositiveInfinity.ToString(), float.PositiveInfinity };
             yield return new object[] { double.NegativeInfinity.ToString(), float.NegativeInfinity };
-        }
-
-        public static IEnumerable<object[]> FromString_NotSupported_TestData()
-        {
-            yield break;
         }
 
         public static IEnumerable<object[]> FromString_Invalid_TestData()

--- a/src/Microsoft.VisualBasic.Core/tests/StringTypeTests.cs
+++ b/src/Microsoft.VisualBasic.Core/tests/StringTypeTests.cs
@@ -110,7 +110,7 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
         [MemberData(nameof(FromUInt16_TestData))]
         [MemberData(nameof(FromUInt32_TestData))]
         [MemberData(nameof(FromUInt64_TestData))]
-        public void FromObject_NotSupported(object value, string expected)
+        public void FromObject_NotSupported(object value)
         {
             Assert.Throws<InvalidCastException>(() => StringType.FromObject(value));
         }
@@ -156,26 +156,26 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
 
         public static IEnumerable<object[]> FromSByte_TestData()
         {
-            yield return new object[] { sbyte.MinValue, "-128" };
-            yield return new object[] { (sbyte)(-1), "-1" };
-            yield return new object[] { (sbyte)0, "0" };
-            yield return new object[] { (sbyte)1, "1" };
-            yield return new object[] { sbyte.MaxValue, "127" };
-            yield return new object[] { (SByteEnum)sbyte.MinValue, "-128" };
-            yield return new object[] { (SByteEnum)(-1), "-1" };
-            yield return new object[] { (SByteEnum)0, "0" };
-            yield return new object[] { (SByteEnum)1, "1" };
-            yield return new object[] { (SByteEnum)sbyte.MaxValue, "127" };
+            yield return new object[] { sbyte.MinValue };
+            yield return new object[] { (sbyte)(-1) };
+            yield return new object[] { (sbyte)0 };
+            yield return new object[] { (sbyte)1 };
+            yield return new object[] { sbyte.MaxValue };
+            yield return new object[] { (SByteEnum)sbyte.MinValue };
+            yield return new object[] { (SByteEnum)(-1) };
+            yield return new object[] { (SByteEnum)0 };
+            yield return new object[] { (SByteEnum)1 };
+            yield return new object[] { (SByteEnum)sbyte.MaxValue };
         }
 
         public static IEnumerable<object[]> FromUInt16_TestData()
         {
-            yield return new object[] { ushort.MinValue, "0" };
-            yield return new object[] { (ushort)1, "1" };
-            yield return new object[] { ushort.MaxValue, "65535" };
-            yield return new object[] { (UShortEnum)ushort.MinValue, "0" };
-            yield return new object[] { (UShortEnum)1, "1" };
-            yield return new object[] { (UShortEnum)ushort.MaxValue, "65535" };
+            yield return new object[] { ushort.MinValue };
+            yield return new object[] { (ushort)1 };
+            yield return new object[] { ushort.MaxValue };
+            yield return new object[] { (UShortEnum)ushort.MinValue };
+            yield return new object[] { (UShortEnum)1 };
+            yield return new object[] { (UShortEnum)ushort.MaxValue };
         }
 
         public static IEnumerable<object[]> FromInt16_TestData()
@@ -194,12 +194,12 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
 
         public static IEnumerable<object[]> FromUInt32_TestData()
         {
-            yield return new object[] { uint.MinValue, "0" };
-            yield return new object[] { (uint)1, "1" };
-            yield return new object[] { uint.MaxValue, "4294967295" };
-            yield return new object[] { (UIntEnum)uint.MinValue, "0" };
-            yield return new object[] { (UIntEnum)1, "1" };
-            yield return new object[] { (UIntEnum)uint.MaxValue, "4294967295" };
+            yield return new object[] { uint.MinValue };
+            yield return new object[] { (uint)1 };
+            yield return new object[] { uint.MaxValue };
+            yield return new object[] { (UIntEnum)uint.MinValue };
+            yield return new object[] { (UIntEnum)1 };
+            yield return new object[] { (UIntEnum)uint.MaxValue };
         }
 
         public static IEnumerable<object[]> FromInt32_TestData()
@@ -218,12 +218,12 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
 
         public static IEnumerable<object[]> FromUInt64_TestData()
         {
-            yield return new object[] { ulong.MinValue, "0" };
-            yield return new object[] { (ulong)1, "1" };
-            yield return new object[] { ulong.MaxValue, "18446744073709551615" };
-            yield return new object[] { (ULongEnum)ulong.MinValue, "0" };
-            yield return new object[] { (ULongEnum)1, "1" };
-            yield return new object[] { (ULongEnum)ulong.MaxValue, "18446744073709551615" };
+            yield return new object[] { ulong.MinValue };
+            yield return new object[] { (ulong)1 };
+            yield return new object[] { ulong.MaxValue };
+            yield return new object[] { (ULongEnum)ulong.MinValue };
+            yield return new object[] { (ULongEnum)1 };
+            yield return new object[] { (ULongEnum)ulong.MaxValue };
         }
 
         public static IEnumerable<object[]> FromInt64_TestData()

--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_GetValue_str_obj_b.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_GetValue_str_obj_b.cs
@@ -59,12 +59,11 @@ namespace Microsoft.Win32.RegistryTests
 
         [Theory]
         [MemberData(nameof(TestExpandableStrings))]
-        public void GetExpandableStringValueWithNoneOption(string testValue, string expectedValue)
+        public void GetExpandableStringValue(string testValue, string expectedValue, RegistryValueOptions getOptions)
         {
-            // [] Make sure NoExpand = false works with some valid values.
             const string valueName = "MyTestKey";
             TestRegistryKey.SetValue(valueName, testValue, RegistryValueKind.ExpandString);
-            Assert.Equal(expectedValue, TestRegistryKey.GetValue(valueName, null, RegistryValueOptions.None).ToString());
+            Assert.Equal(expectedValue, TestRegistryKey.GetValue(valueName, null, getOptions).ToString());
             TestRegistryKey.DeleteValue(valueName);
         }
 
@@ -95,22 +94,13 @@ namespace Microsoft.Win32.RegistryTests
             TestRegistryKey.DeleteValue(valueName);
         }
 
-        [Theory]
-        [MemberData(nameof(TestExpandableStrings))]
-        public void GetExpandableStringValueWithDoNotExpandOption(string testValue, string expectedValue)
-        {
-            const string valueName = "MyTestKey";
-            TestRegistryKey.SetValue(valueName, testValue, RegistryValueKind.ExpandString);
-            Assert.Equal(testValue, TestRegistryKey.GetValue(valueName, null, RegistryValueOptions.DoNotExpandEnvironmentNames).ToString());
-            TestRegistryKey.DeleteValue(valueName);
-        }
-
         public static IEnumerable<object[]> TestEnvironment { get { return TestData.TestEnvironment; } }
 
         [Theory]
         [MemberData(nameof(TestEnvironment))]
         public void GetValueWithEnvironmentVariable(string valueName, string envVariableName, string expectedVariableValue)
         {
+            _ = envVariableName;
             TestRegistryKey.SetValue(valueName, expectedVariableValue, RegistryValueKind.ExpandString);
             Assert.Equal(expectedVariableValue, TestRegistryKey.GetValue(valueName, null, RegistryValueOptions.DoNotExpandEnvironmentNames).ToString());
             TestRegistryKey.DeleteValue(valueName);

--- a/src/Microsoft.Win32.Registry/tests/TestData.cs
+++ b/src/Microsoft.Win32.Registry/tests/TestData.cs
@@ -107,28 +107,56 @@ namespace Microsoft.Win32.RegistryTests
             const string sysRootVar = "%Systemroot%";
             const string pathVar = "%path%";
             const string tmpVar = "%tmp%";
+
             s_testExpandableStrings = new[]
             {
                 new object[]
                 {
                     sysRootVar + @"\mydrive\mydirectory\myfile.xxx",
-                    Environment.ExpandEnvironmentVariables(sysRootVar) + @"\mydrive\mydirectory\myfile.xxx"
+                    Environment.ExpandEnvironmentVariables(sysRootVar) + @"\mydrive\mydirectory\myfile.xxx",
+                    RegistryValueOptions.None,
+                },
+                new object[]
+                {
+                    sysRootVar + @"\mydrive\mydirectory\myfile.xxx",
+                    sysRootVar + @"\mydrive\mydirectory\myfile.xxx",
+                    RegistryValueOptions.DoNotExpandEnvironmentNames,
                 },
                 new object[]
                 {
                     tmpVar + @"\gfdhghdfgk\fsdfds\dsd.yyy",
-                    Environment.ExpandEnvironmentVariables(tmpVar) + @"\gfdhghdfgk\fsdfds\dsd.yyy"
+                    Environment.ExpandEnvironmentVariables(tmpVar) + @"\gfdhghdfgk\fsdfds\dsd.yyy",
+                    RegistryValueOptions.None,
+                },
+                new object[]
+                {
+                    tmpVar + @"\gfdhghdfgk\fsdfds\dsd.yyy",
+                    tmpVar + @"\gfdhghdfgk\fsdfds\dsd.yyy",
+                    RegistryValueOptions.DoNotExpandEnvironmentNames,
                 },
                 new object[]
                 {
                     pathVar + @"\rwerew.zzz",
-                    Environment.ExpandEnvironmentVariables(pathVar) + @"\rwerew.zzz"
+                    Environment.ExpandEnvironmentVariables(pathVar) + @"\rwerew.zzz",
+                    RegistryValueOptions.None,
+                },
+                new object[]
+                {
+                    pathVar + @"\rwerew.zzz",
+                    pathVar + @"\rwerew.zzz",
+                    RegistryValueOptions.DoNotExpandEnvironmentNames,
                 },
                 new object[]
                 {
                     sysRootVar + @"\mydrive\" + pathVar + @"\myfile.xxx",
-                    Environment.ExpandEnvironmentVariables(sysRootVar) + @"\mydrive\" +
-                    Environment.ExpandEnvironmentVariables(pathVar) + @"\myfile.xxx"
+                    Environment.ExpandEnvironmentVariables(sysRootVar) + @"\mydrive\" + Environment.ExpandEnvironmentVariables(pathVar) + @"\myfile.xxx",
+                    RegistryValueOptions.None,
+                },
+                new object[]
+                {
+                    sysRootVar + @"\mydrive\" + pathVar + @"\myfile.xxx",
+                    sysRootVar + @"\mydrive\" + pathVar + @"\myfile.xxx",
+                    RegistryValueOptions.DoNotExpandEnvironmentNames,
                 }
             };
 

--- a/src/System.CodeDom/tests/Microsoft/CSharp/CSharpCodeProviderTests.cs
+++ b/src/System.CodeDom/tests/Microsoft/CSharp/CSharpCodeProviderTests.cs
@@ -32,7 +32,7 @@ namespace System.CodeDom.Compiler.Tests
         [MemberData(nameof(Ctor_IDictionary_TestData))]
         public void Ctor_IDictionaryStringString(IDictionary<string, string> providerOptions)
         {
-            CSharpCodeProvider provider = new CSharpCodeProvider();
+            CSharpCodeProvider provider = new CSharpCodeProvider(providerOptions);
 #pragma warning disable 0618
             Assert.NotNull(provider.CreateGenerator());
             Assert.Same(provider.CreateGenerator(), provider.CreateCompiler());

--- a/src/System.CodeDom/tests/Microsoft/VisualBasic/VBCodeProviderTests.cs
+++ b/src/System.CodeDom/tests/Microsoft/VisualBasic/VBCodeProviderTests.cs
@@ -32,7 +32,7 @@ namespace System.CodeDom.Compiler.Tests
         [MemberData(nameof(Ctor_IDictionary_TestData))]
         public void Ctor_IDictionaryStringString(IDictionary<string, string> providerOptions)
         {
-            VBCodeProvider provider = new VBCodeProvider();
+            VBCodeProvider provider = new VBCodeProvider(providerOptions);
 #pragma warning disable 0618
             Assert.NotNull(provider.CreateGenerator());
             Assert.Same(provider.CreateGenerator(), provider.CreateCompiler());

--- a/src/System.CodeDom/tests/System/CodeDom/CodeAttachEventStatementTests.cs
+++ b/src/System.CodeDom/tests/System/CodeDom/CodeAttachEventStatementTests.cs
@@ -53,8 +53,9 @@ namespace System.CodeDom.Tests
 
         [Theory]
         [MemberData(nameof(CodeEventReferenceExpression_CodeExpression_TestData))]
-        public void Event_Set_Get_ReturnsExpected(CodeEventReferenceExpression value, CodeExpression _)
+        public void Event_Set_Get_ReturnsExpected(CodeEventReferenceExpression value, CodeExpression listener)
         {
+            _ = listener;
             var attachEvent = new CodeAttachEventStatement();
             attachEvent.Event = value;
             Assert.Equal((value ?? new CodeEventReferenceExpression()).TargetObject, attachEvent.Event.TargetObject);

--- a/src/System.CodeDom/tests/System/CodeDom/CodeCommentStatementTests.cs
+++ b/src/System.CodeDom/tests/System/CodeDom/CodeCommentStatementTests.cs
@@ -28,6 +28,7 @@ namespace System.CodeDom.Tests
         [MemberData(nameof(Comment_TestData))]
         public void Ctor_String(string text, bool docComment)
         {
+            _ = docComment;
             CodeCommentStatement comment = new CodeCommentStatement(text);
             Assert.Equal(text ?? string.Empty, comment.Comment.Text);
             Assert.False(comment.Comment.DocComment);

--- a/src/System.CodeDom/tests/System/CodeDom/CodeIterationStatementTests.cs
+++ b/src/System.CodeDom/tests/System/CodeDom/CodeIterationStatementTests.cs
@@ -38,18 +38,14 @@ namespace System.CodeDom.Tests
             Assert.Equal(statements, iteration.Statements.Cast<CodeStatement>());
         }
 
-        [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        public void Ctor_NullStatements_ThrowsArgumentNullException(string value)
+        [Fact]
+        public void Ctor_NullStatements_ThrowsArgumentNullException()
         {
             AssertExtensions.Throws<ArgumentNullException>("value", () => new CodeIterationStatement(null, null, null, null));
         }
 
-        [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        public void Ctor_NullObjectInStatements_ThrowsArgumentNullException(string value)
+        [Fact]
+        public void Ctor_NullObjectInStatements_ThrowsArgumentNullException()
         {
             CodeStatement[] statements = new CodeStatement[] { null };
             AssertExtensions.Throws<ArgumentNullException>("value", () => new CodeIterationStatement(null, null, null, statements));

--- a/src/System.CodeDom/tests/System/CodeDom/CodeRemoveEventStatementTests.cs
+++ b/src/System.CodeDom/tests/System/CodeDom/CodeRemoveEventStatementTests.cs
@@ -53,8 +53,9 @@ namespace System.CodeDom.Tests
 
         [Theory]
         [MemberData(nameof(CodeEventReferenceExpression_CodeExpression_TestData))]
-        public void Event_Set_Get_ReturnsExpected(CodeEventReferenceExpression value, CodeExpression _)
+        public void Event_Set_Get_ReturnsExpected(CodeEventReferenceExpression value, CodeExpression listener)
         {
+            _ = listener;
             var removeEvent = new CodeRemoveEventStatement();
             removeEvent.Event = value;
             Assert.Equal((value ?? new CodeEventReferenceExpression()).TargetObject, removeEvent.Event.TargetObject);

--- a/src/System.CodeDom/tests/System/CodeDom/Compiler/CSharpCodeGenerationTests.cs
+++ b/src/System.CodeDom/tests/System/CodeDom/Compiler/CSharpCodeGenerationTests.cs
@@ -1928,7 +1928,7 @@ namespace System.CodeDom.Compiler.Tests
         [Fact]
         public void Params()
         {
-            Func<string, int, CodeStatement> createStatement = (objName, iNum) =>
+            static CodeStatement CreateStatement(string objName, int iNum)
             {
                 CodeAssignStatement statement = new CodeAssignStatement(new CodeVariableReferenceExpression("str"),
                                     new CodeMethodInvokeExpression(
@@ -1940,7 +1940,7 @@ namespace System.CodeDom.Compiler.Tests
                                             new CodeArrayIndexerExpression(new CodeVariableReferenceExpression("array"), new CodePrimitiveExpression(iNum)),
                                             "ToString")}));
                 return statement;
-            };
+            }
 
             CodeNamespace ns = new CodeNamespace("Namespace1");
             ns.Imports.Add(new CodeNamespaceImport("System"));
@@ -1969,9 +1969,9 @@ namespace System.CodeDom.Compiler.Tests
 
             fooMethod1.Statements.Add(new CodeVariableDeclarationStatement(typeof(string), "str"));
 
-            fooMethod1.Statements.Add(createStatement("format", 0));
-            fooMethod1.Statements.Add(createStatement("str", 1));
-            fooMethod1.Statements.Add(createStatement("str", 2));
+            fooMethod1.Statements.Add(CreateStatement("format", 0));
+            fooMethod1.Statements.Add(CreateStatement("str", 1));
+            fooMethod1.Statements.Add(CreateStatement("str", 2));
 
             fooMethod1.Statements.Add(new CodeMethodReturnStatement(new CodeVariableReferenceExpression("str")));
 

--- a/src/System.CodeDom/tests/System/CodeDom/Compiler/VBCodeGenerationTests.cs
+++ b/src/System.CodeDom/tests/System/CodeDom/Compiler/VBCodeGenerationTests.cs
@@ -1818,7 +1818,7 @@ namespace System.CodeDom.Compiler.Tests
         [Fact]
         public void Params()
         {
-            Func<string, int, CodeStatement> createStatement = (objName, iNum) =>
+            static CodeStatement CreateStatement(string objName, int iNum)
             {
                 CodeAssignStatement statement = new CodeAssignStatement(new CodeVariableReferenceExpression("str"),
                                     new CodeMethodInvokeExpression(
@@ -1830,7 +1830,7 @@ namespace System.CodeDom.Compiler.Tests
                                             new CodeArrayIndexerExpression(new CodeVariableReferenceExpression("array"), new CodePrimitiveExpression(iNum)),
                                             "ToString")}));
                 return statement;
-            };
+            }
 
             CodeNamespace ns = new CodeNamespace("Namespace1");
             ns.Imports.Add(new CodeNamespaceImport("System"));
@@ -1859,9 +1859,9 @@ namespace System.CodeDom.Compiler.Tests
 
             fooMethod1.Statements.Add(new CodeVariableDeclarationStatement(typeof(string), "str"));
 
-            fooMethod1.Statements.Add(createStatement("format", 0));
-            fooMethod1.Statements.Add(createStatement("str", 1));
-            fooMethod1.Statements.Add(createStatement("str", 2));
+            fooMethod1.Statements.Add(CreateStatement("format", 0));
+            fooMethod1.Statements.Add(CreateStatement("str", 1));
+            fooMethod1.Statements.Add(CreateStatement("str", 2));
 
             fooMethod1.Statements.Add(new CodeMethodReturnStatement(new CodeVariableReferenceExpression("str")));
 

--- a/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableArrayTest.cs
@@ -1670,6 +1670,7 @@ namespace System.Collections.Immutable.Tests
         [MemberData(nameof(IsDefaultOrEmptyData))]
         public void IsDefault(IEnumerable<int> source, bool isDefault, bool isEmpty)
         {
+            _ = isEmpty;
             var array = source.ToImmutableArray();
 
             Assert.Equal(isDefault, array.IsDefault);
@@ -2192,11 +2193,10 @@ namespace System.Collections.Immutable.Tests
             yield return new object[] { new[] { 1, 2, 3, 4 }, 4 };
         }
 
-        [Theory]
-        [MemberData(nameof(BinarySearchData))]
-        public void BinarySearchDefaultInvalid(IEnumerable<int> source, int value)
+        [Fact]
+        public void BinarySearchDefaultInvalid()
         {
-            AssertExtensions.Throws<ArgumentNullException>("array", () => ImmutableArray.BinarySearch(s_emptyDefault, value));
+            AssertExtensions.Throws<ArgumentNullException>("array", () => ImmutableArray.BinarySearch(s_emptyDefault, 42));
         }
 
         [Fact]

--- a/src/System.Collections.Specialized/tests/BitVector32Tests.cs
+++ b/src/System.Collections.Specialized/tests/BitVector32Tests.cs
@@ -299,6 +299,8 @@ namespace System.Collections.Specialized.Tests
         [MemberData(nameof(Mask_SetUnset_Multiple_Data))]
         public static void Set_Mask_MultipleTest(int expected, int start, int[] maskPositions)
         {
+            _ = expected;
+            _ = start;
             int mask = maskPositions.Sum(x => 1 << (x - 1));
 
             BitVector32 blank = new BitVector32();
@@ -321,6 +323,8 @@ namespace System.Collections.Specialized.Tests
         [MemberData(nameof(Mask_SetUnset_Multiple_Data))]
         public static void Set_Mask_Multiple_UnsetTest(int start, int expected, int[] maskPositions)
         {
+            _ = start;
+            _ = expected;
             int mask = maskPositions.Sum(x => 1 << (x - 1));
 
             BitVector32 set = new BitVector32();

--- a/src/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.ClearTests.cs
+++ b/src/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.ClearTests.cs
@@ -10,10 +10,10 @@ namespace System.Collections.Specialized.Tests
     {
         [Theory]
         [InlineData(0)]
-        [InlineData(5)]
+        [InlineData(10)]
         public void Clear(int count)
         {
-            NameValueCollection nameValueCollection = Helpers.CreateNameValueCollection(10);
+            NameValueCollection nameValueCollection = Helpers.CreateNameValueCollection(count);
             nameValueCollection.Clear();
             Assert.Equal(0, nameValueCollection.Count);
             Assert.Equal(0, nameValueCollection.AllKeys.Length);

--- a/src/System.Collections.Specialized/tests/StringCollectionTests.cs
+++ b/src/System.Collections.Specialized/tests/StringCollectionTests.cs
@@ -164,6 +164,7 @@ namespace System.Collections.Specialized.Tests
         [MemberData(nameof(StringCollection_Duplicates_Data))]
         public static void AddRange_NullTest(StringCollection collection, string[] data)
         {
+            _ = data;
             AssertExtensions.Throws<ArgumentNullException>("value", () => collection.AddRange(null));
         }
 

--- a/src/System.Collections/tests/BitArray/BitArray_CtorTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_CtorTests.cs
@@ -140,6 +140,8 @@ namespace System.Collections.Tests
         [MemberData(nameof(Ctor_BitArray_TestData))]
         public static void Ctor_BitArray(string label, BitArray bits)
         {
+            _ = label;
+
             BitArray bitArray = new BitArray(bits);
             Assert.Equal(bits.Length, bitArray.Length);
             for (int i = 0; i < bitArray.Length; i++)

--- a/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
@@ -396,6 +396,8 @@ namespace System.Collections.Tests
         [MemberData(nameof(CopyTo_Hidden_Data))]
         public static void CopyTo_Int_Hidden(string label, BitArray bits)
         {
+            _ = label;
+
             int allBitsSet = unchecked((int)0xffffffff); // 32 bits set to 1 = -1
             int fullInts = bits.Length / BitsPerInt32;
             int remainder = bits.Length % BitsPerInt32;
@@ -416,6 +418,8 @@ namespace System.Collections.Tests
         [MemberData(nameof(CopyTo_Hidden_Data))]
         public static void CopyTo_Byte_Hidden(string label, BitArray bits)
         {
+            _ = label;
+
             byte allBitsSet = (1 << BitsPerByte) - 1; // 8 bits set to 1 = 255
 
             int fullBytes = bits.Length / BitsPerByte;

--- a/src/System.Collections/tests/BitArray/BitArray_OperatorsTests.netcoreapp.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_OperatorsTests.netcoreapp.cs
@@ -126,6 +126,8 @@ namespace System.Collections.Tests
         [MemberData(nameof(RightShift_Hidden_Data))]
         public static void RightShift_Hidden(string label, BitArray bits)
         {
+            _ = label;
+
             Assert.All(bits.Cast<bool>(), bit => Assert.False(bit));
             bits.RightShift(1);
             Assert.All(bits.Cast<bool>(), bit => Assert.False(bit));

--- a/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.Keys.cs
+++ b/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.Keys.cs
@@ -39,9 +39,8 @@ namespace System.Collections.Tests
 
         protected override Type ICollection_Generic_CopyTo_IndexLargerThanArrayCount_ThrowType => typeof(ArgumentOutOfRangeException);
 
-        [Theory]
-        [MemberData(nameof(ValidCollectionSizes))]
-        public void Dictionary_Generic_KeyCollection_Constructor_NullDictionary(int count)
+        [Fact]
+        public void Dictionary_Generic_KeyCollection_Constructor_NullDictionary()
         {
             Assert.Throws<ArgumentNullException>(() => new Dictionary<string, string>.KeyCollection(null));
         }

--- a/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.Values.cs
+++ b/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.Values.cs
@@ -40,9 +40,8 @@ namespace System.Collections.Tests
 
         protected override Type ICollection_Generic_CopyTo_IndexLargerThanArrayCount_ThrowType => typeof(ArgumentOutOfRangeException);
 
-        [Theory]
-        [MemberData(nameof(ValidCollectionSizes))]
-        public void Dictionary_Generic_ValueCollection_Constructor_NullDictionary(int count)
+        [Fact]
+        public void Dictionary_Generic_ValueCollection_Constructor_NullDictionary()
         {
             Assert.Throws<ArgumentNullException>(() => new Dictionary<string, string>.ValueCollection(null));
         }

--- a/src/System.Collections/tests/Generic/Dictionary/Dictionary.Tests.cs
+++ b/src/System.Collections/tests/Generic/Dictionary/Dictionary.Tests.cs
@@ -45,17 +45,15 @@ namespace System.Collections.Tests
 
         #region IDictionary tests
 
-        [Theory]
-        [MemberData(nameof(ValidCollectionSizes))]
-        public void IDictionary_NonGeneric_ItemSet_NullValueWhenDefaultValueIsNonNull(int count)
+        [Fact]
+        public void IDictionary_NonGeneric_ItemSet_NullValueWhenDefaultValueIsNonNull()
         {
             IDictionary dictionary = new Dictionary<string, int>();
             Assert.Throws<ArgumentNullException>(() => dictionary[GetNewKey(dictionary)] = null);
         }
 
-        [Theory]
-        [MemberData(nameof(ValidCollectionSizes))]
-        public void IDictionary_NonGeneric_ItemSet_KeyOfWrongType(int count)
+        [Fact]
+        public void IDictionary_NonGeneric_ItemSet_KeyOfWrongType()
         {
             if (!IsReadOnly)
             {
@@ -65,9 +63,8 @@ namespace System.Collections.Tests
             }
         }
 
-        [Theory]
-        [MemberData(nameof(ValidCollectionSizes))]
-        public void IDictionary_NonGeneric_ItemSet_ValueOfWrongType(int count)
+        [Fact]
+        public void IDictionary_NonGeneric_ItemSet_ValueOfWrongType()
         {
             if (!IsReadOnly)
             {
@@ -78,9 +75,8 @@ namespace System.Collections.Tests
             }
         }
 
-        [Theory]
-        [MemberData(nameof(ValidCollectionSizes))]
-        public void IDictionary_NonGeneric_Add_KeyOfWrongType(int count)
+        [Fact]
+        public void IDictionary_NonGeneric_Add_KeyOfWrongType()
         {
             if (!IsReadOnly)
             {
@@ -91,9 +87,8 @@ namespace System.Collections.Tests
             }
         }
 
-        [Theory]
-        [MemberData(nameof(ValidCollectionSizes))]
-        public void IDictionary_NonGeneric_Add_ValueOfWrongType(int count)
+        [Fact]
+        public void IDictionary_NonGeneric_Add_ValueOfWrongType()
         {
             if (!IsReadOnly)
             {
@@ -104,9 +99,8 @@ namespace System.Collections.Tests
             }
         }
 
-        [Theory]
-        [MemberData(nameof(ValidCollectionSizes))]
-        public void IDictionary_NonGeneric_Add_NullValueWhenDefaultTValueIsNonNull(int count)
+        [Fact]
+        public void IDictionary_NonGeneric_Add_NullValueWhenDefaultTValueIsNonNull()
         {
             if (!IsReadOnly)
             {
@@ -117,9 +111,8 @@ namespace System.Collections.Tests
             }
         }
 
-        [Theory]
-        [MemberData(nameof(ValidCollectionSizes))]
-        public void IDictionary_NonGeneric_Contains_KeyOfWrongType(int count)
+        [Fact]
+        public void IDictionary_NonGeneric_Contains_KeyOfWrongType()
         {
             if (!IsReadOnly)
             {

--- a/src/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.cs
@@ -69,6 +69,8 @@ namespace System.Collections.Tests
         [MemberData(nameof(EnumerableTestData))]
         public void HashSet_Generic_Constructor_IEnumerable(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
+            _ = setLength;
+            _ = numberOfMatchingElements;
             IEnumerable<T> enumerable = CreateEnumerable(enumerableType, null, enumerableLength, 0, numberOfDuplicateElements);
             HashSet<T> set = new HashSet<T>(enumerable);
             Assert.True(set.SetEquals(enumerable));
@@ -109,6 +111,9 @@ namespace System.Collections.Tests
         [MemberData(nameof(EnumerableTestData))]
         public void HashSet_Generic_Constructor_IEnumerable_IEqualityComparer(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
+            _ = setLength;
+            _ = numberOfMatchingElements;
+            _ = numberOfDuplicateElements;
             IEnumerable<T> enumerable = CreateEnumerable(enumerableType, null, enumerableLength, 0, 0);
             HashSet<T> set = new HashSet<T>(enumerable, GetIEqualityComparer());
             Assert.True(set.SetEquals(enumerable));
@@ -137,9 +142,8 @@ namespace System.Collections.Tests
             Assert.Equal(setLength, set.Count);
         }
 
-        [Theory]
-        [MemberData(nameof(ValidCollectionSizes))]
-        public void HashSet_Generic_RemoveWhere_NewObject(int setLength) // Regression Dev10_624201
+        [Fact]
+        public void HashSet_Generic_RemoveWhere_NewObject() // Regression Dev10_624201
         {
             object[] array = new object[2];
             object obj = new object();

--- a/src/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.cs
@@ -492,6 +492,8 @@ namespace System.Collections.Tests
         [MemberData(nameof(EnumerableTestData))]
         public void LinkedList_Generic_Constructor_IEnumerable(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
+            _ = setLength;
+            _ = numberOfMatchingElements;
             IEnumerable<T> enumerable = CreateEnumerable(enumerableType, null, enumerableLength, 0, numberOfDuplicateElements);
             LinkedList<T> queue = new LinkedList<T>(enumerable);
             Assert.Equal(enumerable, queue);

--- a/src/System.Collections/tests/Generic/List/List.Generic.Tests.Constructor.cs
+++ b/src/System.Collections/tests/Generic/List/List.Generic.Tests.Constructor.cs
@@ -49,6 +49,8 @@ namespace System.Collections.Tests
         [MemberData(nameof(EnumerableTestData))]
         public void Constructor_IEnumerable(EnumerableType enumerableType, int listLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
+            _ = listLength;
+            _ = numberOfMatchingElements;
             IEnumerable<T> enumerable = CreateEnumerable(enumerableType, null, enumerableLength, 0, numberOfDuplicateElements);
             List<T> list = new List<T>(enumerable);
             List<T> expected = enumerable.ToList();

--- a/src/System.Collections/tests/Generic/List/List.Generic.Tests.IndexOf.cs
+++ b/src/System.Collections/tests/Generic/List/List.Generic.Tests.IndexOf.cs
@@ -79,6 +79,7 @@ namespace System.Collections.Tests
         [MemberData(nameof(IndexOfTestData))]
         public void IndexOf_NoDuplicates(IndexOfMethod indexOfMethod, int count, bool frontToBackOrder)
         {
+            _ = frontToBackOrder;
             List<T> list = GenericListFactory(count);
             List<T> expectedList = list.ToList();
             IndexOfDelegate IndexOf = IndexOfDelegateFromType(indexOfMethod);
@@ -93,6 +94,7 @@ namespace System.Collections.Tests
         [MemberData(nameof(IndexOfTestData))]
         public void IndexOf_NonExistingValues(IndexOfMethod indexOfMethod, int count, bool frontToBackOrder)
         {
+            _ = frontToBackOrder;
             List<T> list = GenericListFactory(count);
             IEnumerable<T> nonexistentValues = CreateEnumerable(EnumerableType.List, list, count: count, numberOfMatchingElements: 0, numberOfDuplicateElements: 0);
             IndexOfDelegate IndexOf = IndexOfDelegateFromType(indexOfMethod);
@@ -107,7 +109,8 @@ namespace System.Collections.Tests
         [MemberData(nameof(IndexOfTestData))]
         public void IndexOf_DefaultValue(IndexOfMethod indexOfMethod, int count, bool frontToBackOrder)
         {
-            T defaultValue = default(T);
+            _ = frontToBackOrder;
+            T defaultValue = default;
             List<T> list = GenericListFactory(count);
             IndexOfDelegate IndexOf = IndexOfDelegateFromType(indexOfMethod);
             while (list.Remove(defaultValue))

--- a/src/System.Collections/tests/Generic/List/List.Generic.Tests.Misc.cs
+++ b/src/System.Collections/tests/Generic/List/List.Generic.Tests.Misc.cs
@@ -661,12 +661,8 @@ namespace System.Collections.Tests
 
             public void TrueForAll_VerifyExceptions(T[] items)
             {
-                List<T> list = new List<T>();
-                Predicate<T> predicate = delegate (T item) { return true; };
-                for (int i = 0; i < items.Length; ++i)
-                    list.Add(items[i]);
-
-                //[] Verify Null match
+                var list = new List<T>(items);
+                Assert.True(list.TrueForAll(item => true));
                 Assert.Throws<ArgumentNullException>(() => list.TrueForAll(null)); //"Err_858ahia Expected null match to throw ArgumentNullException"
             }
 

--- a/src/System.Collections/tests/Generic/Queue/Queue.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/Queue/Queue.Generic.Tests.cs
@@ -61,6 +61,8 @@ namespace System.Collections.Tests
         [MemberData(nameof(EnumerableTestData))]
         public void Queue_Generic_Constructor_IEnumerable(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
+            _ = setLength;
+            _ = numberOfMatchingElements;
             IEnumerable<T> enumerable = CreateEnumerable(enumerableType, null, enumerableLength, 0, numberOfDuplicateElements);
             Queue<T> queue = new Queue<T>(enumerable);
             Assert.Equal(enumerable, queue);

--- a/src/System.Collections/tests/Generic/SortedDictionary/SortedDictionary.Generic.Tests.Keys.cs
+++ b/src/System.Collections/tests/Generic/SortedDictionary/SortedDictionary.Generic.Tests.Keys.cs
@@ -37,9 +37,8 @@ namespace System.Collections.Tests
             return Convert.ToBase64String(bytes);
         }
 
-        [Theory]
-        [MemberData(nameof(ValidCollectionSizes))]
-        public void SortedDictionary_Generic_KeyCollection_Constructor_NullDictionary(int count)
+        [Fact]
+        public void SortedDictionary_Generic_KeyCollection_Constructor_NullDictionary()
         {
             Assert.Throws<ArgumentNullException>(() => new SortedDictionary<string, string>.KeyCollection(null));
         }

--- a/src/System.Collections/tests/Generic/SortedDictionary/SortedDictionary.Generic.Tests.Values.cs
+++ b/src/System.Collections/tests/Generic/SortedDictionary/SortedDictionary.Generic.Tests.Values.cs
@@ -39,9 +39,8 @@ namespace System.Collections.Tests
             return Convert.ToBase64String(bytes);
         }
 
-        [Theory]
-        [MemberData(nameof(ValidCollectionSizes))]
-        public void SortedDictionary_Generic_ValueCollection_Constructor_NullDictionary(int count)
+        [Fact]
+        public void SortedDictionary_Generic_ValueCollection_Constructor_NullDictionary()
         {
             Assert.Throws<ArgumentNullException>(() => new SortedDictionary<string, string>.ValueCollection(null));
         }

--- a/src/System.Collections/tests/Generic/SortedDictionary/SortedDictionary.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/SortedDictionary/SortedDictionary.Generic.Tests.cs
@@ -46,9 +46,8 @@ namespace System.Collections.Tests
             Assert.Equal(source, copied);
         }
 
-        [Theory]
-        [MemberData(nameof(ValidCollectionSizes))]
-        public void SortedDictionary_Generic_Constructor_NullIDictionary_ThrowsArgumentNullException(int count)
+        [Fact]
+        public void SortedDictionary_Generic_Constructor_NullIDictionary_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() => new SortedDictionary<TKey, TValue>((IDictionary<TKey, TValue>)null));
         }

--- a/src/System.Collections/tests/Generic/SortedDictionary/SortedDictionary.Tests.cs
+++ b/src/System.Collections/tests/Generic/SortedDictionary/SortedDictionary.Tests.cs
@@ -42,17 +42,15 @@ namespace System.Collections.Tests
 
         #region IDictionary tests
 
-        [Theory]
-        [MemberData(nameof(ValidCollectionSizes))]
-        public void IDictionary_NonGeneric_ItemSet_NullValueWhenDefaultValueIsNonNull(int count)
+        [Fact]
+        public void IDictionary_NonGeneric_ItemSet_NullValueWhenDefaultValueIsNonNull()
         {
             IDictionary dictionary = new SortedDictionary<string, int>();
             Assert.Throws<ArgumentNullException>(() => dictionary[GetNewKey(dictionary)] = null);
         }
 
-        [Theory]
-        [MemberData(nameof(ValidCollectionSizes))]
-        public void IDictionary_NonGeneric_ItemSet_KeyOfWrongType(int count)
+        [Fact]
+        public void IDictionary_NonGeneric_ItemSet_KeyOfWrongType()
         {
             if (!IsReadOnly)
             {
@@ -62,9 +60,8 @@ namespace System.Collections.Tests
             }
         }
 
-        [Theory]
-        [MemberData(nameof(ValidCollectionSizes))]
-        public void IDictionary_NonGeneric_ItemSet_ValueOfWrongType(int count)
+        [Fact]
+        public void IDictionary_NonGeneric_ItemSet_ValueOfWrongType()
         {
             if (!IsReadOnly)
             {
@@ -75,9 +72,8 @@ namespace System.Collections.Tests
             }
         }
 
-        [Theory]
-        [MemberData(nameof(ValidCollectionSizes))]
-        public void IDictionary_NonGeneric_Add_KeyOfWrongType(int count)
+        [Fact]
+        public void IDictionary_NonGeneric_Add_KeyOfWrongType()
         {
             if (!IsReadOnly)
             {
@@ -88,9 +84,8 @@ namespace System.Collections.Tests
             }
         }
 
-        [Theory]
-        [MemberData(nameof(ValidCollectionSizes))]
-        public void IDictionary_NonGeneric_Add_ValueOfWrongType(int count)
+        [Fact]
+        public void IDictionary_NonGeneric_Add_ValueOfWrongType()
         {
             if (!IsReadOnly)
             {
@@ -101,9 +96,8 @@ namespace System.Collections.Tests
             }
         }
 
-        [Theory]
-        [MemberData(nameof(ValidCollectionSizes))]
-        public void IDictionary_NonGeneric_Add_NullValueWhenDefaultTValueIsNonNull(int count)
+        [Fact]
+        public void IDictionary_NonGeneric_Add_NullValueWhenDefaultTValueIsNonNull()
         {
             if (!IsReadOnly)
             {
@@ -114,9 +108,8 @@ namespace System.Collections.Tests
             }
         }
 
-        [Theory]
-        [MemberData(nameof(ValidCollectionSizes))]
-        public void IDictionary_NonGeneric_Contains_KeyOfWrongType(int count)
+        [Fact]
+        public void IDictionary_NonGeneric_Contains_KeyOfWrongType()
         {
             if (!IsReadOnly)
             {

--- a/src/System.Collections/tests/Generic/SortedList/SortedList.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/SortedList/SortedList.Generic.Tests.cs
@@ -63,9 +63,8 @@ namespace System.Collections.Tests
             Assert.Equal(source, copied);
         }
 
-        [Theory]
-        [MemberData(nameof(ValidCollectionSizes))]
-        public void SortedList_Generic_Constructor_NullIDictionary_ThrowsArgumentNullException(int count)
+        [Fact]
+        public void SortedList_Generic_Constructor_NullIDictionary_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() => new SortedList<TKey, TValue>((IDictionary<TKey, TValue>)null));
         }
@@ -98,9 +97,8 @@ namespace System.Collections.Tests
             Assert.Equal(count, dictionary.Capacity);
         }
 
-        [Theory]
-        [MemberData(nameof(ValidCollectionSizes))]
-        public void SortedList_Generic_Constructor_NegativeCapacity_ThrowsArgumentOutOfRangeException(int count)
+        [Fact]
+        public void SortedList_Generic_Constructor_NegativeCapacity_ThrowsArgumentOutOfRangeException()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => new SortedList<TKey, TValue>(-1));
             Assert.Throws<ArgumentOutOfRangeException>(() => new SortedList<TKey, TValue>(int.MinValue));

--- a/src/System.Collections/tests/Generic/SortedList/SortedList.Tests.cs
+++ b/src/System.Collections/tests/Generic/SortedList/SortedList.Tests.cs
@@ -33,17 +33,15 @@ namespace System.Collections.Tests
 
         #region IDictionary tests
 
-        [Theory]
-        [MemberData(nameof(ValidCollectionSizes))]
-        public void IDictionary_NonGeneric_ItemSet_NullValueWhenDefaultValueIsNonNull(int count)
+        [Fact]
+        public void IDictionary_NonGeneric_ItemSet_NullValueWhenDefaultValueIsNonNull()
         {
             IDictionary dictionary = new SortedList<string, int>();
             Assert.Throws<ArgumentNullException>(() => dictionary[GetNewKey(dictionary)] = null);
         }
 
-        [Theory]
-        [MemberData(nameof(ValidCollectionSizes))]
-        public void IDictionary_NonGeneric_ItemSet_KeyOfWrongType(int count)
+        [Fact]
+        public void IDictionary_NonGeneric_ItemSet_KeyOfWrongType()
         {
             if (!IsReadOnly)
             {
@@ -53,9 +51,8 @@ namespace System.Collections.Tests
             }
         }
 
-        [Theory]
-        [MemberData(nameof(ValidCollectionSizes))]
-        public void IDictionary_NonGeneric_ItemSet_ValueOfWrongType(int count)
+        [Fact]
+        public void IDictionary_NonGeneric_ItemSet_ValueOfWrongType()
         {
             if (!IsReadOnly)
             {
@@ -66,9 +63,8 @@ namespace System.Collections.Tests
             }
         }
 
-        [Theory]
-        [MemberData(nameof(ValidCollectionSizes))]
-        public void IDictionary_NonGeneric_Add_KeyOfWrongType(int count)
+        [Fact]
+        public void IDictionary_NonGeneric_Add_KeyOfWrongType()
         {
             if (!IsReadOnly)
             {
@@ -79,9 +75,8 @@ namespace System.Collections.Tests
             }
         }
 
-        [Theory]
-        [MemberData(nameof(ValidCollectionSizes))]
-        public void IDictionary_NonGeneric_Add_ValueOfWrongType(int count)
+        [Fact]
+        public void IDictionary_NonGeneric_Add_ValueOfWrongType()
         {
             if (!IsReadOnly)
             {
@@ -92,9 +87,8 @@ namespace System.Collections.Tests
             }
         }
 
-        [Theory]
-        [MemberData(nameof(ValidCollectionSizes))]
-        public void IDictionary_NonGeneric_Add_NullValueWhenDefaultTValueIsNonNull(int count)
+        [Fact]
+        public void IDictionary_NonGeneric_Add_NullValueWhenDefaultTValueIsNonNull()
         {
             if (!IsReadOnly)
             {
@@ -105,9 +99,8 @@ namespace System.Collections.Tests
             }
         }
 
-        [Theory]
-        [MemberData(nameof(ValidCollectionSizes))]
-        public void IDictionary_NonGeneric_Contains_KeyOfWrongType(int count)
+        [Fact]
+        public void IDictionary_NonGeneric_Contains_KeyOfWrongType()
         {
             if (!IsReadOnly)
             {

--- a/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/SortedSet/SortedSet.Generic.Tests.cs
@@ -43,6 +43,8 @@ namespace System.Collections.Tests
         [MemberData(nameof(EnumerableTestData))]
         public void SortedSet_Generic_Constructor_IEnumerable(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
+            _ = setLength;
+            _ = numberOfMatchingElements;
             IEnumerable<T> enumerable = CreateEnumerable(enumerableType, null, enumerableLength, 0, numberOfDuplicateElements);
             SortedSet<T> set = new SortedSet<T>(enumerable);
             Assert.True(set.SetEquals(enumerable));
@@ -59,6 +61,9 @@ namespace System.Collections.Tests
         [MemberData(nameof(EnumerableTestData))]
         public void SortedSet_Generic_Constructor_IEnumerable_IComparer_Netcoreapp(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
+            _ = setLength;
+            _ = numberOfMatchingElements;
+            _ = numberOfDuplicateElements;
             IEnumerable<T> enumerable = CreateEnumerable(enumerableType, null, enumerableLength, 0, 0);
             SortedSet<T> set = new SortedSet<T>(enumerable, GetIComparer());
             Assert.True(set.SetEquals(enumerable));
@@ -68,6 +73,9 @@ namespace System.Collections.Tests
         [MemberData(nameof(EnumerableTestData))]
         public void SortedSet_Generic_Constructor_IEnumerable_IComparer_NullComparer_Netcoreapp(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
+            _ = setLength;
+            _ = numberOfMatchingElements;
+            _ = numberOfDuplicateElements;
             IEnumerable<T> enumerable = CreateEnumerable(enumerableType, null, enumerableLength, 0, 0);
             SortedSet<T> set = new SortedSet<T>(enumerable, comparer: null);
             Assert.True(set.SetEquals(enumerable));

--- a/src/System.Collections/tests/Generic/Stack/Stack.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/Stack/Stack.Generic.Tests.cs
@@ -74,6 +74,8 @@ namespace System.Collections.Tests
         [MemberData(nameof(EnumerableTestData))]
         public void Stack_Generic_Constructor_IEnumerable(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
+            _ = setLength;
+            _ = numberOfMatchingElements;
             IEnumerable<T> enumerable = CreateEnumerable(enumerableType, null, enumerableLength, 0, numberOfDuplicateElements);
             Stack<T> stack = new Stack<T>(enumerable);
             Assert.Equal(enumerable.ToArray().Reverse(), stack.ToArray());

--- a/src/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/RegularExpressionAttributeTests.cs
+++ b/src/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/RegularExpressionAttributeTests.cs
@@ -71,7 +71,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
         [InlineData(-2)]
         public static void Validate_InvalidMatchTimeoutInMilliseconds_ThrowsArgumentOutOfRangeException(int timeout)
         {
-            RegularExpressionAttribute attribute = new RegularExpressionAttribute("[^a]+\\.[^z]+") { MatchTimeoutInMilliseconds = 0 };
+            RegularExpressionAttribute attribute = new RegularExpressionAttribute("[^a]+\\.[^z]+") { MatchTimeoutInMilliseconds = timeout };
             AssertExtensions.Throws<ArgumentOutOfRangeException>("matchTimeout", () => attribute.Validate("a", new ValidationContext(new object())));
         }
 

--- a/src/System.Data.SqlClient/tests/FunctionalTests/AADAccessTokenTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/AADAccessTokenTest.cs
@@ -17,6 +17,7 @@ namespace System.Data.SqlClient.Tests
         [InlineData("Test combination of Access Token and Credentials", new object[] { "sampleUserId" })]
         public void InvalidCombinationOfAccessToken(string description, object[] Params)
         {
+            _ = description;
             _builder = new SqlConnectionStringBuilder
             {
                 ["Data Source"] = "sample.database.windows.net"

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/ConnectionPoolTest/PoolBlockPeriodTest.netcoreapp.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/ConnectionPoolTest/PoolBlockPeriodTest.netcoreapp.cs
@@ -34,6 +34,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [InlineData("Azure with Never Policy must Disable Blocking", new object[] { AzureEndpointSample, PoolBlockingPeriod.NeverBlock })]
         public void TestAzureBlockingPeriod(string description, object[] Params)
         {
+            _ = description;
             string serverName = Params[0] as string;
             PoolBlockingPeriod? policy = null;
             if (Params.Length > 1)
@@ -54,6 +55,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [InlineData("NonAzure (which contains azure endpoint - nonexistent.database.windows.net.else) with Default Policy must Enable Blocking", new object[] { "nonexistent.database.windows.net.else" })]
         public void TestNonAzureBlockingPeriod(string description, object[] Params)
         {
+            _ = description;
             string serverName = Params[0] as string;
             PoolBlockingPeriod? policy = null;
 
@@ -75,6 +77,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         [InlineData("Test policy with Never (PascalCase)", "NeverBlock")]
         public void TestSetPolicyWithVariations(string description, string policyString)
         {
+            _ = description;
             PoolBlockingPeriod? policy = null;
             if (policyString.ToLower().Contains("auto"))
             {

--- a/src/System.Diagnostics.StackTrace/tests/StackTraceTests.cs
+++ b/src/System.Diagnostics.StackTrace/tests/StackTraceTests.cs
@@ -206,7 +206,7 @@ namespace System.Diagnostics.Tests
         [InlineData(false)]
         public void Ctor_Exception_LargeSkipFrames_FNeedFileInfo(bool fNeedFileInfo)
         {
-            var stackTrace = new StackTrace(InvokeException(), int.MaxValue);
+            var stackTrace = new StackTrace(InvokeException(), int.MaxValue, fNeedFileInfo);
             Assert.Equal(0, stackTrace.FrameCount);
             Assert.Empty(stackTrace.GetFrames());
         }

--- a/src/System.Drawing.Common/tests/Drawing2D/LinearGradientBrushTests.cs
+++ b/src/System.Drawing.Common/tests/Drawing2D/LinearGradientBrushTests.cs
@@ -420,13 +420,8 @@ namespace System.Drawing.Drawing2D.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => brush.GammaCorrection = true);
         }
 
-        [ConditionalTheory(Helpers.IsDrawingSupported)]
-        [InlineData(float.PositiveInfinity)]
-        [InlineData(1)]
-        [InlineData(0.5f)]
-        [InlineData(-1)]
-        [InlineData(float.NegativeInfinity)]
-        public void InterpolationColors_SetValid_GetReturnsExpected(float value)
+        [ConditionalFact(Helpers.IsDrawingSupported)]
+        public void InterpolationColors_SetValid_GetReturnsExpected()
         {
             using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
             {

--- a/src/System.Drawing.Common/tests/Drawing2D/PathGradientBrushTests.cs
+++ b/src/System.Drawing.Common/tests/Drawing2D/PathGradientBrushTests.cs
@@ -418,16 +418,10 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
-        [InlineData(1f, 1f)]
-        [InlineData(0f, 1f)]
-        [InlineData(0.5f, 1f)]
-        [InlineData(1f, 0f)]
-        [InlineData(0f, 0f)]
-        [InlineData(0.5f, 0f)]
-        [InlineData(1f, 0.5f)]
-        [InlineData(0f, 0.5f)]
-        [InlineData(0.5f, 0.5f)]
-        public void SetSigmaBellShape_FocusScale_Success(float focus, float scale)
+        [InlineData(1f)]
+        [InlineData(0f)]
+        [InlineData(0.5f)]
+        public void SetSigmaBellShape_FocusScale_Success(float focus)
         {
             using (PathGradientBrush brush = new PathGradientBrush(_defaultFloatPoints))
             {
@@ -529,16 +523,10 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
-        [InlineData(1f, 1f)]
-        [InlineData(0f, 1f)]
-        [InlineData(0.5f, 1f)]
-        [InlineData(1f, 0f)]
-        [InlineData(0f, 0f)]
-        [InlineData(0.5f, 0f)]
-        [InlineData(1f, 0.5f)]
-        [InlineData(0f, 0.5f)]
-        [InlineData(0.5f, 0.5f)]
-        public void SetBlendTriangularShape_FocusScale_Success(float focus, float scale)
+        [InlineData(1f)]
+        [InlineData(0f)]
+        [InlineData(0.5f)]
+        public void SetBlendTriangularShape_FocusScale_Success(float focus)
         {
             using (PathGradientBrush brush = new PathGradientBrush(_defaultFloatPoints))
             {

--- a/src/System.Drawing.Common/tests/FontTests.cs
+++ b/src/System.Drawing.Common/tests/FontTests.cs
@@ -767,13 +767,13 @@ namespace System.Drawing.Tests
 
         [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
-        [InlineData(TextRenderingHint.SystemDefault, 0)]
-        [InlineData(TextRenderingHint.AntiAlias, 3)]
-        [InlineData(TextRenderingHint.AntiAliasGridFit, 3)]
-        [InlineData(TextRenderingHint.SingleBitPerPixel, 3)]
-        [InlineData(TextRenderingHint.SingleBitPerPixelGridFit, 3)]
-        [InlineData(TextRenderingHint.ClearTypeGridFit, 5)]
-        public void ToLogFont_InvokeGraphics_ReturnsExpected(TextRenderingHint textRenderingHint, int expectedQuality)
+        [InlineData(TextRenderingHint.SystemDefault)]
+        [InlineData(TextRenderingHint.AntiAlias)]
+        [InlineData(TextRenderingHint.AntiAliasGridFit)]
+        [InlineData(TextRenderingHint.SingleBitPerPixel)]
+        [InlineData(TextRenderingHint.SingleBitPerPixelGridFit)]
+        [InlineData(TextRenderingHint.ClearTypeGridFit)]
+        public void ToLogFont_InvokeGraphics_ReturnsExpected(TextRenderingHint textRenderingHint)
         {
             using (FontFamily family = FontFamily.GenericMonospace)
             using (var font = new Font(family, 10))

--- a/src/System.Drawing.Common/tests/PenTests.cs
+++ b/src/System.Drawing.Common/tests/PenTests.cs
@@ -24,16 +24,10 @@ namespace System.Drawing.Tests
         [MemberData(nameof(Ctor_Brush_TestData))]
         public void Ctor_Brush<T>(T brush, PenType penType) where T : Brush
         {
-            try
+            using (brush)
+            using (var pen = new Pen(brush))
             {
-                using (var pen = new Pen(brush))
-                {
-                    VerifyPen<T>(pen, penType, expectedWidth: 1);
-                }
-            }
-            finally
-            {
-                brush.Dispose();
+                VerifyPen<T>(pen, penType, expectedWidth: 1);
             }
         }
 
@@ -56,16 +50,10 @@ namespace System.Drawing.Tests
         [MemberData(nameof(Ctor_Brush_Width_TestData))]
         public void Ctor_Brush_Width<T>(T brush, float width, PenType expectedPenType) where T : Brush
         {
-            try
+            using (brush)
+            using (var pen = new Pen(brush, width))
             {
-                using (var pen = new Pen(brush, width))
-                {
-                    VerifyPen<T>(pen, expectedPenType, width);
-                }
-            }
-            finally
-            {
-                brush.Dispose();
+                VerifyPen<T>(pen, expectedPenType, width);
             }
         }
 
@@ -238,7 +226,7 @@ namespace System.Drawing.Tests
         [MemberData(nameof(Clone_TestData))]
         public void Clone_Invoke_ReturnsExpected(Pen pen)
         {
-            try
+            using (pen)
             {
                 Pen clone = Assert.IsType<Pen>(pen.Clone());
                 Assert.NotSame(pen, clone);
@@ -250,10 +238,6 @@ namespace System.Drawing.Tests
                 Assert.Equal(pen.EndCap, clone.EndCap);
                 Assert.Equal(pen.StartCap, clone.StartCap);
                 Assert.Equal(pen.Width, clone.Width);
-            }
-            finally
-            {
-                pen.Dispose();
             }
         }
 
@@ -306,22 +290,17 @@ namespace System.Drawing.Tests
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Ctor_Brush_TestData))]
-        public void Color_Set_GetReturnsExpected(Brush brush, PenType _)
+        public void Color_Set_GetReturnsExpected(Brush brush, PenType penType)
         {
-            try
+            _ = penType;
+            using (brush)
+            using (var pen = new Pen(brush))
             {
-                using (var pen = new Pen(brush))
-                {
-                    pen.Color = Color.Red;
-                    Assert.Equal(Color.Red, pen.Color);
+                pen.Color = Color.Red;
+                Assert.Equal(Color.Red, pen.Color);
 
-                    pen.Color = Color.Red;
-                    Assert.Equal(Color.Red, pen.Color);
-                }
-            }
-            finally
-            {
-                brush.Dispose();
+                pen.Color = Color.Red;
+                Assert.Equal(Color.Red, pen.Color);
             }
         }
 
@@ -1030,29 +1009,23 @@ namespace System.Drawing.Tests
         [MemberData(nameof(RotateTransform_TestData))]
         public void RotateTransform_Invoke_SetsTransformToExpected(Matrix originalTransform, float angle, MatrixOrder matrixOrder)
         {
-            try
+            using (originalTransform)
+            using (var brush = new SolidBrush(Color.Red))
+            using (var pen = new Pen(brush))
+            using (Matrix expected = originalTransform.Clone())
             {
-                using (var brush = new SolidBrush(Color.Red))
-                using (var pen = new Pen(brush))
-                using (Matrix expected = originalTransform.Clone())
+                expected.Rotate(angle, matrixOrder);
+                pen.Transform = originalTransform;
+
+                if (matrixOrder == MatrixOrder.Prepend)
                 {
-                    expected.Rotate(angle, matrixOrder);
-                    pen.Transform = originalTransform;
-
-                    if (matrixOrder == MatrixOrder.Prepend)
-                    {
-                        Pen clone = (Pen)pen.Clone();
-                        clone.RotateTransform(angle);
-                        Assert.Equal(expected, clone.Transform);
-                    }
-
-                    pen.RotateTransform(angle, matrixOrder);
-                    Assert.Equal(expected, pen.Transform);
+                    Pen clone = (Pen)pen.Clone();
+                    clone.RotateTransform(angle);
+                    Assert.Equal(expected, clone.Transform);
                 }
-            }
-            finally
-            {
-                originalTransform.Dispose();
+
+                pen.RotateTransform(angle, matrixOrder);
+                Assert.Equal(expected, pen.Transform);
             }
         }
 
@@ -1100,29 +1073,23 @@ namespace System.Drawing.Tests
         [MemberData(nameof(ScaleTransform_TestData))]
         public void ScaleTransform_Invoke_SetsTransformToExpected(Matrix originalTransform, float scaleX, float scaleY, MatrixOrder matrixOrder)
         {
-            try
+            using (originalTransform)
+            using (var brush = new SolidBrush(Color.Red))
+            using (var pen = new Pen(brush))
+            using (Matrix expected = originalTransform.Clone())
             {
-                using (var brush = new SolidBrush(Color.Red))
-                using (var pen = new Pen(brush))
-                using (Matrix expected = originalTransform.Clone())
+                expected.Scale(scaleX, scaleY, matrixOrder);
+                pen.Transform = originalTransform;
+
+                if (matrixOrder == MatrixOrder.Prepend)
                 {
-                    expected.Scale(scaleX, scaleY, matrixOrder);
-                    pen.Transform = originalTransform;
-
-                    if (matrixOrder == MatrixOrder.Prepend)
-                    {
-                        Pen clone = (Pen)pen.Clone();
-                        clone.ScaleTransform(scaleX, scaleY);
-                        Assert.Equal(expected, clone.Transform);
-                    }
-
-                    pen.ScaleTransform(scaleX, scaleY, matrixOrder);
-                    Assert.Equal(expected, pen.Transform);
+                    Pen clone = (Pen)pen.Clone();
+                    clone.ScaleTransform(scaleX, scaleY);
+                    Assert.Equal(expected, clone.Transform);
                 }
-            }
-            finally
-            {
-                originalTransform.Dispose();
+
+                pen.ScaleTransform(scaleX, scaleY, matrixOrder);
+                Assert.Equal(expected, pen.Transform);
             }
         }
 
@@ -1305,29 +1272,23 @@ namespace System.Drawing.Tests
         [MemberData(nameof(TranslateTransform_TestData))]
         public void TranslateTransform_Invoke_SetsTransformToExpected(Matrix originalTransform, float dX, float dY, MatrixOrder matrixOrder)
         {
-            try
+            using (originalTransform)
+            using (var brush = new SolidBrush(Color.Red))
+            using (var pen = new Pen(brush))
+            using (Matrix expected = originalTransform.Clone())
             {
-                using (var brush = new SolidBrush(Color.Red))
-                using (var pen = new Pen(brush))
-                using (Matrix expected = originalTransform.Clone())
+                expected.Translate(dX, dY, matrixOrder);
+                pen.Transform = originalTransform;
+
+                if (matrixOrder == MatrixOrder.Prepend)
                 {
-                    expected.Translate(dX, dY, matrixOrder);
-                    pen.Transform = originalTransform;
-
-                    if (matrixOrder == MatrixOrder.Prepend)
-                    {
-                        Pen clone = (Pen)pen.Clone();
-                        clone.TranslateTransform(dX, dY);
-                        Assert.Equal(expected, clone.Transform);
-                    }
-
-                    pen.TranslateTransform(dX, dY, matrixOrder);
-                    Assert.Equal(expected, pen.Transform);
+                    Pen clone = (Pen)pen.Clone();
+                    clone.TranslateTransform(dX, dY);
+                    Assert.Equal(expected, clone.Transform);
                 }
-            }
-            finally
-            {
-                originalTransform.Dispose();
+
+                pen.TranslateTransform(dX, dY, matrixOrder);
+                Assert.Equal(expected, pen.Transform);
             }
         }
 

--- a/src/System.Drawing.Common/tests/RegionTests.cs
+++ b/src/System.Drawing.Common/tests/RegionTests.cs
@@ -586,22 +586,22 @@ namespace System.Drawing.Tests
 
         public static IEnumerable<object[]> Equals_TestData()
         {
-            Func<Region> empty = () =>
+            static Region Empty()
             {
                 var emptyRegion = new Region();
                 emptyRegion.MakeEmpty();
                 return emptyRegion;
-            };
+            }
 
             var createdRegion = new Region();
             yield return new object[] { createdRegion, createdRegion, true };
             yield return new object[] { new Region(), new Region(), true };
-            yield return new object[] { new Region(), empty(), false };
+            yield return new object[] { new Region(), Empty(), false };
             yield return new object[] { new Region(), new Region(new Rectangle(1, 2, 3, 4)), false };
 
-            yield return new object[] { empty(), empty(), true };
-            yield return new object[] { empty(), new Region(new Rectangle(0, 0, 0, 0)), true };
-            yield return new object[] { empty(), new Region(new Rectangle(1, 2, 3, 3)), false };
+            yield return new object[] { Empty(), Empty(), true };
+            yield return new object[] { Empty(), new Region(new Rectangle(0, 0, 0, 0)), true };
+            yield return new object[] { Empty(), new Region(new Rectangle(1, 2, 3, 3)), false };
 
             yield return new object[] { new Region(new Rectangle(1, 2, 3, 4)), new Region(new Rectangle(1, 2, 3, 4)), true };
             yield return new object[] { new Region(new Rectangle(1, 2, 3, 4)), new Region(new RectangleF(1, 2, 3, 4)), true };
@@ -2020,11 +2020,11 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
-        [InlineData(1, 2, 0, 0, 0)]
-        [InlineData(0, 0, 2, 2, 0)]
-        [InlineData(0, 0, 0.5, 0.5, 0)]
-        [InlineData(0, 0, 1, 1, 45)]
-        public void Transform_Infinity_Nop(int x, int y, float scaleX, float scaleY, int angle)
+        [InlineData(0, 0, 0)]
+        [InlineData(2, 2, 0)]
+        [InlineData(0.5, 0.5, 0)]
+        [InlineData(1, 1, 45)]
+        public void Transform_Infinity_Nop(float scaleX, float scaleY, int angle)
         {
             using (var region = new Region())
             using (var matrix = new Matrix())

--- a/src/System.Globalization.Calendars/tests/Misc/Calendars.cs
+++ b/src/System.Globalization.Calendars/tests/Misc/Calendars.cs
@@ -90,28 +90,35 @@ namespace System.Globalization.Tests
         [MemberData(nameof(Calendars_TestData))]
         public static void CloningTest(Calendar calendar, int yearHasLeapMonth, CalendarAlgorithmType algorithmType)
         {
+            _ = yearHasLeapMonth;
+            _ = algorithmType;
             Calendar cloned = (Calendar) calendar.Clone();
             Assert.Equal(calendar.GetType(), cloned.GetType());
         }
-        
+
         [Theory]
         [MemberData(nameof(Calendars_TestData))]
         public static void GetLeapMonthTest(Calendar calendar, int yearHasLeapMonth, CalendarAlgorithmType algorithmType)
         {
+            _ = algorithmType;
             if (yearHasLeapMonth > 0)
             {
-                Assert.NotEqual(0,  calendar.GetLeapMonth(yearHasLeapMonth));
+                Assert.NotEqual(0, calendar.GetLeapMonth(yearHasLeapMonth));
                 Assert.Equal(0, calendar.GetLeapMonth(yearHasLeapMonth - 1));
             }
             else
-                Assert.True(calendar.GetLeapMonth(calendar.GetYear(DateTime.Today)) == 0, 
+            {
+                Assert.True(calendar.GetLeapMonth(calendar.GetYear(DateTime.Today)) == 0,
                             "calendar.GetLeapMonth returned wrong value");
+            }
         }
 
         [Theory]
         [MemberData(nameof(Calendars_TestData))]
         public static void ReadOnlyTest(Calendar calendar, int yearHasLeapMonth, CalendarAlgorithmType algorithmType)
         {
+            _ = yearHasLeapMonth;
+            _ = algorithmType;
             Assert.False(calendar.IsReadOnly);
             var readOnlyCal = Calendar.ReadOnly(calendar);
             Assert.True(readOnlyCal.IsReadOnly, "expect readOnlyCal.IsReadOnly returns true");
@@ -123,6 +130,7 @@ namespace System.Globalization.Tests
         [MemberData(nameof(Calendars_TestData))]
         public static void AlgorithmTypeTest(Calendar calendar, int yearHasLeapMonth, CalendarAlgorithmType algorithmType)
         {
+            _ = yearHasLeapMonth;
             Assert.Equal(calendar.AlgorithmType, algorithmType);
         }
 

--- a/src/System.Globalization.Calendars/tests/ThaiBuddhistCalendar/ThaiBuddhistCalendarToFourDigitYear.cs
+++ b/src/System.Globalization.Calendars/tests/ThaiBuddhistCalendar/ThaiBuddhistCalendarToFourDigitYear.cs
@@ -9,17 +9,12 @@ namespace System.Globalization.Tests
 {
     public class ThaiBuddhistCalendarToFourDigitYear
     {
-        public static IEnumerable<object[]> ToFourDigitYear_TestData()
-        {
-            yield return new object[] { 2029, new Random(-55).Next(1, 99) };
-            yield return new object[] { 2029 + 543, new Random(-55).Next(544, 10542) };
-            yield return new object[] { 2029 + 543, 10542 };
-            yield return new object[] { 2029, 0 };
-        }
-
         [Theory]
-        [MemberData(nameof(ToFourDigitYear_TestData))]
-        public void ToFourDigitYear(int originalTwoYearMax, int year)
+        [InlineData(0)]
+        [InlineData(46)]
+        [InlineData(5139)]
+        [InlineData(10542)]
+        public void ToFourDigitYear(int year)
         {
             ThaiBuddhistCalendar calendar = new ThaiBuddhistCalendar();
             calendar.TwoDigitYearMax = 2029;

--- a/src/System.Globalization/tests/CultureInfo/CultureInfoAll.cs
+++ b/src/System.Globalization/tests/CultureInfo/CultureInfoAll.cs
@@ -2,10 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Runtime.InteropServices;
+using System.Text;
 using Xunit;
 
 namespace System.Globalization.Tests
@@ -538,6 +539,8 @@ namespace System.Globalization.Tests
         [MemberData(nameof(CultureInfo_TestData))]
         public void LcidTest(string cultureName, int lcid, string specificCultureName, string threeLetterISOLanguageName, string threeLetterWindowsLanguageName, string alternativeCultureName, string consoleUICultureName)
         {
+            _ = alternativeCultureName;
+
             CultureInfo ci = new CultureInfo(lcid);
             Assert.Equal(cultureName, ci.Name);
             Assert.Equal(lcid, ci.LCID);
@@ -604,6 +607,12 @@ namespace System.Globalization.Tests
         [MemberData(nameof(CultureInfo_TestData))]
         public void GetCulturesTest(string cultureName, int lcid, string specificCultureName, string threeLetterISOLanguageName, string threeLetterWindowsLanguageName, string alternativeCultureName, string consoleUICultureName)
         {
+            _ = lcid;
+            _ = specificCultureName;
+            _ = threeLetterISOLanguageName;
+            _ = threeLetterWindowsLanguageName;
+            _ = consoleUICultureName;
+
             bool found = false;
             Assert.All(CultureInfo.GetCultures(CultureTypes.NeutralCultures), 
                        c => Assert.True( (c.IsNeutralCulture && ((c.CultureTypes & CultureTypes.NeutralCultures) != 0)) || c.Equals(CultureInfo.InvariantCulture)));

--- a/src/System.Globalization/tests/CultureInfo/CultureInfoAsync.cs
+++ b/src/System.Globalization/tests/CultureInfo/CultureInfoAsync.cs
@@ -49,18 +49,18 @@ namespace System.Globalization.Tests
             
             CultureInfo.CurrentCulture = newCurrentCulture;
             CultureInfo.CurrentUICulture = newCurrentUICulture;
-            
-            Func<Task> mainAsync = async delegate 
+
+            async Task MainAsync()
             {
                 await Task.Delay(1).ConfigureAwait(false);
-                
+
                 Assert.Equal(CultureInfo.CurrentCulture, newCurrentCulture);
                 Assert.Equal(CultureInfo.CurrentUICulture, newCurrentUICulture);
-            };
-            
+            }
+
             try 
             {
-                mainAsync().Wait();
+                MainAsync().Wait();
             }
             finally
             {

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrencyNegativePattern.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrencyNegativePattern.cs
@@ -64,7 +64,7 @@ namespace System.Globalization.Tests
         public void CurrencyNegativePattern_SetInvalid_ThrowsArgumentOutOfRangeException(int value)
         {
             var format = new NumberFormatInfo();
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("value", "CurrencyNegativePattern", () => format.CurrencyNegativePattern = -1);
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("value", "CurrencyNegativePattern", () => format.CurrencyNegativePattern = value);
         }
 
         [Fact]

--- a/src/System.IO.FileSystem/tests/FileStream/FlushAsync.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/FlushAsync.cs
@@ -66,11 +66,8 @@ namespace System.IO.Tests
             }
         }
 
-        [Theory]
-        [InlineData(null)]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task FlushAfterReading(bool? flushToDisk)
+        [Fact]
+        public async Task FlushAfterReading()
         {
             string fileName = GetTestFilePath();
             File.WriteAllBytes(fileName, TestBuffer);

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
@@ -293,10 +293,12 @@ namespace System.IO.MemoryMappedFiles.Tests
             new FileMode[] { FileMode.Open, FileMode.OpenOrCreate },
             new string[] { null, "CreateUniqueMapName()" },
             new long[] { 1, 256, -1 /*pagesize*/, 10000 },
-            new MemoryMappedFileAccess[] { MemoryMappedFileAccess.Read, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileAccess.CopyOnWrite })]
+            new MemoryMappedFileAccess[] { MemoryMappedFileAccess.ReadWrite })]
         public void ValidArgumentCombinationsWithPath_ModesOpenOrCreate(
             FileMode mode, string mapName, long capacity, MemoryMappedFileAccess access)
         {
+            _ = access;
+
             // Test each of the four path-based CreateFromFile overloads
 
             using (TempFile file = new TempFile(GetTestFilePath(), capacity))

--- a/src/System.IO.Pipelines/tests/PipeWriterTests.cs
+++ b/src/System.IO.Pipelines/tests/PipeWriterTests.cs
@@ -60,15 +60,11 @@ namespace System.IO.Pipelines.Tests
         }
 
         [Theory]
-        [InlineData(0, 0, 3)]
-        [InlineData(0, 1, 2)]
-        [InlineData(0, 2, 1)]
-        [InlineData(0, 1, 1)]
-        [InlineData(1, 0, 3)]
-        [InlineData(1, 1, 2)]
-        [InlineData(1, 2, 1)]
-        [InlineData(1, 1, 1)]
-        public void CanWriteWithOffsetAndLenght(int alloc, int offset, int length)
+        [InlineData(0, 3)]
+        [InlineData(1, 1)]
+        [InlineData(1, 2)]
+        [InlineData(2, 1)]
+        public void CanWriteWithOffsetAndLength(int offset, int length)
         {
             PipeWriter writer = Pipe.Writer;
             var array = new byte[] { 1, 2, 3 };

--- a/src/System.IO/tests/StreamReader/StreamReaderTests.netcoreapp.cs
+++ b/src/System.IO/tests/StreamReader/StreamReaderTests.netcoreapp.cs
@@ -47,7 +47,8 @@ namespace System.IO.Tests
             {
                 while (dst.Length > 0)
                 {
-                    int read = sr.Read(dst);
+                    int toRead = Math.Min(readLength, dst.Length);
+                    int read = sr.Read(dst.Slice(0, toRead));
                     Assert.InRange(read, 1, dst.Length);
                     dst = dst.Slice(read);
                 }
@@ -77,7 +78,8 @@ namespace System.IO.Tests
             {
                 while (dst.Length > 0)
                 {
-                    int read = sr.ReadBlock(dst);
+                    int toRead = Math.Min(readLength, dst.Length);
+                    int read = sr.ReadBlock(dst.Slice(0, toRead));
                     Assert.InRange(read, 1, dst.Length);
                     dst = dst.Slice(read);
                 }
@@ -107,7 +109,8 @@ namespace System.IO.Tests
             {
                 while (dst.Length > 0)
                 {
-                    int read = await sr.ReadAsync(dst);
+                    int toRead = Math.Min(readLength, dst.Length);
+                    int read = await sr.ReadAsync(dst.Slice(0, toRead));
                     Assert.InRange(read, 1, dst.Length);
                     dst = dst.Slice(read);
                 }
@@ -137,7 +140,8 @@ namespace System.IO.Tests
             {
                 while (dst.Length > 0)
                 {
-                    int read = await sr.ReadBlockAsync(dst);
+                    int toRead = Math.Min(readLength, dst.Length);
+                    int read = await sr.ReadBlockAsync(dst.Slice(0, toRead));
                     Assert.InRange(read, 1, dst.Length);
                     dst = dst.Slice(read);
                 }

--- a/src/System.Linq.Expressions/tests/Array/ArrayLengthTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayLengthTests.cs
@@ -1590,8 +1590,8 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(3, func());
         }
 
-        [Theory, ClassData(typeof(CompilationTypes))]
-        public static void ArrayExplicitlyTypeArrayNotAllowed(bool useInterpreter)
+        [Fact]
+        public static void ArrayExplicitlyTypeArrayNotAllowed()
         {
             Array arr = new[] { 1, 2, 3 };
             Expression arrayExpression = Expression.Constant(arr, typeof(Array));

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryAddTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryAddTests.cs
@@ -159,8 +159,8 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
-        [Theory, ClassData(typeof(CompilationTypes))]
-        public static void CheckCharAddTest(bool useInterpreter)
+        [Fact]
+        public static void CheckCharAddTest()
         {
             char[] array = new char[] { '\0', '\b', 'A', '\uffff' };
             for (int i = 0; i < array.Length; i++)

--- a/src/System.Linq.Expressions/tests/Convert/ConvertTests.cs
+++ b/src/System.Linq.Expressions/tests/Convert/ConvertTests.cs
@@ -16640,8 +16640,8 @@ namespace System.Linq.Expressions.Tests
             Assert.Null(f(null));
         }
 
-        [Theory, ClassData(typeof(CompilationTypes))]
-        public static void ImplicitHalfLiftedReverseConversion(bool useInterpreter)
+        [Fact]
+        public static void ImplicitHalfLiftedReverseConversion()
         {
             // In the case where there is a conversion from? -> to, then if
             // we want to do from? -> to? we should do two conversions;

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
@@ -791,8 +791,8 @@ namespace System.Linq.Expressions.Tests
         }
 
 #if FEATURE_COMPILE
-        [Theory, ClassData(typeof(CompilationTypes))]
-        public void AboveByteMaxArityArgIL(bool useInterpreter)
+        [Fact]
+        public void AboveByteMaxArityArgIL()
         {
             ParameterExpression[] pars = Enumerable.Range(0, 300)
                 .Select(_ => Expression.Parameter(typeof(int)))

--- a/src/System.Linq.Expressions/tests/ReadOnlyCollectionBuilderTests.cs
+++ b/src/System.Linq.Expressions/tests/ReadOnlyCollectionBuilderTests.cs
@@ -728,8 +728,9 @@ namespace System.Linq.Expressions.Tests
 
         [Theory]
         [MemberData(nameof(Versioning))]
-        public void ReadOnlyCollectionBuilder_IEnumeratorOfT_Versioning_MoveNext(int index, Action<ReadOnlyCollectionBuilder<int>> edit)
+        public void ReadOnlyCollectionBuilder_IEnumeratorOfT_Versioning_MoveNext(int theoryIndex, Action<ReadOnlyCollectionBuilder<int>> edit)
         {
+            _ = theoryIndex;
             var rocb = new ReadOnlyCollectionBuilder<int>(new[] { 1, 2, 3 });
 
             IEnumerator<int> enumerator = rocb.GetEnumerator();
@@ -743,8 +744,9 @@ namespace System.Linq.Expressions.Tests
 
         [Theory]
         [MemberData(nameof(Versioning))]
-        public void ReadOnlyCollectionBuilder_IEnumeratorOfT_Versioning_Reset(int index, Action<ReadOnlyCollectionBuilder<int>> edit)
+        public void ReadOnlyCollectionBuilder_IEnumeratorOfT_Versioning_Reset(int theoryIndex, Action<ReadOnlyCollectionBuilder<int>> edit)
         {
+            _ = theoryIndex;
             var rocb = new ReadOnlyCollectionBuilder<int>(new[] { 1, 2, 3 });
 
             IEnumerator<int> enumerator = rocb.GetEnumerator();
@@ -758,8 +760,9 @@ namespace System.Linq.Expressions.Tests
 
         [Theory]
         [MemberData(nameof(Versioning))]
-        public void ReadOnlyCollectionBuilder_IEnumerator_Versioning_MoveNext(int index, Action<ReadOnlyCollectionBuilder<int>> edit)
+        public void ReadOnlyCollectionBuilder_IEnumerator_Versioning_MoveNext(int theoryIndex, Action<ReadOnlyCollectionBuilder<int>> edit)
         {
+            _ = theoryIndex;
             var rocb = new ReadOnlyCollectionBuilder<int>(new[] { 1, 2, 3 });
 
             IEnumerator enumerator = ((IEnumerable)rocb).GetEnumerator();
@@ -773,8 +776,9 @@ namespace System.Linq.Expressions.Tests
 
         [Theory]
         [MemberData(nameof(Versioning))]
-        public void ReadOnlyCollectionBuilder_IEnumerator_Versioning_Reset(int index, Action<ReadOnlyCollectionBuilder<int>> edit)
+        public void ReadOnlyCollectionBuilder_IEnumerator_Versioning_Reset(int theoryIndex, Action<ReadOnlyCollectionBuilder<int>> edit)
         {
+            _ = theoryIndex;
             var rocb = new ReadOnlyCollectionBuilder<int>(new[] { 1, 2, 3 });
 
             IEnumerator enumerator = ((IEnumerable)rocb).GetEnumerator();
@@ -910,6 +914,6 @@ namespace System.Linq.Expressions.Tests
                 e => ((IList)e).Remove(1),
                 e => e.RemoveAt(0),
                 e => e.Reverse(),
-            }.Select((x, i) => new object[] { i, x });
+            }.Select((x, i) => new object[] { i, x }); // index used to help identify which item was the cause of a theory failure
     }
 }

--- a/src/System.Linq.Expressions/tests/Switch/SwitchTests.cs
+++ b/src/System.Linq.Expressions/tests/Switch/SwitchTests.cs
@@ -626,8 +626,8 @@ namespace System.Linq.Expressions.Tests
             public static bool WithinTwo(int x, int y) => Math.Abs(x - y) < 2;
         }
 
-        [Theory, ClassData(typeof(CompilationTypes))]
-        public void OpenGenericMethodDeclarer(bool useInterpreter)
+        [Fact]
+        public void OpenGenericMethodDeclarer()
         {
             Expression switchVal = Expression.Constant(30);
             Expression defaultExp = Expression.Constant(0);

--- a/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PostDecrementAssignTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PostDecrementAssignTests.cs
@@ -28,8 +28,9 @@ namespace System.Linq.Expressions.Tests
         [PerCompilationType(nameof(NullableSinglesAndDecrements))]
         [PerCompilationType(nameof(DoublesAndDecrements))]
         [PerCompilationType(nameof(NullableDoublesAndDecrements))]
-        public void ReturnsCorrectValues(Type type, object value, object _, bool useInterpreter)
+        public void ReturnsCorrectValues(Type type, object value, object ignored, bool useInterpreter)
         {
+            _ = ignored;
             ParameterExpression variable = Expression.Variable(type);
             BlockExpression block = Expression.Block(
                 new[] { variable },

--- a/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PostIncrementAssignTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PostIncrementAssignTests.cs
@@ -28,8 +28,9 @@ namespace System.Linq.Expressions.Tests
         [PerCompilationType(nameof(NullableSinglesAndIncrements))]
         [PerCompilationType(nameof(DoublesAndIncrements))]
         [PerCompilationType(nameof(NullableDoublesAndIncrements))]
-        public void ReturnsCorrectValues(Type type, object value, object _, bool useInterpreter)
+        public void ReturnsCorrectValues(Type type, object value, object ignored, bool useInterpreter)
         {
+            _ = ignored;
             ParameterExpression variable = Expression.Variable(type);
             BlockExpression block = Expression.Block(
                 new[] { variable },

--- a/src/System.Linq.Parallel/tests/Combinatorial/ParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/ParallelQueryCombinationTests.cs
@@ -142,7 +142,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Concat(Labeled<Operation> source, Labeled<Operation> operation)
         {
-            Action<Operation, Operation> concat = (left, right) =>
+            void Concat(Operation left, Operation right)
             {
                 int seen = DefaultStart;
                 foreach (int i in left(DefaultStart, DefaultSize / 2, source.Item)
@@ -151,9 +151,9 @@ namespace System.Linq.Parallel.Tests
                     Assert.Equal(seen++, i);
                 }
                 Assert.Equal(DefaultStart + DefaultSize, seen);
-            };
-            concat(operation.Item, LabeledDefaultSource.AsOrdered().Item);
-            concat(LabeledDefaultSource.AsOrdered().Item, operation.Item);
+            }
+            Concat(operation.Item, LabeledDefaultSource.AsOrdered().Item);
+            Concat(LabeledDefaultSource.AsOrdered().Item, operation.Item);
         }
 
         [Theory]
@@ -161,7 +161,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Concat_NotPipelined(Labeled<Operation> source, Labeled<Operation> operation)
         {
-            Action<Operation, Operation> concat = (left, right) =>
+            void Concat(Operation left, Operation right)
             {
                 int seen = DefaultStart;
                 Assert.All(
@@ -170,9 +170,9 @@ namespace System.Linq.Parallel.Tests
                     x => Assert.Equal(seen++, x)
                     );
                 Assert.Equal(DefaultStart + DefaultSize, seen);
-            };
-            concat(operation.Item, LabeledDefaultSource.AsOrdered().Item);
-            concat(LabeledDefaultSource.AsOrdered().Item, operation.Item);
+            }
+            Concat(operation.Item, LabeledDefaultSource.AsOrdered().Item);
+            Concat(LabeledDefaultSource.AsOrdered().Item, operation.Item);
         }
 
         [Theory]
@@ -299,7 +299,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Except(Labeled<Operation> source, Labeled<Operation> operation)
         {
-            Action<Operation, Operation> except = (left, right) =>
+            void Except(Operation left, Operation right)
             {
                 int seen = DefaultStart;
                 ParallelQuery<int> query = left(DefaultStart, DefaultSize + DefaultSize / 2, source.Item)
@@ -309,9 +309,9 @@ namespace System.Linq.Parallel.Tests
                     Assert.Equal(seen++, i);
                 }
                 Assert.Equal(DefaultStart + DefaultSize, seen);
-            };
-            except(operation.Item, DefaultSource);
-            except(LabeledDefaultSource.AsOrdered().Item, operation.Item);
+            }
+            Except(operation.Item, DefaultSource);
+            Except(LabeledDefaultSource.AsOrdered().Item, operation.Item);
         }
 
         [Theory]
@@ -319,16 +319,16 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Except_NotPipelined(Labeled<Operation> source, Labeled<Operation> operation)
         {
-            Action<Operation, Operation> except = (left, right) =>
+            void Except(Operation left, Operation right)
             {
                 int seen = DefaultStart;
                 ParallelQuery<int> query = left(DefaultStart, DefaultSize + DefaultSize / 2, source.Item)
                     .Except(right(DefaultStart + DefaultSize, DefaultSize, source.Item));
                 Assert.All(query.ToList(), x => Assert.Equal(seen++, x));
                 Assert.Equal(DefaultStart + DefaultSize, seen);
-            };
-            except(operation.Item, DefaultSource);
-            except(LabeledDefaultSource.AsOrdered().Item, operation.Item);
+            }
+            Except(operation.Item, DefaultSource);
+            Except(LabeledDefaultSource.AsOrdered().Item, operation.Item);
         }
 
         [Theory]
@@ -469,7 +469,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void GroupJoin(Labeled<Operation> source, Labeled<Operation> operation)
         {
-            Action<Operation, Operation> groupJoin = (left, right) =>
+            void GroupJoin(Operation left, Operation right)
             {
                 int seenKey = DefaultStart / GroupFactor;
                 foreach (KeyValuePair<int, IEnumerable<int>> group in left(DefaultStart / GroupFactor, DefaultSize / GroupFactor, source.Item)
@@ -481,9 +481,9 @@ namespace System.Linq.Parallel.Tests
                     Assert.Equal((group.Key + 1) * GroupFactor, seenElement);
                 }
                 Assert.Equal((DefaultStart + DefaultSize) / GroupFactor, seenKey);
-            };
-            groupJoin(operation.Item, LabeledDefaultSource.AsOrdered().Item);
-            groupJoin(LabeledDefaultSource.AsOrdered().Item, operation.Item);
+            }
+            GroupJoin(operation.Item, LabeledDefaultSource.AsOrdered().Item);
+            GroupJoin(LabeledDefaultSource.AsOrdered().Item, operation.Item);
         }
 
         [Theory]
@@ -491,7 +491,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void GroupJoin_NotPipelined(Labeled<Operation> source, Labeled<Operation> operation)
         {
-            Action<Operation, Operation> groupJoin = (left, right) =>
+            void GroupJoin(Operation left, Operation right)
             {
                 int seenKey = DefaultStart / GroupFactor;
                 foreach (KeyValuePair<int, IEnumerable<int>> group in left(DefaultStart / GroupFactor, DefaultSize / GroupFactor, source.Item)
@@ -503,9 +503,9 @@ namespace System.Linq.Parallel.Tests
                     Assert.Equal((group.Key + 1) * GroupFactor, seenElement);
                 }
                 Assert.Equal((DefaultStart + DefaultSize) / GroupFactor, seenKey);
-            };
-            groupJoin(operation.Item, LabeledDefaultSource.AsOrdered().Item);
-            groupJoin(LabeledDefaultSource.AsOrdered().Item, operation.Item);
+            }
+            GroupJoin(operation.Item, LabeledDefaultSource.AsOrdered().Item);
+            GroupJoin(LabeledDefaultSource.AsOrdered().Item, operation.Item);
         }
 
         [Theory]
@@ -513,7 +513,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Intersect(Labeled<Operation> source, Labeled<Operation> operation)
         {
-            Action<Operation, Operation> intersect = (left, right) =>
+            void Intersect(Operation left, Operation right)
             {
                 int seen = DefaultStart;
                 ParallelQuery<int> query = left(DefaultStart - DefaultSize / 2, DefaultSize + DefaultSize / 2, source.Item)
@@ -523,9 +523,9 @@ namespace System.Linq.Parallel.Tests
                     Assert.Equal(seen++, i);
                 }
                 Assert.Equal(DefaultStart + DefaultSize, seen);
-            };
-            intersect(operation.Item, DefaultSource);
-            intersect(LabeledDefaultSource.AsOrdered().Item, operation.Item);
+            }
+            Intersect(operation.Item, DefaultSource);
+            Intersect(LabeledDefaultSource.AsOrdered().Item, operation.Item);
         }
 
         [Theory]
@@ -533,16 +533,16 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Intersect_NotPipelined(Labeled<Operation> source, Labeled<Operation> operation)
         {
-            Action<Operation, Operation> intersect = (left, right) =>
+            void Intersect(Operation left, Operation right)
             {
                 int seen = DefaultStart;
                 ParallelQuery<int> query = left(DefaultStart - DefaultSize / 2, DefaultSize + DefaultSize / 2, source.Item)
                     .Intersect(right(DefaultStart, DefaultSize + DefaultSize / 2, source.Item));
                 Assert.All(query.ToList(), x => Assert.Equal(seen++, x));
                 Assert.Equal(DefaultStart + DefaultSize, seen);
-            };
-            intersect(operation.Item, DefaultSource);
-            intersect(LabeledDefaultSource.AsOrdered().Item, operation.Item);
+            }
+            Intersect(operation.Item, DefaultSource);
+            Intersect(LabeledDefaultSource.AsOrdered().Item, operation.Item);
         }
 
         [Theory]
@@ -550,7 +550,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Join(Labeled<Operation> source, Labeled<Operation> operation)
         {
-            Action<Operation, Operation> join = (left, right) =>
+            void Join(Operation left, Operation right)
             {
                 int seen = DefaultStart;
                 ParallelQuery<KeyValuePair<int, int>> query = left(DefaultStart / GroupFactor, DefaultSize / GroupFactor, source.Item)
@@ -561,9 +561,9 @@ namespace System.Linq.Parallel.Tests
                     Assert.Equal(p.Key, p.Value / GroupFactor);
                 }
                 Assert.Equal(DefaultStart + DefaultSize, seen);
-            };
-            join(operation.Item, LabeledDefaultSource.AsOrdered().Item);
-            join(LabeledDefaultSource.AsOrdered().Item, operation.Item);
+            }
+            Join(operation.Item, LabeledDefaultSource.AsOrdered().Item);
+            Join(LabeledDefaultSource.AsOrdered().Item, operation.Item);
         }
 
         [Theory]
@@ -571,7 +571,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Join_NotPipelined(Labeled<Operation> source, Labeled<Operation> operation)
         {
-            Action<Operation, Operation> join = (left, right) =>
+            void Join(Operation left, Operation right)
             {
                 int seen = DefaultStart;
                 ParallelQuery<KeyValuePair<int, int>> query = left(DefaultStart / GroupFactor, DefaultSize / GroupFactor, source.Item)
@@ -582,9 +582,9 @@ namespace System.Linq.Parallel.Tests
                     Assert.Equal(p.Key, p.Value / GroupFactor);
                 }
                 Assert.Equal(DefaultStart + DefaultSize, seen);
-            };
-            join(operation.Item, LabeledDefaultSource.AsOrdered().Item);
-            join(LabeledDefaultSource.AsOrdered().Item, operation.Item);
+            }
+            Join(operation.Item, LabeledDefaultSource.AsOrdered().Item);
+            Join(LabeledDefaultSource.AsOrdered().Item, operation.Item);
         }
 
         [Theory]
@@ -1386,7 +1386,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Union(Labeled<Operation> source, Labeled<Operation> operation)
         {
-            Action<Operation, Operation> union = (left, right) =>
+            void Union(Operation left, Operation right)
             {
                 int seen = DefaultStart;
                 ParallelQuery<int> query = left(DefaultStart, DefaultSize * 3 / 4, source.Item)
@@ -1396,9 +1396,9 @@ namespace System.Linq.Parallel.Tests
                     Assert.Equal(seen++, i);
                 }
                 Assert.Equal(DefaultStart + DefaultSize, seen);
-            };
-            union(operation.Item, LabeledDefaultSource.AsOrdered().Item);
-            union(LabeledDefaultSource.AsOrdered().Item, operation.Item);
+            }
+            Union(operation.Item, LabeledDefaultSource.AsOrdered().Item);
+            Union(LabeledDefaultSource.AsOrdered().Item, operation.Item);
         }
 
         [Theory]
@@ -1406,16 +1406,16 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Union_NotPipelined(Labeled<Operation> source, Labeled<Operation> operation)
         {
-            Action<Operation, Operation> union = (left, right) =>
+            void Union(Operation left, Operation right)
             {
                 int seen = DefaultStart;
                 ParallelQuery<int> query = left(DefaultStart, DefaultSize * 3 / 4, source.Item)
                     .Union(right(DefaultStart + DefaultSize / 2, DefaultSize / 2, source.Item));
                 Assert.All(query.ToList(), x => Assert.Equal(seen++, x));
                 Assert.Equal(DefaultStart + DefaultSize, seen);
-            };
-            union(operation.Item, LabeledDefaultSource.AsOrdered().Item);
-            union(LabeledDefaultSource.AsOrdered().Item, operation.Item);
+            }
+            Union(operation.Item, LabeledDefaultSource.AsOrdered().Item);
+            Union(LabeledDefaultSource.AsOrdered().Item, operation.Item);
         }
 
         [Theory]
@@ -1469,7 +1469,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Zip(Labeled<Operation> source, Labeled<Operation> operation)
         {
-            Action<Operation, Operation> zip = (left, right) =>
+            void Zip(Operation left, Operation right)
             {
                 int seen = DefaultStart;
                 ParallelQuery<int> query = left(DefaultStart * 2, DefaultSize, source.Item)
@@ -1479,9 +1479,9 @@ namespace System.Linq.Parallel.Tests
                     Assert.Equal(seen++, i);
                 }
                 Assert.Equal(DefaultStart + DefaultSize, seen);
-            };
-            zip(operation.Item, LabeledDefaultSource.AsOrdered().Item);
-            zip(LabeledDefaultSource.AsOrdered().Item, operation.Item);
+            }
+            Zip(operation.Item, LabeledDefaultSource.AsOrdered().Item);
+            Zip(LabeledDefaultSource.AsOrdered().Item, operation.Item);
         }
 
         [Theory]
@@ -1489,16 +1489,16 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperators))]
         public static void Zip_NotPipelined(Labeled<Operation> source, Labeled<Operation> operation)
         {
-            Action<Operation, Operation> zip = (left, right) =>
+            void Zip(Operation left, Operation right)
             {
                 int seen = DefaultStart;
                 ParallelQuery<int> query = left(DefaultStart * 2, DefaultSize, source.Item)
                     .Zip(right(0, DefaultSize, source.Item), (x, y) => (x + y) / 2);
                 Assert.All(query.ToList(), x => Assert.Equal(seen++, x));
                 Assert.Equal(DefaultStart + DefaultSize, seen);
-            };
-            zip(operation.Item, LabeledDefaultSource.AsOrdered().Item);
-            zip(LabeledDefaultSource.AsOrdered().Item, operation.Item);
+            }
+            Zip(operation.Item, LabeledDefaultSource.AsOrdered().Item);
+            Zip(LabeledDefaultSource.AsOrdered().Item, operation.Item);
         }
     }
 }

--- a/src/System.Linq.Parallel/tests/Combinatorial/UnorderedParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/UnorderedParallelQueryCombinationTests.cs
@@ -38,7 +38,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperations))]
         public static void Concat_Unordered(Labeled<Operation> operation)
         {
-            Action<Operation, Operation> concat = (left, right) =>
+            static void Concat(Operation left, Operation right)
             {
                 IntegerRangeSet seen = new IntegerRangeSet(DefaultStart, DefaultSize);
                 foreach (int i in left(DefaultStart, DefaultSize / 2, DefaultSource)
@@ -47,9 +47,9 @@ namespace System.Linq.Parallel.Tests
                     seen.Add(i);
                 }
                 seen.AssertComplete();
-            };
-            concat(operation.Item, DefaultSource);
-            concat(DefaultSource, operation.Item);
+            }
+            Concat(operation.Item, DefaultSource);
+            Concat(DefaultSource, operation.Item);
         }
 
         [Theory]
@@ -57,7 +57,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperations))]
         public static void Concat_Unordered_NotPipelined(Labeled<Operation> operation)
         {
-            Action<Operation, Operation> concat = (left, right) =>
+            static void Concat(Operation left, Operation right)
             {
                 IntegerRangeSet seen = new IntegerRangeSet(DefaultStart, DefaultSize);
                 Assert.All(
@@ -65,9 +65,9 @@ namespace System.Linq.Parallel.Tests
                         .Concat(right(DefaultStart + DefaultSize / 2, DefaultSize / 2, DefaultSource)).ToList(),
                     x => seen.Add(x));
                 seen.AssertComplete();
-            };
-            concat(operation.Item, DefaultSource);
-            concat(DefaultSource, operation.Item);
+            }
+            Concat(operation.Item, DefaultSource);
+            Concat(DefaultSource, operation.Item);
         }
 
         [Theory]
@@ -123,7 +123,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperations))]
         public static void Except_Unordered(Labeled<Operation> operation)
         {
-            Action<Operation, Operation> except = (left, right) =>
+            static void Except(Operation left, Operation right)
             {
                 IntegerRangeSet seen = new IntegerRangeSet(DefaultStart, DefaultSize);
                 ParallelQuery<int> query = left(DefaultStart, DefaultSize + DefaultSize / 2, DefaultSource)
@@ -133,9 +133,9 @@ namespace System.Linq.Parallel.Tests
                     seen.Add(i);
                 }
                 seen.AssertComplete();
-            };
-            except(operation.Item, DefaultSource);
-            except(DefaultSource, operation.Item);
+            }
+            Except(operation.Item, DefaultSource);
+            Except(DefaultSource, operation.Item);
         }
 
         [Theory]
@@ -143,16 +143,16 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperations))]
         public static void Except_Unordered_NotPipelined(Labeled<Operation> operation)
         {
-            Action<Operation, Operation> except = (left, right) =>
+            static void Except(Operation left, Operation right)
             {
                 IntegerRangeSet seen = new IntegerRangeSet(DefaultStart, DefaultSize);
                 ParallelQuery<int> query = left(DefaultStart, DefaultSize + DefaultSize / 2, DefaultSource)
                     .Except(right(DefaultStart + DefaultSize, DefaultSize, DefaultSource));
                 Assert.All(query.ToList(), x => seen.Add((int)x));
                 seen.AssertComplete();
-            };
-            except(operation.Item, DefaultSource);
-            except(DefaultSource, operation.Item);
+            }
+            Except(operation.Item, DefaultSource);
+            Except(DefaultSource, operation.Item);
         }
 
         [Theory]
@@ -242,7 +242,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperations))]
         public static void GroupJoin_Unordered(Labeled<Operation> operation)
         {
-            Action<Operation, Operation> groupJoin = (left, right) =>
+            static void GroupJoin(Operation left, Operation right)
             {
                 IntegerRangeSet seenKey = new IntegerRangeSet(DefaultStart / GroupFactor, DefaultSize / GroupFactor);
                 foreach (KeyValuePair<int, IEnumerable<int>> group in left(DefaultStart / GroupFactor, DefaultSize / GroupFactor, DefaultSource)
@@ -254,9 +254,9 @@ namespace System.Linq.Parallel.Tests
                     seenElement.AssertComplete();
                 }
                 seenKey.AssertComplete();
-            };
-            groupJoin(operation.Item, DefaultSource);
-            groupJoin(DefaultSource, operation.Item);
+            }
+            GroupJoin(operation.Item, DefaultSource);
+            GroupJoin(DefaultSource, operation.Item);
         }
 
         [Theory]
@@ -264,7 +264,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperations))]
         public static void GroupJoin_Unordered_NotPipelined(Labeled<Operation> operation)
         {
-            Action<Operation, Operation> groupJoin = (left, right) =>
+            static void GroupJoin(Operation left, Operation right)
             {
                 IntegerRangeSet seenKey = new IntegerRangeSet(DefaultStart / GroupFactor, DefaultSize / GroupFactor);
                 foreach (KeyValuePair<int, IEnumerable<int>> group in left(DefaultStart / GroupFactor, DefaultSize / GroupFactor, DefaultSource)
@@ -276,9 +276,9 @@ namespace System.Linq.Parallel.Tests
                     seenElement.AssertComplete();
                 }
                 seenKey.AssertComplete();
-            };
-            groupJoin(operation.Item, DefaultSource);
-            groupJoin(DefaultSource, operation.Item);
+            }
+            GroupJoin(operation.Item, DefaultSource);
+            GroupJoin(DefaultSource, operation.Item);
         }
 
         [Theory]
@@ -286,7 +286,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperations))]
         public static void Intersect_Unordered(Labeled<Operation> operation)
         {
-            Action<Operation, Operation> intersect = (left, right) =>
+            static void Intersect(Operation left, Operation right)
             {
                 IntegerRangeSet seen = new IntegerRangeSet(DefaultStart, DefaultSize);
                 ParallelQuery<int> query = left(DefaultStart - DefaultSize / 2, DefaultSize + DefaultSize / 2, DefaultSource)
@@ -296,9 +296,9 @@ namespace System.Linq.Parallel.Tests
                     seen.Add(i);
                 }
                 seen.AssertComplete();
-            };
-            intersect(operation.Item, DefaultSource);
-            intersect(DefaultSource, operation.Item);
+            }
+            Intersect(operation.Item, DefaultSource);
+            Intersect(DefaultSource, operation.Item);
         }
 
         [Theory]
@@ -306,16 +306,16 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperations))]
         public static void Intersect_Unordered_NotPipelined(Labeled<Operation> operation)
         {
-            Action<Operation, Operation> intersect = (left, right) =>
+            static void Intersect(Operation left, Operation right)
             {
                 IntegerRangeSet seen = new IntegerRangeSet(DefaultStart, DefaultSize);
                 ParallelQuery<int> query = left(DefaultStart - DefaultSize / 2, DefaultSize + DefaultSize / 2, DefaultSource)
                     .Intersect(right(DefaultStart, DefaultSize + DefaultSize / 2, DefaultSource));
                 Assert.All(query.ToList(), x => seen.Add(x));
                 seen.AssertComplete();
-            };
-            intersect(operation.Item, DefaultSource);
-            intersect(DefaultSource, operation.Item);
+            }
+            Intersect(operation.Item, DefaultSource);
+            Intersect(DefaultSource, operation.Item);
         }
 
         [Theory]
@@ -323,7 +323,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperations))]
         public static void Join_Unordered(Labeled<Operation> operation)
         {
-            Action<Operation, Operation> join = (left, right) =>
+            static void Join(Operation left, Operation right)
             {
                 IntegerRangeSet seen = new IntegerRangeSet(DefaultStart, DefaultSize);
                 ParallelQuery<KeyValuePair<int, int>> query = left(DefaultStart / GroupFactor, DefaultSize / GroupFactor, DefaultSource)
@@ -334,17 +334,17 @@ namespace System.Linq.Parallel.Tests
                     seen.Add(p.Value);
                 }
                 seen.AssertComplete();
-            };
-            join(operation.Item, DefaultSource);
-            join(DefaultSource, operation.Item);
+            }
+            Join(operation.Item, DefaultSource);
+            Join(DefaultSource, operation.Item);
         }
 
         [Theory]
-        [MemberData(nameof(UnaryUnorderedOperators))]
-        [MemberData(nameof(BinaryUnorderedOperators))]
-        public static void Join_Unordered_NotPipelined(Labeled<Operation> source, Labeled<Operation> operation)
+        [MemberData(nameof(UnaryOperations))]
+        [MemberData(nameof(BinaryOperations))]
+        public static void Join_Unordered_NotPipelined(Labeled<Operation> operation)
         {
-            Action<Operation, Operation> join = (left, right) =>
+            static void Join(Operation left, Operation right)
             {
                 IntegerRangeSet seen = new IntegerRangeSet(DefaultStart, DefaultSize);
                 ParallelQuery<KeyValuePair<int, int>> query = left(DefaultStart / GroupFactor, DefaultSize / GroupFactor, DefaultSource)
@@ -355,9 +355,9 @@ namespace System.Linq.Parallel.Tests
                     seen.Add(p.Value);
                 }
                 seen.AssertComplete();
-            };
-            join(operation.Item, DefaultSource);
-            join(DefaultSource, operation.Item);
+            }
+            Join(operation.Item, DefaultSource);
+            Join(DefaultSource, operation.Item);
         }
 
         [Theory]
@@ -600,7 +600,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperations))]
         public static void Union_Unordered(Labeled<Operation> operation)
         {
-            Action<Operation, Operation> union = (left, right) =>
+            static void Union(Operation left, Operation right)
             {
                 IntegerRangeSet seen = new IntegerRangeSet(DefaultStart, DefaultSize);
                 ParallelQuery<int> query = left(DefaultStart, DefaultSize * 3 / 4, DefaultSource)
@@ -610,9 +610,9 @@ namespace System.Linq.Parallel.Tests
                     seen.Add(i);
                 }
                 seen.AssertComplete();
-            };
-            union(operation.Item, DefaultSource);
-            union(DefaultSource, operation.Item);
+            }
+            Union(operation.Item, DefaultSource);
+            Union(DefaultSource, operation.Item);
         }
 
         [Theory]
@@ -620,16 +620,16 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperations))]
         public static void Union_Unordered_NotPipelined(Labeled<Operation> operation)
         {
-            Action<Operation, Operation> union = (left, right) =>
+            static void Union(Operation left, Operation right)
             {
                 IntegerRangeSet seen = new IntegerRangeSet(DefaultStart, DefaultSize);
                 ParallelQuery<int> query = left(DefaultStart, DefaultSize * 3 / 4, DefaultSource)
                     .Union(right(DefaultStart + DefaultSize / 2, DefaultSize / 2, DefaultSource));
                 Assert.All(query.ToList(), x => seen.Add(x));
                 seen.AssertComplete();
-            };
-            union(operation.Item, DefaultSource);
-            union(DefaultSource, operation.Item);
+            }
+            Union(operation.Item, DefaultSource);
+            Union(DefaultSource, operation.Item);
         }
 
         [Theory]
@@ -683,19 +683,19 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperations))]
         public static void Zip_Unordered(Labeled<Operation> operation)
         {
-            Action<Operation, Operation> zip = (left, right) =>
-             {
-                 IntegerRangeSet seen = new IntegerRangeSet(DefaultStart, DefaultSize);
-                 ParallelQuery<int> query = left(DefaultStart, DefaultSize, DefaultSource)
-                     .Zip(right(0, DefaultSize, DefaultSource), (x, y) => x);
-                 foreach (int i in query)
-                 {
-                     seen.Add(i);
-                 }
-                 seen.AssertComplete();
-             };
-            zip(operation.Item, DefaultSource);
-            zip(DefaultSource, operation.Item);
+            static void Zip(Operation left, Operation right)
+            {
+                IntegerRangeSet seen = new IntegerRangeSet(DefaultStart, DefaultSize);
+                ParallelQuery<int> query = left(DefaultStart, DefaultSize, DefaultSource)
+                    .Zip(right(0, DefaultSize, DefaultSource), (x, y) => x);
+                foreach (int i in query)
+                {
+                    seen.Add(i);
+                }
+                seen.AssertComplete();
+            }
+            Zip(operation.Item, DefaultSource);
+            Zip(DefaultSource, operation.Item);
         }
 
         [Theory]
@@ -703,16 +703,16 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(BinaryOperations))]
         public static void Zip_Unordered_NotPipelined(Labeled<Operation> operation)
         {
-            Action<Operation, Operation> zip = (left, right) =>
+            static void Zip(Operation left, Operation right)
             {
                 IntegerRangeSet seen = new IntegerRangeSet(DefaultStart, DefaultSize);
                 ParallelQuery<int> query = left(DefaultStart, DefaultSize, DefaultSource)
                     .Zip(right(0, DefaultSize, DefaultSource), (x, y) => x);
                 Assert.All(query.ToList(), x => seen.Add(x));
                 seen.AssertComplete();
-            };
-            zip(operation.Item, DefaultSource);
-            zip(DefaultSource, operation.Item);
+            }
+            Zip(operation.Item, DefaultSource);
+            Zip(DefaultSource, operation.Item);
         }
     }
 }

--- a/src/System.Linq.Parallel/tests/DegreeOfParallelismTests.cs
+++ b/src/System.Linq.Parallel/tests/DegreeOfParallelismTests.cs
@@ -135,6 +135,7 @@ namespace System.Linq.Parallel.Tests
         [OuterLoop]
         public static void DegreeOfParallelism_OutOfRange(Labeled<ParallelQuery<int>> labeled, int count, int degree)
         {
+            _ = count;
             Assert.Throws<ArgumentOutOfRangeException>(() => labeled.Item.WithDegreeOfParallelism(degree));
         }
 

--- a/src/System.Linq.Parallel/tests/ExchangeTests.cs
+++ b/src/System.Linq.Parallel/tests/ExchangeTests.cs
@@ -92,6 +92,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(PartitioningData), new[] { 0, 1, 2, 16, 1024 })]
         public static void Partitioning_Default(Labeled<ParallelQuery<int>> labeled, int count, int partitions)
         {
+            _ = count;
             int seen = 0;
             foreach (int i in labeled.Item.WithDegreeOfParallelism(partitions).Select(i => i))
             {
@@ -130,6 +131,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(MergeData), new[] { 0, 1, 2, 16, 1024 })]
         public static void Merge_Ordered(Labeled<ParallelQuery<int>> labeled, int count, ParallelMergeOptions options)
         {
+            _ = count;
             int seen = 0;
             foreach (int i in labeled.Item.WithMergeOptions(options).Select(i => i))
             {
@@ -172,6 +174,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 2 }, MemberType = typeof(UnorderedSources))]
         public static void Merge_ArgumentException(Labeled<ParallelQuery<int>> labeled, int count)
         {
+            _ = count;
             ParallelQuery<int> query = labeled.Item;
 
             AssertExtensions.Throws<ArgumentException>(null, () => query.WithMergeOptions((ParallelMergeOptions)4));
@@ -196,9 +199,12 @@ namespace System.Linq.Parallel.Tests
         // This test verifies any such ODEs are not reflected in the output exception.
         [Theory]
         [MemberData(nameof(UnorderedSources.BinaryRanges), new[] { 16 }, new[] { 16 }, MemberType = typeof(UnorderedSources))]
-        public static void PlinqChunkPartitioner_DontEnumerateAfterException(Labeled<ParallelQuery<int>> left, int leftCount,
+        public static void PlinqChunkPartitioner_DontEnumerateAfterException(
+            Labeled<ParallelQuery<int>> left, int leftCount,
             Labeled<ParallelQuery<int>> right, int rightCount)
         {
+            _ = leftCount;
+            _ = rightCount;
             ParallelQuery<int> query =
                 left.Item.WithExecutionMode(ParallelExecutionMode.ForceParallelism)
                     .Select(x => { if (x == 4) throw new DeliberateTestException(); return x; })
@@ -220,6 +226,8 @@ namespace System.Linq.Parallel.Tests
             Labeled<ParallelQuery<int>> left, int leftCount,
             Labeled<ParallelQuery<int>> right, int rightCount)
         {
+            _ = leftCount;
+            _ = rightCount;
             ParallelQuery<int> query =
                 Partitioner.Create(left.Item.WithExecutionMode(ParallelExecutionMode.ForceParallelism)
                     .Select(x => { if (x == 4) throw new DeliberateTestException(); return x; })

--- a/src/System.Linq.Parallel/tests/ParallelEnumerableTests.cs
+++ b/src/System.Linq.Parallel/tests/ParallelEnumerableTests.cs
@@ -248,20 +248,14 @@ namespace System.Linq.Parallel.Tests
         //
         // Empty
         //
-        public static IEnumerable<object[]> EmptyData()
-        {
-            yield return new object[] { default(int) };
-            yield return new object[] { default(long) };
-            yield return new object[] { default(double) };
-            // [ActiveIssue("https://github.com/xunit/xunit/issues/1771")]
-            //yield return new object[] { default(decimal) };
-            yield return new object[] { default(string) };
-            yield return new object[] { default(object) };
-        }
 
-        [Theory]
-        [MemberData(nameof(EmptyData))]
-        public static void Empty<T>(T def)
+        [Fact]
+        public static void EmptyStruct() => Empty<int>();
+
+        [Fact]
+        public static void EmptyClass() => Empty<string>();
+
+        private static void Empty<T>()
         {
             Assert.Empty(ParallelEnumerable.Empty<T>());
             Assert.False(ParallelEnumerable.Empty<T>().Any(x => true));

--- a/src/System.Linq.Parallel/tests/PlinqModesTests.cs
+++ b/src/System.Linq.Parallel/tests/PlinqModesTests.cs
@@ -153,6 +153,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 2 }, MemberType = typeof(UnorderedSources))]
         public static void WithExecutionMode_ArgumentException(Labeled<ParallelQuery<int>> labeled, int count)
         {
+            _ = count;
             ParallelQuery<int> query = labeled.Item;
             AssertExtensions.Throws<ArgumentException>(null, () => query.WithExecutionMode((ParallelExecutionMode)2));
         }

--- a/src/System.Linq.Parallel/tests/QueryOperators/AverageTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/AverageTests.cs
@@ -48,8 +48,10 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(AverageData), new[] { 1, 2, 16 })]
-        public static void Average_Int_AllNull(int count, double average)
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(16)]
+        public static void Average_Int_AllNull(int count)
         {
             Assert.Null(UnorderedSources.Default(count).Select(x => (int?)null).Average());
             Assert.Null(UnorderedSources.Default(count).Average(x => (int?)null));

--- a/src/System.Linq.Parallel/tests/QueryOperators/CastTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/CastTests.cs
@@ -100,6 +100,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(Sources.Ranges), new[] { 0 }, MemberType = typeof(Sources))]
         public static void Cast_Empty(Labeled<ParallelQuery<int>> labeled, int count)
         {
+            _ = count;
             ParallelQuery<int> empty = labeled.Item;
 
             Assert.IsAssignableFrom<ParallelQuery<int>>(empty.Cast<string>().Cast<int>());
@@ -121,6 +122,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(Sources.Ranges), new[] { 1, 2, 16 }, MemberType = typeof(Sources))]
         public static void Cast_InvalidCastException(Labeled<ParallelQuery<int>> labeled, int count)
         {
+            _ = count;
             AssertThrows.Wrapped<InvalidCastException>(() => labeled.Item.Cast<double>().ForAll(x => {; }));
             AssertThrows.Wrapped<InvalidCastException>(() => labeled.Item.Cast<double>().ToList());
         }
@@ -139,6 +141,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(Sources.Ranges), new[] { 1, 2, 16 }, MemberType = typeof(Sources))]
         public static void Cast_Assignable_InvalidCastException(Labeled<ParallelQuery<int>> labeled, int count)
         {
+            _ = count;
             AssertThrows.Wrapped<InvalidCastException>(() => labeled.Item.Select(x => (Int32)x).Cast<Castable>().ForAll(x => {; }));
             AssertThrows.Wrapped<InvalidCastException>(() => labeled.Item.Select(x => (Int32)x).Cast<Castable>().ToList());
         }

--- a/src/System.Linq.Parallel/tests/QueryOperators/ElementAtElementAtOrDefaultTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ElementAtElementAtOrDefaultTests.cs
@@ -39,6 +39,7 @@ namespace System.Linq.Parallel.Tests
         {
             // For unordered collections, which element is chosen isn't actually guaranteed, but an effect of the implementation.
             // If this test starts failing it should be split, and possibly mentioned in release notes.
+            _ = count;
             ParallelQuery<int> query = labeled.Item;
             Assert.Equal(position, query.ElementAt(position));
         }
@@ -56,6 +57,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(ElementAtOutOfRangeData), new[] { 0, 1, 2, 16 })]
         public static void ElementAt_OutOfRange(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
+            _ = count;
             ParallelQuery<int> query = labeled.Item;
             Assert.Throws<ArgumentOutOfRangeException>(() => query.ElementAt(position));
         }
@@ -75,6 +77,7 @@ namespace System.Linq.Parallel.Tests
         {
             // For unordered collections, which element is chosen isn't actually guaranteed, but an effect of the implementation.
             // If this test starts failing it should be split, and possibly mentioned in release notes.
+            _ = count;
             ParallelQuery<int> query = labeled.Item;
             Assert.Equal(position, query.ElementAtOrDefault(position));
         }
@@ -92,8 +95,9 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(ElementAtOutOfRangeData), new[] { 0, 1, 2, 16 })]
         public static void ElementAtOrDefault_OutOfRange(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
+            _ = count;
             ParallelQuery<int> query = labeled.Item;
-            Assert.Equal(default(int), query.ElementAtOrDefault(position));
+            Assert.Equal(default, query.ElementAtOrDefault(position));
         }
 
         [Theory]

--- a/src/System.Linq.Parallel/tests/QueryOperators/ExceptTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ExceptTests.cs
@@ -85,8 +85,13 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [MemberData(nameof(ExceptData), new[] { 0, 1, 2, 16 })]
-        public static void Except(Labeled<ParallelQuery<int>> left, int leftCount, ParallelQuery<int> rightQuery, int rightCount, int start, int count)
+        public static void Except(
+            Labeled<ParallelQuery<int>> left, int leftCount,
+            ParallelQuery<int> rightQuery, int rightCount,
+            int start, int count)
         {
+            _ = leftCount;
+            _ = rightCount;
             ParallelQuery<int> leftQuery = left.Item;
             int seen = start;
             foreach (int i in leftQuery.Except(rightQuery))
@@ -125,8 +130,13 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [MemberData(nameof(ExceptData), new[] { 0, 1, 2, 16 })]
-        public static void Except_NotPipelined(Labeled<ParallelQuery<int>> left, int leftCount, ParallelQuery<int> rightQuery, int rightCount, int start, int count)
+        public static void Except_NotPipelined(
+            Labeled<ParallelQuery<int>> left, int leftCount,
+            ParallelQuery<int> rightQuery, int rightCount,
+            int start, int count)
         {
+            _ = leftCount;
+            _ = rightCount;
             ParallelQuery<int> leftQuery = left.Item;
             int seen = start;
             Assert.All(leftQuery.Except(rightQuery).ToList(), x => Assert.Equal(seen++, x));
@@ -145,6 +155,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(ExceptUnorderedData), new[] { 0, 1, 2, 16 })]
         public static void Except_Unordered_Distinct(int leftCount, int rightStart, int rightCount, int start, int count)
         {
+            _ = start;
+            _ = count;
             ParallelQuery<int> leftQuery = UnorderedSources.Default(leftCount);
             ParallelQuery<int> rightQuery = UnorderedSources.Default(rightStart, rightCount);
             leftCount = Math.Min(DuplicateFactor * 2, leftCount);
@@ -170,6 +182,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(ExceptData), new[] { 0, 1, 2, 16 })]
         public static void Except_Distinct(Labeled<ParallelQuery<int>> left, int leftCount, ParallelQuery<int> rightQuery, int rightCount, int start, int count)
         {
+            _ = start;
+            _ = count;
             ParallelQuery<int> leftQuery = left.Item;
             leftCount = Math.Min(DuplicateFactor * 2, leftCount);
             rightCount = Math.Min(DuplicateFactor, (rightCount + 1) / 2);
@@ -194,6 +208,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(ExceptUnorderedData), new[] { 0, 1, 2, 16 })]
         public static void Except_Unordered_Distinct_NotPipelined(int leftCount, int rightStart, int rightCount, int start, int count)
         {
+            _ = start;
+            _ = count;
             ParallelQuery<int> leftQuery = UnorderedSources.Default(leftCount);
             ParallelQuery<int> rightQuery = UnorderedSources.Default(rightStart, rightCount);
             leftCount = Math.Min(DuplicateFactor * 2, leftCount);
@@ -217,6 +233,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(ExceptData), new[] { 0, 1, 2, 16 })]
         public static void Except_Distinct_NotPipelined(Labeled<ParallelQuery<int>> left, int leftCount, ParallelQuery<int> rightQuery, int rightCount, int start, int count)
         {
+            _ = start;
+            _ = count;
             ParallelQuery<int> leftQuery = left.Item;
             leftCount = Math.Min(DuplicateFactor * 2, leftCount);
             rightCount = Math.Min(DuplicateFactor, (rightCount + 1) / 2);
@@ -243,6 +261,8 @@ namespace System.Linq.Parallel.Tests
             // get non-unique results from ParallelEnumerable.Range()...
             // Those tests either need modification of source (via .Select(x => x / DuplicateFactor) or similar,
             // or via a comparator that considers some elements equal.
+            _ = leftCount;
+            _ = rightCount;
             IntegerRangeSet seen = new IntegerRangeSet(start, count);
             Assert.All(leftQuery.AsUnordered().Except(rightQuery), x => seen.Add(x));
             seen.AssertComplete();
@@ -260,6 +280,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(ExceptSourceMultipleData), new[] { 0, 1, 2, 16 })]
         public static void Except_SourceMultiple(ParallelQuery<int> leftQuery, int leftCount, ParallelQuery<int> rightQuery, int rightCount, int start, int count)
         {
+            _ = leftCount;
+            _ = rightCount;
             int seen = start;
             Assert.All(leftQuery.Except(rightQuery), x => Assert.Equal(seen++, x));
             Assert.Equal(start + count, seen);

--- a/src/System.Linq.Parallel/tests/QueryOperators/FirstFirstOrDefaultTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/FirstFirstOrDefaultTests.cs
@@ -37,6 +37,7 @@ namespace System.Linq.Parallel.Tests
         {
             // For unordered collections, which element is chosen isn't actually guaranteed, but an effect of the implementation.
             // If this test starts failing it should be split, and possibly mentioned in release notes.
+            _ = count;
             ParallelQuery<int> query = labeled.Item;
             Assert.Equal(0, query.First());
             Assert.Equal(position, query.First(x => x >= position));
@@ -58,6 +59,7 @@ namespace System.Linq.Parallel.Tests
         {
             // For unordered collections, which element is chosen isn't actually guaranteed, but an effect of the implementation.
             // If this test starts failing it should be split, and possibly mentioned in release notes.
+            _ = count;
             ParallelQuery<int> query = labeled.Item;
             Assert.Equal(0, query.FirstOrDefault());
             Assert.Equal(position, query.FirstOrDefault(x => x >= position));
@@ -77,6 +79,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(FirstData), new[] { 0 })]
         public static void First_Empty(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
+            _ = count;
+            _ = position;
             ParallelQuery<int> query = labeled.Item;
             Assert.Throws<InvalidOperationException>(() => query.First());
         }
@@ -86,6 +90,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(FirstData), new[] { 0 })]
         public static void FirstOrDefault_Empty(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
+            _ = count;
+            _ = position;
             ParallelQuery<int> query = labeled.Item;
             Assert.Equal(default(int), query.FirstOrDefault());
         }
@@ -95,6 +101,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(FirstData), new[] { 0, 1, 2, 16 })]
         public static void First_NoMatch(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
+            _ = position;
             ParallelQuery<int> query = labeled.Item;
             IntegerRangeSet seen = new IntegerRangeSet(0, count);
             Assert.Throws<InvalidOperationException>(() => query.First(x => !seen.Add(x)));
@@ -115,6 +122,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(FirstData), new[] { 0, 1, 2, 16 })]
         public static void FirstOrDefault_NoMatch(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
+            _ = position;
             ParallelQuery<int> query = labeled.Item;
             IntegerRangeSet seen = new IntegerRangeSet(0, count);
             Assert.Equal(default(int), query.FirstOrDefault(x => !seen.Add(x)));

--- a/src/System.Linq.Parallel/tests/QueryOperators/GetEnumeratorTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/GetEnumeratorTests.cs
@@ -100,6 +100,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(Sources.Ranges), new[] { 128 }, MemberType = typeof(Sources))]
         public static void GetEnumerator_OperationCanceledException(Labeled<ParallelQuery<int>> labeled, int count)
         {
+            _ = count;
             CancellationTokenSource source = new CancellationTokenSource();
             int countdown = 4;
             Action cancel = () => { if (Interlocked.Decrement(ref countdown) == 0) source.Cancel(); };
@@ -113,6 +114,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(Sources.Ranges), new[] { 1 }, MemberType = typeof(Sources))]
         public static void GetEnumerator_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
+            _ = count;
             Assert.Throws<OperationCanceledException>(() => { foreach (var i in labeled.Item.WithCancellation(new CancellationToken(canceled: true))) { throw new ShouldNotBeInvokedException(); }; });
         }
 
@@ -120,6 +122,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void GetEnumerator_MoveNextAfterQueryOpeningFailsIsIllegal(Labeled<ParallelQuery<int>> labeled, int count)
         {
+            _ = count;
             ParallelQuery<int> query = labeled.Item.Select<int, int>(x => { throw new DeliberateTestException(); }).OrderBy(x => x);
 
             IEnumerator<int> enumerator = query.GetEnumerator();
@@ -178,6 +181,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2 }, MemberType = typeof(UnorderedSources))]
         public static void GetEnumerator_DisposeBeforeFirstMoveNext(Labeled<ParallelQuery<int>> labeled, int count)
         {
+            _ = count;
             IEnumerator<int> e = labeled.Item.Select(i => i).GetEnumerator();
             e.Dispose();
             Assert.Throws<ObjectDisposedException>(() => e.MoveNext());
@@ -187,6 +191,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 1, 2 }, MemberType = typeof(UnorderedSources))]
         public static void GetEnumerator_DisposeAfterMoveNext(Labeled<ParallelQuery<int>> labeled, int count)
         {
+            _ = count;
             IEnumerator<int> e = labeled.Item.Select(i => i).GetEnumerator();
             e.MoveNext();
             e.Dispose();

--- a/src/System.Linq.Parallel/tests/QueryOperators/IntersectTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/IntersectTests.cs
@@ -86,6 +86,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(IntersectData), new[] { 0, 1, 2, 16 })]
         public static void Intersect(Labeled<ParallelQuery<int>> left, int leftCount, ParallelQuery<int> rightQuery, int rightCount, int count)
         {
+            _ = leftCount;
+            _ = rightCount;
             ParallelQuery<int> leftQuery = left.Item;
             int seen = 0;
             foreach (int i in leftQuery.Intersect(rightQuery))
@@ -126,6 +128,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(IntersectData), new[] { 0, 1, 2, 16 })]
         public static void Intersect_NotPipelined(Labeled<ParallelQuery<int>> left, int leftCount, ParallelQuery<int> rightQuery, int rightCount, int count)
         {
+            _ = leftCount;
+            _ = rightCount;
             ParallelQuery<int> leftQuery = left.Item;
             int seen = 0;
             Assert.All(leftQuery.Intersect(rightQuery).ToList(), x => Assert.Equal(seen++, x));
@@ -144,6 +148,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(IntersectUnorderedData), new[] { 0, 1, 2, 16 })]
         public static void Intersect_Unordered_Distinct(int leftCount, int rightStart, int rightCount, int count)
         {
+            _ = count;
             ParallelQuery<int> leftQuery = UnorderedSources.Default(leftCount);
             ParallelQuery<int> rightQuery = UnorderedSources.Default(rightStart, rightCount);
             leftCount = Math.Min(DuplicateFactor * 2, leftCount);
@@ -168,6 +173,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(IntersectData), new[] { 0, 1, 2, 16 })]
         public static void Intersect_Distinct(Labeled<ParallelQuery<int>> left, int leftCount, ParallelQuery<int> rightQuery, int rightCount, int count)
         {
+            _ = count;
             ParallelQuery<int> leftQuery = left.Item;
             leftCount = Math.Min(DuplicateFactor * 2, leftCount);
             rightCount = Math.Min(DuplicateFactor, (rightCount + 1) / 2);
@@ -191,6 +197,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(IntersectUnorderedData), new[] { 0, 1, 2, 16 })]
         public static void Intersect_Unordered_Distinct_NotPipelined(int leftCount, int rightStart, int rightCount, int count)
         {
+            _ = count;
             ParallelQuery<int> leftQuery = UnorderedSources.Default(leftCount);
             ParallelQuery<int> rightQuery = UnorderedSources.Default(rightStart, rightCount);
             leftCount = Math.Min(DuplicateFactor * 2, leftCount);
@@ -212,6 +219,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(IntersectData), new[] { 0, 1, 2, 16 })]
         public static void Intersect_Distinct_NotPipelined(Labeled<ParallelQuery<int>> left, int leftCount, ParallelQuery<int> rightQuery, int rightCount, int count)
         {
+            _ = count;
             ParallelQuery<int> leftQuery = left.Item;
             leftCount = Math.Min(DuplicateFactor * 2, leftCount);
             rightCount = Math.Min(DuplicateFactor, (rightCount + 1) / 2);
@@ -236,6 +244,8 @@ namespace System.Linq.Parallel.Tests
             // get non-unique results from ParallelEnumerable.Range()...
             // Those tests either need modification of source (via .Select(x => x /DuplicateFactor) or similar,
             // or via a comparator that considers some elements equal.
+            _ = leftCount;
+            _ = rightCount;
             IntegerRangeSet seen = new IntegerRangeSet(0, count);
             Assert.All(leftQuery.AsUnordered().Intersect(rightQuery), x => seen.Add(x));
             seen.AssertComplete();
@@ -253,6 +263,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(IntersectSourceMultipleData), new[] { 0, 1, 2, 16 })]
         public static void Intersect_SourceMultiple(ParallelQuery<int> leftQuery, int leftCount, ParallelQuery<int> rightQuery, int rightCount, int count)
         {
+            _ = leftCount;
+            _ = rightCount;
             int seen = 0;
             Assert.All(leftQuery.Intersect(rightQuery), x => Assert.Equal(seen++, x));
             Assert.Equal(count, seen);

--- a/src/System.Linq.Parallel/tests/QueryOperators/JoinTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/JoinTests.cs
@@ -279,9 +279,9 @@ namespace System.Linq.Parallel.Tests
             }
             else
             {
-                Func<int, int, int> cartesian = (key, other) => (other + (KeyFactor - 1) - key % KeyFactor) / KeyFactor;
-                Assert.All(seenOuter, kv => Assert.Equal(cartesian(kv.Key, rightCount), kv.Value));
-                Assert.All(seenInner, kv => Assert.Equal(cartesian(kv.Key, leftCount), kv.Value));
+                int Cartesian(int key, int other) => (other + (KeyFactor - 1) - key % KeyFactor) / KeyFactor;
+                Assert.All(seenOuter, kv => Assert.Equal(Cartesian(kv.Key, rightCount), kv.Value));
+                Assert.All(seenInner, kv => Assert.Equal(Cartesian(kv.Key, leftCount), kv.Value));
             }
         }
 

--- a/src/System.Linq.Parallel/tests/QueryOperators/LastLastOrDefaultTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/LastLastOrDefaultTests.cs
@@ -77,6 +77,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(LastData), new[] { 0 })]
         public static void Last_Empty(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
+            _ = count;
+            _ = position;
             ParallelQuery<int> query = labeled.Item;
             Assert.Throws<InvalidOperationException>(() => query.Last());
         }
@@ -86,6 +88,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(LastData), new[] { 0 })]
         public static void LastOrDefault_Empty(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
+            _ = count;
+            _ = position;
             ParallelQuery<int> query = labeled.Item;
             Assert.Equal(default(int), query.LastOrDefault());
         }
@@ -95,6 +99,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(LastData), new[] { 1, 2, 16 })]
         public static void Last_NoMatch(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
+            _ = position;
             ParallelQuery<int> query = labeled.Item;
             IntegerRangeSet seen = new IntegerRangeSet(0, count);
             Assert.Throws<InvalidOperationException>(() => query.Last(x => !seen.Add(x)));
@@ -115,6 +120,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(LastData), new[] { 1, 2, 16 })]
         public static void LastOrDefault_NoMatch(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
+            _ = position;
             ParallelQuery<int> query = labeled.Item;
             IntegerRangeSet seen = new IntegerRangeSet(0, count);
             Assert.Equal(default(int), query.LastOrDefault(x => !seen.Add(x)));

--- a/src/System.Linq.Parallel/tests/QueryOperators/MaxTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/MaxTests.cs
@@ -14,10 +14,11 @@ namespace System.Linq.Parallel.Tests
         {
             counts = counts.DefaultIfEmpty(Sources.OuterLoopCount).ToArray();
 
-            Func<int, int> max = x => x - 1;
+            static int Max(int x) => x - 1;
+
             foreach (int count in counts)
             {
-                yield return new object[] { Labeled.Label("Default", UnorderedSources.Default(0, count)), count, max(count) };
+                yield return new object[] { Labeled.Label("Default", UnorderedSources.Default(0, count)), count, Max(count) };
             }
 
             // A source with data explicitly created out of order
@@ -30,7 +31,7 @@ namespace System.Linq.Parallel.Tests
                     data[i] = data[count - i - 1];
                     data[count - i - 1] = tmp;
                 }
-                yield return new object[] { Labeled.Label("Out-of-order input", data.AsParallel()), count, max(count) };
+                yield return new object[] { Labeled.Label("Out-of-order input", data.AsParallel()), count, Max(count) };
             }
         }
 
@@ -42,6 +43,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(MaxData), new[] { 1, 2, 16 })]
         public static void Max_Int(Labeled<ParallelQuery<int>> labeled, int count, int max)
         {
+            _ = count;
             ParallelQuery<int> query = labeled.Item;
             Assert.Equal(max, query.Max());
             Assert.Equal(max, query.Select(x => (int?)x).Max());
@@ -70,6 +72,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(MaxData), new[] { 1, 2, 16 })]
         public static void Max_Int_AllNull(Labeled<ParallelQuery<int>> labeled, int count, int max)
         {
+            _ = count;
+            _ = max;
             ParallelQuery<int> query = labeled.Item;
             Assert.Null(query.Select(x => (int?)null).Max());
             Assert.Null(query.Max(x => (int?)null));
@@ -79,6 +83,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(MaxData), new[] { 1, 2, 16 })]
         public static void Max_Long(Labeled<ParallelQuery<int>> labeled, int count, long max)
         {
+            _ = count;
             ParallelQuery<int> query = labeled.Item;
             Assert.Equal(max, query.Select(x => (long)x).Max());
             Assert.Equal(max, query.Select(x => (long?)x).Max());
@@ -107,6 +112,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(MaxData), new[] { 1, 2, 16 })]
         public static void Max_Long_AllNull(Labeled<ParallelQuery<int>> labeled, int count, long max)
         {
+            _ = count;
+            _ = max;
             ParallelQuery<int> query = labeled.Item;
             Assert.Null(query.Select(x => (long?)null).Max());
             Assert.Null(query.Max(x => (long?)null));
@@ -146,6 +153,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(MaxData), new[] { 1, 2, 16 })]
         public static void Max_Float_AllNull(Labeled<ParallelQuery<int>> labeled, int count, float max)
         {
+            _ = count;
+            _ = max;
             ParallelQuery<int> query = labeled.Item;
             Assert.Null(query.Select(x => (float?)null).Max());
             Assert.Null(query.Max(x => (float?)null));
@@ -185,6 +194,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(MaxData), new[] { 1, 2, 16 })]
         public static void Max_Double_AllNull(Labeled<ParallelQuery<int>> labeled, int count, double max)
         {
+            _ = count;
+            _ = max;
             ParallelQuery<int> query = labeled.Item;
             Assert.Null(query.Select(x => (double?)null).Max());
             Assert.Null(query.Max(x => (double?)null));
@@ -194,6 +205,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(MaxData), new[] { 1, 2, 16 })]
         public static void Max_Decimal(Labeled<ParallelQuery<int>> labeled, int count, decimal max)
         {
+            _ = count;
             ParallelQuery<int> query = labeled.Item;
             Assert.Equal(max, query.Select(x => (decimal)x).Max());
             Assert.Equal(max, query.Select(x => (decimal?)x).Max());
@@ -222,6 +234,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(MaxData), new[] { 1, 2, 16 })]
         public static void Max_Decimal_AllNull(Labeled<ParallelQuery<int>> labeled, int count, decimal max)
         {
+            _ = count;
+            _ = max;
             ParallelQuery<int> query = labeled.Item;
             Assert.Null(query.Select(x => (decimal?)null).Max());
             Assert.Null(query.Max(x => (decimal?)null));
@@ -231,6 +245,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(MaxData), new[] { 1, 2, 16 })]
         public static void Max_Other(Labeled<ParallelQuery<int>> labeled, int count, int max)
         {
+            _ = count;
             ParallelQuery<int> query = labeled.Item;
             Assert.Equal(max, query.Select(x => DelgatedComparable.Delegate(x, Comparer<int>.Default)).Max().Value);
             Assert.Equal(0, query.Select(x => DelgatedComparable.Delegate(x, ReverseComparer.Instance)).Max().Value);
@@ -248,6 +263,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(MaxData), new[] { 1 })]
         public static void Max_NotComparable(Labeled<ParallelQuery<int>> labeled, int count, int max)
         {
+            _ = count;
+            _ = max;
             NotComparable a = new NotComparable(0);
             Assert.Equal(a, labeled.Item.Max(x => a));
         }
@@ -265,6 +282,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(MaxData), new[] { 1, 2, 16 })]
         public static void Max_Other_AllNull(Labeled<ParallelQuery<int>> labeled, int count, int max)
         {
+            _ = count;
+            _ = max;
             ParallelQuery<int> query = labeled.Item;
             Assert.Null(query.Select(x => (string)null).Max());
             Assert.Null(query.Max(x => (string)null));

--- a/src/System.Linq.Parallel/tests/QueryOperators/MinTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/MinTests.cs
@@ -14,10 +14,11 @@ namespace System.Linq.Parallel.Tests
         {
             counts = counts.DefaultIfEmpty(Sources.OuterLoopCount).ToArray();
 
-            Func<int, int> min = x => 1 - x;
+            static int Min(int x) => 1 - x;
+
             foreach (int count in counts)
             {
-                yield return new object[] { Labeled.Label("Default", UnorderedSources.Default(count)), count, min(count) };
+                yield return new object[] { Labeled.Label("Default", UnorderedSources.Default(count)), count, Min(count) };
             }
 
             // A source with data explicitly created out of order
@@ -30,7 +31,7 @@ namespace System.Linq.Parallel.Tests
                     data[i] = data[count - i - 1];
                     data[count - i - 1] = tmp;
                 }
-                yield return new object[] { Labeled.Label("Out-of-order input", data.AsParallel()), count, min(count) };
+                yield return new object[] { Labeled.Label("Out-of-order input", data.AsParallel()), count, Min(count) };
             }
         }
 
@@ -41,6 +42,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(MinData), new[] { 1, 2, 16 })]
         public static void Min_Int(Labeled<ParallelQuery<int>> labeled, int count, int min)
         {
+            _ = count;
             ParallelQuery<int> query = labeled.Item;
             Assert.Equal(0, query.Min());
             Assert.Equal(0, query.Select(x => (int?)x).Min());
@@ -69,6 +71,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(MinData), new[] { 1, 2, 16 })]
         public static void Min_Int_AllNull(Labeled<ParallelQuery<int>> labeled, int count, int min)
         {
+            _ = count;
+            _ = min;
             ParallelQuery<int> query = labeled.Item;
             Assert.Null(query.Select(x => (int?)null).Min());
             Assert.Null(query.Min(x => (int?)null));
@@ -78,6 +82,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(MinData), new[] { 1, 2, 16 })]
         public static void Min_Long(Labeled<ParallelQuery<int>> labeled, int count, long min)
         {
+            _ = count;
             ParallelQuery<int> query = labeled.Item;
             Assert.Equal(0, query.Select(x => (long)x).Min());
             Assert.Equal(0, query.Select(x => (long?)x).Min());
@@ -106,6 +111,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(MinData), new[] { 1, 2, 16 })]
         public static void Min_Long_AllNull(Labeled<ParallelQuery<int>> labeled, int count, long min)
         {
+            _ = count;
+            _ = min;
             ParallelQuery<int> query = labeled.Item;
             Assert.Null(query.Select(x => (long?)null).Min());
             Assert.Null(query.Min(x => (long?)null));
@@ -147,6 +154,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(MinData), new[] { 3 })]
         public static void Min_Float_Special(Labeled<ParallelQuery<int>> labeled, int count, float min)
         {
+            _ = min;
+
             // Null is defined as 'least' when ordered, but is not the minimum.
             Func<int, float?> translate = x =>
                 x % 3 == 0 ? (float?)null :
@@ -162,6 +171,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(MinData), new[] { 1, 2, 16 })]
         public static void Min_Float_AllNull(Labeled<ParallelQuery<int>> labeled, int count, float min)
         {
+            _ = count;
+            _ = min;
             ParallelQuery<int> query = labeled.Item;
             Assert.Null(query.Select(x => (float?)null).Min());
             Assert.Null(query.Min(x => (float?)null));
@@ -194,6 +205,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(MinData), new[] { 3 })]
         public static void Min_Double_Special(Labeled<ParallelQuery<int>> labeled, int count, double min)
         {
+            _ = min;
+
             // Null is defined as 'least' when ordered, but is not the minimum.
             Func<int, double?> translate = x =>
                 x % 3 == 0 ? (double?)null :
@@ -218,6 +231,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(MinData), new[] { 1, 2, 16 })]
         public static void Min_Double_AllNull(Labeled<ParallelQuery<int>> labeled, int count, double min)
         {
+            _ = count;
+            _ = min;
             ParallelQuery<int> query = labeled.Item;
             Assert.Null(query.Select(x => (double?)null).Min());
             Assert.Null(query.Min(x => (double?)null));
@@ -227,6 +242,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(MinData), new[] { 1, 2, 16 })]
         public static void Min_Decimal(Labeled<ParallelQuery<int>> labeled, int count, decimal min)
         {
+            _ = count;
             ParallelQuery<int> query = labeled.Item;
             Assert.Equal(0, query.Select(x => (decimal)x).Min());
             Assert.Equal(0, query.Select(x => (decimal?)x).Min());
@@ -255,6 +271,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(MinData), new[] { 1, 2, 16 })]
         public static void Min_Decimal_AllNull(Labeled<ParallelQuery<int>> labeled, int count, decimal min)
         {
+            _ = count;
+            _ = min;
             ParallelQuery<int> query = labeled.Item;
             Assert.Null(query.Select(x => (decimal?)null).Min());
             Assert.Null(query.Min(x => (decimal?)null));
@@ -264,6 +282,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(MinData), new[] { 1, 2, 16 })]
         public static void Min_Other(Labeled<ParallelQuery<int>> labeled, int count, int min)
         {
+            _ = min;
             ParallelQuery<int> query = labeled.Item;
             Assert.Equal(0, query.Select(x => DelgatedComparable.Delegate(x, Comparer<int>.Default)).Min().Value);
             Assert.Equal(count - 1, query.Select(x => DelgatedComparable.Delegate(x, ReverseComparer.Instance)).Min().Value);
@@ -281,6 +300,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(MinData), new[] { 1 })]
         public static void Min_NotComparable(Labeled<ParallelQuery<int>> labeled, int count, int min)
         {
+            _ = count;
+            _ = min;
             NotComparable a = new NotComparable(0);
             Assert.Equal(a, labeled.Item.Min(x => a));
         }
@@ -289,6 +310,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(MinData), new[] { 1, 2, 16 })]
         public static void Min_Other_SomeNull(Labeled<ParallelQuery<int>> labeled, int count, int min)
         {
+            _ = min;
             ParallelQuery<int> query = labeled.Item;
             Assert.Equal(count / 2, query.Min(x => x >= count / 2 ? DelgatedComparable.Delegate(x, Comparer<int>.Default) : null).Value);
             Assert.Equal(count - 1, query.Min(x => x >= count / 2 ? DelgatedComparable.Delegate(x, ReverseComparer.Instance) : null).Value);
@@ -298,6 +320,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(MinData), new[] { 1, 2, 16 })]
         public static void Min_Other_AllNull(Labeled<ParallelQuery<int>> labeled, int count, int min)
         {
+            _ = count;
+            _ = min;
             ParallelQuery<int> query = labeled.Item;
             Assert.Null(query.Select(x => (string)null).Min());
             Assert.Null(query.Min(x => (string)null));

--- a/src/System.Linq.Parallel/tests/QueryOperators/OfTypeTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/OfTypeTests.cs
@@ -93,6 +93,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
         public static void OfType_NoneValid(Labeled<ParallelQuery<int>> labeled, int count)
         {
+            _ = count;
             ParallelQuery<int> query = labeled.Item;
             Assert.Empty(query.OfType<long>());
         }
@@ -111,6 +112,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
         public static void OfType_NoneValid_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
+            _ = count;
             ParallelQuery<int> query = labeled.Item;
             Assert.Empty(query.OfType<long>().ToList());
         }

--- a/src/System.Linq.Parallel/tests/QueryOperators/OrderByThenByTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/OrderByThenByTests.cs
@@ -412,6 +412,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 2 }, MemberType = typeof(UnorderedSources))]
         public static void OrderBy_NotComparable(Labeled<ParallelQuery<int>> labeled, int count)
         {
+            _ = count;
             ParallelQuery<int> query = labeled.Item.OrderBy(x => new NotComparable(x));
             AssertThrows.Wrapped<ArgumentException>(() => { foreach (int i in query) ; });
             AssertThrows.Wrapped<ArgumentException>(() => query.ToList());
@@ -449,6 +450,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 2 }, MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending_NotComparable(Labeled<ParallelQuery<int>> labeled, int count)
         {
+            _ = count;
             ParallelQuery<int> query = labeled.Item.OrderByDescending(x => new NotComparable(x));
             AssertThrows.Wrapped<ArgumentException>(() => { foreach (int i in query) ; });
             AssertThrows.Wrapped<ArgumentException>(() => query.ToList());
@@ -506,6 +508,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(OrderByThreadedData), new[] { 1, 2, 16, 128, 1024 }, new[] { 1, 2, 4, 7, 8, 31, 32 })]
         public static void OrderBy_ThreadedDeadlock(Labeled<ParallelQuery<int>> labeled, int count, int degree)
         {
+            _ = count;
             ParallelQuery<int> query = labeled.Item.WithDegreeOfParallelism(degree).OrderBy<int, int>(x => { throw new DeliberateTestException(); });
 
             AggregateException ae = Assert.Throws<AggregateException>(() => { foreach (int i in query) { } });
@@ -1115,6 +1118,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 2 }, MemberType = typeof(UnorderedSources))]
         public static void ThenBy_NotComparable(Labeled<ParallelQuery<int>> labeled, int count)
         {
+            _ = count;
             ParallelQuery<int> query = labeled.Item.OrderBy(x => 0).ThenBy(x => new NotComparable(x));
             AssertThrows.Wrapped<ArgumentException>(() => { foreach (int i in query) ; });
             AssertThrows.Wrapped<ArgumentException>(() => query.ToList());
@@ -1152,6 +1156,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 2 }, MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_NotComparable(Labeled<ParallelQuery<int>> labeled, int count)
         {
+            _ = count;
             ParallelQuery<int> query = labeled.Item.OrderBy(x => 0).ThenByDescending(x => new NotComparable(x));
             AssertThrows.Wrapped<ArgumentException>(() => { foreach (int i in query) ; });
             AssertThrows.Wrapped<ArgumentException>(() => query.ToList());

--- a/src/System.Linq.Parallel/tests/QueryOperators/SequenceEqualTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/SequenceEqualTests.cs
@@ -54,6 +54,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(SequenceEqualData), new[] { 0, 1, 2, 16 })]
         public static void SequenceEqual(Labeled<ParallelQuery<int>> left, Labeled<ParallelQuery<int>> right, int count)
         {
+            _ = count;
             ParallelQuery<int> leftQuery = left.Item;
             ParallelQuery<int> rightQuery = right.Item;
             Assert.True(leftQuery.SequenceEqual(rightQuery));
@@ -98,6 +99,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(SequenceEqualUnequalSizeData), new[] { 0, 4, 16 })]
         public static void SequenceEqual_UnequalSize(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
+            _ = leftCount;
+            _ = rightCount;
             ParallelQuery<int> leftQuery = left.Item;
             ParallelQuery<int> rightQuery = right.Item;
             Assert.False(leftQuery.SequenceEqual(rightQuery));
@@ -118,6 +121,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(SequenceEqualUnequalData), new[] { 1, 2, 16 })]
         public static void SequenceEqual_Unequal(Labeled<ParallelQuery<int>> left, Labeled<ParallelQuery<int>> right, int count, int item)
         {
+            _ = count;
             ParallelQuery<int> leftQuery = left.Item;
             ParallelQuery<int> rightQuery = right.Item.Select(x => x == item ? -1 : x);
 
@@ -173,6 +177,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(SequenceEqualData), new[] { 4 })]
         public static void SequenceEqual_AggregateException(Labeled<ParallelQuery<int>> left, Labeled<ParallelQuery<int>> right, int count)
         {
+            _ = count;
             AssertThrows.Wrapped<DeliberateTestException>(() => left.Item.SequenceEqual(right.Item, new FailingEqualityComparer<int>()));
         }
 
@@ -200,6 +205,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(SequenceEqualData), new[] { 0, 1, 2, 16 })]
         public static void SequenceEqual_DisposeException(Labeled<ParallelQuery<int>> left, Labeled<ParallelQuery<int>> right, int count)
         {
+            _ = count;
             ParallelQuery<int> leftQuery = left.Item;
             ParallelQuery<int> rightQuery = right.Item;
 

--- a/src/System.Linq.Parallel/tests/QueryOperators/SkipSkipWhileTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/SkipSkipWhileTests.cs
@@ -293,6 +293,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(SkipData), new[] { 0, 1, 2, 16 })]
         public static void SkipWhile_AllFalse(Labeled<ParallelQuery<int>> labeled, int count, int skip)
         {
+            _ = skip;
             ParallelQuery<int> query = labeled.Item;
             int seen = 0;
             Assert.All(query.SkipWhile(x => false), x => Assert.Equal(seen++, x));
@@ -311,6 +312,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(SkipData), new[] { 0, 1, 2, 16 })]
         public static void SkipWhile_AllTrue(Labeled<ParallelQuery<int>> labeled, int count, int skip)
         {
+            _ = skip;
             ParallelQuery<int> query = labeled.Item;
             IntegerRangeSet seen = new IntegerRangeSet(0, count);
             Assert.Empty(query.SkipWhile(x => seen.Add(x)));

--- a/src/System.Linq.Parallel/tests/QueryOperators/TakeTakeWhileTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/TakeTakeWhileTests.cs
@@ -294,6 +294,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(TakeUnorderedData), new[] { 0, 1, 2, 16 })]
         public static void TakeWhile_AllFalse(int count, int take)
         {
+            _ = take;
             Assert.Empty(UnorderedSources.Default(count).TakeWhile(x => false));
         }
 
@@ -309,6 +310,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(TakeData), new[] { 0, 1, 2, 16 })]
         public static void TakeWhile_AllTrue(Labeled<ParallelQuery<int>> labeled, int count, int take)
         {
+            _ = take;
             ParallelQuery<int> query = labeled.Item;
             int seen = 0;
             Assert.All(query.TakeWhile(x => true), x => Assert.Equal(seen++, x));
@@ -327,6 +329,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(TakeWhileData), new[] { 2, 16 })]
         public static void TakeWhile_SomeTrue(Labeled<ParallelQuery<int>> labeled, int count, int[] take)
         {
+            _ = count;
             ParallelQuery<int> query = labeled.Item;
             int seen = 0;
             Assert.All(query.TakeWhile(x => take.Contains(x)), x => Assert.Equal(seen++, x));
@@ -345,6 +348,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(TakeWhileData), new[] { 2, 16 })]
         public static void TakeWhile_SomeFalse(Labeled<ParallelQuery<int>> labeled, int count, int[] take)
         {
+            _ = count;
             ParallelQuery<int> query = labeled.Item;
             int seen = 0;
             Assert.All(query.TakeWhile(x => !take.Contains(x)), x => Assert.Equal(seen++, x));

--- a/src/System.Linq.Parallel/tests/QueryOperators/ToDictionaryTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ToDictionaryTests.cs
@@ -210,6 +210,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void ToDictionary_AggregateException(Labeled<ParallelQuery<int>> labeled, int count)
         {
+            _ = count;
+
             AssertThrows.Wrapped<DeliberateTestException>(() => labeled.Item.ToDictionary((Func<int, int>)(x => { throw new DeliberateTestException(); })));
             AssertThrows.Wrapped<DeliberateTestException>(() => labeled.Item.ToDictionary((Func<int, int>)(x => { throw new DeliberateTestException(); }), y => y));
             AssertThrows.Wrapped<DeliberateTestException>(() => labeled.Item.ToDictionary(x => x, (Func<int, int>)(y => { throw new DeliberateTestException(); })));

--- a/src/System.Linq.Parallel/tests/QueryOperators/ToLookupTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ToLookupTests.cs
@@ -278,6 +278,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void ToLookup_AggregateException(Labeled<ParallelQuery<int>> labeled, int count)
         {
+            _ = count;
+
             AssertThrows.Wrapped<DeliberateTestException>(() => labeled.Item.ToLookup((Func<int, int>)(x => { throw new DeliberateTestException(); })));
             AssertThrows.Wrapped<DeliberateTestException>(() => labeled.Item.ToLookup((Func<int, int>)(x => { throw new DeliberateTestException(); }), y => y));
             AssertThrows.Wrapped<DeliberateTestException>(() => labeled.Item.ToLookup(x => x, (Func<int, int>)(y => { throw new DeliberateTestException(); })));

--- a/src/System.Linq.Parallel/tests/QueryOperators/UnionTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/UnionTests.cs
@@ -378,6 +378,8 @@ namespace System.Linq.Parallel.Tests
             // get non-unique results from ParallelEnumerable.Range()...
             // Those tests either need modification of source (via .Select(x => x / DuplicateFactor) or similar,
             // or via a comparator that considers some elements equal.
+            _ = leftCount;
+            _ = rightCount;
             IntegerRangeSet seen = new IntegerRangeSet(0, count);
             Assert.All(leftQuery.Union(rightQuery), x => seen.Add(x));
             seen.AssertComplete();
@@ -395,6 +397,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(UnionSourceMultipleData), new[] { 0, 1, 2, DuplicateFactor * 2 })]
         public static void Union_SourceMultiple(ParallelQuery<int> leftQuery, int leftCount, ParallelQuery<int> rightQuery, int rightCount, int count)
         {
+            _ = leftCount;
+            _ = rightCount;
             int seen = 0;
             Assert.All(leftQuery.AsOrdered().Union(rightQuery.AsOrdered()), x => Assert.Equal(seen++, x));
             Assert.Equal(count, seen);

--- a/src/System.Linq.Parallel/tests/QueryOperators/ZipTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ZipTests.cs
@@ -160,6 +160,8 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(ZipThreadedData), new[] { 1, 2, 16, 128, 1024 }, new[] { 1, 2, 4, 7, 8, 31, 32 })]
         public static void Zip_AsOrdered_ThreadedDeadlock(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount, int degree)
         {
+            _ = leftCount;
+            _ = rightCount;
             ParallelQuery<int> query = left.Item.WithDegreeOfParallelism(degree).Zip<int, int, int>(right.Item, (a, b) => { throw new DeliberateTestException(); });
 
             AssertThrows.Wrapped<DeliberateTestException>(() => query.ToArray());

--- a/src/System.Linq.Parallel/tests/WithCancellationTests.cs
+++ b/src/System.Linq.Parallel/tests/WithCancellationTests.cs
@@ -52,6 +52,7 @@ namespace System.Linq.Parallel.Tests
         public static void WithCancellation_DisposedEnumerator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             // Disposing an enumerator should throw ODE and not OCE.
+            _ = count;
             ParallelQuery<int> query = labeled.Item;
             DisposedEnumerator(query);
             DisposedEnumerator(query.WithMergeOptions(ParallelMergeOptions.Default));
@@ -87,8 +88,9 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(ProducerBlocked_Data))]
         public static void WithCancellation_DisposedEnumerator_ChannelCancellation_ProducerBlocked(Labeled<ParallelQuery<int>> labeled, int count)
         {
-            ParallelQuery<int> query = labeled.Item;
             // Larger size, delay may cause enumerator.Dispose() to hang
+            _ = count;
+            ParallelQuery<int> query = labeled.Item;
             DisposedEnumerator(query, true);
             DisposedEnumerator(query.WithMergeOptions(ParallelMergeOptions.Default), true);
             DisposedEnumerator(query.WithMergeOptions(ParallelMergeOptions.AutoBuffered), true);
@@ -104,6 +106,7 @@ namespace System.Linq.Parallel.Tests
         public static void WithCancellation_ODEIssue(Labeled<ParallelQuery<int>> labeled, int count)
         {
             //the failure was an ODE coming out due to an ephemeral disposed merged cancellation token source.
+            _ = count;
             ParallelQuery<int> left = labeled.Item.AsUnordered().WithExecutionMode(ParallelExecutionMode.ForceParallelism);
             ParallelQuery<int> right = Enumerable.Range(0, 1024).Select(x => x).AsParallel().AsUnordered();
             AssertThrows.Wrapped<OperationCanceledException>(() => left.GroupJoin(right, x => { throw new OperationCanceledException(); }, y => y, (x, e) => x).ForAll(x => { }));
@@ -117,6 +120,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(UnorderedSources.Ranges), new[] { 16 }, MemberType = typeof(UnorderedSources))]
         public static void WithCancellation_CancelThenDispose(Labeled<ParallelQuery<int>> labeled, int count)
         {
+            _ = count;
             CancellationTokenSource cancel = new CancellationTokenSource();
             IEnumerator<int> enumerator = labeled.Item.WithCancellation(cancel.Token).GetEnumerator();
             enumerator.MoveNext();

--- a/src/System.Linq/tests/ConcatTests.cs
+++ b/src/System.Linq/tests/ConcatTests.cs
@@ -206,7 +206,7 @@ namespace System.Linq.Tests
 
         [Theory]
         [MemberData(nameof(ManyConcatsData))]
-        public void ManyConcats(IEnumerable<IEnumerable<int>> sources, IEnumerable<int> expected)
+        public void ManyConcats(IEnumerable<IEnumerable<int>> sources)
         {
             foreach (var transform in IdentityTransforms<int>())
             {
@@ -223,7 +223,7 @@ namespace System.Linq.Tests
 
         [Theory]
         [MemberData(nameof(ManyConcatsData))]
-        public void ManyConcatsRunOnce(IEnumerable<IEnumerable<int>> sources, IEnumerable<int> expected)
+        public void ManyConcatsRunOnce(IEnumerable<IEnumerable<int>> sources)
         {
             foreach (var transform in IdentityTransforms<int>())
             {
@@ -239,10 +239,10 @@ namespace System.Linq.Tests
 
         public static IEnumerable<object[]> ManyConcatsData()
         {
-            yield return new object[] { Enumerable.Repeat(Enumerable.Empty<int>(), 256), Enumerable.Empty<int>() };
-            yield return new object[] { Enumerable.Repeat(Enumerable.Repeat(6, 1), 256), Enumerable.Repeat(6, 256) };
+            yield return new object[] { Enumerable.Repeat(Enumerable.Empty<int>(), 256) };
+            yield return new object[] { Enumerable.Repeat(Enumerable.Repeat(6, 1), 256) };
             // Make sure Concat doesn't accidentally swap around the sources, e.g. [3, 4], [1, 2] should not become [1..4]
-            yield return new object[] { Enumerable.Range(0, 500).Select(i => Enumerable.Repeat(i, 1)).Reverse(), Enumerable.Range(0, 500).Reverse() };
+            yield return new object[] { Enumerable.Range(0, 500).Select(i => Enumerable.Repeat(i, 1)).Reverse() };
         }
 
         [Fact]
@@ -251,25 +251,20 @@ namespace System.Linq.Tests
             var supposedlyLargeCollection = new DelegateBasedCollection<int> { CountWorker = () => int.MaxValue };
             var tinyCollection = new DelegateBasedCollection<int> { CountWorker = () => 1 };
 
-            Action<Action> assertThrows = (testCode) =>
-            {
-                Assert.Throws<OverflowException>(testCode);
-            };
-
             // We need to use checked arithmetic summing up the collections' counts.
-            assertThrows(() => supposedlyLargeCollection.Concat(tinyCollection).Count());
-            assertThrows(() => tinyCollection.Concat(tinyCollection).Concat(supposedlyLargeCollection).Count());
-            assertThrows(() => tinyCollection.Concat(tinyCollection).Concat(tinyCollection).Concat(supposedlyLargeCollection).Count());
+            Assert.Throws<OverflowException>(() => supposedlyLargeCollection.Concat(tinyCollection).Count());
+            Assert.Throws<OverflowException>(() => tinyCollection.Concat(tinyCollection).Concat(supposedlyLargeCollection).Count());
+            Assert.Throws<OverflowException>(() => tinyCollection.Concat(tinyCollection).Concat(tinyCollection).Concat(supposedlyLargeCollection).Count());
 
             // This applies to ToArray() and ToList() as well, which try to preallocate the exact size
             // needed if all inputs are ICollections.
-            assertThrows(() => supposedlyLargeCollection.Concat(tinyCollection).ToArray());
-            assertThrows(() => tinyCollection.Concat(tinyCollection).Concat(supposedlyLargeCollection).ToArray());
-            assertThrows(() => tinyCollection.Concat(tinyCollection).Concat(tinyCollection).Concat(supposedlyLargeCollection).ToArray());
+            Assert.Throws<OverflowException>(() => supposedlyLargeCollection.Concat(tinyCollection).ToArray());
+            Assert.Throws<OverflowException>(() => tinyCollection.Concat(tinyCollection).Concat(supposedlyLargeCollection).ToArray());
+            Assert.Throws<OverflowException>(() => tinyCollection.Concat(tinyCollection).Concat(tinyCollection).Concat(supposedlyLargeCollection).ToArray());
 
-            assertThrows(() => supposedlyLargeCollection.Concat(tinyCollection).ToList());
-            assertThrows(() => tinyCollection.Concat(tinyCollection).Concat(supposedlyLargeCollection).ToList());
-            assertThrows(() => tinyCollection.Concat(tinyCollection).Concat(tinyCollection).Concat(supposedlyLargeCollection).ToList());
+            Assert.Throws<OverflowException>(() => supposedlyLargeCollection.Concat(tinyCollection).ToList());
+            Assert.Throws<OverflowException>(() => tinyCollection.Concat(tinyCollection).Concat(supposedlyLargeCollection).ToList());
+            Assert.Throws<OverflowException>(() => tinyCollection.Concat(tinyCollection).Concat(tinyCollection).Concat(supposedlyLargeCollection).ToList());
         }
 
         [Fact]

--- a/src/System.Linq/tests/ToArrayTests.cs
+++ b/src/System.Linq/tests/ToArrayTests.cs
@@ -31,25 +31,20 @@ namespace System.Linq.Tests
         {
             int[] emptySourceArray = Array.Empty<int>();
 
-            // .NET Core returns the instance as an optimization.
-            // see https://github.com/dotnet/corefx/pull/2401.
-            Action<object, object> assertSame = (objA, objB) => Assert.True(ReferenceEquals(objA, objB));
+            Assert.Same(emptySourceArray.ToArray(), emptySourceArray.ToArray());
 
+            Assert.Same(emptySourceArray.Select(i => i).ToArray(), emptySourceArray.Select(i => i).ToArray());
+            Assert.Same(emptySourceArray.ToList().Select(i => i).ToArray(), emptySourceArray.ToList().Select(i => i).ToArray());
+            Assert.Same(new Collection<int>(emptySourceArray).Select(i => i).ToArray(), new Collection<int>(emptySourceArray).Select(i => i).ToArray());
+            Assert.Same(emptySourceArray.OrderBy(i => i).ToArray(), emptySourceArray.OrderBy(i => i).ToArray());
 
-            assertSame(emptySourceArray.ToArray(), emptySourceArray.ToArray());
+            Assert.Same(Enumerable.Range(5, 0).ToArray(), Enumerable.Range(3, 0).ToArray());
+            Assert.Same(Enumerable.Range(5, 3).Take(0).ToArray(), Enumerable.Range(3, 0).ToArray());
+            Assert.Same(Enumerable.Range(5, 3).Skip(3).ToArray(), Enumerable.Range(3, 0).ToArray());
 
-            assertSame(emptySourceArray.Select(i => i).ToArray(), emptySourceArray.Select(i => i).ToArray());
-            assertSame(emptySourceArray.ToList().Select(i => i).ToArray(), emptySourceArray.ToList().Select(i => i).ToArray());
-            assertSame(new Collection<int>(emptySourceArray).Select(i => i).ToArray(), new Collection<int>(emptySourceArray).Select(i => i).ToArray());
-            assertSame(emptySourceArray.OrderBy(i => i).ToArray(), emptySourceArray.OrderBy(i => i).ToArray());
-
-            assertSame(Enumerable.Range(5, 0).ToArray(), Enumerable.Range(3, 0).ToArray());
-            assertSame(Enumerable.Range(5, 3).Take(0).ToArray(), Enumerable.Range(3, 0).ToArray());
-            assertSame(Enumerable.Range(5, 3).Skip(3).ToArray(), Enumerable.Range(3, 0).ToArray());
-
-            assertSame(Enumerable.Repeat(42, 0).ToArray(), Enumerable.Range(84, 0).ToArray());
-            assertSame(Enumerable.Repeat(42, 3).Take(0).ToArray(), Enumerable.Range(84, 3).Take(0).ToArray());
-            assertSame(Enumerable.Repeat(42, 3).Skip(3).ToArray(), Enumerable.Range(84, 3).Skip(3).ToArray());
+            Assert.Same(Enumerable.Repeat(42, 0).ToArray(), Enumerable.Range(84, 0).ToArray());
+            Assert.Same(Enumerable.Repeat(42, 3).Take(0).ToArray(), Enumerable.Range(84, 3).Take(0).ToArray());
+            Assert.Same(Enumerable.Repeat(42, 3).Skip(3).ToArray(), Enumerable.Range(84, 3).Skip(3).ToArray());
         }
 
 

--- a/src/System.Memory/tests/ParsersAndFormatters/StandardFormatTests.cs
+++ b/src/System.Memory/tests/ParsersAndFormatters/StandardFormatTests.cs
@@ -138,6 +138,8 @@ namespace System.Buffers.Text.Tests
         [MemberData(nameof(EqualityTestData))]
         public static void StandardFormatGetHashCodeIsContentBased(StandardFormat f1, StandardFormat f2, bool expectedToBeEqual)
         {
+            _ = f2;
+            _ = expectedToBeEqual;
             object boxedf1 = f1;
             object aDifferentBoxedF1 = f1;
             int h1 = boxedf1.GetHashCode();

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Cancellation.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Cancellation.cs
@@ -79,8 +79,8 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Theory]
-        [MemberData(nameof(TwoBoolsAndCancellationMode))]
-        public async Task GetAsync_CancelDuringResponseHeadersReceived_TaskCanceledQuickly(bool chunkedTransfer, bool connectionClose, CancellationMode mode)
+        [MemberData(nameof(OneBoolAndCancellationMode))]
+        public async Task GetAsync_CancelDuringResponseHeadersReceived_TaskCanceledQuickly(bool connectionClose, CancellationMode mode)
         {
             using (HttpClient client = CreateHttpClient())
             {
@@ -582,6 +582,11 @@ namespace System.Net.Http.Functional.Tests
         }
 
         private static readonly bool[] s_bools = new[] { true, false };
+
+        public static IEnumerable<object[]> OneBoolAndCancellationMode() =>
+            from first in s_bools
+            from mode in new[] { CancellationMode.Token, CancellationMode.CancelPendingRequests, CancellationMode.DisposeHttpClient, CancellationMode.Token | CancellationMode.CancelPendingRequests }
+            select new object[] { first, mode };
 
         public static IEnumerable<object[]> TwoBoolsAndCancellationMode() =>
             from first in s_bools

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -592,7 +592,7 @@ namespace System.Net.Http.Functional.Tests
                 using (HttpClient client = CreateHttpClient(handler))
                 {
                     Task<HttpResponseMessage> getResponseTask = client.GetAsync(url);
-                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync(HttpStatusCode.Unauthorized);
+                    Task<List<string>> serverTask = server.AcceptConnectionSendResponseAndCloseAsync(HttpStatusCode.Unauthorized, additionalHeaders: authHeaders);
 
                     await TestHelper.WhenAllCompletedOrAnyFailed(getResponseTask, serverTask);
                     using (HttpResponseMessage response = await getResponseTask)

--- a/src/System.Net.Http/tests/UnitTests/Headers/CurlResponseHeaderReaderTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/Headers/CurlResponseHeaderReaderTest.cs
@@ -23,7 +23,7 @@ namespace System.Net.Http.Tests
         private const string invalidChars = "()<>@,;\\\"/[]?={} \t";
 
         public static readonly IEnumerable<object[]> ValidStatusCodeLines = GetStatusCodeLines(StatusCodeTemplate);
-        public static readonly IEnumerable<object[]> InvalidStatusCodeLines = GetStatusCodeLines(MissingSpaceFormat);
+        public static IEnumerable<object[]> InvalidStatusCodeLines => GetStatusCodeLines(MissingSpaceFormat).Select(o => new object[] { o[0] });
         public static readonly IEnumerable<object[]> StatusCodeVersionLines = GetStatusCodeLinesForMajorVersions(1, 10).Concat(GetStatusCodeLinesForMajorMinorVersions(1, 10));
         public static readonly IEnumerable<object[]> InvalidHeaderLines = GetInvalidHeaderLines();
 
@@ -82,7 +82,7 @@ namespace System.Net.Http.Tests
         }
 
         [Theory, MemberData(nameof(InvalidStatusCodeLines))]
-        public unsafe void ReadStatusLine_InvalidStatusCode_ThrowsHttpRequestException(string statusLine, HttpStatusCode expectedCode, string phrase)
+        public unsafe void ReadStatusLine_InvalidStatusCode_ThrowsHttpRequestException(string statusLine)
         {
             byte[] buffer = statusLine.Select(c => checked((byte)c)).ToArray();
 

--- a/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Headers.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerResponseTests.Headers.cs
@@ -64,13 +64,18 @@ namespace System.Net.Tests
             Assert.Equal("value1,value2", response.Headers["name"]);
         }
 
-        [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        public async Task AppendHeader_NullOrEmptyName_ThrowsArgumentNullException(string name)
+        [Fact]
+        public async Task AppendHeader_NullName_ThrowsArgumentNullException()
         {
             HttpListenerResponse response = await GetResponse();
             AssertExtensions.Throws<ArgumentNullException>("name", () => response.AppendHeader(null, ""));
+        }
+
+        [Fact]
+        public async Task AppendHeader_EmptyName_ThrowsArgumentException()
+        {
+            HttpListenerResponse response = await GetResponse();
+            AssertExtensions.Throws<ArgumentException>("name", () => response.AppendHeader("", ""));
         }
 
         [Fact]

--- a/src/System.Net.Mail/tests/Unit/SmtpDateTimeTest.cs
+++ b/src/System.Net.Mail/tests/Unit/SmtpDateTimeTest.cs
@@ -76,17 +76,11 @@ namespace System.Net.Mime.Tests
         }
 
         [Theory]
-        [InlineData(ValidCompleteDateString, 2009, 5, 17, 15, 34, 7, "GMT", DateTimeKind.Unspecified)]
-        [InlineData(ValidDateStringWithKnownShortHandTimeZone, 2009, 5, 17, 15, 34, 7, "GMT", DateTimeKind.Unspecified)]
-        [InlineData(ValidDateStringWithNoDayOfWeek, 2009, 5, 17, 15, 34, 7, "GMT", DateTimeKind.Unspecified)]
-        [InlineData(ValidDateStringWithOnlyTabsAsWhitespace, 2009, 5, 17, 15, 34, 7, "GMT", DateTimeKind.Unspecified)]
-        [InlineData(ValidDateStringWithTrailingWhitespaceAndCommentAfterTimeZone, 2009, 5, 17, 15, 34, 7, "GMT", DateTimeKind.Unspecified)]
-        [InlineData(ValidDateStringWithMixedTabsAndSpacesAsWhitespace, 2009, 5, 17, 15, 34, 7, "GMT", DateTimeKind.Unspecified)]
+        [InlineData(2009, 5, 17, 15, 34, 7, "GMT")]
         public void SmtpDateTime_CreatedFromDateTimeString_ShouldParseCorrectly(
-            string input,
             int expectedYear, int expectedMonth, int expectedDay,
             int expectedHour, int expectedMinut, int expectedSecond,
-            string expectedTimeZoneOffset, DateTimeKind expectedKind)
+            string expectedTimeZoneOffset)
         {
             var smtpDt = new SmtpDateTime(DateTime.Now);
 

--- a/src/System.Net.Mail/tests/Unit/SmtpDateTimeTest.cs
+++ b/src/System.Net.Mail/tests/Unit/SmtpDateTimeTest.cs
@@ -76,16 +76,22 @@ namespace System.Net.Mime.Tests
         }
 
         [Theory]
-        [InlineData(2009, 5, 17, 15, 34, 7, "GMT")]
+        [InlineData(ValidCompleteDateString, 2009, 5, 17, 15, 34, 7, "+0000", DateTimeKind.Unspecified)]
+        [InlineData(ValidDateStringWithKnownShortHandTimeZone, 2009, 5, 17, 15, 34, 7, "GMT", DateTimeKind.Unspecified)]
+        [InlineData(ValidDateStringWithNoDayOfWeek, 2009, 5, 17, 15, 34, 7, "+0000", DateTimeKind.Unspecified)]
+        [InlineData(ValidDateStringWithOnlyTabsAsWhitespace, 2009, 5, 17, 15, 34, 7, "GMT", DateTimeKind.Unspecified)]
+        [InlineData(ValidDateStringWithTrailingWhitespaceAndCommentAfterTimeZone, 2009, 5, 17, 15, 34, 7, "GMT", DateTimeKind.Unspecified)]
+        [InlineData(ValidDateStringWithMixedTabsAndSpacesAsWhitespace, 2009, 5, 17, 15, 34, 7, "GMT", DateTimeKind.Unspecified)]
         public void SmtpDateTime_CreatedFromDateTimeString_ShouldParseCorrectly(
+            string input,
             int expectedYear, int expectedMonth, int expectedDay,
             int expectedHour, int expectedMinut, int expectedSecond,
-            string expectedTimeZoneOffset)
+            string expectedTimeZoneOffset,
+            DateTimeKind expectedKind)
         {
             var smtpDt = new SmtpDateTime(DateTime.Now);
 
-            string timeZoneOffset;
-            DateTime result = smtpDt.ParseValue(ValidDateStringWithKnownShortHandTimeZone, out timeZoneOffset);
+            DateTime result = smtpDt.ParseValue(input, out string timeZoneOffset);
 
             Assert.Equal(expectedYear, result.Year);
             Assert.Equal(expectedMonth, result.Month);
@@ -93,6 +99,7 @@ namespace System.Net.Mime.Tests
             Assert.Equal(expectedHour, result.Hour);
             Assert.Equal(expectedMinut, result.Minute);
             Assert.Equal(expectedSecond, result.Second);
+            Assert.Equal(expectedKind, result.Kind);
             Assert.Equal(expectedTimeZoneOffset, timeZoneOffset);
         }
 

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/PhysicalAddressTest.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/PhysicalAddressTest.cs
@@ -155,8 +155,9 @@ namespace System.Net.NetworkInformation.Tests
 
         [Theory]
         [MemberData(nameof(RoundtripParseToString_String_Bytes))]
-        public void ToStringParseGetAddressBytes_Roundtrips(string _, byte[] inputBytes)
+        public void ToStringParseGetAddressBytes_Roundtrips(string expectedAddress, byte[] inputBytes)
         {
+            _ = expectedAddress;
             Assert.Equal(inputBytes, PhysicalAddress.Parse(new PhysicalAddress(inputBytes).ToString()).GetAddressBytes());
         }
     }

--- a/src/System.Net.Primitives/tests/FunctionalTests/IPAddressParsingSpan.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/IPAddressParsingSpan.cs
@@ -38,6 +38,7 @@ namespace System.Net.Primitives.Functional.Tests
         [MemberData(nameof(ValidIpv6Addresses))]
         public void TryFormat_ProvidedBufferTooSmall_Failure(string addressString, string expected)
         {
+            _ = expected;
             IPAddress address = IPAddress.Parse(addressString);
             var result = new char[address.ToString().Length - 1];
             Assert.False(address.TryFormat(new Span<char>(result), out int charsWritten));

--- a/src/System.Net.Primitives/tests/FunctionalTests/IPEndPointParsing.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/IPEndPointParsing.cs
@@ -110,14 +110,16 @@ namespace System.Net.Primitives.Functional.Tests
         [MemberData(nameof(IPAddressParsing.ValidIpv4Addresses), MemberType = typeof(IPAddressParsing))]
         public void Parse_InvalidPort_IPv4_Throws(string address, string expectedAddress)
         {
-            Parse_InvalidPort_Throws(address, true);
+            _ = expectedAddress;
+            Parse_InvalidPort_Throws(address, isIPv4: true);
         }
 
         [Theory]
         [MemberData(nameof(IPAddressParsing.ValidIpv6Addresses), MemberType = typeof(IPAddressParsing))]
         public void Parse_InvalidPort_IPv6_Throws(string address, string expectedAddress)
         {
-            Parse_InvalidPort_Throws(address, false);
+            _ = expectedAddress;
+            Parse_InvalidPort_Throws(address, isIPv4: false);
         }
 
         private void Parse_InvalidPort_Throws(string address, bool isIPv4)

--- a/src/System.Private.Xml.Linq/tests/Properties/NamespaceAccessors.cs
+++ b/src/System.Private.Xml.Linq/tests/Properties/NamespaceAccessors.cs
@@ -96,9 +96,9 @@ namespace System.Xml.Linq.Tests
         }
 
         [Theory]
-        [InlineData("<A xmlns='x' xmlns:p='redefme'><p:C xmlns:p='nsc'><X:Sub xmlns:X='xx'/></p:C><B/></A>", null, null, typeof(ArgumentNullException))]
-        [InlineData("<A xmlns='x' xmlns:p='redefme'><p:C xmlns:p='nsc'><X:Sub xmlns:X='xx'/></p:C><B/></A>", "", null, typeof(ArgumentException))]
-        public void NamespaceForPrefixNull(string xml, string prefix, string ns, Type expectedException)
+        [InlineData("<A xmlns='x' xmlns:p='redefme'><p:C xmlns:p='nsc'><X:Sub xmlns:X='xx'/></p:C><B/></A>", null, typeof(ArgumentNullException))]
+        [InlineData("<A xmlns='x' xmlns:p='redefme'><p:C xmlns:p='nsc'><X:Sub xmlns:X='xx'/></p:C><B/></A>", "", typeof(ArgumentException))]
+        public void NamespaceForPrefixNull(string xml, string prefix, Type expectedException)
         {
             XElement e = XElement.Parse(xml);
             Assert.Throws(expectedException, () => (e.FirstNode as XElement).GetNamespaceOfPrefix(prefix));
@@ -164,8 +164,8 @@ namespace System.Xml.Linq.Tests
         }
 
         [Theory]
-        [InlineData("<A xmlns='x' xmlns:p='redefme'><p:C xmlns:p='nsc'><X:Sub xmlns:X='xx'/></p:C><B/></A>", null, null)]
-        public void PrefixOfNamespaceNull(string xml, string prefix, string ns)
+        [InlineData("<A xmlns='x' xmlns:p='redefme'><p:C xmlns:p='nsc'><X:Sub xmlns:X='xx'/></p:C><B/></A>", null)]
+        public void PrefixOfNamespaceNull(string xml, string ns)
         {
             XElement e = XElement.Parse(xml);
             Assert.Throws<ArgumentNullException>(() => (e.FirstNode as XElement).GetPrefixOfNamespace(ns));

--- a/src/System.Private.Xml.Linq/tests/misc/XLinqErrata4.cs
+++ b/src/System.Private.Xml.Linq/tests/misc/XLinqErrata4.cs
@@ -54,20 +54,20 @@ namespace System.Xml.Linq.Tests
         }
 
         // Get valid(Fifth Edition) surrogate characters but since surrogates are not supported in Fourth Edition Xml we still expect an exception.
-        [InlineData("InValid", "NameSurrogateLowChar", "XName")] // XName with Valid Name Surrogate Low Characters
-        [InlineData("InValid", "NameSurrogateLowChar", "XAttribute")] // XAttribute with Valid Name Surrogate Low Characters
-        [InlineData("InValid", "NameSurrogateLowChar", "XElement")] // XElement with Valid Name Surrogate Low Characters
-        [InlineData("InValid", "NameSurrogateHighChar", "XName")] // XName with Valid Name Surrogate High Characters
-        [InlineData("InValid", "NameSurrogateHighChar", "XAttribute")] // XAttribute with Valid Name Surrogate High Characters
-        [InlineData("InValid", "NameSurrogateHighChar", "XElement")] // XElement with Valid Name Surrogate High Characters
-        [InlineData("InValid", "NameStartSurrogateLowChar", "XName")] // XName with Valid NameStart Surrogate Low Characters
-        [InlineData("InValid", "NameStartSurrogateLowChar", "XAttribute")] // XAttribute with Valid NameStart Surrogate Low Characters
-        [InlineData("InValid", "NameStartSurrogateLowChar", "XElement")] // XElement with Valid NameStart Surrogate Low Characters
-        [InlineData("InValid", "NameStartSurrogateHighChar", "XName")] // XName with Valid NameStart Surrogate High Characters
-        [InlineData("InValid", "NameStartSurrogateHighChar", "XAttribute")] // XAttribute with Valid NameStart Surrogate High Characters
-        [InlineData("InValid", "NameStartSurrogateHighChar", "XElement")] // XElement with Valid NameStart Surrogate High Characters
+        [InlineData("NameSurrogateLowChar", "XName")] // XName with Valid Name Surrogate Low Characters
+        [InlineData("NameSurrogateLowChar", "XAttribute")] // XAttribute with Valid Name Surrogate Low Characters
+        [InlineData("NameSurrogateLowChar", "XElement")] // XElement with Valid Name Surrogate Low Characters
+        [InlineData("NameSurrogateHighChar", "XName")] // XName with Valid Name Surrogate High Characters
+        [InlineData("NameSurrogateHighChar", "XAttribute")] // XAttribute with Valid Name Surrogate High Characters
+        [InlineData("NameSurrogateHighChar", "XElement")] // XElement with Valid Name Surrogate High Characters
+        [InlineData("NameStartSurrogateLowChar", "XName")] // XName with Valid NameStart Surrogate Low Characters
+        [InlineData("NameStartSurrogateLowChar", "XAttribute")] // XAttribute with Valid NameStart Surrogate Low Characters
+        [InlineData("NameStartSurrogateLowChar", "XElement")] // XElement with Valid NameStart Surrogate Low Characters
+        [InlineData("NameStartSurrogateHighChar", "XName")] // XName with Valid NameStart Surrogate High Characters
+        [InlineData("NameStartSurrogateHighChar", "XAttribute")] // XAttribute with Valid NameStart Surrogate High Characters
+        [InlineData("NameStartSurrogateHighChar", "XElement")] // XElement with Valid NameStart Surrogate High Characters
         [Theory]
-        public void varation2(string testType, string charType, string nodeType)
+        public void varation2(string charType, string nodeType)
         {
             int iterations = 0;
             foreach (char c in GetRandomCharacters("Valid", charType))

--- a/src/System.Private.Xml/tests/Writers/XmlWriterApi/EndOfLineHandlingTests.cs
+++ b/src/System.Private.Xml/tests/Writers/XmlWriterApi/EndOfLineHandlingTests.cs
@@ -652,19 +652,19 @@ namespace System.Xml.Tests
         }
 
         [Theory]
-        [XmlWriterInlineData(~WriterType.Async & WriterType.AllButCustom, 1)]
-        [XmlWriterInlineData(~WriterType.Async & WriterType.AllButCustom, 2)]
-        [XmlWriterInlineData(~WriterType.Async & WriterType.AllButCustom, 3)]
-        [XmlWriterInlineData(~WriterType.Async & WriterType.AllButCustom, 4)]
-        [XmlWriterInlineData(~WriterType.Async & WriterType.AllButCustom, 5)]
-        [XmlWriterInlineData(~WriterType.Async & WriterType.AllButCustom, 6)]
-        [XmlWriterInlineData(~WriterType.Async & WriterType.AllButCustom, 7)]
-        [XmlWriterInlineData(~WriterType.Async & WriterType.AllButCustom, 8)]
-        [XmlWriterInlineData(~WriterType.Async & WriterType.AllButCustom, 9)]
-        [XmlWriterInlineData(~WriterType.Async & WriterType.AllButCustom, 10)]
-        [XmlWriterInlineData(~WriterType.Async & WriterType.AllButCustom, 11)]
-        [XmlWriterInlineData(~WriterType.Async & WriterType.AllButCustom, 12)]
-        public void EOF_Handling_20(XmlWriterUtils utils, int param)
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(6)]
+        [InlineData(7)]
+        [InlineData(8)]
+        [InlineData(9)]
+        [InlineData(10)]
+        [InlineData(11)]
+        [InlineData(12)]
+        public void EOF_Handling_20(int param)
         {
             XmlWriterSettings ws = new XmlWriterSettings();
             switch (param)

--- a/src/System.Private.Xml/tests/Writers/XmlWriterApi/ErrorCondition.cs
+++ b/src/System.Private.Xml/tests/Writers/XmlWriterApi/ErrorCondition.cs
@@ -492,11 +492,11 @@ namespace System.Xml.Tests
         }
 
         [Theory]
-        [XmlWriterInlineData(1)]
-        [XmlWriterInlineData(2)]
-        [XmlWriterInlineData(3)]
-        [XmlWriterInlineData(4)]
-        public void var_11(XmlWriterUtils utils, int param)
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        public void var_11(int param)
         {
             XmlWriterSettings ws = new XmlWriterSettings();
             try
@@ -665,9 +665,9 @@ namespace System.Xml.Tests
         }
 
         [Theory]
-        [XmlWriterInlineData(1)]
-        [XmlWriterInlineData(2)]
-        public void var_14(XmlWriterUtils utils, int param)
+        [InlineData(1)]
+        [InlineData(2)]
+        public void var_14(int param)
         {
             XmlWriterSettings ws = new XmlWriterSettings();
             try

--- a/src/System.Private.Xml/tests/Writers/XmlWriterApi/TCDefaultWriterSettingsTests.cs
+++ b/src/System.Private.Xml/tests/Writers/XmlWriterApi/TCDefaultWriterSettingsTests.cs
@@ -36,9 +36,8 @@ namespace System.Xml.Tests
             return;
         }
 
-        [Theory]
-        [XmlWriterInlineData(WriterType.AllButCustom)]
-        public void default_2(XmlWriterUtils utils)
+        [Fact]
+        public void default_2()
         {
             XmlWriterSettings wSettings = new XmlWriterSettings();
             CError.Compare(wSettings.OmitXmlDeclaration, false, "Incorrect default value of OmitXmlDeclaration");
@@ -118,9 +117,8 @@ namespace System.Xml.Tests
             return;
         }
 
-        [Theory]
-        [XmlWriterInlineData(WriterType.AllButCustom)]
-        public void default_8(XmlWriterUtils utils)
+        [Fact]
+        public void default_8()
         {
             XmlWriterSettings wSettings = new XmlWriterSettings();
             CError.Compare(wSettings.CloseOutput, false, "Incorrect default value of CloseOutput");

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Imports.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Imports.cs
@@ -596,9 +596,9 @@ namespace System.Xml.Tests
         }
 
         //[Variation(Desc = "v102.2 - Import: Add B(no ns) with ns-b , then A(ns-a) which imports B (no ns)", Priority = 1, Params = new object[] { "import_v5_a.xsd", "import_v4_b.xsd", 3, "ns-b", null })]
-        [InlineData("import_v5_a.xsd", "import_v4_b.xsd", 3, "ns-b", null)]
+        [InlineData("import_v5_a.xsd", "import_v4_b.xsd", "ns-b")]
         [Theory]
-        public void v102a(object param0, object param1, object param2, object param3, object param4)
+        public void v102a(object param0, object param1, object param3)
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();
@@ -1292,9 +1292,9 @@ namespace System.Xml.Tests
         }
 
         //[Variation(Desc = "v202.2 - Import: Add B(no ns) with ns-b , then A(ns-a) which imports B (no ns)", Priority = 1, Params = new object[] { "import_v5_a.xsd", "import_v4_b.xsd", 3, "ns-b", null })]
-        [InlineData("import_v5_a.xsd", "import_v4_b.xsd", 3, "ns-b", null)]
+        [InlineData("import_v5_a.xsd", "import_v4_b.xsd", "ns-b")]
         [Theory]
-        public void v202a(object param0, object param1, object param2, object param3, object param4)
+        public void v202a(object param0, object param1, object param3)
         {
             XmlSchemaSet sc = new XmlSchemaSet();
             sc.XmlResolver = new XmlUrlResolver();

--- a/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/OutputSettings.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/OutputSettings.cs
@@ -119,13 +119,13 @@ namespace System.Xml.Tests
         }
 
         //[Variation(id = 10, Desc = "Verify OmitXmlDeclaration when omit-xml-declared is omitted in XSLT, expected false", Pri = 0, Params = new object[] { "books.xml", "OmitXmlDecl_Default.xsl", false, "Default value for OmitXmlDeclaration is 'no'" })]
-        [InlineData("books.xml", "OmitXmlDecl_Default.xsl", false, "Default value for OmitXmlDeclaration is 'no'")]
+        [InlineData("books.xml", "OmitXmlDecl_Default.xsl", false)]
         //[Variation(id = 11, Desc = "Verify OmitXmlDeclaration when omit-xml-declared is yes in XSLT, expected true", Pri = 0, Params = new object[] { "books.xml", "OmitXmlDecl_Yes.xsl", true, "OmitXmlDeclaration must be 'yes'" })]
-        [InlineData("books.xml", "OmitXmlDecl_Yes.xsl", true, "OmitXmlDeclaration must be 'yes'")]
+        [InlineData("books.xml", "OmitXmlDecl_Yes.xsl", true)]
         //[Variation(id = 12, Desc = "Verify OmitXmlDeclaration when omit-xml-declared is no in XSLT, expected false", Pri = 1, Params = new object[] { "books.xml", "OmitXmlDecl_No.xsl", false, "OmitXmlDeclaration must be 'no'" })]
-        [InlineData("books.xml", "OmitXmlDecl_No.xsl", false, "OmitXmlDeclaration must be 'no'")]
+        [InlineData("books.xml", "OmitXmlDecl_No.xsl", false)]
         [Theory]
-        public void OS3(object param0, object param1, object param2, object param3)
+        public void OS3(object param0, object param1, object param2)
         {
             Init(param0.ToString(), param1.ToString());
             _xsl.Load(_xslFile);
@@ -177,24 +177,24 @@ namespace System.Xml.Tests
         }
 
         //[Variation(id = 18, Desc = "Verify Encoding set to windows-1252 explicitly, expected windows-1252", Pri = 1, Params = new object[] { "books.xml", "Encoding4.xsl", "windows-1252", "Encoding must be windows-1252" })]
-        [InlineData("books.xml", "Encoding4.xsl", "windows-1252", "Encoding must be windows-1252")]
+        [InlineData("books.xml", "Encoding4.xsl", "windows-1252")]
         [Theory]
-        public void OS6_Windows1252Encoding(object param0, object param1, object param2, object param3)
+        public void OS6_Windows1252Encoding(object param0, object param1, object param2)
         {
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-            OS6(param0, param1, param2, param3);
+            OS6(param0, param1, param2);
         }
 
         //[Variation(id = 15, Desc = "Verify default Encoding, expected UTF-8", Pri = 1, Params = new object[] { "books.xml", "Encoding1.xsl", "utf-8", "Default Encoding must be utf-8" })]
-        [InlineData("books.xml", "Encoding1.xsl", "utf-8", "Default Encoding must be utf-8")]
+        [InlineData("books.xml", "Encoding1.xsl", "utf-8")]
         //[Variation(id = 16, Desc = "Verify Encoding set to UTF-8 explicitly, expected UTF-8", Pri = 1, Params = new object[] { "books.xml", "Encoding2.xsl", "utf-8", "Encoding must be utf-8" })]
-        [InlineData("books.xml", "Encoding2.xsl", "utf-8", "Encoding must be utf-8")]
+        [InlineData("books.xml", "Encoding2.xsl", "utf-8")]
         //[Variation(id = 17, Desc = "Verify Encoding set to UTF-16 explicitly, expected UTF-16", Pri = 1, Params = new object[] { "books.xml", "Encoding3.xsl", "utf-16", "Encoding must be utf-16" })]
-        [InlineData("books.xml", "Encoding3.xsl", "utf-16", "Encoding must be utf-16")]
+        [InlineData("books.xml", "Encoding3.xsl", "utf-16")]
         //[Variation(id = 19, Desc = "Verify Encoding when multiple xsl:output tags are present, expected the last set (iso-8859-1)", Pri = 1, Params = new object[] { "books.xml", "Encoding5.xsl", "iso-8859-1", "Encoding must be iso-8859-1" })]
-        [InlineData("books.xml", "Encoding5.xsl", "iso-8859-1", "Encoding must be iso-8859-1")]
+        [InlineData("books.xml", "Encoding5.xsl", "iso-8859-1")]
         [Theory]
-        public void OS6(object param0, object param1, object param2, object param3)
+        public void OS6(object param0, object param1, object param2)
         {
             Init(param0.ToString(), param1.ToString());
             _xsl.Load(_xslFile);
@@ -205,13 +205,13 @@ namespace System.Xml.Tests
         }
 
         //[Variation(id = 20, Desc = "Verify Indent when indent is omitted in XSLT, expected false", Pri = 0, Params = new object[] { "books.xml", "Indent_Default.xsl", false, "Default value for Indent is 'no'" })]
-        [InlineData("books.xml", "Indent_Default.xsl", false, "Default value for Indent is 'no'")]
+        [InlineData("books.xml", "Indent_Default.xsl", false)]
         //[Variation(id = 21, Desc = "Verify Indent when indent is yes in XSLT, expected true", Pri = 0, Params = new object[] { "books.xml", "Indent_Yes.xsl", true, "Indent must be 'yes'" })]
-        [InlineData("books.xml", "Indent_Yes.xsl", true, "Indent must be 'yes'")]
+        [InlineData("books.xml", "Indent_Yes.xsl", true)]
         //[Variation(id = 22, Desc = "Verify Indent when indent is no in XSLT, expected false", Pri = 1, Params = new object[] { "books.xml", "Indent_No.xsl", false, "Indent must be 'no'" })]
-        [InlineData("books.xml", "Indent_No.xsl", false, "Indent must be 'no'")]
+        [InlineData("books.xml", "Indent_No.xsl", false)]
         [Theory]
-        public void OS7(object param0, object param1, object param2, object param3)
+        public void OS7(object param0, object param1, object param2)
         {
             Init(param0.ToString(), param1.ToString());
             _xsl.Load(_xslFile);

--- a/src/System.Private.Xml/tests/Xslt/XslTransformApi/CXslTransform.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslTransformApi/CXslTransform.cs
@@ -1069,20 +1069,11 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Style sheet has import/include, call Load first with default resolver and then with custom null resolver, should fail")]
-        [InlineData(InputType.Reader, ReaderType.XmlValidatingReader, TransformType.Reader, DocType.XPathDocument)]
-        [InlineData(InputType.Reader, ReaderType.XmlValidatingReader, TransformType.Stream, DocType.XPathDocument)]
-        [InlineData(InputType.Reader, ReaderType.XmlValidatingReader, TransformType.Writer, DocType.XPathDocument)]
-        [InlineData(InputType.Reader, ReaderType.XmlValidatingReader, TransformType.TextWriter, DocType.XPathDocument)]
-        [InlineData(InputType.URI, ReaderType.XmlValidatingReader, TransformType.Reader, DocType.XPathDocument)]
-        [InlineData(InputType.URI, ReaderType.XmlValidatingReader, TransformType.Writer, DocType.XPathDocument)]
-        [InlineData(InputType.URI, ReaderType.XmlValidatingReader, TransformType.Stream, DocType.XPathDocument)]
-        [InlineData(InputType.URI, ReaderType.XmlValidatingReader, TransformType.TextWriter, DocType.XPathDocument)]
-        [InlineData(InputType.Navigator, ReaderType.XmlValidatingReader, TransformType.Reader, DocType.XPathDocument)]
-        [InlineData(InputType.Navigator, ReaderType.XmlValidatingReader, TransformType.Writer, DocType.XPathDocument)]
-        [InlineData(InputType.Navigator, ReaderType.XmlValidatingReader, TransformType.Stream, DocType.XPathDocument)]
-        [InlineData(InputType.Navigator, ReaderType.XmlValidatingReader, TransformType.TextWriter, DocType.XPathDocument)]
+        [InlineData(InputType.Reader, ReaderType.XmlValidatingReader)]
+        [InlineData(InputType.URI, ReaderType.XmlValidatingReader)]
+        [InlineData(InputType.Navigator, ReaderType.XmlValidatingReader)]
         [Theory]
-        public void TC_No_Explicit_Resolver_Prohibits_External_Url(InputType inputType, ReaderType readerType, TransformType transformType, DocType docType)
+        public void TC_No_Explicit_Resolver_Prohibits_External_Url(InputType inputType, ReaderType readerType)
         {
             AppContext.TryGetSwitch("Switch.System.Xml.AllowDefaultResolver", out bool isEnabled);
             Assert.False(isEnabled);
@@ -2583,11 +2574,11 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Pass XmlUrlResolver, load style sheet with document function, should resolve during transform")]
-        [InlineData(InputType.Reader, ReaderType.XmlValidatingReader, TransformType.Stream)]
-        [InlineData(InputType.URI, ReaderType.XmlValidatingReader, TransformType.Stream)]
-        [InlineData(InputType.Navigator, ReaderType.XmlValidatingReader, TransformType.Stream)]
+        [InlineData(InputType.Reader, ReaderType.XmlValidatingReader)]
+        [InlineData(InputType.URI, ReaderType.XmlValidatingReader)]
+        [InlineData(InputType.Navigator, ReaderType.XmlValidatingReader)]
         [Theory]
-        public void TC_Xslt_Document_Function_Use_XmlUrlResolver(InputType inputType, ReaderType readerType, TransformType transformType)
+        public void TC_Xslt_Document_Function_Use_XmlUrlResolver(InputType inputType, ReaderType readerType)
         {
             // "xmlResolver_document_function.xsl" contains
             // <xsl:for-each select="document('xmlResolver_document_function.xml')//elem">

--- a/src/System.Reflection.Emit.ILGeneration/tests/CustomAttributeBuilderTests.cs
+++ b/src/System.Reflection.Emit.ILGeneration/tests/CustomAttributeBuilderTests.cs
@@ -202,33 +202,33 @@ namespace System.Reflection.Emit.Tests
         {
             PropertyInfo[] namedProperties = Helpers.GetProperties(typeof(TestAttribute), propertyNames);
             FieldInfo[] namedFields = Helpers.GetFields(typeof(TestAttribute), fieldNames);
-            
-            Action<CustomAttributeBuilder> verify = attr =>
+
+            void Verify(CustomAttributeBuilder attr)
             {
                 VerifyCustomAttributeBuilder(attr, TestAttribute.AllProperties, expectedPropertyValues, TestAttribute.AllFields, expectedFieldValues);
-            };
-            
+            }
+
             if (namedProperties.Length == 0)
             {
                 if (namedFields.Length == 0)
                 {
                     // Use CustomAttributeBuilder(ConstructorInfo, object[])
                     CustomAttributeBuilder attribute1 = new CustomAttributeBuilder(con, constructorArgs);
-                    verify(attribute1);
+                    Verify(attribute1);
                 }
                 // Use CustomAttributeBuilder(ConstructorInfo, object[], FieldInfo[], object[])
                 CustomAttributeBuilder attribute2 = new CustomAttributeBuilder(con, constructorArgs, namedFields, fieldValues);
-                verify(attribute2);
+                Verify(attribute2);
             }
             if (namedFields.Length == 0)
             {
                 // Use CustomAttributeBuilder(ConstructorInfo, object[], PropertyInfo[], object[])
                 CustomAttributeBuilder attribute3 = new CustomAttributeBuilder(con, constructorArgs, namedProperties, propertyValues);
-                verify(attribute3);
+                Verify(attribute3);
             }
             // Use CustomAttributeBuilder(ConstructorInfo, object[], PropertyInfo[], object[], FieldInfo[], object[])
             CustomAttributeBuilder attribute4 = new CustomAttributeBuilder(con, constructorArgs, namedProperties, propertyValues, namedFields, fieldValues);
-            verify(attribute4);
+            Verify(attribute4);
         }
         
         private static void VerifyCustomAttributeBuilder(CustomAttributeBuilder builder,
@@ -456,7 +456,7 @@ namespace System.Reflection.Emit.Tests
                                                   PropertyInfo[] namedProperties, object[] propertyValues,
                                                   FieldInfo[] namedFields, object[] fieldValues)
         {
-            CustomAttributeBuilder attribute = new CustomAttributeBuilder(con, new object[0], namedProperties, propertyValues, namedFields, fieldValues);
+            CustomAttributeBuilder attribute = new CustomAttributeBuilder(con, constructorArgs, namedProperties, propertyValues, namedFields, fieldValues);
 
             AssemblyBuilder assembly = Helpers.DynamicAssembly();
             assembly.SetCustomAttribute(attribute);

--- a/src/System.Reflection.Emit/tests/MethodBuilder/MethodBuilderDefineGenericParameters.cs
+++ b/src/System.Reflection.Emit/tests/MethodBuilder/MethodBuilderDefineGenericParameters.cs
@@ -99,7 +99,7 @@ namespace System.Reflection.Emit.Tests
         [InlineData(TypeAttributes.Public, MethodAttributes.Public | MethodAttributes.Static)]
         public void DefineGenericParameters_NullNames_ThrowsArgumentNullException(TypeAttributes typeAttributes, MethodAttributes methodAttributes)
         {
-            TypeBuilder type = Helpers.DynamicType(TypeAttributes.NotPublic);
+            TypeBuilder type = Helpers.DynamicType(typeAttributes);
             MethodBuilder method = type.DefineMethod("TestMethod", methodAttributes);
             AssertExtensions.Throws<ArgumentNullException>("names", () => method.DefineGenericParameters(null));
         }
@@ -109,7 +109,7 @@ namespace System.Reflection.Emit.Tests
         [InlineData(TypeAttributes.Public, MethodAttributes.Public | MethodAttributes.Static)]
         public void DefineGenericParameters_NamesContainsNull_ThrowsArgumentNullException(TypeAttributes typeAttributes, MethodAttributes methodAttributes)
         {
-            TypeBuilder type = Helpers.DynamicType(TypeAttributes.NotPublic);
+            TypeBuilder type = Helpers.DynamicType(typeAttributes);
             MethodBuilder method = type.DefineMethod("Test", methodAttributes);
             string[] typeParamNames = new string[] { "T", null, "U" };
             AssertExtensions.Throws<ArgumentNullException>("names", () => method.DefineGenericParameters(typeParamNames));
@@ -120,7 +120,7 @@ namespace System.Reflection.Emit.Tests
         [InlineData(TypeAttributes.Public, MethodAttributes.Public | MethodAttributes.Static)]
         public void DefineGenericParameters_EmptyNames_ThrowsArgumentException(TypeAttributes typeAttributes, MethodAttributes methodAttributes)
         {
-            TypeBuilder type = Helpers.DynamicType(TypeAttributes.NotPublic);
+            TypeBuilder type = Helpers.DynamicType(typeAttributes);
             MethodBuilder builder = type.DefineMethod("TestMethod", methodAttributes);
             AssertExtensions.Throws<ArgumentException>("names", () => builder.DefineGenericParameters());
         }

--- a/src/System.Reflection.Emit/tests/ModuleBuilder/ModuleBuilderDefineType.cs
+++ b/src/System.Reflection.Emit/tests/ModuleBuilder/ModuleBuilderDefineType.cs
@@ -42,11 +42,11 @@ namespace System.Reflection.Emit.Tests
             bool isDefaultParent = parent == null;
             bool isDefaultAttributes = attributes == TypeAttributes.NotPublic;
 
-            Action<TypeBuilder, Module> verify = (type, module) =>
+            void Verify(TypeBuilder type, Module module)
             {
                 Type baseType = attributes.HasFlag(TypeAttributes.Abstract) && parent == null ? null : (parent ?? typeof(object));
                 Helpers.VerifyType(type, module, null, name, attributes, baseType, typesize, packingSize, implementedInterfaces);
-            };
+            }
 
             if (isDefaultImplementedInterfaces)
             {
@@ -58,38 +58,38 @@ namespace System.Reflection.Emit.Tests
                         {
                             // Use DefineType(string)
                             ModuleBuilder module1 = Helpers.DynamicModule();
-                            verify(module1.DefineType(name), module1);
+                            Verify(module1.DefineType(name), module1);
                         }
                         // Use DefineType(string, TypeAttributes)
                         ModuleBuilder module2 = Helpers.DynamicModule();
-                        verify(module2.DefineType(name, attributes), module2);
+                        Verify(module2.DefineType(name, attributes), module2);
                     }
                     // Use DefineType(string, TypeAttributes, Type)
                     ModuleBuilder module3 = Helpers.DynamicModule();
-                    verify(module3.DefineType(name, attributes, parent), module3);
+                    Verify(module3.DefineType(name, attributes, parent), module3);
                 }
                 else if (isDefaultSize)
                 {
                     // Use DefineType(string, TypeAttributes, Type, PackingSize)
                     ModuleBuilder module4 = Helpers.DynamicModule();
-                    verify(module4.DefineType(name, attributes, parent, packingSize), module4);
+                    Verify(module4.DefineType(name, attributes, parent, packingSize), module4);
                 }
                 else if (isDefaultPackingSize)
                 {
                     // Use DefineType(string, TypeAttributes, Type, int)
                     ModuleBuilder module5 = Helpers.DynamicModule();
-                    verify(module5.DefineType(name, attributes, parent, typesize), module5);
+                    Verify(module5.DefineType(name, attributes, parent, typesize), module5);
                 }
                 // Use DefineType(string, TypeAttributes, Type, PackingSize, int)
                 ModuleBuilder module6 = Helpers.DynamicModule();
-                verify(module6.DefineType(name, attributes, parent, packingSize, typesize), module6);
+                Verify(module6.DefineType(name, attributes, parent, packingSize, typesize), module6);
             }
             else
             {
                 // Use DefineType(string, TypeAttributes, Type, Type[])
                 Assert.True(isDefaultSize && isDefaultPackingSize); // Sanity check
                 ModuleBuilder module7 = Helpers.DynamicModule();
-                verify(module7.DefineType(name, attributes, parent, implementedInterfaces), module7);
+                Verify(module7.DefineType(name, attributes, parent, implementedInterfaces), module7);
             }
         }
 

--- a/src/System.Reflection.Emit/tests/TypeBuilder/TypeBuilderDefineDefaultConstructor.cs
+++ b/src/System.Reflection.Emit/tests/TypeBuilder/TypeBuilderDefineDefaultConstructor.cs
@@ -10,22 +10,22 @@ namespace System.Reflection.Emit.Tests
     public class TypeBuilderDefineDefaultConstructor
     {
         [Theory]
-        [InlineData(MethodAttributes.Public, MethodAttributes.Public)]
-        [InlineData(MethodAttributes.Static, MethodAttributes.Static)]
-        [InlineData(MethodAttributes.Family, MethodAttributes.Family)]
-        [InlineData(MethodAttributes.Assembly, MethodAttributes.Assembly)]
-        [InlineData(MethodAttributes.Private, MethodAttributes.Private)]
-        [InlineData(MethodAttributes.PrivateScope, MethodAttributes.PrivateScope)]
-        [InlineData(MethodAttributes.FamORAssem, MethodAttributes.FamORAssem)]
-        [InlineData(MethodAttributes.FamANDAssem, MethodAttributes.FamANDAssem)]
-        [InlineData(MethodAttributes.Final | MethodAttributes.Public, MethodAttributes.Final | MethodAttributes.Public)]
-        [InlineData(MethodAttributes.Final | MethodAttributes.Family, MethodAttributes.Final | MethodAttributes.Family)]
-        [InlineData(MethodAttributes.SpecialName | MethodAttributes.Family, MethodAttributes.SpecialName | MethodAttributes.Family)]
-        [InlineData(MethodAttributes.UnmanagedExport | MethodAttributes.Family, MethodAttributes.UnmanagedExport | MethodAttributes.Family)]
-        [InlineData(MethodAttributes.RTSpecialName | MethodAttributes.Family, MethodAttributes.RTSpecialName | MethodAttributes.Family)]
-        [InlineData(MethodAttributes.HideBySig | MethodAttributes.Family, MethodAttributes.HideBySig | MethodAttributes.Family)]
-        [InlineData((MethodAttributes)0x8000, MethodAttributes.PrivateScope | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName)]
-        public void DefineDefaultConstructor(MethodAttributes attributes, MethodAttributes expectedAttributes)
+        [InlineData(MethodAttributes.Public)]
+        [InlineData(MethodAttributes.Static)]
+        [InlineData(MethodAttributes.Family)]
+        [InlineData(MethodAttributes.Assembly)]
+        [InlineData(MethodAttributes.Private)]
+        [InlineData(MethodAttributes.PrivateScope)]
+        [InlineData(MethodAttributes.FamORAssem)]
+        [InlineData(MethodAttributes.FamANDAssem)]
+        [InlineData(MethodAttributes.Final | MethodAttributes.Public)]
+        [InlineData(MethodAttributes.Final | MethodAttributes.Family)]
+        [InlineData(MethodAttributes.SpecialName | MethodAttributes.Family)]
+        [InlineData(MethodAttributes.UnmanagedExport | MethodAttributes.Family)]
+        [InlineData(MethodAttributes.RTSpecialName | MethodAttributes.Family)]
+        [InlineData(MethodAttributes.HideBySig | MethodAttributes.Family)]
+        [InlineData((MethodAttributes)0x8000)]
+        public void DefineDefaultConstructor(MethodAttributes attributes)
         {
             TypeBuilder type = Helpers.DynamicType(TypeAttributes.Class | TypeAttributes.Public);
             ConstructorBuilder constructor = type.DefineDefaultConstructor(attributes);

--- a/src/System.Reflection.Emit/tests/TypeBuilder/TypeBuilderDefineNestedType.cs
+++ b/src/System.Reflection.Emit/tests/TypeBuilder/TypeBuilderDefineNestedType.cs
@@ -64,12 +64,12 @@ namespace System.Reflection.Emit.Tests
             bool isDefaultParent = parent == null;
             bool isDefaultAttributes = attributes == TypeAttributes.NestedPrivate;
 
-            Action<TypeBuilder, TypeBuilder> verify = (type, declaringType) =>
+            void Verify(TypeBuilder type, TypeBuilder declaringType)
             {
                 bool allowsNullParent = attributes.HasFlag(TypeAttributes.Abstract) && attributes.HasFlag(TypeAttributes.ClassSemanticsMask);
                 Type baseType = allowsNullParent ? parent : (parent ?? typeof(object));
                 Helpers.VerifyType(type, declaringType.Module, declaringType, name, attributes, baseType, typesize, packingSize, implementedInterfaces);
-            };
+            }
 
             if (isDefaultImplementedInterfaces)
             {
@@ -81,38 +81,38 @@ namespace System.Reflection.Emit.Tests
                         {
                             // Use DefineNestedType(string)
                             TypeBuilder type1 = Helpers.DynamicType(TypeAttributes.Public);
-                            verify(type1.DefineNestedType(name), type1);
+                            Verify(type1.DefineNestedType(name), type1);
                         }
                         // Use DefineNestedType(string, TypeAttributes)
                         TypeBuilder type2 = Helpers.DynamicType(TypeAttributes.Public);
-                        verify(type2.DefineNestedType(name, attributes), type2);
+                        Verify(type2.DefineNestedType(name, attributes), type2);
                     }
                     // Use DefineNestedType(string, TypeAttributes, Type)
                     TypeBuilder type3 = Helpers.DynamicType(TypeAttributes.Public);
-                    verify(type3.DefineNestedType(name, attributes, parent), type3);
+                    Verify(type3.DefineNestedType(name, attributes, parent), type3);
                 }
                 else if (isDefaultSize)
                 {
                     // Use DefineNestedType(string, TypeAttributes, Type, PackingSize)
                     TypeBuilder type4 = Helpers.DynamicType(TypeAttributes.Public);
-                    verify(type4.DefineNestedType(name, attributes, parent, packingSize), type4);
+                    Verify(type4.DefineNestedType(name, attributes, parent, packingSize), type4);
                 }
                 else if (isDefaultPackingSize)
                 {
                     // Use DefineNestedType(string, TypeAttributes, Type, int)
                     TypeBuilder type5 = Helpers.DynamicType(TypeAttributes.Public);
-                    verify(type5.DefineNestedType(name, attributes, parent, typesize), type5);
+                    Verify(type5.DefineNestedType(name, attributes, parent, typesize), type5);
                 }
                 // Use DefineNestedType(string, TypeAttributes, Type, PackingSize, int);
                 TypeBuilder type6 = Helpers.DynamicType(TypeAttributes.Public);
-                verify(type6.DefineNestedType(name, attributes, parent, packingSize, typesize), type6);
+                Verify(type6.DefineNestedType(name, attributes, parent, packingSize, typesize), type6);
             }
             else
             {
                 // Use DefineNestedType(string, TypeAttributes, Type, Type[])
                 Assert.True(isDefaultSize && isDefaultPackingSize); // Sanity check
                 TypeBuilder type7 = Helpers.DynamicType(TypeAttributes.Public);
-                verify(type7.DefineNestedType(name, attributes, parent, implementedInterfaces), type7);
+                Verify(type7.DefineNestedType(name, attributes, parent, implementedInterfaces), type7);
             }
         }
 

--- a/src/System.Reflection/tests/AssemblyNameTests.cs
+++ b/src/System.Reflection/tests/AssemblyNameTests.cs
@@ -353,7 +353,7 @@ namespace System.Reflection.Tests
         {
             AssemblyName assemblyName = new AssemblyName("MyAssemblyName");
             assemblyName.Name = name;
-            Assert.Equal(name, assemblyName.Name);
+            Assert.Equal(expectedName, assemblyName.Name);
         }
 
         [Fact]
@@ -496,22 +496,21 @@ namespace System.Reflection.Tests
         {
             Assert.NotNull(expectedVersion);
 
-            Action<AssemblyName> verify =
-                an =>
+            void Verify(AssemblyName an)
+            {
+                if (expectedVersion == null)
                 {
-                    if (expectedVersion == null)
-                    {
-                        Assert.Null(an.Version);
-                    }
-                    else
-                    {
-                        Assert.Equal(expectedVersion, an.Version);
-                    }
-                };
+                    Assert.Null(an.Version);
+                }
+                else
+                {
+                    Assert.Equal(expectedVersion, an.Version);
+                }
+            }
 
             var assemblyNameFromStr = new AssemblyName("a, Version=" + versionStr);
-            verify(assemblyNameFromStr);
-            verify(new AssemblyName(assemblyNameFromStr.FullName));
+            Verify(assemblyNameFromStr);
+            Verify(new AssemblyName(assemblyNameFromStr.FullName));
 
             var versionFromStr = new Version(versionStr);
 
@@ -522,12 +521,12 @@ namespace System.Reflection.Tests
             }
 
             assemblyNameFromStr = new AssemblyName("a, Version=" + versionFromStr);
-            verify(assemblyNameFromStr);
-            verify(new AssemblyName(assemblyNameFromStr.FullName));
+            Verify(assemblyNameFromStr);
+            Verify(new AssemblyName(assemblyNameFromStr.FullName));
 
             assemblyNameFromStr = new AssemblyName() { Name = "a", Version = expectedVersion };
-            verify(assemblyNameFromStr);
-            verify(new AssemblyName(assemblyNameFromStr.FullName));
+            Verify(assemblyNameFromStr);
+            Verify(new AssemblyName(assemblyNameFromStr.FullName));
         }
 
         [Fact]
@@ -634,6 +633,7 @@ namespace System.Reflection.Tests
         [MemberData(nameof(Ctor_ProcessorArchitecture_TestData))]
         public void GetFullNameAndToString_AreEquivalentAndDoNotPreserveArchitecture(string name, ProcessorArchitecture expected)
         {
+            _ = expected;
             string originalFullName = "Test, Culture=en-US, PublicKeyToken=b77a5c561934e089, ProcessorArchitecture=" + name;
             string expectedSerializedFullName = "Test, Culture=en-US, PublicKeyToken=b77a5c561934e089";
 

--- a/src/System.Resources.ResourceManager/tests/ResourceManagerTests.cs
+++ b/src/System.Resources.ResourceManager/tests/ResourceManagerTests.cs
@@ -223,18 +223,20 @@ namespace System.Resources.Tests
 
         public static IEnumerable<object[]> EnglishNonStringResourceData()
         {
-            yield return new object[] { "Int", 42 };
-            yield return new object[] { "Float", 3.14159 };
-            yield return new object[] { "Bytes", new byte[] { 41, 42, 43, 44, 192, 168, 1, 1 } };
-            yield return new object[] { "InvalidKeyName", null };
+            yield return new object[] { "Int", 42, false };
+            yield return new object[] { "Float", 3.14159, false };
+            yield return new object[] { "Bytes", new byte[] { 41, 42, 43, 44, 192, 168, 1, 1 }, false };
+            yield return new object[] { "InvalidKeyName", null, false };
+
             yield return new object[] { "Point", new Point(50, 60), true };
             yield return new object[] { "Size", new Size(20, 30), true };
         }
 
         [Theory]
         [MemberData(nameof(EnglishNonStringResourceData))]
-        public static void GetObject(string key, object expectedValue, bool requiresBinaryFormatter = false)
+        public static void GetObject(string key, object expectedValue, bool requiresBinaryFormatter)
         {
+            _ = requiresBinaryFormatter;
             var manager = new ResourceManager("System.Resources.Tests.Resources.TestResx.netstandard17", typeof(ResourceManagerTests).GetTypeInfo().Assembly);
             Assert.Equal(expectedValue, manager.GetObject(key));
             Assert.Equal(expectedValue, manager.GetObject(key, new CultureInfo("en-US")));
@@ -303,8 +305,9 @@ namespace System.Resources.Tests
 
         [Theory]
         [MemberData(nameof(EnglishNonStringResourceData))]
-        public static void GetResourceSet_NonStrings(string key, object expectedValue, bool requiresBinaryFormatter = false)
+        public static void GetResourceSet_NonStrings(string key, object expectedValue, bool requiresBinaryFormatter)
         {
+            _ = requiresBinaryFormatter;
             var manager = new ResourceManager("System.Resources.Tests.Resources.TestResx.netstandard17", typeof(ResourceManagerTests).GetTypeInfo().Assembly);
             var culture = new CultureInfo("en-US");
             ResourceSet set = manager.GetResourceSet(culture, true, true);
@@ -324,7 +327,7 @@ namespace System.Resources.Tests
 
         [Theory]
         [MemberData(nameof(EnglishNonStringResourceData))]
-        public static void File_GetObject(string key, object expectedValue, bool requiresBinaryFormatter = false)
+        public static void File_GetObject(string key, object expectedValue, bool requiresBinaryFormatter)
         {
             var manager = ResourceManager.CreateFileBasedResourceManager("TestResx.netstandard17", Directory.GetCurrentDirectory(), null);
             if (requiresBinaryFormatter)
@@ -341,7 +344,7 @@ namespace System.Resources.Tests
 
         [Theory]
         [MemberData(nameof(EnglishNonStringResourceData))]
-        public static void File_GetResourceSet_NonStrings(string key, object expectedValue, bool requiresBinaryFormatter = false)
+        public static void File_GetResourceSet_NonStrings(string key, object expectedValue, bool requiresBinaryFormatter)
         {
             var manager = ResourceManager.CreateFileBasedResourceManager("TestResx.netstandard17", Directory.GetCurrentDirectory(), null);
             var culture = new CultureInfo("en-US");

--- a/src/System.Runtime.Extensions/tests/System/IO/PathTests_Unix.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/PathTests_Unix.cs
@@ -17,6 +17,7 @@ namespace System.IO.Tests
         public static void GetPathRoot(string value, string expected)
         {
             // UNCs and device paths have no special meaning in Unix
+            _ = expected;
             Assert.Empty(Path.GetPathRoot(value));
         }
 

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/Common/CommonTypes.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/Common/CommonTypes.cs
@@ -20,13 +20,13 @@ namespace System.Runtime.InteropServices.Tests.Common
     public struct NonGenericStruct { }
 
     [ComVisible(true)]
-    public interface GenericInterface<T> { }
+    public interface IGenericInterface<T> { }
 
     [ComVisible(true)]
-    public interface NonGenericInterface { }
+    public interface INonGenericInterface { }
 
     [ComVisible(false)]
-    public interface NonComVisibleInterface { }
+    public interface INonComVisibleInterface { }
 
     [ComVisible(false)]
     public class NonComVisibleClass { }

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/DestroyStructureTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/DestroyStructureTests.cs
@@ -80,8 +80,8 @@ namespace System.Runtime.InteropServices.Tests
 
             yield return new object[] { typeof(GenericStruct<>) };
             yield return new object[] { typeof(GenericStruct<string>) };
-            yield return new object[] { typeof(GenericInterface<>) };
-            yield return new object[] { typeof(GenericInterface<string>) };
+            yield return new object[] { typeof(IGenericInterface<>) };
+            yield return new object[] { typeof(IGenericInterface<string>) };
 
             yield return new object[] { typeof(GenericClass<>).GetTypeInfo().GenericTypeParameters[0] };
 

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GenerateGuidForTypeTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GenerateGuidForTypeTests.cs
@@ -27,8 +27,8 @@ namespace System.Runtime.InteropServices.Tests
             yield return new object[] { typeof(NonGenericStruct) };
             yield return new object[] { typeof(GenericStruct<string>) };
 
-            yield return new object[] { typeof(NonGenericInterface) };
-            yield return new object[] { typeof(GenericInterface<string>) };
+            yield return new object[] { typeof(INonGenericInterface) };
+            yield return new object[] { typeof(IGenericInterface<string>) };
 
             yield return new object[] { typeof(GenericClass<>) };
             yield return new object[] { typeof(GenericClass<>).GetTypeInfo().GenericTypeParameters[0] };

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GenerateProgIdForTypeTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GenerateProgIdForTypeTests.cs
@@ -55,8 +55,8 @@ namespace System.Runtime.InteropServices.Tests
 
             yield return new object[] { typeof(GenericClass<string>) };
             yield return new object[] { typeof(GenericStruct<string>) };
-            yield return new object[] { typeof(NonGenericInterface) };
-            yield return new object[] { typeof(GenericInterface<string>) };
+            yield return new object[] { typeof(INonGenericInterface) };
+            yield return new object[] { typeof(IGenericInterface<string>) };
 
             yield return new object[] { typeof(GenericClass<>) };
             yield return new object[] { typeof(GenericClass<>).GetTypeInfo().GenericTypeParameters[0] };

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetComInterfaceForObjectTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetComInterfaceForObjectTests.cs
@@ -17,7 +17,7 @@ namespace System.Runtime.InteropServices.Tests
         public void GetComInterfaceForObject_GenericWithValidClass_ReturnsExpected()
         {
             var o = new ClassWithInterface();
-            IntPtr iUnknown = Marshal.GetComInterfaceForObject<ClassWithInterface, NonGenericInterface>(o);
+            IntPtr iUnknown = Marshal.GetComInterfaceForObject<ClassWithInterface, INonGenericInterface>(o);
             try
             {
                 Assert.NotEqual(IntPtr.Zero, iUnknown);
@@ -33,7 +33,7 @@ namespace System.Runtime.InteropServices.Tests
         public void GetComInterfaceForObject_GenericWithValidStruct_ReturnsExpected()
         {
             var o = new StructWithInterface();
-            IntPtr iUnknown = Marshal.GetComInterfaceForObject<StructWithInterface, NonGenericInterface>(o);
+            IntPtr iUnknown = Marshal.GetComInterfaceForObject<StructWithInterface, INonGenericInterface>(o);
             try
             {
                 Assert.NotEqual(IntPtr.Zero, iUnknown);
@@ -49,7 +49,7 @@ namespace System.Runtime.InteropServices.Tests
         public void GetComInterfaceForObject_NonGenericWithValidClass_ReturnsExpected()
         {
             var o = new ClassWithInterface();
-            IntPtr iUnknown = Marshal.GetComInterfaceForObject(o, typeof(NonGenericInterface));
+            IntPtr iUnknown = Marshal.GetComInterfaceForObject(o, typeof(INonGenericInterface));
             try
             {
                 Assert.NotEqual(IntPtr.Zero, iUnknown);
@@ -65,7 +65,7 @@ namespace System.Runtime.InteropServices.Tests
         public void GetComInterfaceForObject_NonGenericWithValidStruct_ReturnsExpected()
         {
             var o = new StructWithInterface();
-            IntPtr iUnknown = Marshal.GetComInterfaceForObject(o, typeof(NonGenericInterface));
+            IntPtr iUnknown = Marshal.GetComInterfaceForObject(o, typeof(INonGenericInterface));
             try
             {
                 Assert.NotEqual(IntPtr.Zero, iUnknown);
@@ -85,7 +85,7 @@ namespace System.Runtime.InteropServices.Tests
         public void GetComInterfaceForObject_NonGenericCustomQueryInterfaceModeWithValidClass_ReturnsExpected(CustomQueryInterfaceMode mode)
         {
             var o = new ClassWithInterface();
-            IntPtr iUnknown = Marshal.GetComInterfaceForObject(o, typeof(NonGenericInterface));
+            IntPtr iUnknown = Marshal.GetComInterfaceForObject(o, typeof(INonGenericInterface), mode);
             try
             {
                 Assert.NotEqual(IntPtr.Zero, iUnknown);
@@ -105,7 +105,7 @@ namespace System.Runtime.InteropServices.Tests
         public void GetComInterfaceForObject_NonGenericCustomQueryInterfaceModeWithValidStruct_ReturnsExpected(CustomQueryInterfaceMode mode)
         {
             var o = new StructWithInterface();
-            IntPtr iUnknown = Marshal.GetComInterfaceForObject(o, typeof(NonGenericInterface), mode);
+            IntPtr iUnknown = Marshal.GetComInterfaceForObject(o, typeof(INonGenericInterface), mode);
             try
             {
                 Assert.NotEqual(IntPtr.Zero, iUnknown);
@@ -116,8 +116,8 @@ namespace System.Runtime.InteropServices.Tests
             }
         }
 
-        public class ClassWithInterface : NonGenericInterface { }
-        public class StructWithInterface : NonGenericInterface { }
+        public class ClassWithInterface : INonGenericInterface { }
+        public struct StructWithInterface : INonGenericInterface { }
 
         [Fact]
         [PlatformSpecific(TestPlatforms.AnyUnix)]
@@ -132,8 +132,8 @@ namespace System.Runtime.InteropServices.Tests
         [PlatformSpecific(TestPlatforms.Windows)]
         public void GetComInterfaceForObject_NullObject_ThrowsArgumentNullException()
         {
-            AssertExtensions.Throws<ArgumentNullException>("o", () => Marshal.GetComInterfaceForObject(null, typeof(NonGenericInterface)));
-            AssertExtensions.Throws<ArgumentNullException>("o", () => Marshal.GetComInterfaceForObject(null, typeof(NonGenericInterface), CustomQueryInterfaceMode.Allow));
+            AssertExtensions.Throws<ArgumentNullException>("o", () => Marshal.GetComInterfaceForObject(null, typeof(INonGenericInterface)));
+            AssertExtensions.Throws<ArgumentNullException>("o", () => Marshal.GetComInterfaceForObject(null, typeof(INonGenericInterface), CustomQueryInterfaceMode.Allow));
             AssertExtensions.Throws<ArgumentNullException>("o", () => Marshal.GetComInterfaceForObject<string, string>(null));
         }
 
@@ -158,8 +158,8 @@ namespace System.Runtime.InteropServices.Tests
 
             yield return new object[] { typeof(GenericStruct<>) };
             yield return new object[] { typeof(GenericStruct<string>) };
-            yield return new object[] { typeof(GenericInterface<>) };
-            yield return new object[] { typeof(GenericInterface<string>) };
+            yield return new object[] { typeof(IGenericInterface<>) };
+            yield return new object[] { typeof(IGenericInterface<string>) };
 
             yield return new object[] { typeof(GenericClass<>).GetTypeInfo().GenericTypeParameters[0] };
 
@@ -170,7 +170,7 @@ namespace System.Runtime.InteropServices.Tests
 
             yield return new object[] { typeof(NonComVisibleClass) };
             yield return new object[] { typeof(NonComVisibleStruct) };
-            yield return new object[] { typeof(NonComVisibleInterface) };
+            yield return new object[] { typeof(INonComVisibleInterface) };
 
             AssemblyBuilder collectibleAssemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);
             ModuleBuilder collectibleModuleBuilder = collectibleAssemblyBuilder.DefineDynamicModule("Module");
@@ -199,18 +199,18 @@ namespace System.Runtime.InteropServices.Tests
         [PlatformSpecific(TestPlatforms.Windows)]
         public void GetComInterfaceForObject_InvalidObject_ThrowsArgumentException(object o)
         {
-            AssertExtensions.Throws<ArgumentException>("o", () => Marshal.GetComInterfaceForObject(o, typeof(NonGenericInterface)));
-            AssertExtensions.Throws<ArgumentException>("o", () => Marshal.GetComInterfaceForObject(o, typeof(NonGenericInterface), CustomQueryInterfaceMode.Allow));
-            AssertExtensions.Throws<ArgumentException>("o", () => Marshal.GetComInterfaceForObject<object, NonGenericInterface>(o));
+            AssertExtensions.Throws<ArgumentException>("o", () => Marshal.GetComInterfaceForObject(o, typeof(INonGenericInterface)));
+            AssertExtensions.Throws<ArgumentException>("o", () => Marshal.GetComInterfaceForObject(o, typeof(INonGenericInterface), CustomQueryInterfaceMode.Allow));
+            AssertExtensions.Throws<ArgumentException>("o", () => Marshal.GetComInterfaceForObject<object, INonGenericInterface>(o));
         }
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void GetTypedObjectForIUnknown_UncastableType_ThrowsInvalidCastException()
         {
-            Assert.Throws<InvalidCastException>(() => Marshal.GetComInterfaceForObject(new object(), typeof(NonGenericInterface)));
-            Assert.Throws<InvalidCastException>(() => Marshal.GetComInterfaceForObject(new object(), typeof(NonGenericInterface), CustomQueryInterfaceMode.Allow));
-            Assert.Throws<InvalidCastException>(() => Marshal.GetComInterfaceForObject<object, NonGenericInterface>(new object()));
+            Assert.Throws<InvalidCastException>(() => Marshal.GetComInterfaceForObject(new object(), typeof(INonGenericInterface)));
+            Assert.Throws<InvalidCastException>(() => Marshal.GetComInterfaceForObject(new object(), typeof(INonGenericInterface), CustomQueryInterfaceMode.Allow));
+            Assert.Throws<InvalidCastException>(() => Marshal.GetComInterfaceForObject<object, INonGenericInterface>(new object()));
         }
     }
 }

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetDelegateForFunctionPointerTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetDelegateForFunctionPointerTests.cs
@@ -107,8 +107,8 @@ namespace System.Runtime.InteropServices.Tests
 
             yield return new object[] { typeof(GenericStruct<>) };
             yield return new object[] { typeof(GenericStruct<string>) };
-            yield return new object[] { typeof(GenericInterface<>) };
-            yield return new object[] { typeof(GenericInterface<string>) };
+            yield return new object[] { typeof(IGenericInterface<>) };
+            yield return new object[] { typeof(IGenericInterface<string>) };
 
             yield return new object[] { typeof(GenericClass<>).GetTypeInfo().GenericTypeParameters[0] };
 

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetEndComSlotTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetEndComSlotTests.cs
@@ -55,11 +55,11 @@ namespace System.Runtime.InteropServices.Tests
             yield return new object[] { typeof(GenericClass<string>) };
             yield return new object[] { typeof(GenericStruct<>) };
             yield return new object[] { typeof(GenericStruct<string>) };
-            yield return new object[] { typeof(GenericInterface<>) };
-            yield return new object[] { typeof(GenericInterface<string>) };
+            yield return new object[] { typeof(IGenericInterface<>) };
+            yield return new object[] { typeof(IGenericInterface<string>) };
             yield return new object[] { typeof(NonComVisibleClass) };
             yield return new object[] { typeof(NonComVisibleStruct) };
-            yield return new object[] { typeof(NonComVisibleInterface) };
+            yield return new object[] { typeof(INonComVisibleInterface) };
             yield return new object[] { typeof(int[]) };
             yield return new object[] { typeof(int[][]) };
             yield return new object[] { typeof(int[,]) };

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetNativeVariantForObjectTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetNativeVariantForObjectTests.cs
@@ -156,7 +156,7 @@ namespace System.Runtime.InteropServices.Tests
             var structWithInterface = new StructWithInterface();
             yield return new object[] { new ClassWithInterface[] { classWithInterface, null }, (VarEnum)8201, (IntPtr)(-1), new object[] { classWithInterface, null } };
             yield return new object[] { new StructWithInterface[] { structWithInterface }, (VarEnum)8228, (IntPtr)(-1), new StructWithInterface[] { structWithInterface } };
-            yield return new object[] { new NonGenericInterface[] { classWithInterface, structWithInterface, null }, (VarEnum)8201, (IntPtr)(-1), new object[] { classWithInterface, structWithInterface, null } };
+            yield return new object[] { new INonGenericInterface[] { classWithInterface, structWithInterface, null }, (VarEnum)8201, (IntPtr)(-1), new object[] { classWithInterface, structWithInterface, null } };
 
             // Enums.
             yield return new object[] { SByteEnum.Value2, VarEnum.VT_I1, (IntPtr)1, (sbyte)1 };
@@ -431,8 +431,8 @@ namespace System.Runtime.InteropServices.Tests
             public int Value;
         }
 
-        public class ClassWithInterface : NonGenericInterface { }
-        public struct StructWithInterface : NonGenericInterface { }
+        public class ClassWithInterface : INonGenericInterface { }
+        public struct StructWithInterface : INonGenericInterface { }
 
         public enum SByteEnum : sbyte { Value1, Value2 }
         public enum Int16Enum : short { Value1, Value2 }

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetStartComSlotTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetStartComSlotTests.cs
@@ -55,11 +55,11 @@ namespace System.Runtime.InteropServices.Tests
             yield return new object[] { typeof(GenericClass<string>) };
             yield return new object[] { typeof(GenericStruct<>) };
             yield return new object[] { typeof(GenericStruct<string>) };
-            yield return new object[] { typeof(GenericInterface<>) };
-            yield return new object[] { typeof(GenericInterface<string>) };
+            yield return new object[] { typeof(IGenericInterface<>) };
+            yield return new object[] { typeof(IGenericInterface<string>) };
             yield return new object[] { typeof(NonComVisibleClass) };
             yield return new object[] { typeof(NonComVisibleStruct) };
-            yield return new object[] { typeof(NonComVisibleInterface) };
+            yield return new object[] { typeof(INonComVisibleInterface) };
             yield return new object[] { typeof(int[]) };
             yield return new object[] { typeof(int[][]) };
             yield return new object[] { typeof(int[,]) };

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetTypedObjectForIUnknownTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetTypedObjectForIUnknownTests.cs
@@ -43,8 +43,8 @@ namespace System.Runtime.InteropServices.Tests
                 }
             }
 
-            yield return new object[] { new ClassWithInterface(), typeof(NonGenericInterface) };
-            yield return new object[] { new StructWithInterface(), typeof(NonGenericInterface) };
+            yield return new object[] { new ClassWithInterface(), typeof(INonGenericInterface) };
+            yield return new object[] { new StructWithInterface(), typeof(INonGenericInterface) };
 
             yield return new object[] { new GenericClass<string>(), typeof(object) };
             yield return new object[] { new Dictionary<string, int>(), typeof(object) };
@@ -113,7 +113,7 @@ namespace System.Runtime.InteropServices.Tests
         {
             yield return new object[] { typeof(GenericClass<string>) };
             yield return new object[] { typeof(GenericStruct<string>) };
-            yield return new object[] { typeof(GenericInterface<string>) };
+            yield return new object[] { typeof(IGenericInterface<string>) };
 
             yield return new object[] { typeof(GenericClass<>) };
 
@@ -145,7 +145,7 @@ namespace System.Runtime.InteropServices.Tests
             yield return new object[] { new object(), typeof(NonGenericClass) };
             yield return new object[] { new object(), typeof(NonGenericStruct) };
             yield return new object[] { new object(), typeof(NonGenericStruct) };
-            yield return new object[] { new object(), typeof(NonGenericInterface) };
+            yield return new object[] { new object(), typeof(INonGenericInterface) };
 
             yield return new object[] { new NonGenericClass(), typeof(IFormattable) };
             yield return new object[] { new ClassWithInterface(), typeof(IFormattable) };
@@ -198,8 +198,8 @@ namespace System.Runtime.InteropServices.Tests
             }
         }
 
-        public class ClassWithInterface : NonGenericInterface { }
-        public struct StructWithInterface : NonGenericInterface { }
+        public class ClassWithInterface : INonGenericInterface { }
+        public struct StructWithInterface : INonGenericInterface { }
 
         private static void NonGenericMethod(int i) { }
         public delegate void NonGenericDelegate(int i);

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/IsTypeVisibleFromComTests.Windows.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/IsTypeVisibleFromComTests.Windows.cs
@@ -21,7 +21,7 @@ namespace System.Runtime.InteropServices.Tests
             yield return new object[] { typeof(ProtectedType), false };
             yield return new object[] { typeof(InternalType), false };
             yield return new object[] { typeof(InnerManagedInterface), false};
-            yield return new object[] { typeof(NonGenericInterface), true };
+            yield return new object[] { typeof(INonGenericInterface), true };
             yield return new object[] { typeof(NonGenericStruct), true };
             yield return new object[] { typeof(ManagedClassWithComVisibleFalse), false };
             yield return new object[] { typeof(ManagedClassWithComVisibleTrue), true };

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/PrelinkAllTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/PrelinkAllTests.cs
@@ -25,8 +25,8 @@ namespace System.Runtime.InteropServices.Tests
             yield return new object[] { typeof(AbstractClass) };
             yield return new object[] { typeof(NonGenericStruct) };
             yield return new object[] { typeof(GenericStruct<string>) };
-            yield return new object[] { typeof(NonGenericInterface) };
-            yield return new object[] { typeof(GenericInterface<string>) };
+            yield return new object[] { typeof(INonGenericInterface) };
+            yield return new object[] { typeof(IGenericInterface<string>) };
 
             yield return new object[] { typeof(GenericClass<>) };
             yield return new object[] { typeof(GenericClass<>).GetTypeInfo().GenericTypeParameters[0] };

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/PtrToStructureTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/PtrToStructureTests.cs
@@ -192,8 +192,8 @@ namespace System.Runtime.InteropServices.Tests
             yield return new object[] { typeof(GenericClass<>) };
             yield return new object[] { typeof(GenericStruct<string>) };
             yield return new object[] { typeof(GenericStruct<>) };
-            yield return new object[] { typeof(GenericInterface<string>) };
-            yield return new object[] { typeof(GenericInterface<>) };
+            yield return new object[] { typeof(IGenericInterface<string>) };
+            yield return new object[] { typeof(IGenericInterface<>) };
         }
 
         [Theory]

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/SizeOfTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/SizeOfTests.cs
@@ -60,8 +60,8 @@ namespace System.Runtime.InteropServices.Tests
             yield return new object[] { typeof(GenericClass<string>), "t" };
             yield return new object[] { typeof(GenericStruct<>), "t" };
             yield return new object[] { typeof(GenericStruct<string>), "t" };
-            yield return new object[] { typeof(GenericInterface<>), "t" };
-            yield return new object[] { typeof(GenericInterface<string>), "t" };
+            yield return new object[] { typeof(IGenericInterface<>), "t" };
+            yield return new object[] { typeof(IGenericInterface<string>), "t" };
 
             yield return new object[] { typeof(GenericClass<>).GetTypeInfo().GenericTypeParameters[0], null };
 

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/SafeBufferTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/SafeBufferTests.cs
@@ -65,8 +65,8 @@ namespace System.Runtime.InteropServices.Tests
             var buffer = new SubBuffer(true);
             buffer.Initialize(4);
 
-            Assert.Throws<ArgumentException>(null, () => buffer.Read<int>(4));
-            Assert.Throws<ArgumentException>(null, () => buffer.Write<int>(4, 2));
+            Assert.Throws<ArgumentException>(null, () => buffer.Read<int>(byteOffset));
+            Assert.Throws<ArgumentException>(null, () => buffer.Write<int>(byteOffset, 2));
         }
 
         [Fact]

--- a/src/System.Runtime.Numerics/tests/ComplexTests.cs
+++ b/src/System.Runtime.Numerics/tests/ComplexTests.cs
@@ -392,7 +392,8 @@ namespace System.Numerics.Tests
         public static void AddDouble(double realLeft, double imaginaryLeft, double realRight, double imaginaryRight)
         {
             var left = new Complex(realLeft, imaginaryLeft);
-            var right = realRight;
+            _ = imaginaryRight; // not used when testing operations with doubles
+            double right = realRight;
 
             // Calculate the expected results
             Complex expected = left + new Complex(right, 0.0);
@@ -734,7 +735,8 @@ namespace System.Numerics.Tests
         public static void DivideByDouble(double realLeft, double imaginaryLeft, double realRight, double imaginaryRight)
         {
             var dividend = new Complex(realLeft, imaginaryLeft);
-            var divisor = realRight;
+            _ = imaginaryRight; // not used when testing operations with doubles
+            double divisor = realRight;
 
             Complex expected = dividend / new Complex(realRight, 0.0);
             double expectedReal = expected.Real;
@@ -755,7 +757,8 @@ namespace System.Numerics.Tests
         [MemberData(nameof(Invalid_4_TestData))]
         public static void DivideByComplex(double realLeft, double imaginaryLeft, double realRight, double imaginaryRight)
         {
-            var dividend = realLeft;
+            _ = imaginaryLeft; // not used when testing operations with doubles
+            double dividend = realLeft;
             var divisor = new Complex(realRight, imaginaryRight);
 
             Complex expected = new Complex(realLeft, 0.0) / divisor;
@@ -1182,7 +1185,8 @@ namespace System.Numerics.Tests
         public static void MultiplyDouble(double realLeft, double imaginaryLeft, double realRight, double imaginaryRight)
         {
             var left = new Complex(realLeft, imaginaryLeft);
-            var right = realRight;
+            _ = imaginaryRight; // not used when testing operations with doubles
+            double right = realRight;
 
             Complex expected = left * new Complex(right, 0.0);
             double expectedReal = expected.Real;
@@ -1499,7 +1503,8 @@ namespace System.Numerics.Tests
         public static void SubtractDouble(double realLeft, double imaginaryLeft, double realRight, double imaginaryRight)
         {
             var left = new Complex(realLeft, imaginaryLeft);
-            var right = realRight;
+            _ = imaginaryRight; // not used when testing operations with doubles
+            double right = realRight;
 
             // calculate the expected results
             Complex expected = left - new Complex(right, 0.0);

--- a/src/System.Runtime/tests/System/ArrayTests.cs
+++ b/src/System.Runtime/tests/System/ArrayTests.cs
@@ -1604,8 +1604,9 @@ namespace System.Tests
         [MemberData(nameof(Copy_SZArray_PrimitiveWidening_TestData))]
         [MemberData(nameof(Copy_SZArray_UnreliableConversion_CanPerform_TestData))]
         [MemberData(nameof(Copy_Array_UnreliableConversion_CanPerform_TestData))]
-        public static void ConstrainedCopy_UnreliableConversion_ThrowsArrayTypeMismatchException(Array sourceArray, int sourceIndex, Array destinationArray, int destinationIndex, int length, Array _)
+        public static void ConstrainedCopy_UnreliableConversion_ThrowsArrayTypeMismatchException(Array sourceArray, int sourceIndex, Array destinationArray, int destinationIndex, int length, Array ignored)
         {
+            _ = ignored;
             Assert.Throws<ArrayTypeMismatchException>(() => Array.ConstrainedCopy(sourceArray, sourceIndex, destinationArray, destinationIndex, length));
         }
 

--- a/src/System.Runtime/tests/System/DateTimeTests.cs
+++ b/src/System.Runtime/tests/System/DateTimeTests.cs
@@ -319,8 +319,7 @@ namespace System.Tests
         [InlineData(10000)]
         public void IsLeapYear_InvalidYear_ThrowsArgumentOutOfRangeException(int year)
         {
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("year", () => DateTime.IsLeapYear(0));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("year", () => DateTime.IsLeapYear(10000));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("year", () => DateTime.IsLeapYear(year));
         }
 
         public static IEnumerable<object[]> IsDaylightSavingTime_TestData()

--- a/src/System.Runtime/tests/System/GuidTests.cs
+++ b/src/System.Runtime/tests/System/GuidTests.cs
@@ -51,8 +51,9 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(GuidStrings_Valid_TestData))]
-        public static void Ctor_String(string input, string _, Guid expected)
+        public static void Ctor_String(string input, string format, Guid expected)
         {
+            _ = format;
             Assert.Equal(expected, new Guid(input));
         }
 

--- a/src/System.Runtime/tests/System/GuidTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/GuidTests.netcoreapp.cs
@@ -52,6 +52,7 @@ namespace System.Tests
         [MemberData(nameof(ToString_TestData))]
         public static void TryFormat_LengthTooSmall_ReturnsFalse(Guid guid, string format, string expected)
         {
+            _ = expected;
             Assert.False(guid.TryFormat(new Span<char>(new char[guid.ToString(format).Length - 1]), out int charsWritten, format));
             Assert.Equal(0, charsWritten);
         }
@@ -60,6 +61,7 @@ namespace System.Tests
         [MemberData(nameof(ToString_TestData))]
         public static void TryFormat_CharsWritten_EqualsZero_WhenSpanTooSmall(Guid guid, string format, string expected)
         {
+            _ = expected;
             Assert.False(guid.TryFormat(new Span<char>(new char[guid.ToString(format).Length - 1]), out int charsWritten, format));
             Assert.Equal(0, charsWritten);
         }

--- a/src/System.Runtime/tests/System/Text/StringBuilderTests.cs
+++ b/src/System.Runtime/tests/System/Text/StringBuilderTests.cs
@@ -571,6 +571,7 @@ namespace System.Text.Tests
         [InlineData("Hello", null, 0, "Hello")]
         public static unsafe void Append_CharPointer(string original, char[] charArray, int valueCount, string expected)
         {
+            _ = charArray; // https://github.com/xunit/xunit/issues/1969
             fixed (char* value = charArray)
             {
                 var builder = new StringBuilder(original);

--- a/src/System.Security.AccessControl/tests/DiscretionaryAcl/DiscretionaryAcl_AddAccess.cs
+++ b/src/System.Security.AccessControl/tests/DiscretionaryAcl/DiscretionaryAcl_AddAccess.cs
@@ -78,7 +78,7 @@ namespace System.Security.AccessControl.Tests
         [MemberData(nameof(DiscretionaryACL_AddAccess))]
         public static void AddAccess(bool isContainer, bool isDS, int accessControlType, string sid, int accessMask, int inheritanceFlags, int propagationFlags, string initialRawAclStr, string verifierRawAclStr)
         {
-            RawAcl rawAcl = Utils.CreateRawAclFromString(verifierRawAclStr);
+            RawAcl rawAcl = Utils.CreateRawAclFromString(initialRawAclStr);
             DiscretionaryAcl discretionaryAcl = new DiscretionaryAcl(isContainer, isDS, rawAcl);
             rawAcl = Utils.CreateRawAclFromString(verifierRawAclStr);
 

--- a/src/System.Security.AccessControl/tests/DiscretionaryAcl/DiscretionaryAcl_Constructor3.cs
+++ b/src/System.Security.AccessControl/tests/DiscretionaryAcl/DiscretionaryAcl_Constructor3.cs
@@ -95,7 +95,7 @@ namespace System.Security.AccessControl.Tests
         [MemberData(nameof(DiscretionaryACL_Constructor3))]
         public static void Constructor3(bool isContainer, bool isDS, string initialRaqAclStr, string verifierRawAclStr, bool wasCanonicalInitially)
         {
-            RawAcl rawAcl = Utils.CreateRawAclFromString(verifierRawAclStr);
+            RawAcl rawAcl = Utils.CreateRawAclFromString(initialRaqAclStr);
             DiscretionaryAcl discretionaryAcl = new DiscretionaryAcl(isContainer, isDS, rawAcl);
             rawAcl = Utils.CreateRawAclFromString(verifierRawAclStr);
 

--- a/src/System.Security.AccessControl/tests/DiscretionaryAcl/DiscretionaryAcl_RemoveAccess.cs
+++ b/src/System.Security.AccessControl/tests/DiscretionaryAcl/DiscretionaryAcl_RemoveAccess.cs
@@ -79,7 +79,7 @@ namespace System.Security.AccessControl.Tests
         [MemberData(nameof(DiscretionaryACL_RemoveAccess))]
         public static void RemoveAccess(bool isContainer, bool isDS, int accessControlType, string sid, int accessMask, int inheritanceFlags, int propagationFlags, string initialRawAclStr, string verifierRawAclStr, bool removePossible)
         {
-            RawAcl rawAcl = Utils.CreateRawAclFromString(verifierRawAclStr);
+            RawAcl rawAcl = Utils.CreateRawAclFromString(initialRawAclStr);
             DiscretionaryAcl discretionaryAcl = new DiscretionaryAcl(isContainer, isDS, rawAcl);
             rawAcl = Utils.CreateRawAclFromString(verifierRawAclStr);
 

--- a/src/System.Security.AccessControl/tests/DiscretionaryAcl/DiscretionaryAcl_RemoveAccessSpecific.cs
+++ b/src/System.Security.AccessControl/tests/DiscretionaryAcl/DiscretionaryAcl_RemoveAccessSpecific.cs
@@ -69,7 +69,7 @@ namespace System.Security.AccessControl.Tests
         [MemberData(nameof(DiscretionaryACL_RemoveAccessSpecific))]
         public static void RemoveAccessSpecific(bool isContainer, bool isDS, int accessControlType, string sid, int accessMask, int inheritanceFlags, int propagationFlags, string initialRawAclStr, string verifierRawAclStr)
         {
-            RawAcl rawAcl = Utils.CreateRawAclFromString(verifierRawAclStr);
+            RawAcl rawAcl = Utils.CreateRawAclFromString(initialRawAclStr);
             DiscretionaryAcl discretionaryAcl = new DiscretionaryAcl(isContainer, isDS, rawAcl);
             rawAcl = Utils.CreateRawAclFromString(verifierRawAclStr);
 

--- a/src/System.Security.AccessControl/tests/DiscretionaryAcl/DiscretionaryAcl_SetAccess.cs
+++ b/src/System.Security.AccessControl/tests/DiscretionaryAcl/DiscretionaryAcl_SetAccess.cs
@@ -64,7 +64,7 @@ namespace System.Security.AccessControl.Tests
         [MemberData(nameof(DiscretionaryACL_SetAccess))]
         public static void SetAccess(bool isContainer, bool isDS, int accessControlType, string sid, int accessMask, int inheritanceFlags, int propagationFlags, string initialRawAclStr, string verifierRawAclStr)
         {
-            RawAcl rawAcl = Utils.CreateRawAclFromString(verifierRawAclStr);
+            RawAcl rawAcl = Utils.CreateRawAclFromString(initialRawAclStr);
             DiscretionaryAcl discretionaryAcl = new DiscretionaryAcl(isContainer, isDS, rawAcl);
             rawAcl = Utils.CreateRawAclFromString(verifierRawAclStr);
 

--- a/src/System.Security.Cryptography.Cng/tests/ECDsaCngTests.cs
+++ b/src/System.Security.Cryptography.Cng/tests/ECDsaCngTests.cs
@@ -194,8 +194,8 @@ namespace System.Security.Cryptography.Cng.Tests
             }
         }
 
-        [Theory, MemberData(nameof(TestInvalidCurves))]
-        public static void TestCreateKeyFromCngAlgorithmNegative(CurveDef curveDef)
+        [Fact]
+        public static void TestCreateKeyFromCngAlgorithmNegative()
         {
             CngAlgorithm alg = CngAlgorithm.ECDsa;
             Assert.ThrowsAny<Exception>(() => CngKey.Create(alg));

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ParseTag.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ParseTag.cs
@@ -88,6 +88,7 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData("MultiByte-ValueSubtlyTooBig", "DFC1C0808000")]
         public static void ParseCorruptTag(string description, string inputHex)
         {
+            _ = description;
             byte[] inputBytes = inputHex.HexToByteArray();
 
             Assert.False(Asn1Tag.TryDecode(inputBytes, out Asn1Tag tag, out var bytesRead));

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadBMPString.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadBMPString.cs
@@ -259,6 +259,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             PublicEncodingRules ruleSet,
             string inputHex)
         {
+            _ = description;
             byte[] inputData = inputHex.HexToByteArray();
             AsnReader reader = new AsnReader(inputData, (AsnEncodingRules)ruleSet);
 
@@ -317,6 +318,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             PublicEncodingRules ruleSet,
             string inputHex)
         {
+            _ = description;
             byte[] inputData = inputHex.HexToByteArray();
             byte[] outputData = new byte[inputData.Length + 1];
             outputData[0] = 252;
@@ -379,6 +381,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             PublicEncodingRules ruleSet,
             string inputHex)
         {
+            _ = description;
             byte[] inputData = inputHex.HexToByteArray();
             AsnReader reader = new AsnReader(inputData, (AsnEncodingRules)ruleSet);
 
@@ -441,6 +444,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             PublicEncodingRules ruleSet,
             string inputHex)
         {
+            _ = description;
             byte[] inputData = inputHex.HexToByteArray();
             TryCopyBMPString_Throws(ruleSet, inputData);
         }

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadBitString.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadBitString.cs
@@ -24,6 +24,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             PublicEncodingRules ruleSet,
             string inputHex)
         {
+            _ = description;
             byte[] inputData = inputHex.HexToByteArray();
             AsnReader reader = new AsnReader(inputData, (AsnEncodingRules)ruleSet);
 
@@ -76,6 +77,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             PublicEncodingRules ruleSet,
             string inputHex)
         {
+            _ = description;
             byte[] inputData = inputHex.HexToByteArray();
             AsnReader reader = new AsnReader(inputData, (AsnEncodingRules)ruleSet);
 
@@ -326,6 +328,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             PublicEncodingRules ruleSet,
             string inputHex)
         {
+            _ = description;
             byte[] inputData = inputHex.HexToByteArray();
             TryCopyBitStringBytes_Throws(ruleSet, inputData);
         }

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadBoolean.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadBoolean.cs
@@ -186,6 +186,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             PublicEncodingRules ruleSet,
             string inputHex)
         {
+            _ = description;
             byte[] inputData = inputHex.HexToByteArray();
 
             AsnReader reader = new AsnReader(inputData, (AsnEncodingRules)ruleSet);

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadGeneralizedTime.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadGeneralizedTime.cs
@@ -442,6 +442,7 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData("yyyyMMddHHmmss.secondFrac-HH:mm", "181932303136313130363031323334352E393939392D30313A3138")]
         public static void GetGeneralizedTime_Throws(string description, string inputHex)
         {
+            _ = description;
             byte[] inputData = inputHex.HexToByteArray();
             AsnReader reader = new AsnReader(inputData, AsnEncodingRules.BER);
 

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadIA5String.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadIA5String.cs
@@ -253,6 +253,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             PublicEncodingRules ruleSet,
             string inputHex)
         {
+            _ = description;
             byte[] inputData = inputHex.HexToByteArray();
             AsnReader reader = new AsnReader(inputData, (AsnEncodingRules)ruleSet);
 
@@ -308,6 +309,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             PublicEncodingRules ruleSet,
             string inputHex)
         {
+            _ = description;
             byte[] inputData = inputHex.HexToByteArray();
             byte[] outputData = new byte[inputData.Length + 1];
             outputData[0] = 252;
@@ -347,6 +349,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             PublicEncodingRules ruleSet,
             string inputHex)
         {
+            _ = description;
             byte[] inputData = inputHex.HexToByteArray();
             AsnReader reader = new AsnReader(inputData, (AsnEncodingRules)ruleSet);
 
@@ -403,6 +406,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             PublicEncodingRules ruleSet,
             string inputHex)
         {
+            _ = description;
             byte[] inputData = inputHex.HexToByteArray();
             TryCopyIA5String_Throws(ruleSet, inputData);
         }

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadInteger.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadInteger.cs
@@ -32,6 +32,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             PublicEncodingRules ruleSet,
             string inputHex)
         {
+            _ = description;
             byte[] data = inputHex.HexToByteArray();
             AsnReader reader = new AsnReader(data, (AsnEncodingRules)ruleSet);
 

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadLength.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadLength.cs
@@ -109,6 +109,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             PublicEncodingRules rules,
             string inputHex)
         {
+            _ = description;
             byte[] inputData = inputHex.HexToByteArray();
             AsnReader reader = new AsnReader(inputData, (AsnEncodingRules)rules);
 

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadNull.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadNull.cs
@@ -43,6 +43,7 @@ namespace System.Security.Cryptography.Tests.Asn1
         [InlineData("Incomplete length", PublicEncodingRules.BER, "0581")]
         public static void ReadNull_Throws(string description, PublicEncodingRules ruleSet, string inputHex)
         {
+            _ = description;
             byte[] inputData = inputHex.HexToByteArray();
             AsnReader reader = new AsnReader(inputData, (AsnEncodingRules)ruleSet);
 

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadObjectIdentifier.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadObjectIdentifier.cs
@@ -38,6 +38,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             PublicEncodingRules ruleSet,
             string inputHex)
         {
+            _ = description;
             byte[] inputData = inputHex.HexToByteArray();
             AsnReader reader = new AsnReader(inputData, (AsnEncodingRules)ruleSet);
 

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadOctetString.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadOctetString.cs
@@ -23,6 +23,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             PublicEncodingRules ruleSet,
             string inputHex)
         {
+            _ = description;
             byte[] inputData = inputHex.HexToByteArray();
             AsnReader reader = new AsnReader(inputData, (AsnEncodingRules)ruleSet);
 
@@ -66,6 +67,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             PublicEncodingRules ruleSet,
             string inputHex)
         {
+            _ = description;
             byte[] inputData = inputHex.HexToByteArray();
             AsnReader reader = new AsnReader(inputData, (AsnEncodingRules)ruleSet);
 
@@ -255,6 +257,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             PublicEncodingRules ruleSet,
             string inputHex)
         {
+            _ = description;
             byte[] inputData = inputHex.HexToByteArray();
             TryCopyOctetStringBytes_Throws(ruleSet, inputData);
         }

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadSequence.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadSequence.cs
@@ -88,6 +88,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             PublicEncodingRules ruleSet,
             string inputHex)
         {
+            _ = description;
             byte[] inputData = inputHex.HexToByteArray();
             AsnReader reader = new AsnReader(inputData, (AsnEncodingRules)ruleSet);
 

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadSetOf.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadSetOf.cs
@@ -89,6 +89,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             PublicEncodingRules ruleSet,
             string inputHex)
         {
+            _ = description;
             byte[] inputData = inputHex.HexToByteArray();
             AsnReader reader = new AsnReader(inputData, (AsnEncodingRules)ruleSet);
 

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadUTF8String.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadUTF8String.cs
@@ -267,6 +267,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             PublicEncodingRules ruleSet,
             string inputHex)
         {
+            _ = description;
             byte[] inputData = inputHex.HexToByteArray();
             AsnReader reader = new AsnReader(inputData, (AsnEncodingRules)ruleSet);
 
@@ -322,6 +323,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             PublicEncodingRules ruleSet,
             string inputHex)
         {
+            _ = description;
             byte[] inputData = inputHex.HexToByteArray();
             byte[] outputData = new byte[inputData.Length + 1];
             outputData[0] = 252;
@@ -361,6 +363,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             PublicEncodingRules ruleSet,
             string inputHex)
         {
+            _ = description;
             byte[] inputData = inputHex.HexToByteArray();
             AsnReader reader = new AsnReader(inputData, (AsnEncodingRules)ruleSet);
 
@@ -417,6 +420,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             PublicEncodingRules ruleSet,
             string inputHex)
         {
+            _ = description;
             byte[] inputData = inputHex.HexToByteArray();
             TryCopyUTF8String_Throws(ruleSet, inputData);
         }

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadUtcTime.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Reader/ReadUtcTime.cs
@@ -122,6 +122,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             PublicEncodingRules ruleSet,
             string inputHex)
         {
+            _ = description;
             byte[] inputData = inputHex.HexToByteArray();
             AsnReader reader = new AsnReader(inputData, (AsnEncodingRules)ruleSet);
 

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteObjectIdentifier.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteObjectIdentifier.cs
@@ -64,6 +64,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             PublicEncodingRules ruleSet,
             string nonOidValue)
         {
+            _ = description;
             using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
             {
                 if (nonOidValue == null)
@@ -87,6 +88,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             PublicEncodingRules ruleSet,
             string nonOidValue)
         {
+            _ = description;
             using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
             {
                 Assert.Throws<CryptographicException>(
@@ -101,6 +103,7 @@ namespace System.Security.Cryptography.Tests.Asn1
             PublicEncodingRules ruleSet,
             string nonOidValue)
         {
+            _ = description;
             using (AsnWriter writer = new AsnWriter((AsnEncodingRules)ruleSet))
             {
                 Oid nonOidObj = new Oid(nonOidValue, "FriendlyName does not matter");

--- a/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteUtcTime.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Asn1/Writer/WriteUtcTime.cs
@@ -156,6 +156,7 @@ namespace System.Security.Cryptography.Tests.Asn1
 
                 writer.Reset();
 
+                _ = expectedHexPayload;
                 AssertExtensions.Throws<ArgumentOutOfRangeException>(
                     "value",
                     () => writer.WriteUtcTime(input, input.Year + 100));

--- a/src/System.Security.Cryptography.Encoding/tests/Base64TransformsTests.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Base64TransformsTests.cs
@@ -149,6 +149,7 @@ namespace System.Security.Cryptography.Encoding.Tests
                 Assert.True(inputBytes.Length > 4);
 
                 // Test passing blocks > 4 characters to TransformFinalBlock (not supported)
+                _ = expected;
                 AssertExtensions.Throws<ArgumentOutOfRangeException>("inputCount", () => transform.TransformFinalBlock(inputBytes, 0, inputBytes.Length));
             }
         }

--- a/src/System.Security.Cryptography.Encoding/tests/Oid.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Oid.cs
@@ -184,6 +184,7 @@ namespace System.Security.Cryptography.Encoding.Tests
         public static void LookupOidByValue_Method_WrongGroup(string oidValue, string friendlyName)
         {
             // Oid group is implemented strictly - no fallback to OidGroup.All as with many other parts of Crypto.
+            _ = friendlyName;
             Assert.Throws<CryptographicException>(() => Oid.FromOidValue(oidValue, OidGroup.EncryptionAlgorithm));
         }
 
@@ -240,6 +241,7 @@ namespace System.Security.Cryptography.Encoding.Tests
         public static void LookupOidByFriendlyName_Method_WrongGroup(string oidValue, string friendlyName)
         {
             // Oid group is implemented strictly - no fallback to OidGroup.All as with many other parts of Crypto.
+            _ = oidValue;
             Assert.Throws<CryptographicException>(() => Oid.FromFriendlyName(friendlyName, OidGroup.EncryptionAlgorithm));
         }
 

--- a/src/System.Security.Cryptography.Pkcs/tests/Rfc3161/TimestampTokenInfoTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/Rfc3161/TimestampTokenInfoTests.cs
@@ -374,6 +374,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
             bool shouldParse,
             long? expectedTotalMicroseconds)
         {
+            _ = description;
             string inputHex =
                 "305A0201010601003031300D0609608648016503040201050004200000000000" +
                 "0000000000000000000000000000000000000000000000000000000201081817" +

--- a/src/System.Security.Cryptography.Pkcs/tests/SignedCms/SignedCmsTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/SignedCms/SignedCmsTests.cs
@@ -62,6 +62,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         [InlineData("Too-long BER length", "3005")]
         public static void DecodeInvalid(string description, string inputHex)
         {
+            _ = description;
             byte[] inputData = inputHex.HexToByteArray();
 
             SignedCms cms = new SignedCms();

--- a/src/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/CertificateRequestUsageTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/CertificateRequestUsageTests.cs
@@ -479,6 +479,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         [InlineData("Zero Tag", "0000")]
         public static void InvalidPublicKeyEncoding(string caseName, string parametersHex)
         {
+            _ = caseName;
+
             var generator = new InvalidSignatureGenerator(
                 Array.Empty<byte>(),
                 parametersHex.HexToByteArray(),
@@ -509,6 +511,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         [InlineData("Dangling LengthLength", "300206035102013081")]
         public static void InvalidSignatureAlgorithmEncoding(string caseName, string sigAlgHex)
         {
+            _ = caseName;
+
             var generator = new InvalidSignatureGenerator(
                 Array.Empty<byte>(),
                 new byte[] { 0x05, 0x00 },

--- a/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
@@ -265,9 +265,9 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 DateTime local = utcTime.ToLocalTime();
                 DateTime unspecified = new DateTime(local.Ticks);
 
-                testCases.Add(new object[] { utcTime, true, utcTime.Kind });
-                testCases.Add(new object[] { local, true, local.Kind });
-                testCases.Add(new object[] { unspecified, true, unspecified.Kind });
+                testCases.Add(new object[] { utcTime, true });
+                testCases.Add(new object[] { local, true });
+                testCases.Add(new object[] { unspecified, true });
             }
 
             foreach (DateTime utcTime in invalidTimes)
@@ -275,9 +275,9 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 DateTime local = utcTime.ToLocalTime();
                 DateTime unspecified = new DateTime(local.Ticks);
 
-                testCases.Add(new object[] { utcTime, false, utcTime.Kind });
-                testCases.Add(new object[] { local, false, local.Kind });
-                testCases.Add(new object[] { unspecified, false, unspecified.Kind });
+                testCases.Add(new object[] { utcTime, false });
+                testCases.Add(new object[] { local, false });
+                testCases.Add(new object[] { unspecified, false });
             }
 
             return testCases;
@@ -285,7 +285,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [Theory]
         [MemberData(nameof(VerifyExpressionData))]
-        public static void VerifyExpiration_LocalTime(DateTime verificationTime, bool shouldBeValid, DateTimeKind kind)
+        public static void VerifyExpiration_LocalTime(DateTime verificationTime, bool shouldBeValid)
         {
             using (var microsoftDotCom = new X509Certificate2(TestData.MicrosoftDotComSslCertBytes))
             using (var microsoftDotComIssuer = new X509Certificate2(TestData.MicrosoftDotComIssuerBytes))

--- a/src/System.Security.Cryptography.X509Certificates/tests/ContentTypeTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/ContentTypeTests.cs
@@ -24,6 +24,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [MemberData(nameof(GetContentBlobsWithType))]
         public static void TestBlobContentType(string caseName, byte[] blob, X509ContentType contentType)
         {
+            _ = caseName;
             X509ContentType blobType = X509Certificate2.GetCertContentType(blob);
             Assert.Equal(contentType, blobType);
         }

--- a/src/System.Security.Cryptography.X509Certificates/tests/PublicKeyTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/PublicKeyTests.cs
@@ -312,6 +312,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [Theory, MemberData(nameof(BrainpoolCurves))]
         public static void TestKey_ECDsabrainpool_PublicKey(byte[] curveData, byte[] notUsed)
         {
+            _ = notUsed;
             byte[] helloBytes = Encoding.ASCII.GetBytes("Hello");
 
             try

--- a/src/System.Security.Cryptography.X509Certificates/tests/X500DistinguishedNameTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X500DistinguishedNameTests.cs
@@ -109,21 +109,12 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [Theory]
         [MemberData(nameof(InternallyQuotedRDNs))]
-        public static void QuotedWithQuotes(string quoted, string notQuoted, string hexEncoded)
+        public static void QuotedWithQuotesAsAppropriate(string quoted, string notQuoted, string hexEncoded)
         {
             byte[] encoded = hexEncoded.HexToByteArray();
             X500DistinguishedName dn = new X500DistinguishedName(encoded);
 
             Assert.Equal(quoted, dn.Decode(X500DistinguishedNameFlags.None));
-        }
-
-        [Theory]
-        [MemberData(nameof(InternallyQuotedRDNs))]
-        public static void NotQuotedWithQuotes(string quoted, string notQuoted, string hexEncoded)
-        {
-            byte[] encoded = hexEncoded.HexToByteArray();
-            X500DistinguishedName dn = new X500DistinguishedName(encoded);
-
             Assert.Equal(notQuoted, dn.Decode(X500DistinguishedNameFlags.DoNotUseQuotes));
         }
         

--- a/src/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/Atom10FeedFormatterTests.cs
+++ b/src/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/Atom10FeedFormatterTests.cs
@@ -1754,9 +1754,9 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Theory]
-        [InlineData(true, true)]
-        [InlineData(false, false)]
-        public void Read_EmptyItem_ReturnsExpected(bool preserveAttributeExtensions, bool preserveElementExtensions)
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Read_EmptyItem_ReturnsExpected(bool preserveElementExtensions)
         {
             VerifyRead(@"<feed xmlns=""http://www.w3.org/2005/Atom""></feed>", preserveElementExtensions, preserveElementExtensions, feed =>
             {

--- a/src/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/Atom10ItemFormatterTests.cs
+++ b/src/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/Atom10ItemFormatterTests.cs
@@ -1017,11 +1017,11 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Theory]
-        [InlineData(@"<entry xmlns=""http://www.w3.org/2005/Atom""></entry>", true, true)]
-        [InlineData(@"<entry xmlns=""http://www.w3.org/2005/Atom""></entry>", false, false)]
-        [InlineData(@"<entry xmlns=""http://www.w3.org/2005/Atom"" />", true, true)]
-        [InlineData(@"<entry xmlns=""http://www.w3.org/2005/Atom"" />", false, false)]
-        public void Read_EmptyItem_ReturnsExpected(string xmlString, bool preserveAttributeExtensions, bool preserveElementExtensions)
+        [InlineData(@"<entry xmlns=""http://www.w3.org/2005/Atom""></entry>", true)]
+        [InlineData(@"<entry xmlns=""http://www.w3.org/2005/Atom""></entry>", false)]
+        [InlineData(@"<entry xmlns=""http://www.w3.org/2005/Atom"" />", true)]
+        [InlineData(@"<entry xmlns=""http://www.w3.org/2005/Atom"" />", false)]
+        public void Read_EmptyItem_ReturnsExpected(string xmlString, bool preserveElementExtensions)
         {
             VerifyRead(xmlString, preserveElementExtensions, preserveElementExtensions, item =>
             {

--- a/src/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/Rss20FeedFormatterTests.cs
+++ b/src/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/Rss20FeedFormatterTests.cs
@@ -427,13 +427,19 @@ namespace System.ServiceModel.Syndication.Tests
             }
         }
 
-        [Theory]
-        [MemberData(nameof(WriteTo_TestData))]
-        public void Write_HasFeed_SerializesExpected(SyndicationFeed feed, bool serializeExtensionsAsAtom, string expected)
+        [Fact]
+        public void Write_HasFeed_SerializesExpected()
         {
+            const string Expected =
+@"    <channel>
+        <title />
+        <description />
+    </channel>";
+
+            var feed = new SyndicationFeed();
             var formatter = new Rss20FeedFormatter(feed);
-            string expectedFull = @"<rss xmlns:a10=""http://www.w3.org/2005/Atom"" version=""2.0"">" + Environment.NewLine + expected + Environment.NewLine + "</rss>";
-            string expectedSerializable = @"<feed xmlns:a10=""http://www.w3.org/2005/Atom"" version=""2.0"">" + Environment.NewLine + expected + Environment.NewLine + "</feed>";
+            string expectedFull = @"<rss xmlns:a10=""http://www.w3.org/2005/Atom"" version=""2.0"">" + Environment.NewLine + Expected + Environment.NewLine + "</rss>";
+            string expectedSerializable = @"<feed xmlns:a10=""http://www.w3.org/2005/Atom"" version=""2.0"">" + Environment.NewLine + Expected + Environment.NewLine + "</feed>";
 
             CompareHelper.AssertEqualWriteOutput(expectedFull, writer => formatter.WriteTo(writer));
             CompareHelper.AssertEqualWriteOutput(expectedFull, writer => feed.SaveAsRss20(writer));
@@ -1431,9 +1437,9 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Theory]
-        [InlineData(true, true)]
-        [InlineData(false, false)]
-        public void Read_EmptyItem_ReturnsExpected(bool preserveAttributeExtensions, bool preserveElementExtensions)
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Read_EmptyItem_ReturnsExpected(bool preserveElementExtensions)
         {
             VerifyRead(@"<rss version=""2.0""><channel></channel></rss>", preserveElementExtensions, preserveElementExtensions, feed =>
             {

--- a/src/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/Rss20ItemFormatterTests.cs
+++ b/src/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/Rss20ItemFormatterTests.cs
@@ -1411,9 +1411,9 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Theory]
-        [InlineData(true, true)]
-        [InlineData(false, false)]
-        public void ReadFrom_EmptySource_ReturnsExpected(bool preserveAttributeExtensions, bool preserveElementExtensions)
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ReadFrom_EmptySource_ReturnsExpected(bool preserveElementExtensions)
         {
             VerifyRead(@"<item><source></source></item>", preserveElementExtensions, preserveElementExtensions, item =>
             {
@@ -1435,9 +1435,9 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Theory]
-        [InlineData(true, true)]
-        [InlineData(false, false)]
-        public void ReadFrom_EmptyItem_ReturnsExpected(bool preserveAttributeExtensions, bool preserveElementExtensions)
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ReadFrom_EmptyItem_ReturnsExpected(bool preserveElementExtensions)
         {
             VerifyRead(@"<item></item>", preserveElementExtensions, preserveElementExtensions, item =>
             {

--- a/src/System.Text.Encoding.CodePages/tests/EncodingCodePages.cs
+++ b/src/System.Text.Encoding.CodePages/tests/EncodingCodePages.cs
@@ -573,6 +573,7 @@ namespace System.Text.Tests
         [MemberData(nameof(CodePageInfo))]
         public static void TestEncoderNLSAndDecoderNLSValidateDataRoundTrips(int codePage, string webName, string queryString)
         {
+            _ = webName;
             Encoding encoding;
 
             if (codePage != 20932 && codePage != 50222)
@@ -622,6 +623,8 @@ namespace System.Text.Tests
         [MemberData(nameof(CodePageInfo))]
         public static void TestEncodingDisplayNames(int codePage, string webName, string queryString)
         {
+            _ = webName;
+            _ = queryString;
             var encoding = CodePagesEncodingProvider.Instance.GetEncoding(codePage);
 
             string name = encoding.EncodingName;

--- a/src/System.Text.Encoding/tests/NegativeEncodingTests.cs
+++ b/src/System.Text.Encoding/tests/NegativeEncodingTests.cs
@@ -440,59 +440,59 @@ namespace System.Text.Tests
             int bytesUsed = 0;
             bool completed = false;
 
-            Action verifyOutParams = () =>
+            void VerifyOutParams()
             {
                 Assert.Equal(0, charsUsed);
                 Assert.Equal(0, bytesUsed);
                 Assert.False(completed);
-            };
+            }
 
             // Chars is null
             AssertExtensions.Throws<ArgumentNullException>("chars", () => encoder.Convert(null, 0, 0, new byte[4], 0, 4, flush, out charsUsed, out bytesUsed, out completed));
-            verifyOutParams();
+            VerifyOutParams();
 
             // CharIndex is invalid
             AssertExtensions.Throws<ArgumentOutOfRangeException>("charIndex", () => encoder.Convert(new char[4], -1, 0, new byte[4], 0, 4, flush, out charsUsed, out bytesUsed, out completed));
-            verifyOutParams();
+            VerifyOutParams();
 
             AssertExtensions.Throws<ArgumentOutOfRangeException>("chars", () => encoder.Convert(new char[4], 5, 0, new byte[4], 0, 4, flush, out charsUsed, out bytesUsed, out completed));
-            verifyOutParams();
+            VerifyOutParams();
 
             // CharCount is invalid
             AssertExtensions.Throws<ArgumentOutOfRangeException>("charCount", () => encoder.Convert(new char[4], 0, -1, new byte[4], 0, 4, flush, out charsUsed, out bytesUsed, out completed));
-            verifyOutParams();
+            VerifyOutParams();
 
             AssertExtensions.Throws<ArgumentOutOfRangeException>("chars", () => encoder.Convert(new char[4], 0, 5, new byte[4], 0, 4, flush, out charsUsed, out bytesUsed, out completed));
-            verifyOutParams();
+            VerifyOutParams();
 
             AssertExtensions.Throws<ArgumentOutOfRangeException>("chars", () => encoder.Convert(new char[4], 1, 4, new byte[4], 0, 4, flush, out charsUsed, out bytesUsed, out completed));
-            verifyOutParams();
+            VerifyOutParams();
 
             // Bytes is null
             AssertExtensions.Throws<ArgumentNullException>("bytes", () => encoder.Convert(new char[1], 0, 1, null, 0, 0, flush, out charsUsed, out bytesUsed, out completed));
-            verifyOutParams();
+            VerifyOutParams();
 
             // ByteIndex is invalid
             AssertExtensions.Throws<ArgumentOutOfRangeException>("byteIndex", () => encoder.Convert(new char[1], 0, 0, new byte[4], -1, 4, flush, out charsUsed, out bytesUsed, out completed));
-            verifyOutParams();
+            VerifyOutParams();
 
             AssertExtensions.Throws<ArgumentOutOfRangeException>("bytes", () => encoder.Convert(new char[1], 0, 0, new byte[4], 5, 0, flush, out charsUsed, out bytesUsed, out completed));
-            verifyOutParams();
+            VerifyOutParams();
 
             // ByteCount is invalid
             AssertExtensions.Throws<ArgumentOutOfRangeException>("byteCount", () => encoder.Convert(new char[1], 0, 0, new byte[4], 0, -1, flush, out charsUsed, out bytesUsed, out completed));
-            verifyOutParams();
+            VerifyOutParams();
 
             AssertExtensions.Throws<ArgumentOutOfRangeException>("bytes", () => encoder.Convert(new char[1], 0, 0, new byte[4], 0, 5, flush, out charsUsed, out bytesUsed, out completed));
-            verifyOutParams();
+            VerifyOutParams();
 
             AssertExtensions.Throws<ArgumentOutOfRangeException>("bytes", () => encoder.Convert(new char[1], 0, 0, new byte[4], 1, 4, flush, out charsUsed, out bytesUsed, out completed));
-            verifyOutParams();
+            VerifyOutParams();
 
             // Bytes does not have enough space
             int byteCount = encoder.GetByteCount(new char[] { 'a' }, 0, 1, flush);
             AssertExtensions.Throws<ArgumentException>("bytes", () => encoder.Convert(new char[] { 'a' }, 0, 1, new byte[byteCount - 1], 0, byteCount - 1, flush, out charsUsed, out bytesUsed, out completed));
-            verifyOutParams();
+            VerifyOutParams();
         }
 
         public static IEnumerable<object[]> Decoders_TestData()
@@ -507,8 +507,10 @@ namespace System.Text.Tests
 
         [Theory]
         [MemberData(nameof(Decoders_TestData))]
-        public static void Decoder_GetCharCount_Invalid(Encoding _, Decoder decoder, bool flush)
+        public static void Decoder_GetCharCount_Invalid(Encoding encoding, Decoder decoder, bool flush)
         {
+            _ = encoding;
+
             // Bytes is null
             AssertExtensions.Throws<ArgumentNullException>("bytes", () => decoder.GetCharCount(null, 0, 0, flush));
 
@@ -524,8 +526,10 @@ namespace System.Text.Tests
 
         [Theory]
         [MemberData(nameof(Decoders_TestData))]
-        public static void Decoder_GetChars_Invalid(Encoding _, Decoder decoder, bool flush)
+        public static void Decoder_GetChars_Invalid(Encoding encoding, Decoder decoder, bool flush)
         {
+            _ = encoding;
+
             // Bytes is null
             AssertExtensions.Throws<ArgumentNullException>("bytes", () => decoder.GetChars(null, 0, 0, new char[4], 0, flush));
 
@@ -555,62 +559,64 @@ namespace System.Text.Tests
         [MemberData(nameof(Decoders_TestData))]
         public static void Decoder_Convert_Invalid(Encoding encoding, Decoder decoder, bool flush)
         {
+            _ = encoding;
+
             int bytesUsed = 0;
             int charsUsed = 0;
             bool completed = false;
 
-            Action verifyOutParams = () =>
+            void VerifyOutParams()
             {
                 Assert.Equal(0, bytesUsed);
                 Assert.Equal(0, charsUsed);
                 Assert.False(completed);
-            };
+            }
 
             // Bytes is null
             AssertExtensions.Throws<ArgumentNullException>("bytes", () => decoder.Convert(null, 0, 0, new char[4], 0, 4, flush, out charsUsed, out bytesUsed, out completed));
-            verifyOutParams();
+            VerifyOutParams();
 
             // ByteIndex is invalid
             AssertExtensions.Throws<ArgumentOutOfRangeException>("byteIndex", () => decoder.Convert(new byte[4], -1, 0, new char[4], 0, 4, flush, out charsUsed, out bytesUsed, out completed));
-            verifyOutParams();
+            VerifyOutParams();
 
             AssertExtensions.Throws<ArgumentOutOfRangeException>("bytes", () => decoder.Convert(new byte[4], 5, 0, new char[4], 0, 4, flush, out charsUsed, out bytesUsed, out completed));
-            verifyOutParams();
+            VerifyOutParams();
 
             // ByteCount is invalid
             AssertExtensions.Throws<ArgumentOutOfRangeException>("byteCount", () => decoder.Convert(new byte[4], 0, -1, new char[4], 0, 4, flush, out charsUsed, out bytesUsed, out completed));
-            verifyOutParams();
+            VerifyOutParams();
 
             AssertExtensions.Throws<ArgumentOutOfRangeException>("bytes", () => decoder.Convert(new byte[4], 0, 5, new char[4], 0, 4, flush, out charsUsed, out bytesUsed, out completed));
-            verifyOutParams();
+            VerifyOutParams();
 
             AssertExtensions.Throws<ArgumentOutOfRangeException>("bytes", () => decoder.Convert(new byte[4], 1, 4, new char[4], 0, 4, flush, out charsUsed, out bytesUsed, out completed));
-            verifyOutParams();
+            VerifyOutParams();
 
             // Chars is null
             AssertExtensions.Throws<ArgumentNullException>("chars", () => decoder.Convert(new byte[1], 0, 1, null, 0, 0, flush, out charsUsed, out bytesUsed, out completed));
-            verifyOutParams();
+            VerifyOutParams();
 
             // CharIndex is invalid
             AssertExtensions.Throws<ArgumentOutOfRangeException>("charIndex", () => decoder.Convert(new byte[1], 0, 0, new char[4], -1, 4, flush, out charsUsed, out bytesUsed, out completed));
-            verifyOutParams();
+            VerifyOutParams();
 
             AssertExtensions.Throws<ArgumentOutOfRangeException>("chars", () => decoder.Convert(new byte[1], 0, 0, new char[4], 5, 0, flush, out charsUsed, out bytesUsed, out completed));
-            verifyOutParams();
+            VerifyOutParams();
 
             // CharCount is invalid
             AssertExtensions.Throws<ArgumentOutOfRangeException>("charCount", () => decoder.Convert(new byte[1], 0, 0, new char[4], 0, -1, flush, out charsUsed, out bytesUsed, out completed));
-            verifyOutParams();
+            VerifyOutParams();
 
             AssertExtensions.Throws<ArgumentOutOfRangeException>("chars", () => decoder.Convert(new byte[1], 0, 0, new char[4], 0, 5, flush, out charsUsed, out bytesUsed, out completed));
-            verifyOutParams();
+            VerifyOutParams();
 
             AssertExtensions.Throws<ArgumentOutOfRangeException>("chars", () => decoder.Convert(new byte[1], 0, 0, new char[4], 1, 4, flush, out charsUsed, out bytesUsed, out completed));
-            verifyOutParams();
+            VerifyOutParams();
 
             // Chars does not have enough space
             AssertExtensions.Throws<ArgumentException>("chars", () => decoder.Convert(new byte[4], 0, 4, new char[0], 0, 0, flush, out charsUsed, out bytesUsed, out completed));
-            verifyOutParams();
+            VerifyOutParams();
         }
     }
 

--- a/src/System.Text.Encoding/tests/UTF32Encoding/UTF32EncodingTests.cs
+++ b/src/System.Text.Encoding/tests/UTF32Encoding/UTF32EncodingTests.cs
@@ -99,22 +99,25 @@ namespace System.Text.Tests
 
         [Theory]
         [MemberData(nameof(Encodings_TestData))]
-        public void EncodingName(UTF32Encoding encoding, string _)
+        public void EncodingName(UTF32Encoding encoding, string description)
         {
+            _ = description;
             Assert.NotEmpty(encoding.EncodingName); // Unicode (UTF-32) in en-US
         }
 
         [Theory]
         [MemberData(nameof(Encodings_TestData))]
-        public void IsSingleByte(UTF32Encoding encoding, string _)
+        public void IsSingleByte(UTF32Encoding encoding, string description)
         {
+            _ = description;
             Assert.False(encoding.IsSingleByte);
         }
 
         [Theory]
         [MemberData(nameof(Encodings_TestData))]
-        public void Clone(UTF32Encoding encoding, string _)
+        public void Clone(UTF32Encoding encoding, string description)
         {
+            _ = description;
             UTF32Encoding clone = (UTF32Encoding)encoding.Clone();
             Assert.NotSame(encoding, clone);
             Assert.Equal(encoding, clone);

--- a/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingTests.cs
+++ b/src/System.Text.Encoding/tests/UnicodeEncoding/UnicodeEncodingTests.cs
@@ -99,22 +99,25 @@ namespace System.Text.Tests
 
         [Theory]
         [MemberData(nameof(Encodings_TestData))]
-        public void EncodingName(UnicodeEncoding encoding, string _)
+        public void EncodingName(UnicodeEncoding encoding, string description)
         {
+            _ = description;
             Assert.NotEmpty(encoding.EncodingName); // Unicode (UTF-16) in en-US
         }
 
         [Theory]
         [MemberData(nameof(Encodings_TestData))]
-        public void IsSingleByte(UnicodeEncoding encoding, string _)
+        public void IsSingleByte(UnicodeEncoding encoding, string description)
         {
+            _ = description;
             Assert.False(encoding.IsSingleByte);
         }
 
         [Theory]
         [MemberData(nameof(Encodings_TestData))]
-        public void Clone(UnicodeEncoding encoding, string _)
+        public void Clone(UnicodeEncoding encoding, string description)
         {
+            _ = description;
             UnicodeEncoding clone = (UnicodeEncoding)encoding.Clone();
             Assert.NotSame(encoding, clone);
             Assert.Equal(encoding, clone);

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
@@ -208,6 +208,8 @@ namespace System.Text.Json.Tests
         [MemberData(nameof(SmallTestCases))]
         public static void TestPartialJsonReaderMultiSegment(bool compactData, TestCaseType type, string jsonString)
         {
+            _ = type;
+
             // Remove all formatting/indendation
             if (compactData)
             {
@@ -247,6 +249,8 @@ namespace System.Text.Json.Tests
         [MemberData(nameof(SmallTestCases))]
         public static void TestPartialJsonReaderSlicesMultiSegment(bool compactData, TestCaseType type, string jsonString)
         {
+            _ = type;
+
             // Remove all formatting/indendation
             if (compactData)
             {
@@ -1122,29 +1126,6 @@ namespace System.Text.Json.Tests
 
             Assert.False(json.Read());
             Assert.Equal(0, json.BytesConsumed);
-        }
-
-        [Theory]
-        [InlineData("//", "", 1)]
-        [InlineData("//", "", 2)]
-        [InlineData("//", "", 3)]
-        [InlineData("//", "", 100)]
-        [InlineData("//a", "a", 1)]
-        [InlineData("//a", "a", 2)]
-        [InlineData("//a", "a", 3)]
-        [InlineData("//a", "a", 100)]
-        [InlineData("//abc", "abc", 1)]
-        [InlineData("//abc", "abc", 2)]
-        [InlineData("//abc", "abc", 3)]
-        [InlineData("//abc", "abc", 100)]
-        public static void JsonWithSingleLineCommentWithNoLineEndingsNonFinalBlockMultiSegment(string jsonString, string expectedComment, int segmentSize)
-        {
-            byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
-            var state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = JsonCommentHandling.Allow });
-            ReadOnlySequence<byte> sequence = JsonTestHelper.GetSequence(dataUtf8, segmentSize);
-            var json = new Utf8JsonReader(sequence, isFinalBlock: false, state);
-
-            Assert.False(json.Read());
         }
 
         [Theory]

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.cs
@@ -323,6 +323,8 @@ namespace System.Text.Json.Tests
         [MemberData(nameof(SmallTestCases))]
         public static void TestPartialJsonReader(bool compactData, TestCaseType type, string jsonString)
         {
+            _ = type;
+
             // Remove all formatting/indendation
             if (compactData)
             {
@@ -988,6 +990,7 @@ namespace System.Text.Json.Tests
         [MemberData(nameof(TrySkipValues))]
         public static void TestSkipPartial(string jsonString, JsonTokenType lastToken)
         {
+            _ = lastToken;
             byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
 
             var json = new Utf8JsonReader(dataUtf8, isFinalBlock: false, default);
@@ -1550,6 +1553,7 @@ namespace System.Text.Json.Tests
         [MemberData(nameof(SpecialNumTestCases))]
         public static void TestPartialJsonReaderSpecialNumbers(TestCaseType type, string jsonString)
         {
+            _ = type;
             byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
 
             foreach (JsonCommentHandling commentHandling in Enum.GetValues(typeof(JsonCommentHandling)))
@@ -1569,6 +1573,7 @@ namespace System.Text.Json.Tests
         [MemberData(nameof(SpecialNumTestCases))]
         public static void TestPartialJsonReaderSlicesSpecialNumbers(TestCaseType type, string jsonString)
         {
+            _ = type;
             byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
 
             foreach (JsonCommentHandling commentHandling in Enum.GetValues(typeof(JsonCommentHandling)))
@@ -2402,38 +2407,38 @@ namespace System.Text.Json.Tests
         }
 
         [Theory]
-        [InlineData("//T\u6F22\u5B57his is a \u6F22\u5B57comment before json\n\"hello\"", 32)]
-        [InlineData("\"h\u6F22\u5B57ello\"//This is a \u6F22\u5B57comment after json", 37)]
-        [InlineData("\"h\u6F22\u5B57ello\"//This is a \u6F22\u5B57comment after json\n", 38)]
-        [InlineData("\"a\u6F22\u5B57lpha\" \r\n//This is a \u6F22\u5B57comment after json\n//Here is another comment/*and a multi-line comment*///Another single-line comment", 41)]
-        [InlineData("\"b\u6F22\u5B57eta\" \r\n//This is a \u6F22\u5B57comment after json\n//Here is another comment/*and a multi-line comment*///Another single-line comment\n\t  /*blah * blah*/", 40)]
-        [InlineData("\"g\u6F22\u5B57amma\" \r\n//This is a \u6F22\u5B57comment after json\n//Here is another comment\n/*and a multi-line comment*///Another single-line comment", 41)]
-        [InlineData("\"d\u6F22\u5B57elta\" \r\n//This is a \u6F22\u5B57comment after json\n//Here is another comment\n/*and a multi-line comment*///Another single-line comment\n\t  /*blah * blah*/", 41)]
-        [InlineData("\"h\u6F22\u5B57ello\"//This is a \u6F22\u5B57comment after json with new line\n", 52)]
-        [InlineData("{\"a\u6F22\u5B57ge\" : \n//This is a \u6F22\u5B57comment between key-value pairs\n 30}", 54)]
-        [InlineData("{\"a\u6F22\u5B57ge\" : 30//This is a \u6F22\u5B57comment between key-value pairs on the same line\n}", 72)]
-        [InlineData("\"a\u6F22\u5B57lpha\" \r\n//This is a comment with a carriage return\r//Another single-line comment", 59)]
-        [InlineData("\"a\u6F22\u5B57lpha\" \r\n//This is a comment with a line break\n//Another single-line comment", 54)]
-        [InlineData("\"a\u6F22\u5B57lpha\" \r\n//This is a comment with a carriage return and line break\r\n//Another single-line comment", 75)]
+        [InlineData("//T\u6F22\u5B57his is a \u6F22\u5B57comment before json\n\"hello\"")]
+        [InlineData("\"h\u6F22\u5B57ello\"//This is a \u6F22\u5B57comment after json")]
+        [InlineData("\"h\u6F22\u5B57ello\"//This is a \u6F22\u5B57comment after json\n")]
+        [InlineData("\"a\u6F22\u5B57lpha\" \r\n//This is a \u6F22\u5B57comment after json\n//Here is another comment/*and a multi-line comment*///Another single-line comment")]
+        [InlineData("\"b\u6F22\u5B57eta\" \r\n//This is a \u6F22\u5B57comment after json\n//Here is another comment/*and a multi-line comment*///Another single-line comment\n\t  /*blah * blah*/")]
+        [InlineData("\"g\u6F22\u5B57amma\" \r\n//This is a \u6F22\u5B57comment after json\n//Here is another comment\n/*and a multi-line comment*///Another single-line comment")]
+        [InlineData("\"d\u6F22\u5B57elta\" \r\n//This is a \u6F22\u5B57comment after json\n//Here is another comment\n/*and a multi-line comment*///Another single-line comment\n\t  /*blah * blah*/")]
+        [InlineData("\"h\u6F22\u5B57ello\"//This is a \u6F22\u5B57comment after json with new line\n")]
+        [InlineData("{\"a\u6F22\u5B57ge\" : \n//This is a \u6F22\u5B57comment between key-value pairs\n 30}")]
+        [InlineData("{\"a\u6F22\u5B57ge\" : 30//This is a \u6F22\u5B57comment between key-value pairs on the same line\n}")]
+        [InlineData("\"a\u6F22\u5B57lpha\" \r\n//This is a comment with a carriage return\r//Another single-line comment")]
+        [InlineData("\"a\u6F22\u5B57lpha\" \r\n//This is a comment with a line break\n//Another single-line comment")]
+        [InlineData("\"a\u6F22\u5B57lpha\" \r\n//This is a comment with a carriage return and line break\r\n//Another single-line comment")]
 
-        [InlineData("/*T\u6F22\u5B57his is a multi-line \u6F22\u5B57comment before json*/\"hello\"", 44)]
-        [InlineData("\"h\u6F22\u5B57ello\"/*This is a multi-line \u6F22\u5B57comment after json*/", 50)]
-        [InlineData("\"a\u6F22\u5B57lpha\" \r\n/*This is a multi-line \u6F22\u5B57comment after json*///Here is another comment/*and a multi-line comment*///Another single-line comment", 53)]
-        [InlineData("\"b\u6F22\u5B57eta\" \r\n/*This is a multi-line \u6F22\u5B57comment after json*///Here is another comment/*and a multi-line comment*///Another single-line comment\n\t  /*blah * blah*/", 52)]
-        [InlineData("\"g\u6F22\u5B57amma\" \r\n/*This is a multi-line \u6F22\u5B57comment after json*///Here is another comment\n/*and a multi-line comment*///Another single-line comment", 53)]
-        [InlineData("\"d\u6F22\u5B57elta\" \r\n/*This is a multi-line \u6F22\u5B57comment after json*///Here is another comment\n/*and a multi-line comment*///Another single-line comment\n\t  /*blah * blah*/", 53)]
-        [InlineData("{\"a\u6F22\u5B57ge\" : \n/*This is a \u6F22\u5B57comment between key-value pairs*/ 30}", 55)]
-        [InlineData("{\"a\u6F22\u5B57ge\" : 30/*This is a \u6F22\u5B57comment between key-value pairs on the same line*/}", 73)]
+        [InlineData("/*T\u6F22\u5B57his is a multi-line \u6F22\u5B57comment before json*/\"hello\"")]
+        [InlineData("\"h\u6F22\u5B57ello\"/*This is a multi-line \u6F22\u5B57comment after json*/")]
+        [InlineData("\"a\u6F22\u5B57lpha\" \r\n/*This is a multi-line \u6F22\u5B57comment after json*///Here is another comment/*and a multi-line comment*///Another single-line comment")]
+        [InlineData("\"b\u6F22\u5B57eta\" \r\n/*This is a multi-line \u6F22\u5B57comment after json*///Here is another comment/*and a multi-line comment*///Another single-line comment\n\t  /*blah * blah*/")]
+        [InlineData("\"g\u6F22\u5B57amma\" \r\n/*This is a multi-line \u6F22\u5B57comment after json*///Here is another comment\n/*and a multi-line comment*///Another single-line comment")]
+        [InlineData("\"d\u6F22\u5B57elta\" \r\n/*This is a multi-line \u6F22\u5B57comment after json*///Here is another comment\n/*and a multi-line comment*///Another single-line comment\n\t  /*blah * blah*/")]
+        [InlineData("{\"a\u6F22\u5B57ge\" : \n/*This is a \u6F22\u5B57comment between key-value pairs*/ 30}")]
+        [InlineData("{\"a\u6F22\u5B57ge\" : 30/*This is a \u6F22\u5B57comment between key-value pairs on the same line*/}")]
 
-        [InlineData("/*T\u6F22\u5B57his is a split multi-line \n\u6F22\u5B57comment before json*/\"hello\"", 51)]
-        [InlineData("\"h\u6F22\u5B57ello\"/*This is a split multi-line \n\u6F22\u5B57comment after json*/", 57)]
-        [InlineData("\"a\u6F22\u5B57lpha\" \r\n/*This is a split multi-line \n\u6F22\u5B57comment after json*///Here is another comment/*and a multi-line comment*///Another single-line comment", 60)]
-        [InlineData("\"b\u6F22\u5B57eta\" \r\n/*This is a split multi-line \n\u6F22\u5B57comment after json*///Here is another comment/*and a multi-line comment*///Another single-line comment\n\t  /*blah * blah*/", 59)]
-        [InlineData("\"g\u6F22\u5B57amma\" \r\n/*This is a split multi-line \n\u6F22\u5B57comment after json*///Here is another comment\n/*and a multi-line comment*///Another single-line comment", 60)]
-        [InlineData("\"d\u6F22\u5B57elta\" \r\n/*This is a split multi-line \n\u6F22\u5B57comment after json*///Here is another comment\n/*and a multi-line comment*///Another single-line comment\n\t  /*blah * blah*/", 60)]
-        [InlineData("{\"a\u6F22\u5B57ge\" : \n/*This is a split multi-line \n\u6F22\u5B57comment between key-value pairs*/ 30}", 73)]
-        [InlineData("{\"a\u6F22\u5B57ge\" : 30/*This is a split multi-line \n\u6F22\u5B57comment between key-value pairs on the same line*/}", 91)]
-        public static void Skip(string jsonString, int expectedConsumed)
+        [InlineData("/*T\u6F22\u5B57his is a split multi-line \n\u6F22\u5B57comment before json*/\"hello\"")]
+        [InlineData("\"h\u6F22\u5B57ello\"/*This is a split multi-line \n\u6F22\u5B57comment after json*/")]
+        [InlineData("\"a\u6F22\u5B57lpha\" \r\n/*This is a split multi-line \n\u6F22\u5B57comment after json*///Here is another comment/*and a multi-line comment*///Another single-line comment")]
+        [InlineData("\"b\u6F22\u5B57eta\" \r\n/*This is a split multi-line \n\u6F22\u5B57comment after json*///Here is another comment/*and a multi-line comment*///Another single-line comment\n\t  /*blah * blah*/")]
+        [InlineData("\"g\u6F22\u5B57amma\" \r\n/*This is a split multi-line \n\u6F22\u5B57comment after json*///Here is another comment\n/*and a multi-line comment*///Another single-line comment")]
+        [InlineData("\"d\u6F22\u5B57elta\" \r\n/*This is a split multi-line \n\u6F22\u5B57comment after json*///Here is another comment\n/*and a multi-line comment*///Another single-line comment\n\t  /*blah * blah*/")]
+        [InlineData("{\"a\u6F22\u5B57ge\" : \n/*This is a split multi-line \n\u6F22\u5B57comment between key-value pairs*/ 30}")]
+        [InlineData("{\"a\u6F22\u5B57ge\" : 30/*This is a split multi-line \n\u6F22\u5B57comment between key-value pairs on the same line*/}")]
+        public static void Skip(string jsonString)
         {
             byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
             var state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = JsonCommentHandling.Skip });
@@ -2456,41 +2461,41 @@ namespace System.Text.Json.Tests
         }
 
         [Theory]
-        [InlineData("//T\u6F22\u5B57his is a \u6F22\u5B57comment before json\n\"hello\"", 32)]
-        [InlineData("\"h\u6F22\u5B57ello\"//This is a \u6F22\u5B57comment after json", 37)]
-        [InlineData("\"h\u6F22\u5B57ello\"//This is a \u6F22\u5B57comment after json\n", 38)]
-        [InlineData("\"a\u6F22\u5B57lpha\" \r\n//This is a \u6F22\u5B57comment after json\n//Here is another comment/*and a multi-line comment*///Another single-line comment", 41)]
-        [InlineData("\"b\u6F22\u5B57eta\" \r\n//This is a \u6F22\u5B57comment after json\n//Here is another comment/*and a multi-line comment*///Another single-line comment\n\t  /*blah * blah*/", 40)]
-        [InlineData("\"g\u6F22\u5B57amma\" \r\n//This is a \u6F22\u5B57comment after json\n//Here is another comment\n/*and a multi-line comment*///Another single-line comment", 41)]
-        [InlineData("\"d\u6F22\u5B57elta\" \r\n//This is a \u6F22\u5B57comment after json\n//Here is another comment\n/*and a multi-line comment*///Another single-line comment\n\t  /*blah * blah*/", 41)]
-        [InlineData("\"h\u6F22\u5B57ello\"//This is a \u6F22\u5B57comment after json with new line\n", 52)]
-        [InlineData("{\"a\u6F22\u5B57ge\" : \n//This is a \u6F22\u5B57comment between key-value pairs\n 30}", 54)]
-        [InlineData("{\"a\u6F22\u5B57ge\" : 30//This is a \u6F22\u5B57comment between key-value pairs on the same line\n}", 72)]
+        [InlineData("//T\u6F22\u5B57his is a \u6F22\u5B57comment before json\n\"hello\"")]
+        [InlineData("\"h\u6F22\u5B57ello\"//This is a \u6F22\u5B57comment after json")]
+        [InlineData("\"h\u6F22\u5B57ello\"//This is a \u6F22\u5B57comment after json\n")]
+        [InlineData("\"a\u6F22\u5B57lpha\" \r\n//This is a \u6F22\u5B57comment after json\n//Here is another comment/*and a multi-line comment*///Another single-line comment")]
+        [InlineData("\"b\u6F22\u5B57eta\" \r\n//This is a \u6F22\u5B57comment after json\n//Here is another comment/*and a multi-line comment*///Another single-line comment\n\t  /*blah * blah*/")]
+        [InlineData("\"g\u6F22\u5B57amma\" \r\n//This is a \u6F22\u5B57comment after json\n//Here is another comment\n/*and a multi-line comment*///Another single-line comment")]
+        [InlineData("\"d\u6F22\u5B57elta\" \r\n//This is a \u6F22\u5B57comment after json\n//Here is another comment\n/*and a multi-line comment*///Another single-line comment\n\t  /*blah * blah*/")]
+        [InlineData("\"h\u6F22\u5B57ello\"//This is a \u6F22\u5B57comment after json with new line\n")]
+        [InlineData("{\"a\u6F22\u5B57ge\" : \n//This is a \u6F22\u5B57comment between key-value pairs\n 30}")]
+        [InlineData("{\"a\u6F22\u5B57ge\" : 30//This is a \u6F22\u5B57comment between key-value pairs on the same line\n}")]
 
-        [InlineData("/*T\u6F22\u5B57his is a multi-line \u6F22\u5B57comment before json*/\"hello\"", 44)]
-        [InlineData("\"h\u6F22\u5B57ello\"/*This is a multi-line \u6F22\u5B57comment after json*/", 50)]
-        [InlineData("\"a\u6F22\u5B57lpha\" \r\n/*This is a multi-line \u6F22\u5B57comment after json*///Here is another comment/*and a multi-line comment*///Another single-line comment", 53)]
-        [InlineData("\"b\u6F22\u5B57eta\" \r\n/*This is a multi-line \u6F22\u5B57comment after json*///Here is another comment/*and a multi-line comment*///Another single-line comment\n\t  /*blah * blah*/", 52)]
-        [InlineData("\"g\u6F22\u5B57amma\" \r\n/*This is a multi-line \u6F22\u5B57comment after json*///Here is another comment\n/*and a multi-line comment*///Another single-line comment", 53)]
-        [InlineData("\"d\u6F22\u5B57elta\" \r\n/*This is a multi-line \u6F22\u5B57comment after json*///Here is another comment\n/*and a multi-line comment*///Another single-line comment\n\t  /*blah * blah*/", 53)]
-        [InlineData("{\"a\u6F22\u5B57ge\" : \n/*This is a \u6F22\u5B57comment between key-value pairs*/ 30}", 55)]
-        [InlineData("{\"a\u6F22\u5B57ge\" : 30/*This is a \u6F22\u5B57comment between key-value pairs on the same line*/}", 73)]
-        [InlineData("\"a\u6F22\u5B57lpha\" \r\n//This is a comment with a carriage return\r//Another single-line comment", 59)]
-        [InlineData("\"a\u6F22\u5B57lpha\" \r\n//This is a comment with a line break\n//Another single-line comment", 54)]
-        [InlineData("\"a\u6F22\u5B57lpha\" \r\n//This is a comment with a carriage return and line break\r\n//Another single-line comment", 75)]
+        [InlineData("/*T\u6F22\u5B57his is a multi-line \u6F22\u5B57comment before json*/\"hello\"")]
+        [InlineData("\"h\u6F22\u5B57ello\"/*This is a multi-line \u6F22\u5B57comment after json*/")]
+        [InlineData("\"a\u6F22\u5B57lpha\" \r\n/*This is a multi-line \u6F22\u5B57comment after json*///Here is another comment/*and a multi-line comment*///Another single-line comment")]
+        [InlineData("\"b\u6F22\u5B57eta\" \r\n/*This is a multi-line \u6F22\u5B57comment after json*///Here is another comment/*and a multi-line comment*///Another single-line comment\n\t  /*blah * blah*/")]
+        [InlineData("\"g\u6F22\u5B57amma\" \r\n/*This is a multi-line \u6F22\u5B57comment after json*///Here is another comment\n/*and a multi-line comment*///Another single-line comment")]
+        [InlineData("\"d\u6F22\u5B57elta\" \r\n/*This is a multi-line \u6F22\u5B57comment after json*///Here is another comment\n/*and a multi-line comment*///Another single-line comment\n\t  /*blah * blah*/")]
+        [InlineData("{\"a\u6F22\u5B57ge\" : \n/*This is a \u6F22\u5B57comment between key-value pairs*/ 30}")]
+        [InlineData("{\"a\u6F22\u5B57ge\" : 30/*This is a \u6F22\u5B57comment between key-value pairs on the same line*/}")]
+        [InlineData("\"a\u6F22\u5B57lpha\" \r\n//This is a comment with a carriage return\r//Another single-line comment")]
+        [InlineData("\"a\u6F22\u5B57lpha\" \r\n//This is a comment with a line break\n//Another single-line comment")]
+        [InlineData("\"a\u6F22\u5B57lpha\" \r\n//This is a comment with a carriage return and line break\r\n//Another single-line comment")]
 
-        [InlineData("/*T\u6F22\u5B57his is a split multi-line \n\u6F22\u5B57comment before json*/\"hello\"", 51)]
-        [InlineData("\"h\u6F22\u5B57ello\"/*This is a split multi-line \n\u6F22\u5B57comment after json*/", 57)]
-        [InlineData("\"a\u6F22\u5B57lpha\" \r\n/*This is a split multi-line \n\u6F22\u5B57comment after json*///Here is another comment/*and a multi-line comment*///Another single-line comment", 60)]
-        [InlineData("\"b\u6F22\u5B57eta\" \r\n/*This is a split multi-line \n\u6F22\u5B57comment after json*///Here is another comment/*and a multi-line comment*///Another single-line comment\n\t  /*blah * blah*/", 59)]
-        [InlineData("\"g\u6F22\u5B57amma\" \r\n/*This is a split multi-line \n\u6F22\u5B57comment after json*///Here is another comment\n/*and a multi-line comment*///Another single-line comment", 60)]
-        [InlineData("\"d\u6F22\u5B57elta\" \r\n/*This is a split multi-line \n\u6F22\u5B57comment after json*///Here is another comment\n/*and a multi-line comment*///Another single-line comment\n\t  /*blah * blah*/", 60)]
-        [InlineData("{\"a\u6F22\u5B57ge\" : \n/*This is a split multi-line \n\u6F22\u5B57comment between key-value pairs*/ 30}", 73)]
-        [InlineData("{\"a\u6F22\u5B57ge\" : 30/*This is a split multi-line \n\u6F22\u5B57comment between key-value pairs on the same line*/}", 91)]
+        [InlineData("/*T\u6F22\u5B57his is a split multi-line \n\u6F22\u5B57comment before json*/\"hello\"")]
+        [InlineData("\"h\u6F22\u5B57ello\"/*This is a split multi-line \n\u6F22\u5B57comment after json*/")]
+        [InlineData("\"a\u6F22\u5B57lpha\" \r\n/*This is a split multi-line \n\u6F22\u5B57comment after json*///Here is another comment/*and a multi-line comment*///Another single-line comment")]
+        [InlineData("\"b\u6F22\u5B57eta\" \r\n/*This is a split multi-line \n\u6F22\u5B57comment after json*///Here is another comment/*and a multi-line comment*///Another single-line comment\n\t  /*blah * blah*/")]
+        [InlineData("\"g\u6F22\u5B57amma\" \r\n/*This is a split multi-line \n\u6F22\u5B57comment after json*///Here is another comment\n/*and a multi-line comment*///Another single-line comment")]
+        [InlineData("\"d\u6F22\u5B57elta\" \r\n/*This is a split multi-line \n\u6F22\u5B57comment after json*///Here is another comment\n/*and a multi-line comment*///Another single-line comment\n\t  /*blah * blah*/")]
+        [InlineData("{\"a\u6F22\u5B57ge\" : \n/*This is a split multi-line \n\u6F22\u5B57comment between key-value pairs*/ 30}")]
+        [InlineData("{\"a\u6F22\u5B57ge\" : 30/*This is a split multi-line \n\u6F22\u5B57comment between key-value pairs on the same line*/}")]
 
-        [InlineData("{\r\n   \"value\": 11,\r\n   /* yes, it's mis-spelled */\r\n   \"deelay\": 3\r\n}", 50)]
-        [InlineData("[\r\n   12,\r\n   87,\r\n   /* Isn't it \"nice\" that JSON provides no limits on the length of numbers? */\r\n   123456789012345678901234567890123456789.01234567890123456789e+9876543218976543219876543210\r\n]", 98)]
-        public static void SkipSingleSegment(string jsonString, int expectedConsumed)
+        [InlineData("{\r\n   \"value\": 11,\r\n   /* yes, it's mis-spelled */\r\n   \"deelay\": 3\r\n}")]
+        [InlineData("[\r\n   12,\r\n   87,\r\n   /* Isn't it \"nice\" that JSON provides no limits on the length of numbers? */\r\n   123456789012345678901234567890123456789.01234567890123456789e+9876543218976543219876543210\r\n]")]
+        public static void SkipSingleSegment(string jsonString)
         {
             byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
             var state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = JsonCommentHandling.Skip });

--- a/src/System.Threading.Channels/tests/ChannelTestBase.cs
+++ b/src/System.Threading.Channels/tests/ChannelTestBase.cs
@@ -444,10 +444,8 @@ namespace System.Threading.Channels.Tests
             await Assert.ThrowsAsync<FormatException>(async () => await write);
         }
 
-        [Theory]
-        [InlineData(0)]
-        [InlineData(1)]
-        public void ManyWriteAsync_ThenManyTryRead_Success(int readMode)
+        [Fact]
+        public void ManyWriteAsync_ThenManyTryRead_Success()
         {
             if (RequiresSingleReader || RequiresSingleWriter)
             {

--- a/src/System.Threading.Tasks/tests/CESchedulerPairTests.cs
+++ b/src/System.Threading.Tasks/tests/CESchedulerPairTests.cs
@@ -296,10 +296,8 @@ namespace System.Threading.Tasks.Tests
             Task.WaitAll(taskList.ToArray());
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public static void TestConcurrentBlockage(bool useReader)
+        [Fact]
+        public static void TestConcurrentBlockage()
         {
             ConcurrentExclusiveSchedulerPair schedPair = new ConcurrentExclusiveSchedulerPair();
             TaskFactory readers = new TaskFactory(schedPair.ConcurrentScheduler);

--- a/src/System.Threading.Tasks/tests/System.Runtime.CompilerServices/TaskAwaiterTests.cs
+++ b/src/System.Threading.Tasks/tests/System.Runtime.CompilerServices/TaskAwaiterTests.cs
@@ -406,6 +406,7 @@ namespace System.Threading.Tasks.Tests
         [MemberData(nameof(CanceledTasksAndExpectedCancellationExceptions))]
         public static void OperationCanceledException_PropagatesThroughCanceledTask(int lineNumber, Task task, OperationCanceledException expected)
         {
+            _ = lineNumber;
             var caught = Assert.ThrowsAny<OperationCanceledException>(() => task.GetAwaiter().GetResult());
             Assert.Same(expected, caught);
         }

--- a/src/System.Threading/tests/EventWaitHandleTests.cs
+++ b/src/System.Threading/tests/EventWaitHandleTests.cs
@@ -58,10 +58,10 @@ namespace System.Threading.Tests
         {
             string name = Guid.NewGuid().ToString("N");
             bool createdNew;
-            using (var ewh = new EventWaitHandle(false, EventResetMode.AutoReset, name, out createdNew))
+            using (var ewh = new EventWaitHandle(initialState, mode, name, out createdNew))
             {
                 Assert.True(createdNew);
-                using (new EventWaitHandle(false, EventResetMode.AutoReset, name, out createdNew))
+                using (new EventWaitHandle(initialState, mode, name, out createdNew))
                 {
                     Assert.False(createdNew);
                 }

--- a/src/System.Transactions.Local/tests/CloneTxTests.cs
+++ b/src/System.Transactions.Local/tests/CloneTxTests.cs
@@ -25,46 +25,46 @@ namespace System.Transactions.Tests
         }
 
         [Theory]
-        [InlineData(CloneType.Normal, IsolationLevel.Serializable, false, false, TransactionStatus.Committed)]
-        [InlineData(CloneType.Normal, IsolationLevel.RepeatableRead, false, false, TransactionStatus.Committed)]
-        [InlineData(CloneType.Normal, IsolationLevel.ReadCommitted, false, false, TransactionStatus.Committed)]
-        [InlineData(CloneType.Normal, IsolationLevel.ReadUncommitted, false, false, TransactionStatus.Committed)]
-        [InlineData(CloneType.Normal, IsolationLevel.Snapshot, false, false, TransactionStatus.Committed)]
-        [InlineData(CloneType.Normal, IsolationLevel.Chaos, false, false, TransactionStatus.Committed)]
-        [InlineData(CloneType.Normal, IsolationLevel.Unspecified, false, false, TransactionStatus.Committed)]
-        [InlineData(CloneType.RollbackDependent, IsolationLevel.Serializable, false, false, TransactionStatus.Aborted)]
-        [InlineData(CloneType.RollbackDependent, IsolationLevel.RepeatableRead, false, false, TransactionStatus.Aborted)]
-        [InlineData(CloneType.RollbackDependent, IsolationLevel.ReadCommitted, false, false, TransactionStatus.Aborted)]
-        [InlineData(CloneType.RollbackDependent, IsolationLevel.ReadUncommitted, false, false, TransactionStatus.Aborted)]
-        [InlineData(CloneType.RollbackDependent, IsolationLevel.Snapshot, false, false, TransactionStatus.Aborted)]
-        [InlineData(CloneType.RollbackDependent, IsolationLevel.Chaos, false, false, TransactionStatus.Aborted)]
-        [InlineData(CloneType.RollbackDependent, IsolationLevel.Unspecified, false, false, TransactionStatus.Aborted)]
+        [InlineData(CloneType.Normal, IsolationLevel.Serializable, false, TransactionStatus.Committed)]
+        [InlineData(CloneType.Normal, IsolationLevel.RepeatableRead, false, TransactionStatus.Committed)]
+        [InlineData(CloneType.Normal, IsolationLevel.ReadCommitted, false, TransactionStatus.Committed)]
+        [InlineData(CloneType.Normal, IsolationLevel.ReadUncommitted, false, TransactionStatus.Committed)]
+        [InlineData(CloneType.Normal, IsolationLevel.Snapshot, false, TransactionStatus.Committed)]
+        [InlineData(CloneType.Normal, IsolationLevel.Chaos, false, TransactionStatus.Committed)]
+        [InlineData(CloneType.Normal, IsolationLevel.Unspecified, false, TransactionStatus.Committed)]
+        [InlineData(CloneType.RollbackDependent, IsolationLevel.Serializable, false, TransactionStatus.Aborted)]
+        [InlineData(CloneType.RollbackDependent, IsolationLevel.RepeatableRead, false, TransactionStatus.Aborted)]
+        [InlineData(CloneType.RollbackDependent, IsolationLevel.ReadCommitted, false, TransactionStatus.Aborted)]
+        [InlineData(CloneType.RollbackDependent, IsolationLevel.ReadUncommitted, false, TransactionStatus.Aborted)]
+        [InlineData(CloneType.RollbackDependent, IsolationLevel.Snapshot, false, TransactionStatus.Aborted)]
+        [InlineData(CloneType.RollbackDependent, IsolationLevel.Chaos, false, TransactionStatus.Aborted)]
+        [InlineData(CloneType.RollbackDependent, IsolationLevel.Unspecified, false, TransactionStatus.Aborted)]
         // TODO: Issue #10353 - These variations need to be added once we have promotion support.
         /*
-        [InlineData(CloneType.Normal, true, true, TransactionStatus.Committed)]
-        [InlineData(CloneType.Normal, IsolationLevel.RepeatableRead, false, false, TransactionStatus.Committed)]
-        [InlineData(CloneType.Normal, IsolationLevel.ReadCommitted, false, false, TransactionStatus.Committed)]
-        [InlineData(CloneType.Normal, IsolationLevel.ReadUncommitted, false, false, TransactionStatus.Committed)]
-        [InlineData(CloneType.Normal, IsolationLevel.Snapshot, false, false, TransactionStatus.Committed)]
-        [InlineData(CloneType.Normal, IsolationLevel.Chaos, false, false, TransactionStatus.Committed)]
-        [InlineData(CloneType.Normal, IsolationLevel.Unspecified, false, false, TransactionStatus.Committed)]
-        [InlineData(CloneType.Normal, true, true, TransactionStatus.Committed)]
-        [InlineData(CloneType.BlockingDependent, IsolationLevel.Serializable, true, true, TransactionStatus.Committed)]
-        [InlineData(CloneType.BlockingDependent, IsolationLevel.RepeatableRead, true, true, TransactionStatus.Committed)]
-        [InlineData(CloneType.BlockingDependent, IsolationLevel.ReadCommitted, true, true, TransactionStatus.Committed)]
-        [InlineData(CloneType.BlockingDependent, IsolationLevel.ReadUncommitted, true, true, TransactionStatus.Committed)]
-        [InlineData(CloneType.BlockingDependent, IsolationLevel.Snapshot, true, true, TransactionStatus.Committed)]
-        [InlineData(CloneType.BlockingDependent, IsolationLevel.Chaos, true, true, TransactionStatus.Committed)]
-        [InlineData(CloneType.BlockingDependent, IsolationLevel.Unspecified, true, true, TransactionStatus.Committed)]
-        [InlineData(CloneType.RollbackDependent, IsolationLevel.Serializable, true, true, TransactionStatus.Committed)]
-        [InlineData(CloneType.RollbackDependent, IsolationLevel.RepeatableRead, true, true, TransactionStatus.Committed)]
-        [InlineData(CloneType.RollbackDependent, IsolationLevel.ReadCommitted, true, true, TransactionStatus.Committed)]
-        [InlineData(CloneType.RollbackDependent, IsolationLevel.ReadUncommitted, true, true, TransactionStatus.Committed)]
-        [InlineData(CloneType.RollbackDependent, IsolationLevel.Snapshot, true, true, TransactionStatus.Committed)]
-        [InlineData(CloneType.RollbackDependent, IsolationLevel.Chaos, true, true, TransactionStatus.Committed)]
-        [InlineData(CloneType.RollbackDependent, IsolationLevel.Unspecified, true, true, TransactionStatus.Committed)]
+        [InlineData(CloneType.Normal, true, TransactionStatus.Committed)]
+        [InlineData(CloneType.Normal, IsolationLevel.RepeatableRead, false, TransactionStatus.Committed)]
+        [InlineData(CloneType.Normal, IsolationLevel.ReadCommitted, false, TransactionStatus.Committed)]
+        [InlineData(CloneType.Normal, IsolationLevel.ReadUncommitted, false, TransactionStatus.Committed)]
+        [InlineData(CloneType.Normal, IsolationLevel.Snapshot, false, TransactionStatus.Committed)]
+        [InlineData(CloneType.Normal, IsolationLevel.Chaos, false, TransactionStatus.Committed)]
+        [InlineData(CloneType.Normal, IsolationLevel.Unspecified, false, TransactionStatus.Committed)]
+        [InlineData(CloneType.Normal, true, TransactionStatus.Committed)]
+        [InlineData(CloneType.BlockingDependent, IsolationLevel.Serializable, true, TransactionStatus.Committed)]
+        [InlineData(CloneType.BlockingDependent, IsolationLevel.RepeatableRead, true, TransactionStatus.Committed)]
+        [InlineData(CloneType.BlockingDependent, IsolationLevel.ReadCommitted, true, TransactionStatus.Committed)]
+        [InlineData(CloneType.BlockingDependent, IsolationLevel.ReadUncommitted, true, TransactionStatus.Committed)]
+        [InlineData(CloneType.BlockingDependent, IsolationLevel.Snapshot, true, TransactionStatus.Committed)]
+        [InlineData(CloneType.BlockingDependent, IsolationLevel.Chaos, true, TransactionStatus.Committed)]
+        [InlineData(CloneType.BlockingDependent, IsolationLevel.Unspecified, true, TransactionStatus.Committed)]
+        [InlineData(CloneType.RollbackDependent, IsolationLevel.Serializable, true, TransactionStatus.Committed)]
+        [InlineData(CloneType.RollbackDependent, IsolationLevel.RepeatableRead, true, TransactionStatus.Committed)]
+        [InlineData(CloneType.RollbackDependent, IsolationLevel.ReadCommitted, true, TransactionStatus.Committed)]
+        [InlineData(CloneType.RollbackDependent, IsolationLevel.ReadUncommitted, true, TransactionStatus.Committed)]
+        [InlineData(CloneType.RollbackDependent, IsolationLevel.Snapshot, true, TransactionStatus.Committed)]
+        [InlineData(CloneType.RollbackDependent, IsolationLevel.Chaos, true, TransactionStatus.Committed)]
+        [InlineData(CloneType.RollbackDependent, IsolationLevel.Unspecified, true, TransactionStatus.Committed)]
         */
-        public void Run(CloneType cloneType, IsolationLevel isoLevel, bool forcePromote, bool completeClone, TransactionStatus expectedStatus )
+        public void Run(CloneType cloneType, IsolationLevel isoLevel, bool forcePromote, TransactionStatus expectedStatus )
         {
             TransactionOptions options = new TransactionOptions
             {
@@ -159,16 +159,16 @@ namespace System.Transactions.Tests
 
         [OuterLoop] // transaction timeout of 1.5 seconds per InlineData invocation.
         [Theory]
-        [InlineData(CloneType.BlockingDependent, IsolationLevel.Serializable, false, false, TransactionStatus.Aborted)]
-        [InlineData(CloneType.BlockingDependent, IsolationLevel.RepeatableRead, false, false, TransactionStatus.Aborted)]
-        [InlineData(CloneType.BlockingDependent, IsolationLevel.ReadCommitted, false, false, TransactionStatus.Aborted)]
-        [InlineData(CloneType.BlockingDependent, IsolationLevel.ReadUncommitted, false, false, TransactionStatus.Aborted)]
-        [InlineData(CloneType.BlockingDependent, IsolationLevel.Snapshot, false, false, TransactionStatus.Aborted)]
-        [InlineData(CloneType.BlockingDependent, IsolationLevel.Chaos, false, false, TransactionStatus.Aborted)]
-        [InlineData(CloneType.BlockingDependent, IsolationLevel.Unspecified, false, false, TransactionStatus.Aborted)]
-        public void RunOuterLoop(CloneType cloneType, IsolationLevel isoLevel, bool forcePromote, bool completeClone, TransactionStatus expectedStatus)
+        [InlineData(CloneType.BlockingDependent, IsolationLevel.Serializable, false, TransactionStatus.Aborted)]
+        [InlineData(CloneType.BlockingDependent, IsolationLevel.RepeatableRead, false, TransactionStatus.Aborted)]
+        [InlineData(CloneType.BlockingDependent, IsolationLevel.ReadCommitted, false, TransactionStatus.Aborted)]
+        [InlineData(CloneType.BlockingDependent, IsolationLevel.ReadUncommitted, false, TransactionStatus.Aborted)]
+        [InlineData(CloneType.BlockingDependent, IsolationLevel.Snapshot, false, TransactionStatus.Aborted)]
+        [InlineData(CloneType.BlockingDependent, IsolationLevel.Chaos, false, TransactionStatus.Aborted)]
+        [InlineData(CloneType.BlockingDependent, IsolationLevel.Unspecified, false, TransactionStatus.Aborted)]
+        public void RunOuterLoop(CloneType cloneType, IsolationLevel isoLevel, bool forcePromote, TransactionStatus expectedStatus)
         {
-            Run(cloneType, isoLevel, forcePromote, completeClone, expectedStatus);
+            Run(cloneType, isoLevel, forcePromote, expectedStatus);
         }
     }
 }

--- a/src/System.Transactions.Local/tests/LTMEnlistmentTests.cs
+++ b/src/System.Transactions.Local/tests/LTMEnlistmentTests.cs
@@ -80,10 +80,10 @@ namespace System.Transactions.Tests
         // TODO: Issue #10353 - This test needs to change once we have promotion support.
         // Right now any attempt to create a two phase durable enlistment will attempt to promote and will fail because promotion is not supported. This results in the transaction being
         // aborted.
-        [InlineData(0, EnlistmentOptions.None, EnlistmentOptions.None, Phase1Vote.Prepared, Phase1Vote.Prepared, true, EnlistmentOutcome.Aborted, EnlistmentOutcome.Aborted, TransactionStatus.Aborted)]
-        [InlineData(1, EnlistmentOptions.None, EnlistmentOptions.None, Phase1Vote.Prepared, Phase1Vote.Prepared, true, EnlistmentOutcome.Aborted, EnlistmentOutcome.Aborted, TransactionStatus.Aborted)]
-        [InlineData(2, EnlistmentOptions.None, EnlistmentOptions.None, Phase1Vote.Prepared, Phase1Vote.Prepared, true, EnlistmentOutcome.Aborted, EnlistmentOutcome.Aborted, TransactionStatus.Aborted)]
-        public void TwoPhaseDurable(int volatileCount, EnlistmentOptions volatileEnlistmentOption, EnlistmentOptions durableEnlistmentOption, Phase1Vote volatilePhase1Vote, Phase1Vote durablePhase1Vote, bool commit, EnlistmentOutcome expectedVolatileOutcome, EnlistmentOutcome expectedDurableOutcome, TransactionStatus expectedTxStatus)
+        [InlineData(0, EnlistmentOptions.None, EnlistmentOptions.None, Phase1Vote.Prepared, true, EnlistmentOutcome.Aborted, EnlistmentOutcome.Aborted, TransactionStatus.Aborted)]
+        [InlineData(1, EnlistmentOptions.None, EnlistmentOptions.None, Phase1Vote.Prepared, true, EnlistmentOutcome.Aborted, EnlistmentOutcome.Aborted, TransactionStatus.Aborted)]
+        [InlineData(2, EnlistmentOptions.None, EnlistmentOptions.None, Phase1Vote.Prepared, true, EnlistmentOutcome.Aborted, EnlistmentOutcome.Aborted, TransactionStatus.Aborted)]
+        public void TwoPhaseDurable(int volatileCount, EnlistmentOptions volatileEnlistmentOption, EnlistmentOptions durableEnlistmentOption, Phase1Vote volatilePhase1Vote, bool commit, EnlistmentOutcome expectedVolatileOutcome, EnlistmentOutcome expectedDurableOutcome, TransactionStatus expectedTxStatus)
         {
             Transaction tx = null;
             try
@@ -130,9 +130,9 @@ namespace System.Transactions.Tests
         }
 
         [Theory]
-        [InlineData(EnlistmentOptions.EnlistDuringPrepareRequired, EnlistmentOptions.None, Phase1Vote.Prepared, true, true, EnlistmentOutcome.Committed, TransactionStatus.Committed)]
-        [InlineData(EnlistmentOptions.None, EnlistmentOptions.None, Phase1Vote.Prepared, false, true, EnlistmentOutcome.Committed, TransactionStatus.Committed)]
-        public void EnlistDuringPhase0(EnlistmentOptions enlistmentOption, EnlistmentOptions phase0EnlistmentOption, Phase1Vote phase1Vote, bool expectPhase0EnlistSuccess, bool commit, EnlistmentOutcome expectedOutcome, TransactionStatus expectedTxStatus)
+        [InlineData(EnlistmentOptions.EnlistDuringPrepareRequired, Phase1Vote.Prepared, true, true, EnlistmentOutcome.Committed, TransactionStatus.Committed)]
+        [InlineData(EnlistmentOptions.None, Phase1Vote.Prepared, false, true, EnlistmentOutcome.Committed, TransactionStatus.Committed)]
+        public void EnlistDuringPhase0(EnlistmentOptions enlistmentOption, Phase1Vote phase1Vote, bool expectPhase0EnlistSuccess, bool commit, EnlistmentOutcome expectedOutcome, TransactionStatus expectedTxStatus)
         {
             Transaction tx = null;
             AutoResetEvent outcomeEvent = null;


### PR DESCRIPTION
Some of these were addressed by explicitly discarding theory arguments, generally in cases where either a) the argument was being used as a description to aid in debugging failures, or b) the argument was part of a member data that was used by some theories and not by others all sharing the same member data.

However, there are quite a few legitimate bugs being fixed here, enough that highlights it's worthwhile to have the rule enabled.  Some are cases where the argument was supposed to be used but wasn't.  Some are cases where the argument isn't used at all, and in many cases where we end up running the same test over and over and wasting cycles.  Some are cases where we're unnecessarily including irrelevant inputs to the tests and making the input data more complicated than it needs to be.  Etc.

(Along the way, I also fixed some cases where VS was warning about lambdas being used instead of local functions, and in cases where I agreed I fixed them, via auto-fixers.)

Contributes to https://github.com/dotnet/corefx/issues/39697
cc: @ViktorHofer, @bartonjs 