### PR TITLE
HttpStress: fix unhandled exceptions being eaten

### DIFF
--- a/src/System.Net.Http/tests/StressTests/HttpStress/Program.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/Program.cs
@@ -179,7 +179,7 @@ public static class Program
     private static async Task AwaitCancelKeyPress()
     {
         var tcs = new TaskCompletionSource<bool>();
-        Console.CancelKeyPress += (sender,args) => { Console.Error.WriteLine("Keyboard interrupt"); tcs.TrySetResult(false); };
+        Console.CancelKeyPress += (sender,args) => { Console.Error.WriteLine("Keyboard interrupt"); args.Cancel = true; tcs.TrySetResult(false); };
         await tcs.Task;
     }
 

--- a/src/System.Net.Http/tests/StressTests/HttpStress/StressClient.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/StressClient.cs
@@ -230,7 +230,7 @@ namespace HttpStress
 
                         while (exn != null)
                         {
-                            acc.Add((exn.GetType(), exn.Message, new StackTrace(exn, true).GetFrame(0).ToString()));
+                            acc.Add((exn.GetType(), exn.Message ?? "", new StackTrace(exn, true).GetFrame(0)?.ToString() ?? ""));
                             exn = exn.InnerException;
                         }
 


### PR DESCRIPTION
Fixes an issue where unhandled exceptions in the stress client were being swallowed because the CancelKeyPress event was not being handled properly. Also fixes a nullref issue in the client itself.