### PR TITLE
[release/2.1] Port Kerberos auth fixes to 2.1 branch

### DIFF
--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -592,6 +592,9 @@
     <Compile Include="System\Net\Http\HttpClientHandler.Core.cs" />
     <Compile Include="uap\System\Net\HttpClientHandler.cs" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
+    <Reference Include="System.Net.NameResolution" />
+  </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp' OR '$(TargetGroup)' == 'uap'">
     <Reference Include="Microsoft.Win32.Primitives" />
     <Reference Include="System.Buffers" />


### PR DESCRIPTION
This PR ports some important Kerberos auth fixes from the 3.0 to 2.1 LTS
branch. These fixes help enterprise customers that have complex Kerberos
authentication scenarios that involve cross Windows (Active Directory)
and Linux (Kerberos) domains/realms.

These fixes are from PRs:

* #38465 - Use 'Host' header when calculating SPN for Kerberos auth
* #38377 - Use GSS_C_NT_HOSTBASED_SERVICE format for Linux Kerberos SPN

and are related to issue #36329.