### PR TITLE
[release/3.0] Enable partial package build during source build (#40061)

### DIFF
--- a/eng/Packaging.props
+++ b/eng/Packaging.props
@@ -30,6 +30,19 @@
     <SkipValidatePackageTargetFramework>true</SkipValidatePackageTargetFramework>
     <SkipGenerationCheck>true</SkipGenerationCheck>
   </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
+    <!-- Don't build referenced projects -->
+    <BuildPackageLibraryReferences>false</BuildPackageLibraryReferences>
+    <!-- Omit any files that were not built -->
+    <AllowPartialPackages>true</AllowPartialPackages>
+    <!-- Don't permit harvesting since this requires pre-builts -->
+    <HarvestStablePackage>false</HarvestStablePackage>
+    <!-- Validation will fail in case we were relying on harvested assets or assets not built to satisfy stated support -->
+    <SkipValidatePackage>true</SkipValidatePackage>
+    <!-- Include All BuildConfigurations in package, so that whatever we're building for source build is included -->
+    <PackageConfigurations>$(BuildConfigurations)</PackageConfigurations>
+  </PropertyGroup>
 
   <Import Condition="Exists('../pkg/baseline/baseline.props') AND '$(MSBuildProjectExtension)' == '.pkgproj'" Project="../pkg/baseline/baseline.props" />
 

--- a/eng/Packaging.targets
+++ b/eng/Packaging.targets
@@ -13,7 +13,11 @@
     </ItemGroup>    
   </Target>
 
-  <Target Name="ValidateExcludeCompileDesktop" AfterTargets="GetPackageDependencies" Inputs="%(Dependency.Identity);%(Dependency.TargetFramework)" Outputs="unused">
+  <Target Name="ValidateExcludeCompileDesktop"
+          AfterTargets="GetPackageDependencies"
+          Inputs="%(Dependency.Identity);%(Dependency.TargetFramework)" 
+          Outputs="unused"
+          Condition="'$(SkipValidatePackage)' != 'true'">
     <PropertyGroup>
       <_excludeCompile Condition="@(Dependency->WithMetadataValue('Exclude', 'Compile')->Count()) == @(Dependency->Count())">true</_excludeCompile>
     </PropertyGroup>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -1,11 +1,15 @@
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
 
-  <ItemGroup>
-    <Project Include="$(MSBuildThisFileDirectory)..\pkg\*\*.builds" Condition="'$(SkipManagedPackageBuild)' != 'true'">
+  <PropertyGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
+    <AdditionalBuildConfigurations>$(AdditionalBuildConfigurations);package-$(ConfigurationGroup)</AdditionalBuildConfigurations>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(SkipManagedPackageBuild)' != 'true'">
+    <Project Include="$(MSBuildThisFileDirectory)..\pkg\*\*.builds" >
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
-    <Project Include="*\pkg\**\*.pkgproj" Condition="'$(SkipManagedPackageBuild)' != 'true' AND '$(BuildAllConfigurations)' == 'true'">
+    <Project Include="*\pkg\**\*.pkgproj" Condition="'$(BuildAllConfigurations)' == 'true' OR '$(DotNetBuildFromSource)' == 'true'">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
   </ItemGroup>

--- a/src/src.builds
+++ b/src/src.builds
@@ -1,6 +1,10 @@
 <Project DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
 
+  <PropertyGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
+    <AdditionalBuildConfigurations>$(AdditionalBuildConfigurations);netstandard-$(ConfigurationGroup)</AdditionalBuildConfigurations>
+  </PropertyGroup>
+
   <ItemGroup>
     <Project Include="$(MSBuildThisFileDirectory)*/src/*.csproj" Exclude="@(ProjectExclusions)" />
     <Project Include="$(MSBuildThisFileDirectory)*/src/*.ilproj" Exclude="@(ProjectExclusions)" />


### PR DESCRIPTION
Release port of #40061 
Fixes #39793 
Fixes #39787

#### Description

Upstack repos require some CoreFx packages that are not normally built by source build.  Enable those as "partial" packages in order to flow bits.

#### Customer Impact

Unable to build product from source without prebuilts.

#### Regression?

No

#### Risk

Could break the build or not be enough for all upstack consumers (eg: suppose someone **needs** a netcoreapp2.0 or desktop targeting asset that we don't build during source build because those prebuilts are not available).  We've done our best to mitigate this via manual testing and inspection.