### PR TITLE
[master] Add DecoratedNameAttribute needed by C++/CLI compiler

### DIFF
--- a/src/System.Runtime.CompilerServices.VisualC/ref/System.Runtime.CompilerServices.VisualC.cs
+++ b/src/System.Runtime.CompilerServices.VisualC/ref/System.Runtime.CompilerServices.VisualC.cs
@@ -26,6 +26,11 @@ namespace System.Runtime.CompilerServices
     public static partial class CompilerMarshalOverride
     {
     }
+    [System.AttributeUsage(System.AttributeTargets.All)]
+    internal sealed class DecoratedNameAttribute : System.Attribute
+    {
+        public DecoratedNameAttribute(string decoratedName) {}
+    }
     [System.AttributeUsageAttribute(System.AttributeTargets.Struct)]
     public sealed partial class HasCopySemanticsAttribute : System.Attribute
     {

--- a/src/System.Runtime.CompilerServices.VisualC/src/System/Runtime/CompilerServices/Attributes.cs
+++ b/src/System.Runtime.CompilerServices.VisualC/src/System/Runtime/CompilerServices/Attributes.cs
@@ -21,6 +21,12 @@ namespace System.Runtime.CompilerServices
     {
     }
 
+    [AttributeUsage(AttributeTargets.All)]
+    internal sealed class DecoratedNameAttribute : Attribute
+    {
+        public DecoratedNameAttribute(string decoratedName) {}
+    }
+
     // Indicates that the modified instance is pinned in memory.
     public static class IsPinned
     {


### PR DESCRIPTION
The `System.Runtime.CompilerServices.DecoratedNameAttribute` type is needed by WPF. This type used to exist in .NET Framework; this is just porting the attribute as-is to .NET Core. This type is used by the C++/CLI compiler. Without it, WPF has been seeing "invalid typeref" warnings at crossgen time.

I've confirmed with the C++/CLI team that this change allows them to correctly find the type on their end.

See dotnet/wpf#634

See #40127 for the corresponding change in release/3.0.