### PR TITLE
Map NetSecurityNative.Status to SecurityStatusPalErrorCode

### DIFF
--- a/src/Common/src/Interop/Unix/System.Net.Security.Native/Interop.GssApiException.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Security.Native/Interop.GssApiException.cs
@@ -15,6 +15,11 @@ internal static partial class Interop
         {
             private readonly Status _minorStatus;
 
+            public Status MajorStatus
+            {
+                get { return (Status)HResult;}
+            }
+
             public Status MinorStatus
             {
                 get { return _minorStatus;}

--- a/src/Common/src/Interop/Unix/System.Net.Security.Native/Interop.NetSecurityNative.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Security.Native/Interop.NetSecurityNative.cs
@@ -168,11 +168,32 @@ internal static partial class Interop
             return Unwrap(out minorStatus, contextHandle, inputBytes, offset, count, ref outBuffer);
         }
 
+        // https://www.gnu.org/software/gss/reference/gss.pdf Page 65
+        internal const int GSS_C_ROUTINE_ERROR_OFFSET = 16;
+
+        // https://www.gnu.org/software/gss/reference/gss.pdf Page 9
         internal enum Status : uint
         {
             GSS_S_COMPLETE = 0,
             GSS_S_CONTINUE_NEEDED = 1,
-            GSS_S_BAD_MECH = 65536
+            GSS_S_BAD_MECH = 1 << GSS_C_ROUTINE_ERROR_OFFSET,
+            GSS_S_BAD_NAME = 2 << GSS_C_ROUTINE_ERROR_OFFSET,
+            GSS_S_BAD_NAMETYPE = 3 << GSS_C_ROUTINE_ERROR_OFFSET,
+            GSS_S_BAD_BINDINGS = 4 << GSS_C_ROUTINE_ERROR_OFFSET,
+            GSS_S_BAD_STATUS = 5 << GSS_C_ROUTINE_ERROR_OFFSET,
+            GSS_S_BAD_SIG = 6 << GSS_C_ROUTINE_ERROR_OFFSET,
+            GSS_S_NO_CRED = 7 << GSS_C_ROUTINE_ERROR_OFFSET,
+            GSS_S_NO_CONTEXT = 8 << GSS_C_ROUTINE_ERROR_OFFSET,
+            GSS_S_DEFECTIVE_TOKEN = 9 << GSS_C_ROUTINE_ERROR_OFFSET,
+            GSS_S_DEFECTIVE_CREDENTIAL = 10 << GSS_C_ROUTINE_ERROR_OFFSET,
+            GSS_S_CREDENTIALS_EXPIRED = 11 << GSS_C_ROUTINE_ERROR_OFFSET,
+            GSS_S_CONTEXT_EXPIRED = 12 << GSS_C_ROUTINE_ERROR_OFFSET,
+            GSS_S_FAILURE = 13 << GSS_C_ROUTINE_ERROR_OFFSET,
+            GSS_S_BAD_QOP = 14 << GSS_C_ROUTINE_ERROR_OFFSET,
+            GSS_S_UNAUTHORIZED = 15 << GSS_C_ROUTINE_ERROR_OFFSET,
+            GSS_S_UNAVAILABLE = 16 << GSS_C_ROUTINE_ERROR_OFFSET,
+            GSS_S_DUPLICATE_ELEMENT = 17 << GSS_C_ROUTINE_ERROR_OFFSET,
+            GSS_S_NAME_NOT_MN = 18 << GSS_C_ROUTINE_ERROR_OFFSET,
         }
 
         [Flags]

--- a/src/Common/src/System/Net/Security/NegotiateStreamPal.Unix.cs
+++ b/src/Common/src/System/Net/Security/NegotiateStreamPal.Unix.cs
@@ -419,10 +419,40 @@ namespace System.Net.Security
 
                 return new SecurityStatusPal(errorCode);
             }
+            catch (Interop.NetSecurityNative.GssApiException gex)
+            {
+                if (NetEventSource.IsEnabled) NetEventSource.Error(null, gex);
+                return new SecurityStatusPal(GetErrorCode(gex), gex);
+            }
             catch (Exception ex)
             {
                 if (NetEventSource.IsEnabled) NetEventSource.Error(null, ex);
                 return new SecurityStatusPal(SecurityStatusPalErrorCode.InternalError, ex);
+            }
+        }
+
+        // https://www.gnu.org/software/gss/reference/gss.pdf (page 25)
+        private static SecurityStatusPalErrorCode GetErrorCode(Interop.NetSecurityNative.GssApiException exception)
+        {
+            switch (exception.MajorStatus)
+            {
+                case Interop.NetSecurityNative.Status.GSS_S_NO_CRED:
+                    return SecurityStatusPalErrorCode.UnknownCredentials;
+                case Interop.NetSecurityNative.Status.GSS_S_BAD_BINDINGS:
+                    return SecurityStatusPalErrorCode.BadBinding;
+                case Interop.NetSecurityNative.Status.GSS_S_CREDENTIALS_EXPIRED:
+                    return SecurityStatusPalErrorCode.CertExpired;
+                case Interop.NetSecurityNative.Status.GSS_S_DEFECTIVE_TOKEN:
+                    return SecurityStatusPalErrorCode.InvalidToken;
+                case Interop.NetSecurityNative.Status.GSS_S_DEFECTIVE_CREDENTIAL:
+                    return SecurityStatusPalErrorCode.IncompleteCredentials;
+                case Interop.NetSecurityNative.Status.GSS_S_BAD_SIG:
+                    return SecurityStatusPalErrorCode.MessageAltered;
+                case Interop.NetSecurityNative.Status.GSS_S_BAD_MECH:
+                    return SecurityStatusPalErrorCode.Unsupported;
+                case Interop.NetSecurityNative.Status.GSS_S_NO_CONTEXT:
+                default:
+                    return SecurityStatusPalErrorCode.InternalError;
             }
         }
 


### PR DESCRIPTION
Customers have provided feedback on the new ASP.NET Core Negotiate handler asking for granular error handling (https://github.com/aspnet/AspNetCore/issues/12566). We’d like to address this in 3.0 or 3.1. 
 
HttpListener has a feature where it maps certain SChannel errors to specific HTTP status codes.
https://github.com/dotnet/corefx/blob/3ad1a980399b3656a7c94ad60fcdb877d859add0/src/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs#L1549-L1593
 
This is easy for us to replicate on Windows, but it doesn’t work on Linux because the granular error codes aren’t being surfaced. AcceptSecurityContext always returns SecurityStatusPalErrorCode.InternalError and a custom exception:
https://github.com/dotnet/corefx/blob/7f920b2984a97ce8643bc8e64a93e7bd4d8a059e/src/Common/src/System/Net/Security/NegotiateStreamPal.Unix.cs#L425
https://github.com/dotnet/corefx/blob/7f920b2984a97ce8643bc8e64a93e7bd4d8a059e/src/Common/src/System/Net/Security/NegotiateStreamPal.Unix.cs#L222

GSS_S_NO_CRED is the primary one we're interested in at the moment, but I added mappings for several others documented as being returned  from `gss_accept_sec_context`.

No tests were modified because this field does not surface in NegotiateStream server scenarios. I confirmed the changes locally by temporarily changing CreateExceptionFromError to include the enum value in the exception message.