### PR TITLE
[release/3.0]Handle `UnparseableExtension` status code when building X509Chain on …

### DIFF
--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509chain.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509chain.c
@@ -174,6 +174,8 @@ static void MergeStatusCodes(CFTypeRef key, CFTypeRef value, void* context)
         *pStatus |= PAL_X509ChainRevocationStatusUnknown;
     else if (CFEqual(keyString, CFSTR("MissingIntermediate")))
         *pStatus |= PAL_X509ChainPartialChain;
+    else if (CFEqual(keyString, CFSTR("UnparseableExtension")))
+        *pStatus |= PAL_X509ChainInvalidExtension;
     else if (CFEqual(keyString, CFSTR("WeakLeaf")) || CFEqual(keyString, CFSTR("WeakIntermediates")) ||
              CFEqual(keyString, CFSTR("WeakRoot")) || CFEqual(keyString, CFSTR("WeakKeySize")))
     {

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509chain.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509chain.c
@@ -175,7 +175,10 @@ static void MergeStatusCodes(CFTypeRef key, CFTypeRef value, void* context)
     else if (CFEqual(keyString, CFSTR("MissingIntermediate")))
         *pStatus |= PAL_X509ChainPartialChain;
     else if (CFEqual(keyString, CFSTR("UnparseableExtension")))
-        *pStatus |= PAL_X509ChainInvalidExtension;
+    {
+        //  10.15 introduced new status code value which is not reported by Windows.
+        //  So just ignoring it for now.
+    }
     else if (CFEqual(keyString, CFSTR("WeakLeaf")) || CFEqual(keyString, CFSTR("WeakIntermediates")) ||
              CFEqual(keyString, CFSTR("WeakRoot")) || CFEqual(keyString, CFSTR("WeakKeySize")))
     {

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509chain.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509chain.c
@@ -175,10 +175,7 @@ static void MergeStatusCodes(CFTypeRef key, CFTypeRef value, void* context)
     else if (CFEqual(keyString, CFSTR("MissingIntermediate")))
         *pStatus |= PAL_X509ChainPartialChain;
     else if (CFEqual(keyString, CFSTR("UnparseableExtension")))
-    {
-        //  10.15 introduced new status code value which is not reported by Windows.
-        //  So just ignoring it for now.
-    }
+        *pStatus |= PAL_X509ChainOfflineRevocation;
     else if (CFEqual(keyString, CFSTR("WeakLeaf")) || CFEqual(keyString, CFSTR("WeakIntermediates")) ||
              CFEqual(keyString, CFSTR("WeakRoot")) || CFEqual(keyString, CFSTR("WeakKeySize")))
     {

--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509chain.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509chain.c
@@ -175,7 +175,9 @@ static void MergeStatusCodes(CFTypeRef key, CFTypeRef value, void* context)
     else if (CFEqual(keyString, CFSTR("MissingIntermediate")))
         *pStatus |= PAL_X509ChainPartialChain;
     else if (CFEqual(keyString, CFSTR("UnparseableExtension")))
-        *pStatus |= PAL_X509ChainOfflineRevocation;
+    {
+        // 10.15 introduced new status code value which is not reported by Windows. Ignoring for now.
+    }
     else if (CFEqual(keyString, CFSTR("WeakLeaf")) || CFEqual(keyString, CFSTR("WeakIntermediates")) ||
              CFEqual(keyString, CFSTR("WeakRoot")) || CFEqual(keyString, CFSTR("WeakKeySize")))
     {

--- a/src/System.Security.Cryptography.X509Certificates/tests/DynamicChainTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/DynamicChainTests.cs
@@ -237,8 +237,10 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 using (X509Certificate2 ee = certReq.Create(root, notBefore, notAfter, root.GetSerialNumber()))
                 {
                     X509Chain chain = new X509Chain();
+                    chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
                     Assert.False(chain.Build(ee));
                     Assert.Equal(1, chain.ChainElements.Count);
+                    Assert.Equal(X509ChainStatusFlags.PartialChain, chain.AllStatusFlags());
                 }
             }
         }

--- a/src/System.Security.Cryptography.X509Certificates/tests/DynamicChainTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/DynamicChainTests.cs
@@ -239,6 +239,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                     X509Chain chain = new X509Chain();
                     Assert.False(chain.Build(ee));
                     Assert.Equal(1, chain.ChainElements.Count);
+                    Assert.Contains(chain.ChainStatus, (status) => status.Status.HasFlag(X509ChainStatusFlags.OfflineRevocation));
                 }
             }
         }

--- a/src/System.Security.Cryptography.X509Certificates/tests/DynamicChainTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/DynamicChainTests.cs
@@ -239,7 +239,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                     X509Chain chain = new X509Chain();
                     Assert.False(chain.Build(ee));
                     Assert.Equal(1, chain.ChainElements.Count);
-                    Assert.Contains(chain.ChainStatus, (status) => status.Status.HasFlag(X509ChainStatusFlags.OfflineRevocation));
                 }
             }
         }


### PR DESCRIPTION
Fixes #39988
Port of #40063

#### Description
Handle `UnparseableExtension` status code when building X509Chain on OSX 10.15
#### Impact
Allow building X509Chain to support `UnparseableExtension` status and gracefully fail on latest OSX
#### Regression?
No
#### Risk
Low