### PR TITLE
Change 'in' modifier usage to 'ref' for performance

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.DbRow.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.DbRow.cs
@@ -44,7 +44,7 @@ namespace System.Text.Json
             /// Array: At least one element is an object/array.
             /// Otherwise; false
             /// </summary>
-            internal readonly bool HasComplexChildren => _sizeOrLengthUnion < 0;
+            internal bool HasComplexChildren => _sizeOrLengthUnion < 0;
 
             internal int NumberOfRows =>
                 _numberOfRowsAndTypeUnion & 0x0FFFFFFF; // Number of rows that the current JSON element occupies within the database

--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.DbRow.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.DbRow.cs
@@ -10,15 +10,15 @@ namespace System.Text.Json
     public sealed partial class JsonDocument
     {
         [StructLayout(LayoutKind.Sequential)]
-        internal struct DbRow
+        internal readonly struct DbRow
         {
             internal const int Size = 12;
 
             // Sign bit is currently unassigned
-            private int _location;
+            private readonly int _location;
 
             // Sign bit is used for "HasComplexChildren" (StartArray)
-            private int _sizeOrLengthUnion;
+            private readonly int _sizeOrLengthUnion;
 
             // Top nybble is JsonTokenType
             // remaining nybbles are the number of rows to skip to get to the next value
@@ -29,7 +29,7 @@ namespace System.Text.Json
             /// <summary>
             /// Index into the payload
             /// </summary>
-            internal readonly int Location => _location;
+            internal int Location => _location;
 
             /// <summary>
             /// length of text in JSON payload (or number of elements if its a JSON array)
@@ -44,7 +44,7 @@ namespace System.Text.Json
             /// Array: At least one element is an object/array.
             /// Otherwise; false
             /// </summary>
-            internal bool HasComplexChildren => _sizeOrLengthUnion < 0;
+            internal readonly bool HasComplexChildren => _sizeOrLengthUnion < 0;
 
             internal int NumberOfRows =>
                 _numberOfRowsAndTypeUnion & 0x0FFFFFFF; // Number of rows that the current JSON element occupies within the database

--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.DbRow.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.DbRow.cs
@@ -29,7 +29,7 @@ namespace System.Text.Json
             /// <summary>
             /// Index into the payload
             /// </summary>
-            internal int Location => _location;
+            internal readonly int Location => _location;
 
             /// <summary>
             /// length of text in JSON payload (or number of elements if its a JSON array)

--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.Parse.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.Parse.cs
@@ -554,17 +554,12 @@ namespace System.Text.Json
             byte[] extraRentedBytes)
         {
             ReadOnlySpan<byte> utf8JsonSpan = utf8Json.Span;
-            Utf8JsonReader reader = new Utf8JsonReader(
-                utf8JsonSpan,
-                isFinalBlock: true,
-                new JsonReaderState(options: readerOptions));
-
             var database = new MetadataDb(utf8Json.Length);
             var stack = new StackRowStack(JsonDocumentOptions.DefaultMaxDepth * StackRow.Size);
 
             try
             {
-                Parse(utf8JsonSpan, reader, ref database, ref stack);
+                Parse(utf8JsonSpan, readerOptions, ref database, ref stack);
             }
             catch
             {

--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
@@ -795,7 +795,7 @@ namespace System.Text.Json
                     WriteComplexElement(index, writer);
                     return;
                 case JsonTokenType.String:
-                    WriteString(ref row, writer);
+                    WriteString(row, writer);
                     return;
                 case JsonTokenType.Number:
                     writer.WriteNumberValue(_utf8Json.Slice(row.Location, row.SizeOrLength).Span);
@@ -826,7 +826,7 @@ namespace System.Text.Json
                 switch (row.TokenType)
                 {
                     case JsonTokenType.String:
-                        WriteString(ref row, writer);
+                        WriteString(row, writer);
                         continue;
                     case JsonTokenType.Number:
                         writer.WriteNumberValue(_utf8Json.Slice(row.Location, row.SizeOrLength).Span);
@@ -898,7 +898,7 @@ namespace System.Text.Json
             }
         }
 
-        private ReadOnlySpan<byte> UnescapeString(ref DbRow row, out ArraySegment<byte> rented)
+        private ReadOnlySpan<byte> UnescapeString(in DbRow row, out ArraySegment<byte> rented)
         {
             Debug.Assert(row.TokenType == JsonTokenType.String);
             int loc = row.Location;
@@ -939,7 +939,7 @@ namespace System.Text.Json
             {
                 writer.WriteString(
                     propertyName,
-                    UnescapeString(ref row, out rented));
+                    UnescapeString(row, out rented));
             }
             finally
             {
@@ -947,13 +947,13 @@ namespace System.Text.Json
             }
         }
 
-        private void WriteString(ref DbRow row, Utf8JsonWriter writer)
+        private void WriteString(in DbRow row, Utf8JsonWriter writer)
         {
             ArraySegment<byte> rented = default;
 
             try
             {
-                writer.WriteStringValue(UnescapeString(ref row, out rented));
+                writer.WriteStringValue(UnescapeString(row, out rented));
             }
             finally
             {

--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
@@ -865,7 +865,7 @@ namespace System.Text.Json
                             switch (propertyValue.TokenType)
                             {
                                 case JsonTokenType.String:
-                                    WriteString(propertyName, ref propertyValue, writer);
+                                    WriteString(propertyName, propertyValue, writer);
                                     continue;
                                 case JsonTokenType.Number:
                                     writer.WriteNumber(
@@ -931,7 +931,7 @@ namespace System.Text.Json
             }
         }
 
-        private void WriteString(ReadOnlySpan<byte> propertyName, ref DbRow row, Utf8JsonWriter writer)
+        private void WriteString(ReadOnlySpan<byte> propertyName, in DbRow row, Utf8JsonWriter writer)
         {
             ArraySegment<byte> rented = default;
 

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
@@ -94,7 +94,7 @@ namespace System.Text.Json
                 return lastFrame;
             }
 
-            IEnumerable value = ReadStackFrame.GetEnumerableValue(state.Current);
+            IEnumerable value = ReadStackFrame.GetEnumerableValue(ref state.Current);
 
             if (state.Current.TempEnumerableValues != null)
             {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
@@ -212,7 +212,7 @@ namespace System.Text.Json
             return JsonPropertyInfo.RuntimePropertyType;
         }
 
-        public static IEnumerable GetEnumerableValue(in ReadStackFrame current)
+        public static IEnumerable GetEnumerableValue(ref ReadStackFrame current)
         {
             if (current.IsEnumerable)
             {


### PR DESCRIPTION
Some minor optimizations to change `in` modifier to `ref`. This reduces the generated code size for these cases.

Pertains to https://github.com/dotnet/corefx/issues/39935 (doesn't "fix" as original issue was related to potential bugs).

For example with the code in [UnescapeString] ()https://github.com/dotnet/corefx/blob/1841042b99062de13dc80098cede9413be569238/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs#L904

With `in`:
```
   904:             int loc = row.Location;
 push        rsi  
 sub         rsp,150h  
 vzeroupper  
 lea         rbp,[rsp+160h]  
 mov         rsi,rcx  
 lea         rdi,[rbp-140h]  
 mov         ecx,4Ah  
 xor         eax,eax  
 rep stos    dword ptr [rdi]  
 mov         rcx,rsi  
 mov         qword ptr [rbp+10h],rcx  
 mov         qword ptr [rbp+18h],rdx  
 mov         qword ptr [rbp+20h],r8  
 mov         qword ptr [rbp+28h],r9  
 mov         rcx,qword ptr [rbp+20h]  
 mov         rax,qword ptr [rcx]  
 mov         qword ptr [rbp-50h],rax  
 mov         eax,dword ptr [rcx+8]  
 mov         dword ptr [rbp-48h],eax  
 lea         rcx,[rbp-50h]  
 call        00007FF833E55FE0  
 mov         dword ptr [rbp-14h],eax  
```

And with `ref`:
```
  904:             int loc = row.Location;
 push        rsi  
 sub         rsp,140h  
 vzeroupper  
 lea         rbp,[rsp+150h]  
 mov         rsi,rcx  
 lea         rdi,[rbp-130h]  
 mov         ecx,46h  
 xor         eax,eax  
 rep stos    dword ptr [rdi]  
 mov         rcx,rsi  
 mov         qword ptr [rbp+10h],rcx  
 mov         qword ptr [rbp+18h],rdx  
 mov         qword ptr [rbp+20h],r8  
 mov         qword ptr [rbp+28h],r9  
 mov         rcx,qword ptr [rbp+20h]  
 call        00007FF833E771F0  
 mov         dword ptr [rbp-14h],eax  
```
