### PR TITLE
Improve get/set performance in HashSet<T>

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -484,7 +484,8 @@ namespace System.Collections.Generic
             _comparer = (IEqualityComparer<T>)_siInfo.GetValue(ComparerName, typeof(IEqualityComparer<T>))!;
             _freeList = -1;
 
-            if (_comparer == EqualityComparer<T>.Default)
+            // "==" would fail since they're different instances
+            if (Equals(_comparer, EqualityComparer<T>.Default))
             {
                 _comparer = null;
             }

--- a/src/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -74,7 +74,7 @@ namespace System.Collections.Generic
         private int _count;
         private int _lastIndex;
         private int _freeList;
-        private IEqualityComparer<T>? _comparer = default!;
+        private IEqualityComparer<T>? _comparer;
         private int _version;
 
         private SerializationInfo? _siInfo; // temporary variable needed during deserialization

--- a/src/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -261,7 +261,6 @@ namespace System.Collections.Generic
             {
                 int collisionCount = 0;
                 Slot[] slots = _slots;
-
                 IEqualityComparer<T>? comparer = _comparer;
 
                 if (comparer == null)

--- a/src/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -74,7 +74,7 @@ namespace System.Collections.Generic
         private int _count;
         private int _lastIndex;
         private int _freeList;
-        private IEqualityComparer<T> _comparer = default!;
+        private IEqualityComparer<T>? _comparer = default!;
         private int _version;
 
         private SerializationInfo? _siInfo; // temporary variable needed during deserialization
@@ -82,14 +82,14 @@ namespace System.Collections.Generic
         #region Constructors
 
         public HashSet()
-            : this(EqualityComparer<T>.Default)
+            : this((IEqualityComparer<T>?)null)
         { }
 
         public HashSet(IEqualityComparer<T>? comparer)
         {
-            if (comparer == null)
+            if (comparer == EqualityComparer<T>.Default)
             {
-                comparer = EqualityComparer<T>.Default;
+                comparer = null;
             }
 
             _comparer = comparer;
@@ -100,11 +100,11 @@ namespace System.Collections.Generic
         }
 
         public HashSet(int capacity)
-            : this(capacity, EqualityComparer<T>.Default)
+            : this(capacity, null)
         { }
 
         public HashSet(IEnumerable<T> collection)
-            : this(collection, EqualityComparer<T>.Default)
+            : this(collection, null)
         { }
 
         /// <summary>
@@ -255,27 +255,83 @@ namespace System.Collections.Generic
         /// <returns>true if item contained; false if not</returns>
         public bool Contains(T item)
         {
-            if (_buckets != null)
+            int[]? buckets = _buckets;
+
+            if (buckets != null)
             {
                 int collisionCount = 0;
-                int hashCode = InternalGetHashCode(item);
                 Slot[] slots = _slots;
-                // see note at "HashSet" level describing why "- 1" appears in for loop
-                for (int i = _buckets[hashCode % _buckets.Length] - 1; i >= 0; i = slots[i].next)
-                {
-                    if (slots[i].hashCode == hashCode && _comparer.Equals(slots[i].value, item))
-                    {
-                        return true;
-                    }
 
-                    if (collisionCount >= slots.Length)
+                IEqualityComparer<T>? comparer = _comparer;
+
+                if (comparer == null)
+                {
+                    int hashCode = item == null ? 0 : InternalGetHashCode(item.GetHashCode());
+
+                    if (default(T)! != null) // TODO-NULLABLE: default(T) == null warning (https://github.com/dotnet/roslyn/issues/34757)
                     {
-                        // The chain of entries forms a loop, which means a concurrent update has happened.
-                        throw new InvalidOperationException(SR.InvalidOperation_ConcurrentOperationsNotSupported);
+                        // see note at "HashSet" level describing why "- 1" appears in for loop
+                        for (int i = buckets[hashCode % buckets.Length] - 1; i >= 0; i = slots[i].next)
+                        {
+                            if (slots[i].hashCode == hashCode && EqualityComparer<T>.Default.Equals(slots[i].value, item))
+                            {
+                                return true;
+                            }
+
+                            if (collisionCount >= slots.Length)
+                            {
+                                // The chain of entries forms a loop, which means a concurrent update has happened.
+                                throw new InvalidOperationException(SR.InvalidOperation_ConcurrentOperationsNotSupported);
+                            }
+                            collisionCount++;
+                        }
                     }
-                    collisionCount++;
+                    else
+                    {
+                        // Object type: Shared Generic, EqualityComparer<TValue>.Default won't devirtualize
+                        // https://github.com/dotnet/coreclr/issues/17273
+                        // So cache in a local rather than get EqualityComparer per loop iteration
+                        EqualityComparer<T> defaultComparer = EqualityComparer<T>.Default;
+
+                        // see note at "HashSet" level describing why "- 1" appears in for loop
+                        for (int i = buckets[hashCode % buckets.Length] - 1; i >= 0; i = slots[i].next)
+                        {
+                            if (slots[i].hashCode == hashCode && defaultComparer.Equals(slots[i].value, item))
+                            {
+                                return true;
+                            }
+
+                            if (collisionCount >= slots.Length)
+                            {
+                                // The chain of entries forms a loop, which means a concurrent update has happened.
+                                throw new InvalidOperationException(SR.InvalidOperation_ConcurrentOperationsNotSupported);
+                            }
+                            collisionCount++;
+                        }
+                    }
+                }
+                else
+                {
+                    int hashCode = item == null ? 0 : InternalGetHashCode(comparer.GetHashCode(item));
+
+                    // see note at "HashSet" level describing why "- 1" appears in for loop
+                    for (int i = buckets[hashCode % buckets.Length] - 1; i >= 0; i = slots[i].next)
+                    {
+                        if (slots[i].hashCode == hashCode && comparer.Equals(slots[i].value, item))
+                        {
+                            return true;
+                        }
+
+                        if (collisionCount >= slots.Length)
+                        {
+                            // The chain of entries forms a loop, which means a concurrent update has happened.
+                            throw new InvalidOperationException(SR.InvalidOperation_ConcurrentOperationsNotSupported);
+                        }
+                        collisionCount++;
+                    }
                 }
             }
+
             // either _buckets is null or wasn't found
             return false;
         }
@@ -299,14 +355,15 @@ namespace System.Collections.Generic
         {
             if (_buckets != null)
             {
-                int hashCode = InternalGetHashCode(item);
+                IEqualityComparer<T> comparer = _comparer ?? EqualityComparer<T>.Default;
+                int hashCode = InternalGetHashCode(item, comparer);
                 int bucket = hashCode % _buckets.Length;
                 int last = -1;
                 int collisionCount = 0;
                 Slot[] slots = _slots;
                 for (int i = _buckets[bucket] - 1; i >= 0; last = i, i = slots[i].next)
                 {
-                    if (slots[i].hashCode == hashCode && _comparer.Equals(slots[i].value, item))
+                    if (slots[i].hashCode == hashCode && comparer.Equals(slots[i].value, item))
                     {
                         if (last < 0)
                         {
@@ -398,7 +455,7 @@ namespace System.Collections.Generic
             }
 
             info.AddValue(VersionName, _version); // need to serialize version to avoid problems with serializing while enumerating
-            info.AddValue(ComparerName, _comparer, typeof(IEqualityComparer<T>));
+            info.AddValue(ComparerName, _comparer ?? EqualityComparer<T>.Default, typeof(IEqualityComparer<T>));
             info.AddValue(CapacityName, _buckets == null ? 0 : _buckets.Length);
 
             if (_buckets != null)
@@ -426,6 +483,11 @@ namespace System.Collections.Generic
             int capacity = _siInfo.GetInt32(CapacityName);
             _comparer = (IEqualityComparer<T>)_siInfo.GetValue(ComparerName, typeof(IEqualityComparer<T>))!;
             _freeList = -1;
+
+            if (_comparer == EqualityComparer<T>.Default)
+            {
+                _comparer = null;
+            }
 
             if (capacity != 0)
             {
@@ -1042,7 +1104,7 @@ namespace System.Collections.Generic
         {
             get
             {
-                return _comparer;
+                return _comparer ?? EqualityComparer<T>.Default;
             }
         }
 
@@ -1212,23 +1274,77 @@ namespace System.Collections.Generic
                 Initialize(0);
             }
 
-            int hashCode = InternalGetHashCode(value);
-            int bucket = hashCode % _buckets!.Length;
+            int hashCode;
+            int bucket;
             int collisionCount = 0;
             Slot[] slots = _slots;
-            for (int i = _buckets[bucket] - 1; i >= 0; i = slots[i].next)
-            {
-                if (slots[i].hashCode == hashCode && _comparer.Equals(slots[i].value, value))
-                {
-                    return false;
-                }
 
-                if (collisionCount >= slots.Length)
+            IEqualityComparer<T>? comparer = _comparer;
+
+            if (comparer == null)
+            {
+                hashCode = value == null ? 0 : InternalGetHashCode(value.GetHashCode());
+                bucket = hashCode % _buckets!.Length;
+
+                if (default(T)! != null) // TODO-NULLABLE: default(T) == null warning (https://github.com/dotnet/roslyn/issues/34757)
                 {
-                    // The chain of entries forms a loop, which means a concurrent update has happened.
-                    throw new InvalidOperationException(SR.InvalidOperation_ConcurrentOperationsNotSupported);
+                    for (int i = _buckets[bucket] - 1; i >= 0; i = slots[i].next)
+                    {
+                        if (slots[i].hashCode == hashCode && EqualityComparer<T>.Default.Equals(slots[i].value, value))
+                        {
+                            return false;
+                        }
+
+                        if (collisionCount >= slots.Length)
+                        {
+                            // The chain of entries forms a loop, which means a concurrent update has happened.
+                            throw new InvalidOperationException(SR.InvalidOperation_ConcurrentOperationsNotSupported);
+                        }
+                        collisionCount++;
+                    }
                 }
-                collisionCount++;
+                else
+                {
+                    // Object type: Shared Generic, EqualityComparer<TValue>.Default won't devirtualize
+                    // https://github.com/dotnet/coreclr/issues/17273
+                    // So cache in a local rather than get EqualityComparer per loop iteration
+                    EqualityComparer<T> defaultComparer = EqualityComparer<T>.Default;
+
+                    for (int i = _buckets[bucket] - 1; i >= 0; i = slots[i].next)
+                    {
+                        if (slots[i].hashCode == hashCode && defaultComparer.Equals(slots[i].value, value))
+                        {
+                            return false;
+                        }
+
+                        if (collisionCount >= slots.Length)
+                        {
+                            // The chain of entries forms a loop, which means a concurrent update has happened.
+                            throw new InvalidOperationException(SR.InvalidOperation_ConcurrentOperationsNotSupported);
+                        }
+                        collisionCount++;
+                    }
+                }
+            }
+            else
+            {
+                hashCode = value == null ? 0 : InternalGetHashCode(comparer.GetHashCode(value));
+                bucket = hashCode % _buckets!.Length;
+
+                for (int i = _buckets[bucket] - 1; i >= 0; i = slots[i].next)
+                {
+                    if (slots[i].hashCode == hashCode && comparer.Equals(slots[i].value, value))
+                    {
+                        return false;
+                    }
+
+                    if (collisionCount >= slots.Length)
+                    {
+                        // The chain of entries forms a loop, which means a concurrent update has happened.
+                        throw new InvalidOperationException(SR.InvalidOperation_ConcurrentOperationsNotSupported);
+                    }
+                    collisionCount++;
+                }
             }
 
             int index;
@@ -1266,10 +1382,11 @@ namespace System.Collections.Generic
             int bucket = hashCode % _buckets!.Length;
 
 #if DEBUG
-            Debug.Assert(InternalGetHashCode(value) == hashCode);
+            IEqualityComparer<T> comparer = _comparer ?? EqualityComparer<T>.Default;
+            Debug.Assert(InternalGetHashCode(value, comparer) == hashCode);
             for (int i = _buckets[bucket] - 1; i >= 0; i = _slots[i].next)
             {
-                Debug.Assert(!_comparer.Equals(_slots[i].value, value));
+                Debug.Assert(!comparer.Equals(_slots[i].value, value));
             }
 #endif
 
@@ -1397,11 +1514,12 @@ namespace System.Collections.Generic
             Debug.Assert(_buckets != null, "_buckets was null; callers should check first");
 
             int collisionCount = 0;
-            int hashCode = InternalGetHashCode(item);
+            IEqualityComparer<T> comparer = _comparer ?? EqualityComparer<T>.Default;
+            int hashCode = InternalGetHashCode(item, comparer);
             Slot[] slots = _slots;
             for (int i = _buckets[hashCode % _buckets.Length] - 1; i >= 0; i = slots[i].next)
             {
-                if ((slots[i].hashCode) == hashCode && _comparer.Equals(slots[i].value, item))
+                if ((slots[i].hashCode) == hashCode && comparer.Equals(slots[i].value, item))
                 {
                     return i;
                 }
@@ -1518,13 +1636,14 @@ namespace System.Collections.Generic
         {
             Debug.Assert(_buckets != null, "_buckets is null, callers should have checked");
 
-            int hashCode = InternalGetHashCode(value);
+            IEqualityComparer<T> comparer = _comparer ?? EqualityComparer<T>.Default;
+            int hashCode = InternalGetHashCode(value, comparer);
             int bucket = hashCode % _buckets.Length;
             int collisionCount = 0;
             Slot[] slots = _slots;
             for (int i = _buckets[bucket] - 1; i >= 0; i = slots[i].next)
             {
-                if (slots[i].hashCode == hashCode && _comparer.Equals(slots[i].value, value))
+                if (slots[i].hashCode == hashCode && comparer.Equals(slots[i].value, value))
                 {
                     location = i;
                     return false; //already present
@@ -1731,14 +1850,20 @@ namespace System.Collections.Generic
         /// Workaround Comparers that throw ArgumentNullException for GetHashCode(null).
         /// </summary>
         /// <param name="item"></param>
+        /// <param name="comparer"></param>
         /// <returns>hash code</returns>
-        private int InternalGetHashCode(T item)
+        private static int InternalGetHashCode(T item, IEqualityComparer<T> comparer)
         {
             if (item == null)
             {
                 return 0;
             }
-            return _comparer.GetHashCode(item) & Lower31BitMask;
+            return comparer.GetHashCode(item) & Lower31BitMask;
+        }
+
+        private int InternalGetHashCode(int hashCode)
+        {
+            return hashCode & Lower31BitMask;
         }
 
         #endregion

--- a/src/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -484,12 +484,6 @@ namespace System.Collections.Generic
             _comparer = (IEqualityComparer<T>)_siInfo.GetValue(ComparerName, typeof(IEqualityComparer<T>))!;
             _freeList = -1;
 
-            // "==" would fail since they're different instances
-            if (Equals(_comparer, EqualityComparer<T>.Default))
-            {
-                _comparer = null;
-            }
-
             if (capacity != 0)
             {
                 _buckets = new int[capacity];

--- a/src/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -432,7 +432,7 @@ namespace System.Collections.Generic
             }
             // either _buckets is null or wasn't found
             return false;
-            
+
         ReturnFound:
             if (last < 0)
             {

--- a/src/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -1434,11 +1434,11 @@ namespace System.Collections.Generic
             int bucket = hashCode % _buckets!.Length;
 
 #if DEBUG
-            IEqualityComparer<T>? comparer = _comparer;
+            IEqualityComparer<T> comparer = _comparer ?? EqualityComparer<T>.Default;
             Debug.Assert(InternalGetHashCode(value, comparer) == hashCode);
             for (int i = _buckets[bucket] - 1; i >= 0; i = _slots[i].next)
             {
-                Debug.Assert(!InternalEquals(_slots[i].value, value, comparer));
+                Debug.Assert(!comparer.Equals(_slots[i].value, value));
             }
 #endif
 
@@ -1748,7 +1748,7 @@ namespace System.Collections.Generic
             Slot[] slots = _slots;
             for (int i = _buckets[bucket] - 1; i >= 0; i = slots[i].next)
             {
-                if (slots[i].hashCode == hashCode && InternalEquals(slots[i].value, value, comparer))
+                if (slots[i].hashCode == hashCode && (comparer?.Equals(slots[i].value, value) ?? EqualityComparer<T>.Default.Equals(slots[i].value, value)))
                 {
                     location = i;
                     return false; //already present
@@ -1973,12 +1973,6 @@ namespace System.Collections.Generic
         private int InternalGetHashCode(int hashCode)
         {
             return hashCode & Lower31BitMask;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private bool InternalEquals(T x, T y, IEqualityComparer<T>? comparer)
-        {
-            return comparer?.Equals(x, y) ?? EqualityComparer<T>.Default.Equals(x, y);
         }
 
         #endregion

--- a/src/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -1846,6 +1846,7 @@ namespace System.Collections.Generic
         /// <param name="item"></param>
         /// <param name="comparer"></param>
         /// <returns>hash code</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int InternalGetHashCode(T item, IEqualityComparer<T>? comparer)
         {
             if (item == null)
@@ -1857,11 +1858,13 @@ namespace System.Collections.Generic
             return hashCode & Lower31BitMask;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private int InternalGetHashCode(int hashCode)
         {
             return hashCode & Lower31BitMask;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private bool InternalEquals(T x, T y, IEqualityComparer<T>? comparer)
         {
             return comparer?.Equals(x, y) ?? EqualityComparer<T>.Default.Equals(x, y);

--- a/src/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -359,16 +359,16 @@ namespace System.Collections.Generic
             int i;
             Slot[] slots;
             IEqualityComparer<T>? comparer = _comparer;
-            
+
             if (_buckets != null)
             {
                 slots = _slots;
-                
+
                 if (comparer == null)
                 {
                     hashCode = item == null ? 0 : InternalGetHashCode(item.GetHashCode());
                     bucket = hashCode % _buckets!.Length;
-                    
+
                     if (default(T)! != null) // TODO-NULLABLE: default(T) == null warning (https://github.com/dotnet/roslyn/issues/34757)
                     {
                         for (i = _buckets[bucket] - 1; i >= 0; last = i, i = slots[i].next)
@@ -392,7 +392,7 @@ namespace System.Collections.Generic
                         // https://github.com/dotnet/coreclr/issues/17273
                         // So cache in a local rather than get EqualityComparer per loop iteration
                         EqualityComparer<T> defaultComparer = EqualityComparer<T>.Default;
-                        
+
                         for (i = _buckets[bucket] - 1; i >= 0; last = i, i = slots[i].next)
                         {
                             if (slots[i].hashCode == hashCode && defaultComparer.Equals(slots[i].value, item))
@@ -413,7 +413,7 @@ namespace System.Collections.Generic
                 {
                     hashCode = item == null ? 0 : InternalGetHashCode(comparer.GetHashCode(item));
                     bucket = hashCode % _buckets!.Length;
-                    
+
                     for (i = _buckets[bucket] - 1; i >= 0; last = i, i = slots[i].next)
                     {
                         if (slots[i].hashCode == hashCode && EqualityComparer<T>.Default.Equals(slots[i].value, item))


### PR DESCRIPTION
Similar optimization in Dictionary<,> has been ported to HashSet<>.

`_comparer` has been made nullable, and default by `null`. This
makes us possible to check if it's null for faster branches, instead
of comparing it to `EqualityComparer<T>.Default`. Since `_comparer`
is `null` by default, the constructors and the `OnDeserialization`
method have been modified accordingly to save `null` instead of the
`EqualityComparer<T>.Default` if it's been passed/saved. Also, the
places that use `_comparer` directly much do a null check and switch
to `EqualityComparer<T>.Default` instead.

The major optimization is under `Contains` and `AddIfNotPresent`
methods. Basically the code was:

``
// Code uses _comparer
``

Now it becomes:

```
var comparer = _comparer;
if (comparer == null)
{
  if (default(T) != null)
  {
    // Code uses EqualityComparer<T>.Default for de-virtualizing.
  }
  else
  {
    var defaultComparer = EqualityComparer<T>.Default;
    // Code uses cached defaultComparer
  }
}
else
{
  // Code uses comparer
}
```

I've intentionally kept the origin implementation and comments as
much as possible, and the optimized code is not exactly the same as
in `Dictionary<T>`. Further micro-optimizations might be possible
but I think it's cleaner to keep it that way in the first step.

The `Remove` method hasn't been optimized since it's complicated,
and not been done in `Dictionary` either. Some other methods like
`AddOrGetLocation` or `InternalIndexOf` are not optimized since
they're only used in less-common scenarios, and not in the scope
of the current issue.

The benchmark shows there're obvious improvements in get and set
operations for all cases, especialy if the item is a value type.
I was actually expecting to see some pull back for "slower" case,
like if we use a custom comparer, but it turns out it's getting
faster too, since we have cached the comparer instead of using
`_comparer` directly in the loop.

The benchmark also shows the optimized `HashSet` has close or
better performance comparing to `Dictionary` in almost all cases,
except for `HashSet<string>` with default comparer. The default
comparer in `Dictionary<string>` is a "non-random" implementation
that performs better. Unfortunately the comparer is internal to
the CoreLib.

The optimized `HashSet<string>` is still faster since it's using
cached comparer of type `EqualityComparer<string>`, which uses
virtual method dispatching instead of interface dispatching. It's
just not as faster as `Dictionary<string, T>` yet.

Fix #36448