### PR TITLE
HttpStress: add a 'GET Slow' operation

### DIFF
--- a/src/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
@@ -143,7 +143,7 @@ namespace HttpStress
             }
         }
 
-        // generates a random expected response content length and adds it to the request headers
+        // Generates a random expected response content length and adds it to the request headers
         public int SetExpectedResponseContentLengthHeader(HttpRequestHeaders headers, int minLength = 0)
         {
             int expectedResponseContentLength = _random.Next(minLength, Math.Max(minLength, MaxContentLength));

--- a/src/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
@@ -205,7 +205,7 @@ namespace HttpStress
                     // Validate that request headers are being echoed
                     foreach (KeyValuePair<string, IEnumerable<string>> reqHeader in req.Headers)
                     {
-                        if (!res.Headers.TryGetValues(reqHeader.Key, out var values))
+                        if (!res.Headers.TryGetValues(reqHeader.Key, out IEnumerable<string> values))
                         {
                             throw new Exception($"Expected response header name {reqHeader.Key} missing.");
                         }

--- a/src/System.Net.Http/tests/StressTests/HttpStress/StressServer.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/StressServer.cs
@@ -29,7 +29,7 @@ namespace HttpStress
 {
     public class StressServer : IDisposable
     {
-        // header indicating expected response content length to be returned by the server
+        // Header indicating expected response content length to be returned by the server
         public const string ExpectedResponseContentLength = "Expected-Response-Content-Length";
 
         private EventListener _eventListener;

--- a/src/System.Net.Http/tests/StressTests/HttpStress/StressServer.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/StressServer.cs
@@ -29,6 +29,8 @@ namespace HttpStress
 {
     public class StressServer : IDisposable
     {
+        // header indicating expected response content length to be returned by the server
+        public const string ExpectedResponseContentLength = "Expected-Response-Content-Length";
 
         private EventListener _eventListener;
         private readonly IWebHost _webHost;
@@ -95,7 +97,7 @@ namespace HttpStress
                 {
                     var head = new[] { "HEAD" };
                     app.UseRouting();
-                    app.UseEndpoints(e => MapRoutes(e, configuration.MaxContentLength));
+                    app.UseEndpoints(MapRoutes);
                 });
 
             // Handle command-line arguments.
@@ -109,22 +111,24 @@ namespace HttpStress
             _webHost.Start();
         }
 
-        private static void MapRoutes(IEndpointRouteBuilder endpoints, int maxContentLength)
+        private static void MapRoutes(IEndpointRouteBuilder endpoints)
         {
-            string contentSource = ServerContentUtils.CreateStringContent(maxContentLength);
             var head = new[] { "HEAD" };
 
             endpoints.MapGet("/", async context =>
             {
                 // Get requests just send back the requested content.
-                await context.Response.WriteAsync(contentSource);
+                string content = CreateResponseContent(context);
+                await context.Response.WriteAsync(content);
             });
             endpoints.MapGet("/slow", async context =>
             {
                 // Sends back the content a character at a time.
-                for (int i = 0; i < contentSource.Length; i++)
+                string content = CreateResponseContent(context);
+
+                for (int i = 0; i < content.Length; i++)
                 {
-                    await context.Response.WriteAsync(contentSource[i].ToString());
+                    await context.Response.WriteAsync(content[i].ToString());
                     await context.Response.Body.FlushAsync();
                 }
             });
@@ -171,7 +175,8 @@ namespace HttpStress
             endpoints.MapGet("/abort", async context =>
             {
                 // Server writes some content, then aborts the connection
-                await context.Response.WriteAsync(contentSource.Substring(0, contentSource.Length / 2));
+                string content = CreateResponseContent(context);
+                await context.Response.WriteAsync(content.Substring(0, content.Length / 2));
                 context.Abort();
             });
             endpoints.MapPost("/", async context =>
@@ -199,7 +204,8 @@ namespace HttpStress
             endpoints.MapMethods("/", head, context =>
             {
                 // Just set the max content length on the response.
-                context.Response.Headers.ContentLength = maxContentLength;
+                string content = CreateResponseContent(context);
+                context.Response.Headers.ContentLength = content.Length;
                 return Task.CompletedTask;
             });
             endpoints.MapPut("/", async context =>
@@ -281,6 +287,23 @@ namespace HttpStress
                         Console.WriteLine();
                     }
                 }
+            }
+        }
+
+        private static string CreateResponseContent(HttpContext ctx)
+        {
+            return ServerContentUtils.CreateStringContent(GetExpectedContentLength());
+
+            int GetExpectedContentLength()
+            {
+                if (ctx.Request.Headers.TryGetValue(ExpectedResponseContentLength, out StringValues values) && 
+                    values.Count == 1 &&
+                    Int32.TryParse(values[0], out int result))
+                {
+                    return result;
+                }
+
+                throw new Exception($"Could not parse {ExpectedResponseContentLength} header");
             }
         }
     }

--- a/src/System.Net.Http/tests/StressTests/HttpStress/StressServer.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/StressServer.cs
@@ -298,7 +298,7 @@ namespace HttpStress
             {
                 if (ctx.Request.Headers.TryGetValue(ExpectedResponseContentLength, out StringValues values) && 
                     values.Count == 1 &&
-                    Int32.TryParse(values[0], out int result))
+                    int.TryParse(values[0], out int result))
                 {
                     return result;
                 }


### PR DESCRIPTION
* Adds a 'GET Slow' operation.
* Randomize the response content length in GET requests. Results are validated by having the client specify the expected length in request headers.