### PR TITLE
Improve exception message for cycles during serialization

### DIFF
--- a/src/System.Text.Json/src/Resources/Strings.resx
+++ b/src/System.Text.Json/src/Resources/Strings.resx
@@ -423,4 +423,7 @@
   <data name="FormatUInt16" xml:space="preserve">
     <value>Either the JSON value is not in a supported format, or is out of bounds for a UInt16.</value>
   </data>
+  <data name="SerializerCycleDetected" xml:space="preserve">
+    <value>A possible object cycle was detected which is not supported. This can either be due to a cycle or if the object depth is larger than the maximum allowed depth of {0}.</value>
+  </data>
 </root>

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.cs
@@ -60,7 +60,7 @@ namespace System.Text.Json
                     }
                     else if (writer.CurrentDepth >= options.EffectiveMaxDepth)
                     {
-                        ThrowHelper.ThrowJsonException_DepthTooLarge(writer.CurrentDepth, state, options);
+                        ThrowHelper.ThrowInvalidOperationException_SerializerCycleDetected(options.MaxDepth);
                     }
 
                     // If serialization is not yet end and we surpass beyond flush threshold return false and flush stream.

--- a/src/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -28,6 +28,11 @@ namespace System.Text.Json
             return new NotSupportedException(SR.Format(SR.SerializationNotSupportedCollectionType, propertyType));
         }
 
+        public static void ThrowInvalidOperationException_SerializerCycleDetected(int maxDepth)
+        {
+            throw new JsonException(SR.Format(SR.SerializerCycleDetected, maxDepth));
+        }
+
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowJsonException_DeserializeUnableToConvertValue(Type propertyType, in Utf8JsonReader reader, string path, Exception innerException = null)
         {

--- a/src/System.Text.Json/tests/Serialization/CyclicTests.cs
+++ b/src/System.Text.Json/tests/Serialization/CyclicTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace System.Text.Json.Serialization.Tests
@@ -33,7 +34,7 @@ namespace System.Text.Json.Serialization.Tests
                 var options = new JsonSerializerOptions();
                 options.MaxDepth = depth + 1;
 
-                // No exception since depth was not passed.
+                // No exception since depth was not greater than MaxDepth.
                 string json = JsonSerializer.Serialize(rootObj, options);
                 Assert.False(string.IsNullOrEmpty(json));
             }
@@ -41,7 +42,12 @@ namespace System.Text.Json.Serialization.Tests
             {
                 var options = new JsonSerializerOptions();
                 options.MaxDepth = depth;
-                Assert.Throws<JsonException>(() => JsonSerializer.Serialize(rootObj, options));
+                JsonException ex = Assert.Throws<JsonException>(() => JsonSerializer.Serialize(rootObj, options));
+
+                // Exception should contain the path and MaxDepth.
+                string expectedPath = "$" + string.Concat(Enumerable.Repeat(".Parent", depth));
+                Assert.Contains(expectedPath, ex.Path);
+                Assert.Contains(depth.ToString(), ex.ToString());
             }
         }
 


### PR DESCRIPTION
Improves message as called out by https://github.com/dotnet/corefx/issues/39911

Went from
`CurrentDepth ({0}) is equal to or larger than the maximum allowed depth of {1}. Cannot write the next JSON object or array.`
to
`A possible object cycle was detected which is not supported. This can either be due to a cycle or if the object depth is larger than the maximum allowed depth of {0}.`

I recommend porting this to 3.0.

### Discussion issue:
The exception continues to be `JsonException` (JE) with no inner exception. Having JE allows the cycle to be discovered via the `Path` property which is important for generic logging reasons (ASP.NET and others). If this was a simple case where Path isn't important, we would just throw `InvalidOperationException` (IOE). As a side note we currently wrap almost all exceptions thrown from the reader\writer\document with a generic JE with the message "_The object or value could not be serialized. Path: {0}._" + set the inner exception.

So a valid alternative is to throw IOE instead with the nice error message and allow the current serialization infrastructure to automatically catch this as re-throw as JE. However, that results in that generic JE message which is not very friendly but will show the (very long recursive) path in the message so the cycle will be somewhat obvious.

Another alternative is to use the same nice string message for both the JE and the inner IOE but currently we don't do this anywhere.

It comes down to whether:
- Do we want a "correct" inner exception of IOE?
- Do we want the Path to be visible in the exception message (the one thrown\caught, the not the inner)? With the current PR the path is not visible in the exception message without inspecting the Path property.