### PR TITLE
followup on SocketAddress validation

### DIFF
--- a/src/Common/src/System/Net/SocketAddressPal.Windows.cs
+++ b/src/Common/src/System/Net/SocketAddressPal.Windows.cs
@@ -18,7 +18,7 @@ namespace System.Net
 
         public static unsafe void SetAddressFamily(byte[] buffer, AddressFamily family)
         {
-            if ((int)(family) > UInt.MaxValue)
+            if ((int)(family) > UInt16.MaxValue)
             {
                 // For legacy values family maps directly to Winsock value.
                 // Other values will need new mapping if/when supported.

--- a/src/Common/src/System/Net/SocketAddressPal.Windows.cs
+++ b/src/Common/src/System/Net/SocketAddressPal.Windows.cs
@@ -18,10 +18,10 @@ namespace System.Net
 
         public static unsafe void SetAddressFamily(byte[] buffer, AddressFamily family)
         {
-            if ((int)(family) > (int)AddressFamily.Max)
+            if ((int)(family) > UInt.MaxValue)
             {
-                // For legacy values up to AddressFamily.Max, family maps directly to Winsock value.
-                // Other values will need mapping if/when supported.
+                // For legacy values family maps directly to Winsock value.
+                // Other values will need new mapping if/when supported.
                 // Currently, that is Netlink, Packet and ControllerAreaNetwork, neither of them supported on Windows.
                 throw new PlatformNotSupportedException();
             }

--- a/src/Common/src/System/Net/SocketAddressPal.Windows.cs
+++ b/src/Common/src/System/Net/SocketAddressPal.Windows.cs
@@ -18,7 +18,7 @@ namespace System.Net
 
         public static unsafe void SetAddressFamily(byte[] buffer, AddressFamily family)
         {
-            if ((int)(family) > UInt16.MaxValue)
+            if ((int)(family) > ushort.MaxValue)
             {
                 // For legacy values family maps directly to Winsock value.
                 // Other values will need new mapping if/when supported.

--- a/src/Common/src/System/Net/SocketAddressPal.Windows.cs
+++ b/src/Common/src/System/Net/SocketAddressPal.Windows.cs
@@ -21,7 +21,7 @@ namespace System.Net
             if ((int)(family) > ushort.MaxValue)
             {
                 // For legacy values family maps directly to Winsock value.
-                // Other values will need new mapping if/when supported.
+                // Other values will need mapping if/when supported.
                 // Currently, that is Netlink, Packet and ControllerAreaNetwork, neither of them supported on Windows.
                 throw new PlatformNotSupportedException();
             }

--- a/src/Common/src/System/Net/Sockets/ProtocolFamily.cs
+++ b/src/Common/src/System/Net/Sockets/ProtocolFamily.cs
@@ -42,7 +42,6 @@ namespace System.Net.Internals
         Irda = AddressFamily.Irda,
         NetworkDesigners = AddressFamily.NetworkDesigners,
         Max = 29, //AddressFamily.Max
-        Netlink = AddressFamily.Netlink,
         Packet = AddressFamily.Packet,
         ControllerAreaNetwork = AddressFamily.ControllerAreaNetwork,
     }

--- a/src/Native/Unix/System.Native/pal_networking.c
+++ b/src/Native/Unix/System.Native/pal_networking.c
@@ -492,11 +492,6 @@ static bool TryConvertAddressFamilyPlatformToPal(sa_family_t platformAddressFami
         case AF_INET6:
             *palAddressFamily = AddressFamily_AF_INET6;
             return true;
-#ifdef AF_NETLINK
-        case AF_NETLINK:
-            *palAddressFamily = AddressFamily_AF_NETLINK;
-            return true;
-#endif
 #ifdef AF_PACKET
         case AF_PACKET:
             *palAddressFamily = AddressFamily_AF_PACKET;

--- a/src/Native/Unix/System.Native/pal_networking.h
+++ b/src/Native/Unix/System.Native/pal_networking.h
@@ -60,9 +60,9 @@ typedef enum
     AddressFamily_AF_UNIX = 1,     // System.Net.AddressFamily.Unix
     AddressFamily_AF_INET = 2,     // System.Net.AddressFamily.InterNetwork
     AddressFamily_AF_INET6 = 23,   // System.Net.AddressFamily.InterNetworkV6
-    AddressFamily_AF_NETLINK = 30, // System.Net.AddressFamily.Netlink
-    AddressFamily_AF_PACKET = 31,  // System.Net.AddressFamily.Packet
-    AddressFamily_AF_CAN = 32,     // System.Net.AddressFamily.ControllerAreaNetwork
+    AddressFamily_AF_NETLINK = 65536, // System.Net.AddressFamily.Netlink
+    AddressFamily_AF_PACKET = 65537,  // System.Net.AddressFamily.Packet
+    AddressFamily_AF_CAN = 65538,     // System.Net.AddressFamily.ControllerAreaNetwork
 } AddressFamily;
 
 /*

--- a/src/Native/Unix/System.Native/pal_networking.h
+++ b/src/Native/Unix/System.Native/pal_networking.h
@@ -53,7 +53,7 @@ typedef enum
  *
  * NOTE: these values are taken from System.Net.AddressFamily. If you add
  *       new entries, be sure that the values are chosen accordingly.
- *       Unix specific value have distinct offset to avoid conflict with
+ *       Unix specific values have distinct offset to avoid conflict with
  *       Windows values.
  */
 typedef enum
@@ -62,9 +62,8 @@ typedef enum
     AddressFamily_AF_UNIX = 1,     // System.Net.AddressFamily.Unix
     AddressFamily_AF_INET = 2,     // System.Net.AddressFamily.InterNetwork
     AddressFamily_AF_INET6 = 23,   // System.Net.AddressFamily.InterNetworkV6
-    AddressFamily_AF_NETLINK = 65536, // System.Net.AddressFamily.Netlink
-    AddressFamily_AF_PACKET = 65537,  // System.Net.AddressFamily.Packet
-    AddressFamily_AF_CAN = 65538,     // System.Net.AddressFamily.ControllerAreaNetwork
+    AddressFamily_AF_PACKET = 65536,  // System.Net.AddressFamily.Packet
+    AddressFamily_AF_CAN = 65537,     // System.Net.AddressFamily.ControllerAreaNetwork
 } AddressFamily;
 
 /*

--- a/src/Native/Unix/System.Native/pal_networking.h
+++ b/src/Native/Unix/System.Native/pal_networking.h
@@ -53,6 +53,8 @@ typedef enum
  *
  * NOTE: these values are taken from System.Net.AddressFamily. If you add
  *       new entries, be sure that the values are chosen accordingly.
+ *       Unix specific value have distinct offset to avoid conflict with
+ *       Windows values.
  */
 typedef enum
 {

--- a/src/System.Net.Primitives/ref/System.Net.Primitives.cs
+++ b/src/System.Net.Primitives/ref/System.Net.Primitives.cs
@@ -403,9 +403,9 @@ namespace System.Net.Sockets
         Irda = 26,
         NetworkDesigners = 28,
         Max = 29,
-        Netlink = 30,
-        Packet = 31,
-        ControllerAreaNetwork = 32,
+        Netlink = 65536,
+        Packet = 65537,
+        ControllerAreaNetwork = 65538,
     }
     public enum SocketError
     {

--- a/src/System.Net.Primitives/ref/System.Net.Primitives.cs
+++ b/src/System.Net.Primitives/ref/System.Net.Primitives.cs
@@ -403,9 +403,8 @@ namespace System.Net.Sockets
         Irda = 26,
         NetworkDesigners = 28,
         Max = 29,
-        Netlink = 65536,
-        Packet = 65537,
-        ControllerAreaNetwork = 65538,
+        Packet = 65536,
+        ControllerAreaNetwork = 65537,
     }
     public enum SocketError
     {

--- a/src/System.Net.Primitives/src/System/Net/Sockets/AddressFamily.cs
+++ b/src/System.Net.Primitives/src/System/Net/Sockets/AddressFamily.cs
@@ -41,8 +41,7 @@ namespace System.Net.Sockets
         // Unix specific values are past Uint16.MaxValue to avoid conflicts with Windows values.
         // On Windows we pass values straight to OS and if we add new protocol supported by Windows,
         // we should use actual OS value.
-        Netlink = 65536,        // Netlink protocol
-        Packet = 65537,         // Linux Packet
-        ControllerAreaNetwork = 65538, // Controller Area Network automotive bus protocol
+        Packet = 65536,         // Linux Packet
+        ControllerAreaNetwork = 65537, // Controller Area Network automotive bus protocol
     }
 }

--- a/src/System.Net.Primitives/src/System/Net/Sockets/AddressFamily.cs
+++ b/src/System.Net.Primitives/src/System/Net/Sockets/AddressFamily.cs
@@ -38,6 +38,9 @@ namespace System.Net.Sockets
         Irda = 26,              // IrDA
         NetworkDesigners = 28,  // Network Designers OSI & gateway enabled protocols
         Max = 29,               // Max
+        // Unix specific values are past Uint16.MaxValue to avoid conflicts with Windows values.
+        // On Windows we pass values straight to OS and if we add new protocol supported by Windows,
+        // we should use actual OS value.
         Netlink = 65536,        // Netlink protocol
         Packet = 65537,         // Linux Packet
         ControllerAreaNetwork = 65538, // Controller Area Network automotive bus protocol

--- a/src/System.Net.Primitives/src/System/Net/Sockets/AddressFamily.cs
+++ b/src/System.Net.Primitives/src/System/Net/Sockets/AddressFamily.cs
@@ -38,8 +38,8 @@ namespace System.Net.Sockets
         Irda = 26,              // IrDA
         NetworkDesigners = 28,  // Network Designers OSI & gateway enabled protocols
         Max = 29,               // Max
-        Netlink = 30,           // Netlink protocol
-        Packet = 31,            // Linux Packet
-        ControllerAreaNetwork = 32, // Controller Area Network automotive bus protocol
+        Netlink = 65536,        // Netlink protocol
+        Packet = 65537,         // Linux Packet
+        ControllerAreaNetwork = 65538, // Controller Area Network automotive bus protocol
     }
 }

--- a/src/System.Net.Primitives/tests/FunctionalTests/SocketAddressTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/SocketAddressTest.cs
@@ -76,18 +76,23 @@ namespace System.Net.Primitives.Functional.Tests
         }
 
         [Theory]
-        [InlineData((AddressFamily)123456, -1)]
-        [InlineData((AddressFamily)123456, 16)]
+        [InlineData((AddressFamily)65539, -1)]
+        [InlineData((AddressFamily)65539, 16)]
+        [InlineData((AddressFamily)1_000_000, -1)]
         public static void ToString_UnknownFamily_Throws(AddressFamily family, int size)
         {
+            // Values above last know value should throw.
             Assert.Throws<PlatformNotSupportedException>(() => size >= 0 ? new SocketAddress(family, size) : new SocketAddress(family));
         }
 
-        [Fact]
+        [Theory]
+        [InlineData((AddressFamily)125)]
+        [InlineData((AddressFamily)65535)]
         [PlatformSpecific(TestPlatforms.Windows)]
-        public static void ToString_LegacyUnknownFamily_Success()
+        public static void ToString_LegacyUnknownFamily_Success(AddressFamily family)
         {
-            var sa = new SocketAddress((AddressFamily)125);
+            // For legacy reasons, unknown values in ushort range don't throw on Windows.
+            var sa = new SocketAddress(family);
             Assert.NotNull(sa.ToString());
         }
 

--- a/src/System.Net.Primitives/tests/FunctionalTests/SocketAddressTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/SocketAddressTest.cs
@@ -81,7 +81,7 @@ namespace System.Net.Primitives.Functional.Tests
         [InlineData((AddressFamily)1_000_000, -1)]
         public static void ToString_UnknownFamily_Throws(AddressFamily family, int size)
         {
-            // Values above last know value should throw.
+            // Values above last known value should throw.
             Assert.Throws<PlatformNotSupportedException>(() => size >= 0 ? new SocketAddress(family, size) : new SocketAddress(family));
         }
 

--- a/src/System.Net.Primitives/tests/FunctionalTests/SocketAddressTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/SocketAddressTest.cs
@@ -76,11 +76,19 @@ namespace System.Net.Primitives.Functional.Tests
         }
 
         [Theory]
-        [InlineData((AddressFamily)12345, -1)]
-        [InlineData((AddressFamily)12345, 16)]
+        [InlineData((AddressFamily)123456, -1)]
+        [InlineData((AddressFamily)123456, 16)]
         public static void ToString_UnknownFamily_Throws(AddressFamily family, int size)
         {
             Assert.Throws<PlatformNotSupportedException>(() => size >= 0 ? new SocketAddress(family, size) : new SocketAddress(family));
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public static void ToString_LegacyUnknownFamily_Success()
+        {
+            var sa = new SocketAddress((AddressFamily)125);
+            Assert.NotNull(sa.ToString());
         }
 
         [Theory]

--- a/src/System.Net.Primitives/tests/FunctionalTests/SocketAddressTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/SocketAddressTest.cs
@@ -98,7 +98,6 @@ namespace System.Net.Primitives.Functional.Tests
 
         [Theory]
         [InlineData(AddressFamily.Packet)]
-        [InlineData(AddressFamily.Netlink)]
         [InlineData(AddressFamily.ControllerAreaNetwork)]
         [PlatformSpecific(~TestPlatforms.Linux)]
         public static void ToString_UnsupportedFamily_Throws(AddressFamily family)
@@ -122,7 +121,7 @@ namespace System.Net.Primitives.Functional.Tests
         {
             foreach (AddressFamily family in Enum.GetValues(typeof(AddressFamily)))
             {
-                if (family == AddressFamily.Netlink || family == AddressFamily.Packet || family == AddressFamily.ControllerAreaNetwork)
+                if (family == AddressFamily.Packet || family == AddressFamily.ControllerAreaNetwork)
                 {
                     // Skip Linux specific protocols.
                     continue;

--- a/src/System.Net.Primitives/tests/FunctionalTests/SocketAddressTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/SocketAddressTest.cs
@@ -109,7 +109,7 @@ namespace System.Net.Primitives.Functional.Tests
         {
             foreach (AddressFamily family in Enum.GetValues(typeof(AddressFamily)))
             {
-                if ((int)family > (int)AddressFamily.Max)
+                if (family == AddressFamily.Netlink || family == AddressFamily.Packet || family == AddressFamily.ControllerAreaNetwork)
                 {
                     // Skip Linux specific protocols.
                     continue;

--- a/src/System.Net.Sockets/ref/System.Net.Sockets.cs
+++ b/src/System.Net.Sockets/ref/System.Net.Sockets.cs
@@ -157,9 +157,8 @@ namespace System.Net.Sockets
         Irda = 26,
         NetworkDesigners = 28,
         Max = 29,
-        Netlink = 65536,
-        Packet = 65537,
-        ControllerAreaNetwork = 65538,
+        Packet = 65536,
+        ControllerAreaNetwork = 65537,
     }
     public enum ProtocolType
     {

--- a/src/System.Net.Sockets/ref/System.Net.Sockets.cs
+++ b/src/System.Net.Sockets/ref/System.Net.Sockets.cs
@@ -157,9 +157,9 @@ namespace System.Net.Sockets
         Irda = 26,
         NetworkDesigners = 28,
         Max = 29,
-        Netlink = 30,
-        Packet = 31,
-        ControllerAreaNetwork = 32,
+        Netlink = 65536,
+        Packet = 65537,
+        ControllerAreaNetwork = 65538,
     }
     public enum ProtocolType
     {

--- a/src/System.Net.Sockets/tests/FunctionalTests/CreateSocketTests.netcoreapp.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/CreateSocketTests.netcoreapp.cs
@@ -14,7 +14,6 @@ namespace System.Net.Sockets.Tests
     public partial class CreateSocket
     {
         [Theory]
-        [InlineData(AddressFamily.Netlink)]
         [InlineData(AddressFamily.Packet)]
         [InlineData(AddressFamily.ControllerAreaNetwork)]
         [PlatformSpecific(~TestPlatforms.Linux)]
@@ -25,7 +24,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Theory]
-        [InlineData(AddressFamily.Netlink)]
         [InlineData(AddressFamily.Packet)]
         [InlineData(AddressFamily.ControllerAreaNetwork)]
         [PlatformSpecific(TestPlatforms.Linux)]


### PR DESCRIPTION
Improve validation on AddressFamily across OSes.
Detailed discussion is in #37997.

