### PR TITLE
[release/3.0] Improve exception message for cycles during serialization (#40126)

### DIFF
--- a/src/System.Text.Json/src/Resources/Strings.resx
+++ b/src/System.Text.Json/src/Resources/Strings.resx
@@ -423,4 +423,7 @@
   <data name="FormatUInt16" xml:space="preserve">
     <value>Either the JSON value is not in a supported format, or is out of bounds for a UInt16.</value>
   </data>
+  <data name="SerializerCycleDetected" xml:space="preserve">
+    <value>A possible object cycle was detected which is not supported. This can either be due to a cycle or if the object depth is larger than the maximum allowed depth of {0}.</value>
+  </data>
 </root>

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.cs
@@ -60,7 +60,7 @@ namespace System.Text.Json
                     }
                     else if (writer.CurrentDepth >= options.EffectiveMaxDepth)
                     {
-                        ThrowHelper.ThrowJsonException_DepthTooLarge(writer.CurrentDepth, state, options);
+                        ThrowHelper.ThrowInvalidOperationException_SerializerCycleDetected(options.MaxDepth);
                     }
 
                     // If serialization is not yet end and we surpass beyond flush threshold return false and flush stream.

--- a/src/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -28,6 +28,11 @@ namespace System.Text.Json
             return new NotSupportedException(SR.Format(SR.SerializationNotSupportedCollectionType, propertyType));
         }
 
+        public static void ThrowInvalidOperationException_SerializerCycleDetected(int maxDepth)
+        {
+            throw new JsonException(SR.Format(SR.SerializerCycleDetected, maxDepth));
+        }
+
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowJsonException_DeserializeUnableToConvertValue(Type propertyType, in Utf8JsonReader reader, string path, Exception innerException = null)
         {

--- a/src/System.Text.Json/tests/Serialization/CyclicTests.cs
+++ b/src/System.Text.Json/tests/Serialization/CyclicTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace System.Text.Json.Serialization.Tests
@@ -33,7 +34,7 @@ namespace System.Text.Json.Serialization.Tests
                 var options = new JsonSerializerOptions();
                 options.MaxDepth = depth + 1;
 
-                // No exception since depth was not passed.
+                // No exception since depth was not greater than MaxDepth.
                 string json = JsonSerializer.Serialize(rootObj, options);
                 Assert.False(string.IsNullOrEmpty(json));
             }
@@ -41,7 +42,12 @@ namespace System.Text.Json.Serialization.Tests
             {
                 var options = new JsonSerializerOptions();
                 options.MaxDepth = depth;
-                Assert.Throws<JsonException>(() => JsonSerializer.Serialize(rootObj, options));
+                JsonException ex = Assert.Throws<JsonException>(() => JsonSerializer.Serialize(rootObj, options));
+
+                // Exception should contain the path and MaxDepth.
+                string expectedPath = "$" + string.Concat(Enumerable.Repeat(".Parent", depth));
+                Assert.Contains(expectedPath, ex.Path);
+                Assert.Contains(depth.ToString(), ex.ToString());
             }
         }
 


### PR DESCRIPTION
Port #40126 to 3.0

Improves message as called out by #39911

cc: @ericstj, @danmosemsft

## Description
Changes an exception message to make it more useful when there is a cycle detected during serialization.

Changed from
`CurrentDepth ({0}) is equal to or larger than the maximum allowed depth of {1}. Cannot write the next JSON object or array.`
to
`A possible object cycle was detected which is not supported. This can either be due to a cycle or if the object depth is larger than the maximum allowed depth of {0}.`

## Customer Impact

Improved exception message.

## Regression?

No.

## Risk

Low. A test was modified to verify the exception content.