### PR TITLE
Fix NRE in SmtpConnection.Abort

### DIFF
--- a/src/System.Net.Mail/src/System/Net/Mail/SmtpConnection.cs
+++ b/src/System.Net.Mail/src/System/Net/Mail/SmtpConnection.cs
@@ -182,7 +182,7 @@ namespace System.Net.Mail
                         // DATA command or some similar situation.  This may send a RST
                         // but this is ok in this situation.  Do not reuse this connection
                         _tcpClient.LingerState = new LingerOption(true, 0);
-                        _networkStream.Close();
+                        _networkStream?.Close();
                         _tcpClient.Dispose();
                     }
                     _isClosed = true;


### PR DESCRIPTION
Fixes #39925 

Verified by running the follow code both before and after. Did not include as a unit test due to all of the reflection/dependence on internal implementation details nastiness.

```C#
[Fact]
public void SmtpConnection_Abort_DoesNotThrowNRE()
{
	SmtpClient client = new SmtpClient("smtp.example.com");

	var transport = client.GetType().GetField("_transport", Reflection.BindingFlags.Instance | Reflection.BindingFlags.NonPublic).GetValue(client);
	var transportType = Reflection.Assembly.GetAssembly(typeof(SmtpClient)).GetType("System.Net.Mail.SmtpTransport");
	var abortMethod = transportType.GetMethod("Abort", Reflection.BindingFlags.Instance | Reflection.BindingFlags.NonPublic, null, new Type[0], new Reflection.ParameterModifier[0]);
	var getConnectionMethod = client.GetType().GetMethod("GetConnection", Reflection.BindingFlags.Instance | Reflection.BindingFlags.NonPublic, null, new Type[0], new Reflection.ParameterModifier[0]);

	// This should fail against the host we've specified, but will cause the SmtpClient to initialize its transport.
	// The TargetInvocationException should be wrapping a SocketException
	Assert.Throws<System.Reflection.TargetInvocationException>(() => getConnectionMethod.Invoke(client, new object[0]));

	// Force an abort
	abortMethod.Invoke(transport, new object[0]);
}
```