### PR TITLE
pal_console: add missing mutex_unlock

### DIFF
--- a/src/Native/Unix/System.Native/pal_console.c
+++ b/src/Native/Unix/System.Native/pal_console.c
@@ -252,6 +252,7 @@ void SystemNative_ConfigureTerminalForChildProcess(int32_t childUsesTerminal)
         // If the application is performing a read, assume the child process won't use the terminal.
         if (g_reading)
         {
+            pthread_mutex_unlock(&g_lock);
             return;
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/40137

CC @stephentoub 