### PR TITLE
Don't restore files to later overwrite them during the build

### DIFF
--- a/eng/restore/binplacePackages/binplacePackages.depproj
+++ b/eng/restore/binplacePackages/binplacePackages.depproj
@@ -14,8 +14,8 @@
     </BinPlaceConfiguration>
   </ItemGroup>
 
-  <!-- Runtime / test-runtime binplacing -->
-  <ItemGroup Condition="'$(TargetsNetStandard)' != 'true'">
+  <!-- Runtime / test-runtime binplacing, when we aren't building better live version of these libs -->
+  <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
     <BinPlaceConfiguration Include="$(Configuration)">
       <ItemName>BinPlaceLib</ItemName>
       <RuntimePath>$(RuntimePath)</RuntimePath>

--- a/eng/restore/netstandard/netstandard.depproj
+++ b/eng/restore/netstandard/netstandard.depproj
@@ -81,7 +81,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <_NetStandard21Files Include="$(_NETStandard21RefFolder)\*.dll" />
+      <ExcludeNetStandard21Refs Include="System.Buffers" />
+      <ExcludeNetStandard21Refs Include="System.ComponentModel.Composition" />
+      <ExcludeNetStandard21Refs Include="System.Reflection.DispatchProxy" />
+      <ExcludeNetStandard21Refs Include="System.Reflection.Emit" />
+      <ExcludeNetStandard21Refs Include="System.Reflection.Emit.ILGeneration" />
+      <ExcludeNetStandard21Refs Include="System.Reflection.Emit.Lightweight" />
+      <_NetStandard21Files 
+        Include="$(_NETStandard21RefFolder)\*.dll"
+        Exclude="@(ExcludeNetStandardRefs -> '$(_NETStandard21RefFolder)\%(Identity).dll')"  />
     </ItemGroup>
 
     <Error Condition="'@(_NetStandard21Files)' == ''" Text="Could not find package assets for netstandard2.1" />


### PR DESCRIPTION
NETStandard2.1 includes more facades which we still build in corefx.

Make sure we don't copy these then later overwrite them during the ref build.

binplacePackages was restoring runtime files even on NETCoreApp:
we should never do this.  We have to be careful to only test assemblies
we build in the repo for netcoreapp.  The only test target which needs
these is NETFX.

Source-build was hitting this and it was causing tests to fail because running
build -test after a build was rerunning the copy step in netstandard.depproj 
and the copy was overwriting the ref/netstandard/S.CM.C.dll which was 
hardlinked to the ref/netcoreapp version, and thus breaking the real reference
assembly we build by replacing it with the facade.