### PR TITLE
improve detection of usable KeyChain

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/tests/X509StoreMutableTests.OSX.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X509StoreMutableTests.OSX.cs
@@ -23,7 +23,13 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 const int errSecWrPerm = -61;
                 const int errSecInteractionNotAllowed = -25308;
 
-                if (e.HResult == errSecWrPerm || e.HResult == errSecInteractionNotAllowed)
+                if (e.HResult == errSecInteractionNotAllowed)
+                {
+                    Console.WriteLine("Run 'security unlock-keychain' to make tests runable.");
+                    return false;
+                }
+
+                if (e.HResult == errSecWrPerm)
                 {
                     return false;
                 }

--- a/src/System.Security.Cryptography.X509Certificates/tests/X509StoreMutableTests.OSX.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X509StoreMutableTests.OSX.cs
@@ -21,8 +21,9 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             catch (CryptographicException e)
             {
                 const int errSecWrPerm = -61;
+                const int errSecInteractionNotAllowed = -25308;
 
-                if (e.HResult == errSecWrPerm)
+                if (e.HResult == errSecWrPerm || e.HResult == errSecInteractionNotAllowed)
                 {
                     return false;
                 }


### PR DESCRIPTION
contributes to #40161

This seems to be CI issues where KeyChain is locked when test runs. I'm working with infrastructure team to fix that. But since there was clear intention to make some tests optional, I improved detection for cases where KeyChain is locked because there was no interactive login. This should not happen for developers when running tests on personal device but does happen on headless CI systems after upgrading them to 10.13. 