### PR TITLE
[release/3.0] Add DecoratedNameAttribute

### DIFF
--- a/src/System.Runtime.CompilerServices.VisualC/ref/System.Runtime.CompilerServices.VisualC.cs
+++ b/src/System.Runtime.CompilerServices.VisualC/ref/System.Runtime.CompilerServices.VisualC.cs
@@ -26,6 +26,11 @@ namespace System.Runtime.CompilerServices
     public static partial class CompilerMarshalOverride
     {
     }
+    [System.AttributeUsage(System.AttributeTargets.All)]
+    internal sealed class DecoratedNameAttribute : System.Attribute
+    {
+        public DecoratedNameAttribute(string decoratedName) {}
+    }
     [System.AttributeUsageAttribute(System.AttributeTargets.Struct)]
     public sealed partial class HasCopySemanticsAttribute : System.Attribute
     {

--- a/src/System.Runtime.CompilerServices.VisualC/src/System/Runtime/CompilerServices/Attributes.cs
+++ b/src/System.Runtime.CompilerServices.VisualC/src/System/Runtime/CompilerServices/Attributes.cs
@@ -21,6 +21,12 @@ namespace System.Runtime.CompilerServices
     {
     }
 
+    [AttributeUsage(AttributeTargets.All)]
+    internal sealed class DecoratedNameAttribute : Attribute
+    {
+        public DecoratedNameAttribute(string decoratedName) {}
+    }
+
     // Indicates that the modified instance is pinned in memory.
     public static class IsPinned
     {


### PR DESCRIPTION
#### Description

The `System.Runtime.CompilerServices.DecoratedNameAttribute` type is needed by WPF. This type used to exist in .NET Framework; this is just porting the attribute as-is to .NET Core. This type is used by the C++/CLI compiler. Without it, WPF has been seeing "invalid typeref" warnings at crossgen time.

I've confirmed with the C++/CLI team that this change allows them to correctly find the type on their end.

#### Customer Impact

Without this change, WPF gets `Could not load type 'System.Runtime.CompilerServices.DecoratedNameAttribute' from assembly 'System.Runtime, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. while resolving 0xa000014 - System.Runtime.CompilerServices.DecoratedNameAttribute..ctor` errors when running crossgen on their assemblies.

See dotnet/wpf#634

#### Regression?

No. Since WPF and C++/CLI are new to .NET Core 3.0, this is not a regression.

#### Risk

Minimal. The implementation of the `DecoratedNameAttribute` matches the .NET Framework implementation exactly. I've already verified with @tgani-msft that this enables the C++/CLI compiler to emit a correct typeref token.

See #40125 for the corresponding change in master.