### PR TITLE
Remove unused parameters for custom test errors

### DIFF
--- a/src/System.Collections.Concurrent/tests/BlockingCollectionCancellationTests.cs
+++ b/src/System.Collections.Concurrent/tests/BlockingCollectionCancellationTests.cs
@@ -71,18 +71,14 @@ namespace System.Collections.Concurrent.Tests
 
             int item;
             EnsureOperationCanceledExceptionThrown(
-                () => bc.Take(cs.Token), cs.Token,
-                "ExternalCancel_Take:  The operation should wake up via token cancellation.");
+                () => bc.Take(cs.Token), cs.Token);
             EnsureOperationCanceledExceptionThrown(
-               () => bc.TryTake(out item, 100000, cs.Token), cs.Token,
-                "ExternalCancel_TryTake:  The operation should wake up via token cancellation.");
+                () => bc.TryTake(out item, 100000, cs.Token), cs.Token);
             EnsureOperationCanceledExceptionThrown(
-                () => bc.Add(1, cs.Token), cs.Token,
-                "ExternalCancel_Add:  The operation should wake up via token cancellation.");
+                () => bc.Add(1, cs.Token), cs.Token);
             EnsureOperationCanceledExceptionThrown(
                 () => bc.TryAdd(1, 100000, cs.Token), // a long timeout.
-                cs.Token,
-                "ExternalCancel_TryAdd:  The operation should wake up via token cancellation.");
+                cs.Token);
 
             BlockingCollection<int> bc1 = new BlockingCollection<int>(1);
             BlockingCollection<int> bc2 = new BlockingCollection<int>(1);
@@ -90,17 +86,15 @@ namespace System.Collections.Concurrent.Tests
             bc2.Add(1); //fill the bc.
             EnsureOperationCanceledExceptionThrown(
                 () => BlockingCollection<int>.AddToAny(new[] { bc1, bc2 }, 1, cs.Token),
-                cs.Token,
-                "ExternalCancel_AddToAny:  The operation should wake up via token cancellation.");
+                cs.Token);
             EnsureOperationCanceledExceptionThrown(
                () => BlockingCollection<int>.TryAddToAny(new[] { bc1, bc2 }, 1, 10000, cs.Token),
-               cs.Token,
-               "ExternalCancel_AddToAny:  The operation should wake up via token cancellation.");
+               cs.Token);
 
             IEnumerable<int> enumerable = bc.GetConsumingEnumerable(cs.Token);
             EnsureOperationCanceledExceptionThrown(
                () => enumerable.GetEnumerator().MoveNext(),
-               cs.Token, "ExternalCancel_GetConsumingEnumerable:  The operation should wake up via token cancellation.");
+               cs.Token);
         }
 
         [Fact]
@@ -159,7 +153,7 @@ namespace System.Collections.Concurrent.Tests
 
         #region Helper Methods
 
-        private static void EnsureOperationCanceledExceptionThrown(Action action, CancellationToken token, string message)
+        private static void EnsureOperationCanceledExceptionThrown(Action action, CancellationToken token)
         {
             OperationCanceledException operationCanceledEx =
                 Assert.Throws<OperationCanceledException>(action); // "BlockingCollectionCancellationTests: OperationCanceledException not thrown.");

--- a/src/System.Collections.Immutable/tests/ImmutableStackTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableStackTest.cs
@@ -68,7 +68,7 @@ namespace System.Collections.Immutable.Tests
                 var nextStack = currentStack.Pop();
                 Assert.Equal(expectedCount, currentStack.Count());
                 Assert.NotSame(currentStack, nextStack);
-                AssertAreSame(currentStack.Pop(), currentStack.Pop(), "Popping the stack 2X should yield the same shorter stack.");
+                AssertAreSame(currentStack.Pop(), currentStack.Pop());
                 currentStack = nextStack;
             }
         }
@@ -86,7 +86,7 @@ namespace System.Collections.Immutable.Tests
                 current.Pop(out element);
                 AssertAreSame(current.Peek(), element);
                 var next = current.Pop();
-                AssertAreSame(values[i], current.Peek(), "Pop mutated the stack instance.");
+                AssertAreSame(values[i], current.Peek());
                 current = next;
             }
         }

--- a/src/System.Collections.Immutable/tests/ImmutableTestBase.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableTestBase.cs
@@ -21,7 +21,7 @@ namespace System.Collections.Immutable.Tests
             get { return 100; }
         }
 
-        internal static void AssertAreSame<T>(T expected, T actual, string message = null, params object[] formattingArgs)
+        internal static void AssertAreSame<T>(T expected, T actual)
         {
             if (typeof(T).GetTypeInfo().IsValueType)
             {

--- a/src/System.Composition/tests/Util/AssertX.cs
+++ b/src/System.Composition/tests/Util/AssertX.cs
@@ -10,7 +10,7 @@ namespace System.Composition.UnitTests.Util
 {
     internal static class AssertX
     {
-        public static void Equivalent<T>(IEnumerable<T> expected, IEnumerable<T> actual, string message = null, params object[] args)
+        public static void Equivalent<T>(IEnumerable<T> expected, IEnumerable<T> actual)
         {
             IDictionary<T, int> expectedCounts = expected.GroupBy(x => x).ToDictionary(x => x.Key, x => x.Count());
             IDictionary<T, int> actualCounts = actual.GroupBy(x => x).ToDictionary(x => x.Key, x => x.Count());

--- a/src/System.Runtime.Numerics/tests/BigInteger/Comparison.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/Comparison.cs
@@ -390,16 +390,16 @@ namespace System.Numerics.Tests
             Assert.Equal(expectedEquals, x.Equals((object)y));
             Assert.Equal(expectedEquals, y.Equals((object)x));
 
-            VerifyCompareResult(expectedResult, x.CompareTo(y), "x.CompareTo(y)");
-            VerifyCompareResult(-expectedResult, y.CompareTo(x), "y.CompareTo(x)");
+            VerifyCompareResult(expectedResult, x.CompareTo(y));
+            VerifyCompareResult(-expectedResult, y.CompareTo(x));
 
             IComparable comparableX = x;
             IComparable comparableY = y;
-            VerifyCompareResult(expectedResult, comparableX.CompareTo(y), "comparableX.CompareTo(y)");
-            VerifyCompareResult(-expectedResult, comparableY.CompareTo(x), "comparableY.CompareTo(x)");
+            VerifyCompareResult(expectedResult, comparableX.CompareTo(y));
+            VerifyCompareResult(-expectedResult, comparableY.CompareTo(x));
 
-            VerifyCompareResult(expectedResult, BigInteger.Compare(x, y), "Compare(x,y)");
-            VerifyCompareResult(-expectedResult, BigInteger.Compare(y, x), "Compare(y,x)");
+            VerifyCompareResult(expectedResult, BigInteger.Compare(x, y));
+            VerifyCompareResult(-expectedResult, BigInteger.Compare(y, x));
 
             if (expectedEquals)
             {
@@ -437,7 +437,7 @@ namespace System.Numerics.Tests
 
             Assert.Equal(expectedEquals, x.Equals(y));
 
-            VerifyCompareResult(expectedResult, x.CompareTo(y), "x.CompareTo(y)");
+            VerifyCompareResult(expectedResult, x.CompareTo(y));
 
             if (expectedEquals)
             {
@@ -475,7 +475,7 @@ namespace System.Numerics.Tests
 
             Assert.Equal(expectedEquals, x.Equals(y));
 
-            VerifyCompareResult(expectedResult, x.CompareTo(y), "x.CompareTo(y)");
+            VerifyCompareResult(expectedResult, x.CompareTo(y));
 
             if (expectedEquals)
             {
@@ -514,7 +514,7 @@ namespace System.Numerics.Tests
 
             Assert.Equal(expectedEquals, x.Equals(y));
 
-            VerifyCompareResult(expectedResult, x.CompareTo(y), "x.CompareTo(y)");
+            VerifyCompareResult(expectedResult, x.CompareTo(y));
 
             if (expectedEquals)
             {
@@ -552,7 +552,7 @@ namespace System.Numerics.Tests
 
             Assert.Equal(expectedEquals, x.Equals(y));
 
-            VerifyCompareResult(expectedResult, x.CompareTo(y), "x.CompareTo(y)");
+            VerifyCompareResult(expectedResult, x.CompareTo(y));
 
             if (expectedEquals)
             {
@@ -608,8 +608,8 @@ namespace System.Numerics.Tests
             Assert.Equal(expectedEquals, x.Equals((object)y));
             Assert.Equal(expectedEquals, y.Equals((object)x));
 
-            VerifyCompareResult(expectedResult, x.CompareTo(y), "x.CompareTo(y)");
-            VerifyCompareResult(-expectedResult, y.CompareTo(x), "y.CompareTo(x)");
+            VerifyCompareResult(expectedResult, x.CompareTo(y));
+            VerifyCompareResult(-expectedResult, y.CompareTo(x));
 
             if (expectedEquals)
             {
@@ -637,8 +637,8 @@ namespace System.Numerics.Tests
             Assert.Equal(expectedGreaterThan || expectedEquals, x >= y);
             Assert.Equal(expectedLessThan || expectedEquals, y >= x);
         }
-
-        private static void VerifyCompareResult(int expected, int actual, string message)
+        
+        private static void VerifyCompareResult(int expected, int actual)
         {
             if (0 == expected)
             {

--- a/src/System.Threading/tests/BarrierCancellationTests.cs
+++ b/src/System.Threading/tests/BarrierCancellationTests.cs
@@ -22,14 +22,11 @@ namespace System.Threading.Tests
             TimeSpan timeSpan = new TimeSpan(100);
 
             EnsureOperationCanceledExceptionThrown(
-               () => barrier.SignalAndWait(ct), ct,
-               "CancelBeforeWait:  An OCE should have been thrown.");
+                () => barrier.SignalAndWait(ct), ct);
             EnsureOperationCanceledExceptionThrown(
-               () => barrier.SignalAndWait(millisec, ct), ct,
-               "CancelBeforeWait:  An OCE should have been thrown.");
+                () => barrier.SignalAndWait(millisec, ct), ct);
             EnsureOperationCanceledExceptionThrown(
-               () => barrier.SignalAndWait(timeSpan, ct), ct,
-               "CancelBeforeWait:  An OCE should have been thrown.");
+                () => barrier.SignalAndWait(timeSpan, ct), ct);
 
             barrier.Dispose();
         }
@@ -48,8 +45,7 @@ namespace System.Threading.Tests
             //Now wait.. the wait should abort and an exception should be thrown
             EnsureOperationCanceledExceptionThrown(
                () => barrier.SignalAndWait(cancellationToken),
-               cancellationToken,
-               "CancelAfterWait:  An OCE(null) should have been thrown that references the cancellationToken.");
+               cancellationToken);
 
             // the token should not have any listeners.
             // currently we don't expose this.. but it was verified manually
@@ -73,7 +69,7 @@ namespace System.Threading.Tests
             // currently we don't expose this.. but it was verified manually
         }
 
-        private static void EnsureOperationCanceledExceptionThrown(Action action, CancellationToken token, string message)
+        private static void EnsureOperationCanceledExceptionThrown(Action action, CancellationToken token)
         {
             OperationCanceledException operationCanceledEx =
                 Assert.Throws<OperationCanceledException>(action);

--- a/src/System.Threading/tests/CountdownEventCancellationTests.cs
+++ b/src/System.Threading/tests/CountdownEventCancellationTests.cs
@@ -19,10 +19,9 @@ namespace System.Threading.Tests
 
             const int millisec = 100;
             TimeSpan timeSpan = new TimeSpan(100);
-            string message = "CancelBeforeWait:  > Cancellation token does not match.";
-            EnsureOperationCanceledExceptionThrown(() => countdownEvent.Wait(ct), ct, message);
-            EnsureOperationCanceledExceptionThrown(() => countdownEvent.Wait(millisec, ct), ct, message);
-            EnsureOperationCanceledExceptionThrown(() => countdownEvent.Wait(timeSpan, ct), ct, message);
+            EnsureOperationCanceledExceptionThrown(() => countdownEvent.Wait(ct), ct);
+            EnsureOperationCanceledExceptionThrown(() => countdownEvent.Wait(millisec, ct), ct);
+            EnsureOperationCanceledExceptionThrown(() => countdownEvent.Wait(timeSpan, ct), ct);
 
             countdownEvent.Dispose();
         }
@@ -41,14 +40,13 @@ namespace System.Threading.Tests
             });
 
             //Now wait.. the wait should abort and an exception should be thrown
-            EnsureOperationCanceledExceptionThrown(() => countdownEvent.Wait(cancellationToken), cancellationToken,
-               "CancelAfterWait:  An OCE(null) should have been thrown that references the cancellationToken.");
+            EnsureOperationCanceledExceptionThrown(() => countdownEvent.Wait(cancellationToken), cancellationToken);
 
             // the token should not have any listeners.
             // currently we don't expose this.. but it was verified manually
         }
 
-        private static void EnsureOperationCanceledExceptionThrown(Action action, CancellationToken token, string message)
+        private static void EnsureOperationCanceledExceptionThrown(Action action, CancellationToken token)
         {
             OperationCanceledException operationCanceledEx =
                 Assert.Throws<OperationCanceledException>(action);

--- a/src/System.Threading/tests/ManualResetEventSlimCancellationTests.cs
+++ b/src/System.Threading/tests/ManualResetEventSlimCancellationTests.cs
@@ -20,12 +20,9 @@ namespace System.Threading.Tests
             const int millisec = 100;
             TimeSpan timeSpan = new TimeSpan(100);
 
-            EnsureOperationCanceledExceptionThrown(
-               () => mres.Wait(ct), ct, "CancelBeforeWait:  An OCE should have been thrown.");
-            EnsureOperationCanceledExceptionThrown(
-               () => mres.Wait(millisec, ct), ct, "CancelBeforeWait:  An OCE should have been thrown.");
-            EnsureOperationCanceledExceptionThrown(
-               () => mres.Wait(timeSpan, ct), ct, "CancelBeforeWait:  An OCE should have been thrown.");
+            EnsureOperationCanceledExceptionThrown(() => mres.Wait(ct), ct);
+            EnsureOperationCanceledExceptionThrown(() => mres.Wait(millisec, ct), ct);
+            EnsureOperationCanceledExceptionThrown(() => mres.Wait(timeSpan, ct), ct);
             mres.Dispose();
         }
 
@@ -46,15 +43,13 @@ namespace System.Threading.Tests
                 );
 
             //Now wait.. the wait should abort and an exception should be thrown
-            EnsureOperationCanceledExceptionThrown(
-               () => mres.Wait(cancellationToken), cancellationToken,
-               "CancelBeforeWait:  An OCE(null) should have been thrown that references the cancellationToken.");
+            EnsureOperationCanceledExceptionThrown(() => mres.Wait(cancellationToken), cancellationToken);
 
             // the token should not have any listeners.
             // currently we don't expose this.. but it was verified manually
         }
 
-        private static void EnsureOperationCanceledExceptionThrown(Action action, CancellationToken token, string message)
+        private static void EnsureOperationCanceledExceptionThrown(Action action, CancellationToken token)
         {
             OperationCanceledException operationCanceledEx =
                 Assert.Throws<OperationCanceledException>(action);

--- a/src/System.Threading/tests/SemaphoreSlimCancellationTests.cs
+++ b/src/System.Threading/tests/SemaphoreSlimCancellationTests.cs
@@ -20,9 +20,9 @@ namespace System.Threading.Tests
 
             const int millisec = 100;
             TimeSpan timeSpan = new TimeSpan(100);
-            EnsureOperationCanceledExceptionThrown(() => semaphoreSlim.Wait(ct), ct, "CancelBeforeWait:  An OCE should have been thrown.");
-            EnsureOperationCanceledExceptionThrown(() => semaphoreSlim.Wait(millisec, ct), ct, "CancelBeforeWait:  An OCE should have been thrown.");
-            EnsureOperationCanceledExceptionThrown(() => semaphoreSlim.Wait(timeSpan, ct), ct, "CancelBeforeWait:  An OCE should have been thrown.");
+            EnsureOperationCanceledExceptionThrown(() => semaphoreSlim.Wait(ct), ct);
+            EnsureOperationCanceledExceptionThrown(() => semaphoreSlim.Wait(millisec, ct), ct);
+            EnsureOperationCanceledExceptionThrown(() => semaphoreSlim.Wait(timeSpan, ct), ct);
             semaphoreSlim.Dispose();
         }
 
@@ -44,13 +44,13 @@ namespace System.Threading.Tests
             //Now wait.. the wait should abort and an exception should be thrown
             EnsureOperationCanceledExceptionThrown(
                () => semaphoreSlim.Wait(cancellationToken),
-               cancellationToken, "CancelAfterWait:  An OCE(null) should have been thrown that references the cancellationToken.");
+               cancellationToken);
 
             // the token should not have any listeners.
             // currently we don't expose this.. but it was verified manually
         }
 
-        private static void EnsureOperationCanceledExceptionThrown(Action action, CancellationToken token, string message)
+        private static void EnsureOperationCanceledExceptionThrown(Action action, CancellationToken token)
         {
             OperationCanceledException operationCanceledEx =
                 Assert.Throws<OperationCanceledException>(action);


### PR DESCRIPTION
There are a few places where custom test error messages are passed to helper methods which in turn do not make use of them. This PR removes them in order to avoid confusion and get rid of some code analyzer warnings.

Closes #38575