### PR TITLE
System.Drawing.Common: Clean SuppressMessage attributes

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/BufferedGraphicsContext.Windows.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/BufferedGraphicsContext.Windows.cs
@@ -251,7 +251,6 @@ namespace System.Drawing
         ///       the identity palette mapping between the DIB and the display.
         /// </summary>
         /// <returns>A valid bitmap handle if successful, IntPtr.Zero otherwise.</returns>
-        [SuppressMessage("Microsoft.Interoperability", "CA1404:CallGetLastErrorImmediatelyAfterPInvoke")]
         private IntPtr CreateCompatibleDIB(IntPtr hdc, IntPtr hpal, int ulWidth, int ulHeight, ref IntPtr ppvBits)
         {
             if (hdc == IntPtr.Zero)

--- a/src/System.Drawing.Common/src/System/Drawing/BufferedGraphicsContext.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/BufferedGraphicsContext.cs
@@ -82,7 +82,6 @@ namespace System.Drawing
         /// <summary>
         /// Returns a BufferedGraphics that is matched for the specified target HDC object.
         /// </summary>
-        [SuppressMessage("Microsoft.Reliability", "CA2000:DisposeObjectsBeforeLosingScope")]
         private BufferedGraphics AllocBufferInTempManager(Graphics targetGraphics, IntPtr targetDC, Rectangle targetRectangle)
         {
             BufferedGraphicsContext tempContext = null;

--- a/src/System.Drawing.Common/src/System/Drawing/ColorConverter.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/ColorConverter.cs
@@ -120,7 +120,6 @@ namespace System.Drawing {
         /// <devdoc>
         ///      Converts the given object to the converter's native type.
         /// </devdoc>
-        [SuppressMessage("Microsoft.Performance", "CA1808:AvoidCallsThatBoxValueTypes")]
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value) {
             string strValue = value as string;
             if (strValue != null) {

--- a/src/System.Drawing.Common/src/System/Drawing/FontFamily.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/FontFamily.cs
@@ -26,7 +26,6 @@ namespace System.Drawing
         private int _id;
 #endif
 
-        [SuppressMessage("Microsoft.Security", "CA2106:SecureAsserts")]
         private void SetNativeFamily(IntPtr family)
         {
             Debug.Assert(_nativeFamily == IntPtr.Zero, "Setting GDI+ native font family when already initialized.");

--- a/src/System.Drawing.Common/src/System/Drawing/Gdiplus.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Gdiplus.cs
@@ -520,7 +520,6 @@ namespace System.Drawing
         [DllImport(ExternDll.Gdi32, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern int SelectClipRgn(HandleRef hDC, HandleRef hRgn);
 
-        [SuppressMessage("Microsoft.Security", "CA2101:SpecifyMarshalingForPInvokeStringArguments")]
         [DllImport(ExternDll.Gdi32, SetLastError = true, CharSet = CharSet.Auto)]
         public static extern int AddFontResourceEx(string lpszFilename, int fl, IntPtr pdv);
 

--- a/src/System.Drawing.Common/src/System/Drawing/Graphics.Windows.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Graphics.Windows.cs
@@ -430,8 +430,6 @@ namespace System.Drawing
             }
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
-        [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
         public void EnumerateMetafile(
             Metafile metafile,
             PointF destPoint,
@@ -447,9 +445,6 @@ namespace System.Drawing
                 callbackData,
                 new HandleRef(imageAttr, imageAttr?.nativeImageAttributes ?? IntPtr.Zero)));
         }
-
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
-        [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
         public void EnumerateMetafile(
             Metafile metafile,
             Point destPoint,
@@ -466,8 +461,6 @@ namespace System.Drawing
                 new HandleRef(imageAttr, imageAttr?.nativeImageAttributes ?? IntPtr.Zero)));
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
-        [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
         public void EnumerateMetafile(
             Metafile metafile,
             RectangleF destRect,
@@ -484,8 +477,6 @@ namespace System.Drawing
                 new HandleRef(imageAttr, imageAttr?.nativeImageAttributes ?? IntPtr.Zero)));
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
-        [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
         public void EnumerateMetafile(
             Metafile metafile,
             Rectangle destRect,
@@ -502,8 +493,6 @@ namespace System.Drawing
                 new HandleRef(imageAttr, imageAttr?.nativeImageAttributes ?? IntPtr.Zero)));
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
-        [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
         public unsafe void EnumerateMetafile(
             Metafile metafile,
             PointF[] destPoints,
@@ -528,8 +517,6 @@ namespace System.Drawing
             }
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
-        [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
         public unsafe void EnumerateMetafile(
             Metafile metafile,
             Point[] destPoints,
@@ -554,8 +541,6 @@ namespace System.Drawing
             }
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
-        [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
         public void EnumerateMetafile(
             Metafile metafile,
             PointF destPoint,
@@ -576,8 +561,6 @@ namespace System.Drawing
                 new HandleRef(imageAttr, imageAttr?.nativeImageAttributes ?? IntPtr.Zero)));
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
-        [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
         public void EnumerateMetafile(
             Metafile metafile,
             Point destPoint,
@@ -598,8 +581,6 @@ namespace System.Drawing
                 new HandleRef(imageAttr, imageAttr?.nativeImageAttributes ?? IntPtr.Zero)));
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
-        [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
         public void EnumerateMetafile(
             Metafile metafile,
             RectangleF destRect,
@@ -620,8 +601,6 @@ namespace System.Drawing
                 new HandleRef(imageAttr, imageAttr?.nativeImageAttributes ?? IntPtr.Zero)));
         }
 
-        [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(
             Metafile metafile,
             Rectangle destRect,
@@ -642,8 +621,6 @@ namespace System.Drawing
                 new HandleRef(imageAttr, imageAttr?.nativeImageAttributes ?? IntPtr.Zero)));
         }
 
-        [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public unsafe void EnumerateMetafile(
             Metafile metafile,
             PointF[] destPoints,
@@ -672,8 +649,6 @@ namespace System.Drawing
             }
         }
 
-        [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters")]
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public unsafe void EnumerateMetafile(
             Metafile metafile,
             Point[] destPoints,

--- a/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
@@ -1580,13 +1580,11 @@ namespace System.Drawing
         /// <summary>
         /// Draws the specified image at the specified location.
         /// </summary>
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, PointF point)
         {
             DrawImage(image, point.X, point.Y);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, float x, float y)
         {
             if (image == null)
@@ -1600,13 +1598,11 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, RectangleF rect)
         {
             DrawImage(image, rect.X, rect.Y, rect.Width, rect.Height);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, float x, float y, float width, float height)
         {
             if (image == null)
@@ -1622,13 +1618,11 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, Point point)
         {
             DrawImage(image, point.X, point.Y);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, int x, int y)
         {
             if (image == null)
@@ -1643,13 +1637,11 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, Rectangle rect)
         {
             DrawImage(image, rect.X, rect.Y, rect.Width, rect.Height);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, int x, int y, int width, int height)
         {
             if (image == null)
@@ -1708,7 +1700,6 @@ namespace System.Drawing
         //
         //  @notes Perspective blt only works for bitmap images.
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public unsafe void DrawImage(Image image, PointF[] destPoints)
         {
             if (destPoints == null)
@@ -1732,7 +1723,6 @@ namespace System.Drawing
             }
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public unsafe void DrawImage(Image image, Point[] destPoints)
         {
             if (destPoints == null)
@@ -1756,7 +1746,6 @@ namespace System.Drawing
             }
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, float x, float y, RectangleF srcRect, GraphicsUnit srcUnit)
         {
             if (image == null)
@@ -1773,7 +1762,6 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, int x, int y, Rectangle srcRect, GraphicsUnit srcUnit)
         {
             if (image == null)
@@ -1790,7 +1778,6 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, RectangleF destRect, RectangleF srcRect, GraphicsUnit srcUnit)
         {
             if (image == null)
@@ -1810,7 +1797,6 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, Rectangle destRect, Rectangle srcRect, GraphicsUnit srcUnit)
         {
             if (image == null)
@@ -1830,7 +1816,6 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public unsafe void DrawImage(Image image, PointF[] destPoints, RectangleF srcRect, GraphicsUnit srcUnit)
         {
             if (destPoints == null)
@@ -1859,13 +1844,11 @@ namespace System.Drawing
             }
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, PointF[] destPoints, RectangleF srcRect, GraphicsUnit srcUnit, ImageAttributes imageAttr)
         {
             DrawImage(image, destPoints, srcRect, srcUnit, imageAttr, null, 0);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(
             Image image,
             PointF[] destPoints,
@@ -1877,7 +1860,6 @@ namespace System.Drawing
             DrawImage(image, destPoints, srcRect, srcUnit, imageAttr, callback, 0);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public unsafe void DrawImage(
             Image image,
             PointF[] destPoints,
@@ -1913,13 +1895,11 @@ namespace System.Drawing
             }
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(Image image, Point[] destPoints, Rectangle srcRect, GraphicsUnit srcUnit)
         {
             DrawImage(image, destPoints, srcRect, srcUnit, null, null, 0);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(
             Image image,
             Point[] destPoints,
@@ -1930,7 +1910,6 @@ namespace System.Drawing
             DrawImage(image, destPoints, srcRect, srcUnit, imageAttr, null, 0);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(
             Image image,
             Point[] destPoints,
@@ -1942,7 +1921,6 @@ namespace System.Drawing
             DrawImage(image, destPoints, srcRect, srcUnit, imageAttr, callback, 0);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public unsafe void DrawImage(
             Image image,
             Point[] destPoints,
@@ -1978,7 +1956,6 @@ namespace System.Drawing
             }
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(
             Image image,
             Rectangle destRect,
@@ -1991,7 +1968,6 @@ namespace System.Drawing
             DrawImage(image, destRect, srcX, srcY, srcWidth, srcHeight, srcUnit, null);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(
             Image image,
             Rectangle destRect,
@@ -2005,7 +1981,6 @@ namespace System.Drawing
             DrawImage(image, destRect, srcX, srcY, srcWidth, srcHeight, srcUnit, imageAttrs, null);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(
             Image image,
             Rectangle destRect,
@@ -2020,8 +1995,6 @@ namespace System.Drawing
             DrawImage(image, destRect, srcX, srcY, srcWidth, srcHeight, srcUnit, imageAttrs, callback, IntPtr.Zero);
         }
 
-
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(
             Image image,
             Rectangle destRect,
@@ -2051,7 +2024,6 @@ namespace System.Drawing
             CheckErrorStatus(status);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(
             Image image,
             Rectangle destRect,
@@ -2064,7 +2036,6 @@ namespace System.Drawing
             DrawImage(image, destRect, srcX, srcY, srcWidth, srcHeight, srcUnit, null);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(
             Image image,
             Rectangle destRect,
@@ -2078,7 +2049,6 @@ namespace System.Drawing
             DrawImage(image, destRect, srcX, srcY, srcWidth, srcHeight, srcUnit, imageAttr, null);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(
             Image image,
             Rectangle destRect,
@@ -2093,7 +2063,6 @@ namespace System.Drawing
             DrawImage(image, destRect, srcX, srcY, srcWidth, srcHeight, srcUnit, imageAttr, callback, IntPtr.Zero);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void DrawImage(
             Image image,
             Rectangle destRect,
@@ -2215,61 +2184,51 @@ namespace System.Drawing
             CopyFromScreen(upperLeftSource.X, upperLeftSource.Y, upperLeftDestination.X, upperLeftDestination.Y, blockRegionSize, copyPixelOperation);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, PointF destPoint, EnumerateMetafileProc callback)
         {
             EnumerateMetafile(metafile, destPoint, callback, IntPtr.Zero);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, PointF destPoint, EnumerateMetafileProc callback, IntPtr callbackData)
         {
             EnumerateMetafile(metafile, destPoint, callback, callbackData, null);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, Point destPoint, EnumerateMetafileProc callback)
         {
             EnumerateMetafile(metafile, destPoint, callback, IntPtr.Zero);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, Point destPoint, EnumerateMetafileProc callback, IntPtr callbackData)
         {
             EnumerateMetafile(metafile, destPoint, callback, callbackData, null);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, RectangleF destRect, EnumerateMetafileProc callback)
         {
             EnumerateMetafile(metafile, destRect, callback, IntPtr.Zero);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, RectangleF destRect, EnumerateMetafileProc callback, IntPtr callbackData)
         {
             EnumerateMetafile(metafile, destRect, callback, callbackData, null);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, Rectangle destRect, EnumerateMetafileProc callback)
         {
             EnumerateMetafile(metafile, destRect, callback, IntPtr.Zero);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, Rectangle destRect, EnumerateMetafileProc callback, IntPtr callbackData)
         {
             EnumerateMetafile(metafile, destRect, callback, callbackData, null);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, PointF[] destPoints, EnumerateMetafileProc callback)
         {
             EnumerateMetafile(metafile, destPoints, callback, IntPtr.Zero);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(
             Metafile metafile,
             PointF[] destPoints,
@@ -2279,19 +2238,16 @@ namespace System.Drawing
             EnumerateMetafile(metafile, destPoints, callback, IntPtr.Zero, null);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, Point[] destPoints, EnumerateMetafileProc callback)
         {
             EnumerateMetafile(metafile, destPoints, callback, IntPtr.Zero);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(Metafile metafile, Point[] destPoints, EnumerateMetafileProc callback, IntPtr callbackData)
         {
             EnumerateMetafile(metafile, destPoints, callback, callbackData, null);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(
             Metafile metafile,
             PointF destPoint,
@@ -2302,7 +2258,6 @@ namespace System.Drawing
             EnumerateMetafile(metafile, destPoint, srcRect, srcUnit, callback, IntPtr.Zero);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(
             Metafile metafile,
             PointF destPoint,
@@ -2314,7 +2269,6 @@ namespace System.Drawing
             EnumerateMetafile(metafile, destPoint, srcRect, srcUnit, callback, callbackData, null);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(
             Metafile metafile,
             Point destPoint,
@@ -2325,7 +2279,6 @@ namespace System.Drawing
             EnumerateMetafile(metafile, destPoint, srcRect, srcUnit, callback, IntPtr.Zero);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(
             Metafile metafile,
             Point destPoint,
@@ -2337,7 +2290,6 @@ namespace System.Drawing
             EnumerateMetafile(metafile, destPoint, srcRect, srcUnit, callback, callbackData, null);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(
             Metafile metafile,
             RectangleF destRect,
@@ -2348,7 +2300,6 @@ namespace System.Drawing
             EnumerateMetafile(metafile, destRect, srcRect, srcUnit, callback, IntPtr.Zero);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(
             Metafile metafile,
             RectangleF destRect,
@@ -2360,7 +2311,6 @@ namespace System.Drawing
             EnumerateMetafile(metafile, destRect, srcRect, srcUnit, callback, callbackData, null);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(
             Metafile metafile,
             Rectangle destRect,
@@ -2371,7 +2321,6 @@ namespace System.Drawing
             EnumerateMetafile(metafile, destRect, srcRect, srcUnit, callback, IntPtr.Zero);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(
             Metafile metafile,
             Rectangle destRect,
@@ -2383,7 +2332,6 @@ namespace System.Drawing
             EnumerateMetafile(metafile, destRect, srcRect, srcUnit, callback, callbackData, null);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(
             Metafile metafile,
             PointF[] destPoints,
@@ -2394,7 +2342,6 @@ namespace System.Drawing
             EnumerateMetafile(metafile, destPoints, srcRect, srcUnit, callback, IntPtr.Zero);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(
             Metafile metafile,
             PointF[] destPoints,
@@ -2406,7 +2353,6 @@ namespace System.Drawing
             EnumerateMetafile(metafile, destPoints, srcRect, srcUnit, callback, callbackData, null);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(
             Metafile metafile,
             Point[] destPoints,
@@ -2417,7 +2363,6 @@ namespace System.Drawing
             EnumerateMetafile(metafile, destPoints, srcRect, srcUnit, callback, IntPtr.Zero);
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void EnumerateMetafile(
             Metafile metafile,
             Point[] destPoints,
@@ -2445,7 +2390,6 @@ namespace System.Drawing
             }
         }
 
-        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public unsafe void TransformPoints(CoordinateSpace destSpace, CoordinateSpace srcSpace, Point[] pts)
         {
             if (pts == null)

--- a/src/System.Drawing.Common/src/System/Drawing/Image.Windows.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Image.Windows.cs
@@ -208,7 +208,6 @@ namespace System.Drawing
         /// <summary>
         /// Saves this <see cref='Image'/> to the specified file in the specified format and with the specified encoder parameters.
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void Save(string filename, ImageCodecInfo encoder, EncoderParameters encoderParams)
         {
             if (filename == null)
@@ -288,7 +287,6 @@ namespace System.Drawing
         /// <summary>
         /// Saves this <see cref='Image'/> to the specified stream in the specified format.
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void Save(Stream stream, ImageCodecInfo encoder, EncoderParameters encoderParams)
         {
             if (stream == null)
@@ -340,7 +338,6 @@ namespace System.Drawing
         /// <summary>
         /// Adds an <see cref='EncoderParameters'/> to this <see cref='Image'/>.
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void SaveAdd(EncoderParameters encoderParams)
         {
             IntPtr encoder = IntPtr.Zero;
@@ -365,7 +362,6 @@ namespace System.Drawing
         /// <summary>
         /// Adds an <see cref='EncoderParameters'/> to the specified <see cref='Image'/>.
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public void SaveAdd(Image image, EncoderParameters encoderParams)
         {
             IntPtr encoder = IntPtr.Zero;

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/EmfPlusRecordType.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/EmfPlusRecordType.cs
@@ -264,7 +264,6 @@ namespace System.Drawing.Imaging
         Save,
         Restore,
         BeginContainer,
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         BeginContainerNoParams,
         EndContainer,
         SetWorldTransform,

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/EncoderParameter.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/EncoderParameter.cs
@@ -371,7 +371,6 @@ namespace System.Drawing.Imaging
         }
 
         [Obsolete("This constructor has been deprecated. Use EncoderParameter(Encoder encoder, int numberValues, EncoderParameterValueType type, IntPtr value) instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
         public EncoderParameter(Encoder encoder, int NumberOfValues, int Type, int Value)
         {
             int size;
@@ -420,7 +419,6 @@ namespace System.Drawing.Imaging
             GC.KeepAlive(this);
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2004:RemoveCallsToGCKeepAlive")]
         public EncoderParameter(Encoder encoder, int numberValues, EncoderParameterValueType type, IntPtr value)
         {
             int size;

--- a/src/System.Drawing.Common/src/System/Drawing/NativeMethods.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/NativeMethods.cs
@@ -5,8 +5,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
-[assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "System.Drawing.NativeMethods..ctor()")]
-
 namespace System.Drawing
 {
     internal class NativeMethods

--- a/src/System.Drawing.Common/src/System/Drawing/PointConverter.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/PointConverter.cs
@@ -52,7 +52,6 @@ namespace System.Drawing {
         /// <devdoc>
         ///      Converts the given object to the converter's native type.
         /// </devdoc>
-        [SuppressMessage("Microsoft.Performance", "CA1808:AvoidCallsThatBoxValueTypes")]
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value) {
 
             string strValue = value as string;
@@ -144,8 +143,6 @@ namespace System.Drawing {
         ///      for the object.  This is useful for objects that are immutable, but still
         ///      want to provide changable properties.
         /// </devdoc>
-        [SuppressMessage("Microsoft.Performance", "CA1808:AvoidCallsThatBoxValueTypes")]
-        [SuppressMessage("Microsoft.Security", "CA2102:CatchNonClsCompliantExceptionsInGeneralHandlers")]
         public override object CreateInstance(ITypeDescriptorContext context, IDictionary propertyValues) {
             if( propertyValues == null ) {
                 throw new ArgumentNullException( nameof(propertyValues) );

--- a/src/System.Drawing.Common/src/System/Drawing/RectangleConverter.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/RectangleConverter.cs
@@ -52,7 +52,6 @@ namespace System.Drawing {
         /// <devdoc>
         ///      Converts the given object to the converter's native type.
         /// </devdoc>
-        [SuppressMessage("Microsoft.Performance", "CA1808:AvoidCallsThatBoxValueTypes")]
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value) {
 
             string strValue = value as string;
@@ -149,8 +148,6 @@ namespace System.Drawing {
         ///      for the object.  This is useful for objects that are immutable, but still
         ///      want to provide changable properties.
         /// </devdoc>
-        [SuppressMessage("Microsoft.Performance", "CA1808:AvoidCallsThatBoxValueTypes")]
-        [SuppressMessage("Microsoft.Security", "CA2102:CatchNonClsCompliantExceptionsInGeneralHandlers")]
         public override object CreateInstance(ITypeDescriptorContext context, IDictionary propertyValues) {
             if( propertyValues == null ){
                 throw new ArgumentNullException( nameof(propertyValues) );

--- a/src/System.Drawing.Common/src/System/Drawing/SizeConverter.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/SizeConverter.cs
@@ -52,7 +52,6 @@ namespace System.Drawing {
         /// <devdoc>
         ///      Converts the given object to the converter's native type.
         /// </devdoc>
-        [SuppressMessage("Microsoft.Performance", "CA1808:AvoidCallsThatBoxValueTypes")]
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value) {
 
             string strValue = value as string;
@@ -144,8 +143,6 @@ namespace System.Drawing {
         ///      for the object.  This is useful for objects that are immutable, but still
         ///      want to provide changable properties.
         /// </devdoc>
-        [SuppressMessage("Microsoft.Performance", "CA1808:AvoidCallsThatBoxValueTypes")]
-        [SuppressMessage("Microsoft.Security", "CA2102:CatchNonClsCompliantExceptionsInGeneralHandlers")]
         public override object CreateInstance(ITypeDescriptorContext context, IDictionary propertyValues) {
             if( propertyValues == null ){
                 throw new ArgumentNullException( nameof(propertyValues) );

--- a/src/System.Drawing.Common/src/misc/CompModSwitches.cs
+++ b/src/System.Drawing.Common/src/misc/CompModSwitches.cs
@@ -5,9 +5,6 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
-[assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "System.ComponentModel.CompModSwitches.get_DGEditColumnEditing():System.Diagnostics.TraceSwitch")]
-[assembly: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "System.ComponentModel.CompModSwitches.get_LayoutPerformance():System.Diagnostics.TraceSwitch")]
-
 namespace System.ComponentModel
 {
     internal static class CompModSwitches

--- a/src/System.Drawing.Common/src/misc/GDI/NativeMethods.cs
+++ b/src/System.Drawing.Common/src/misc/GDI/NativeMethods.cs
@@ -9,8 +9,6 @@ namespace System.Drawing.Internal
 {
     internal partial class IntNativeMethods
     {
-        [SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
-
         public const int OBJ_PEN = 1;
         public const int OBJ_BRUSH = 2;
         public const int OBJ_FONT = 6;

--- a/src/System.Drawing.Common/src/misc/GDI/WindowsRegion.cs
+++ b/src/System.Drawing.Common/src/misc/GDI/WindowsRegion.cs
@@ -12,7 +12,6 @@ namespace System.Drawing.Internal
     /// </summary>
     internal sealed partial class WindowsRegion : MarshalByRefObject, ICloneable, IDisposable
     {
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
         private IntPtr _nativeHandle; // The hRegion, this class always takes ownership of the hRegion.
         private bool _ownHandle;
 


### PR DESCRIPTION
Follow up from #39945. It appears none of these rules are actually enabled, so removing the SuppressMessage attributes.