### PR TITLE
Fix build on OSX

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.OSX.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.OSX.cs
@@ -106,10 +106,6 @@ namespace System.Diagnostics
         // ---- Unix PAL layer ends here ----
         // ----------------------------------
 
-        // The ri_proc_start_abstime needs to be converted to seconds to determine
-        // the actual start time of the process.
-        private const int NanoSecondToSecondFactor = 1000000000;
-
         private Interop.libproc.rusage_info_v3 GetCurrentProcessRUsage()
         {
             return Interop.libproc.proc_pid_rusage(Interop.Sys.GetPid());


### PR DESCRIPTION
Seems https://github.com/dotnet/corefx/pull/39572 has forgotten to remove unused field which is causing build to fail. Interestingly this didn't fail on that PR.