### PR TITLE
[release/3.0] Test fix non breaking space

### DIFF
--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -3072,15 +3072,6 @@ public static partial class DataContractJsonSerializerTests
 
     private static string GetAmString(DateTimeFormat dateTimeFormat)
     {
-        var dcjsSettings = new DataContractJsonSerializerSettings() { DateTimeFormat = dateTimeFormat };
-        var dcjs = new DataContractJsonSerializer(typeof(DateTime), dcjsSettings);
-        using (var ms = new MemoryStream())
-        {
-            dcjs.WriteObject(ms, new DateTime());
-            ms.Position = 0;
-            string output = new StreamReader(ms).ReadToEnd();
-            string actualam = output.Contains("a.m.") ? "a.m." : "a. m.";
-            return actualam;
-        }
+        return ((CultureInfo)dateTimeFormat.FormatProvider).DateTimeFormat.AMDesignator;
     }
 }


### PR DESCRIPTION
#### Description
Using Globalization `a.m.` string instead of hard coded one	
Fixes ##40032
Port of #40033
#### Customer Impact
No
#### Regression?
No
#### Risk
No