### PR TITLE
[release/3.0] pal_console: add missing mutex_unlock (#40160)

### DIFF
--- a/src/Native/Unix/System.Native/pal_console.c
+++ b/src/Native/Unix/System.Native/pal_console.c
@@ -252,6 +252,7 @@ void SystemNative_ConfigureTerminalForChildProcess(int32_t childUsesTerminal)
         // If the application is performing a read, assume the child process won't use the terminal.
         if (g_reading)
         {
+            pthread_mutex_unlock(&g_lock);
             return;
         }
 


### PR DESCRIPTION
Port #40160 to release/3.0.
Fixes https://github.com/dotnet/corefx/issues/40137
cc: @danmosemsft, @tmds

## Description

Processes on Unix end up sharing a terminal.  We have a heuristic which assumes that if a parent process is interacting with the terminal, any child processes it launches won't.  As such, when we do Process.Start on Unix, we check if the parent process is currently doing a read (e.g. Console.ReadLine()), and if it is, we avoid doing some configuration of the terminal as part of launching the child.  That check is performed under a lock, and we neglect to release that lock when we find it's doing a read.

## Customer Impact

Certain patterns would simply hang forever, trying to take a lock that will never be released.

## Regression?

Yes, introduced in 3.0 as part of https://github.com/dotnet/corefx/pull/35621.

## Risk

Minimal.  It's obvious from a scoped code review that the previous code was wrong.