### PR TITLE
[release/3.0] Disable System.Net.Http.FunctionalTests SetDelegate_ConnectionSucceeds on OSX

### DIFF
--- a/src/Common/tests/CoreFx.Private.TestUtilities/System/PlatformDetection.Unix.cs
+++ b/src/Common/tests/CoreFx.Private.TestUtilities/System/PlatformDetection.Unix.cs
@@ -46,7 +46,8 @@ namespace System
         public static bool IsMacOsHighSierraOrHigher => IsOSX && (m_osxProductVersion.Value.Major > 10 || (m_osxProductVersion.Value.Major == 10 && m_osxProductVersion.Value.Minor >= 13));
         public static bool IsNotMacOsHighSierraOrHigher => !IsMacOsHighSierraOrHigher;
         public static bool IsMacOsMojaveOrHigher => IsOSX && (m_osxProductVersion.Value.Major > 10 || (m_osxProductVersion.Value.Major == 10 && m_osxProductVersion.Value.Minor >= 14));
-        
+        public static bool IsMacOsCatalinaOrHigher => IsOSX && (m_osxProductVersion.Value.Major > 10 || (m_osxProductVersion.Value.Major == 10 && m_osxProductVersion.Value.Minor >= 15));
+
         // RedHat family covers RedHat and CentOS
         public static bool IsRedHatFamily => IsRedHatFamilyAndVersion();
         public static bool IsNotRedHatFamily => !IsRedHatFamily;

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.AcceptAllCerts.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.AcceptAllCerts.cs
@@ -6,6 +6,7 @@ using System.Net.Security;
 using System.Net.Test.Common;
 using System.Security.Authentication;
 using System.Threading.Tasks;
+using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -27,7 +28,7 @@ namespace System.Net.Http.Functional.Tests
             Assert.True(HttpClientHandler.DangerousAcceptAnyServerCertificateValidator(null, null, null, SslPolicyErrors.None));
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(SslProtocols.Tls, false)] // try various protocols to ensure we correctly set versions even when accepting all certs
         [InlineData(SslProtocols.Tls, true)]
         [InlineData(SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls, false)]
@@ -38,16 +39,26 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(SslProtocols.None, true)]
         public async Task SetDelegate_ConnectionSucceeds(SslProtocols acceptedProtocol, bool requestOnlyThisProtocol)
         {
+            // Overriding flag for the same reason we skip tests on Catalina
+            // On OSX 10.13-10.14 we can override this flag to enable the scenario
+            // Issue: #22089
+            requestOnlyThisProtocol |= PlatformDetection.IsMacOsHighSierraOrHigher && acceptedProtocol == SslProtocols.Tls;
+
+            if (PlatformDetection.IsMacOsCatalinaOrHigher && acceptedProtocol == SslProtocols.Tls && IsCurlHandler)
+            {
+                // Issue: #39989
+                // When the server uses SslProtocols.Tls, on MacOS, SecureTransport ends up picking a cipher suite
+                // for TLS1.2, even though server said it was only using TLS1.0. LibreSsl throws error that
+                // wrong cipher is used for TLS1.0.
+                throw new SkipTestException("OSX may pick future cipher suites when asked for TLS1.0");
+            }
+
             using (HttpClientHandler handler = CreateHttpClientHandler())
             using (HttpClient client = CreateHttpClient(handler))
             {
                 handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
 
-                // Refer issue: #22089
-                // When the server uses SslProtocols.Tls, on MacOS, SecureTransport ends up picking a cipher suite
-                // for TLS1.2, even though server said it was only using TLS1.0. LibreSsl throws error that
-                // wrong cipher is used for TLs1.0.
-                if (requestOnlyThisProtocol || (PlatformDetection.IsMacOsHighSierraOrHigher && acceptedProtocol == SslProtocols.Tls))
+                if (requestOnlyThisProtocol)
                 {
                     handler.SslProtocols = acceptedProtocol;
                 }


### PR DESCRIPTION
Per discussion in #39989 disabling the test on MacOS Catalina.
Ports: https://github.com/dotnet/corefx/pull/40119

#### Description

Disable System.Net.Http.FunctionalTests SetDelegate_ConnectionSucceeds on OSX Catalina

#### Customer Impact

None - this is a test only change (reducing noise on the official test runs)

#### Regression?

No

#### Risk

None - test only change
