### PR TITLE
[release/3.0] HTTP2: Fix hang due to handling of RST_STREAM with error = NO_ERROR after response EndStream

### DIFF
--- a/src/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -235,33 +235,16 @@ namespace System.Net.Test.Common
         }
 
         // Wait for the client to close the connection, e.g. after the HttpClient is disposed.
-        public async Task WaitForClientDisconnectAsync()
+        public async Task WaitForClientDisconnectAsync(bool ignoreUnexpectedFrames = false)
         {
-            Frame frame = await ReadFrameAsync(Timeout);
-            Assert.Null(frame);
-        }
-
-        public void ShutdownSend()
-        {
-            _connectionSocket.Shutdown(SocketShutdown.Send);
-        }
-
-        // This will wait for the client to close the connection,
-        // and ignore any meaningless frames -- i.e. WINDOW_UPDATE or expected SETTINGS ACK --
-        // that we see while waiting for the client to close.
-        // Only call this after sending a GOAWAY.
-        public async Task WaitForConnectionShutdownAsync(bool ignoreUnexpectedFrames = false)
-        {
-            // Shutdown our send side, so the client knows there won't be any more frames coming.
-            ShutdownSend();
-
             IgnoreWindowUpdates();
+
             Frame frame = await ReadFrameAsync(Timeout).ConfigureAwait(false);
             if (frame != null)
             {
                 if (!ignoreUnexpectedFrames)
                 {
-                    throw new Exception($"Unexpected frame received while waiting for client shutdown: {frame}");
+                    throw new Exception($"Unexpected frame received while waiting for client disconnect: {frame}");
                 }
             }
 
@@ -272,6 +255,22 @@ namespace System.Net.Test.Common
 
             _ignoredSettingsAckPromise = null;
             _ignoreWindowUpdates = false;
+        }
+
+        public void ShutdownSend()
+        {
+            _connectionSocket.Shutdown(SocketShutdown.Send);
+        }
+
+        // This will cause a server-initiated shutdown of the connection.
+        // For normal operation, you should send a GOAWAY and complete any remaining streams
+        // before calling this method.
+        public async Task WaitForConnectionShutdownAsync(bool ignoreUnexpectedFrames = false)
+        {
+            // Shutdown our send side, so the client knows there won't be any more frames coming.
+            ShutdownSend();
+
+            await WaitForClientDisconnectAsync(ignoreUnexpectedFrames: ignoreUnexpectedFrames);
         }
 
         // This is similar to WaitForConnectionShutdownAsync but will send GOAWAY for you

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -655,11 +655,11 @@ namespace System.Net.Http
 
             if (protocolError == Http2ProtocolErrorCode.RefusedStream)
             {
-                http2Stream.OnReset(new Http2StreamException(protocolError), canRetry: true);
+                http2Stream.OnReset(new Http2StreamException(protocolError), resetStreamErrorCode: protocolError, canRetry: true);
             }
             else
             {
-                http2Stream.OnReset(new Http2StreamException(protocolError));
+                http2Stream.OnReset(new Http2StreamException(protocolError), resetStreamErrorCode: protocolError);
             }
         }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -2585,6 +2585,122 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [Fact]
+        public async Task PostAsyncDuplex_ServerCompletesResponseBodyThenResetsStreamWithNoError_SuccessAndRequestBodyCancelled()
+        {
+            // Per section 8.1 of the RFC:
+            // Receiving RST_STREAM with NO_ERROR after receiving EndStream on the response body is a special case.
+            // We should stop sending the request body, but treat the request as successful and 
+            // return the completed response body to the user.
+
+            byte[] contentBytes = Encoding.UTF8.GetBytes("Hello world");
+
+            using (var server = Http2LoopbackServer.CreateServer())
+            {
+                Http2LoopbackConnection connection;
+                using (HttpClient client = CreateHttpClient())
+                {
+                    var duplexContent = new DuplexContent();
+
+                    var request = new HttpRequestMessage(HttpMethod.Post, server.Address);
+                    request.Version = new Version(2, 0);
+                    request.Content = duplexContent;
+                    Task<HttpResponseMessage> responseTask = client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+
+                    connection = await server.EstablishConnectionAsync();
+
+                    // Client should have sent the request headers, and the request stream should now be available
+                    Stream requestStream = await duplexContent.WaitForStreamAsync();
+
+                    // Flush the content stream. Otherwise, the request headers are not guaranteed to be sent.
+                    await requestStream.FlushAsync();
+
+                    (int streamId, _) = await connection.ReadAndParseRequestHeaderAsync(readBody: false);
+
+                    // Send data to the server, even before we've received response headers.
+                    await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId);
+
+                    // Send response headers
+                    await connection.SendResponseHeadersAsync(streamId, endStream: false);
+                    HttpResponseMessage response = await responseTask;
+                    Stream responseStream = await response.Content.ReadAsStreamAsync();
+
+                    // Send response body and complete response
+                    await connection.SendResponseDataAsync(streamId, contentBytes, endStream: true);
+
+                    // Send RST_STREAM to client with error = NO_ERROR.
+                    await connection.WriteFrameAsync(new RstStreamFrame(FrameFlags.None, (int)ProtocolErrors.NO_ERROR, streamId));
+
+                    // Ensure client has processed the RST_STREAM.
+                    await connection.PingPong();
+
+                    // Attempting to write on the request body should now fail with OperationCanceledException.
+                    Exception e = await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => { await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId); });
+
+                    // Propagate the exception to the request stream serialization task.
+                    // This allows the request processing to complete.
+                    duplexContent.Fail(e);
+
+                    // We should receive the response body and EOF.
+                    byte[] readBuffer = new byte[contentBytes.Length];
+                    int bytesRead = await responseStream.ReadAsync(readBuffer);
+                    Assert.True(contentBytes.SequenceEqual(readBuffer));
+                    bytesRead = await responseStream.ReadAsync(readBuffer);
+                    Assert.Equal(0, bytesRead);
+                }
+
+                // On handler dispose, client should shutdown the connection without sending additional frames.
+                await connection.WaitForClientDisconnectAsync();
+            }
+        }
+
+        [Fact]
+        public async Task PostAsyncNonDuplex_ServerCompletesResponseBodyThenResetsStreamWithNoError_SuccessAndRequestBodyCancelled()
+        {
+            // Per section 8.1 of the RFC:
+            // Receiving RST_STREAM with NO_ERROR after receiving EndStream on the response body is a special case.
+            // We should stop sending the request body, but treat the request as successful and 
+            // return the completed response body to the user.
+
+            byte[] contentBytes = Encoding.UTF8.GetBytes("Hello world");
+
+            using (var server = Http2LoopbackServer.CreateServer())
+            {
+                Http2LoopbackConnection connection;
+                using (HttpClient client = CreateHttpClient())
+                {
+                    // We want non-duplex content, so use ByteArrayContent,
+                    // but make it large enough to ensure that the content can't be fully sent because of flow control limitations.
+                    // This allows us to validate that the content is actually canceled, not just fully sent and completed.
+                    const int ContentSize = 100_000;
+                    var requestContent = new ByteArrayContent(TestHelper.GenerateRandomContent(ContentSize));
+
+                    var request = new HttpRequestMessage(HttpMethod.Post, server.Address);
+                    request.Version = new Version(2, 0);
+                    request.Content = requestContent;
+                    Task<HttpResponseMessage> responseTask = client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+
+                    connection = await server.EstablishConnectionAsync();
+
+                    (int streamId, _) = await connection.ReadAndParseRequestHeaderAsync(readBody: false);
+
+                    // Send full response
+                    await connection.SendResponseHeadersAsync(streamId, endStream: false);
+                    await connection.SendResponseDataAsync(streamId, contentBytes, endStream: true);
+
+                    // Send RST_STREAM to client with error = NO_ERROR.
+                    await connection.WriteFrameAsync(new RstStreamFrame(FrameFlags.None, (int)ProtocolErrors.NO_ERROR, streamId));
+
+                    // Response should now complete successfully
+                    HttpResponseMessage response = await responseTask;
+                    Assert.Equal("Hello world", await response.Content.ReadAsStringAsync());
+                }
+
+                // On handler dispose, client should shutdown the connection. Ignore any request stream frames already sent.
+                await connection.WaitForClientDisconnectAsync(ignoreUnexpectedFrames: true);
+            }
+        }
+
         [Theory]
         [InlineData(true, HttpStatusCode.Forbidden)]
         [InlineData(false, HttpStatusCode.Forbidden)]


### PR DESCRIPTION
Fixes #39586
Fixes #40030

Port of #39882 to release/3.0

**Description**

The RFC defines special behavior for receiving a RST_STREAM with error = NO_ERROR after the response body stream has been completed. When this happens, a client is supposed to cancel sending the request body but still consider the request successful. Previously, we did not do this.

**Impact**

Fixes a hang found in gRPC scenarios. Also affects non-GRPC scenarios, e.g. POST and receive early 4xx response like Forbidden; many servers will send RST_STREAM with NO_ERROR in this scenario.

**Regression?**

No

**Risk**

Low

@danmosemsft 
