### PR TITLE
detect libinotify on FreeBSD

### DIFF
--- a/src/Native/Unix/Common/pal_config.h.in
+++ b/src/Native/Unix/Common/pal_config.h.in
@@ -42,6 +42,7 @@
 #cmakedefine01 HAVE_STATFS
 #cmakedefine01 HAVE_SYS_SOCKIO_H
 #cmakedefine01 HAVE_SYS_POLL_H
+#cmakedefine01 HAVE_SYS_INOTIFY_H
 #cmakedefine01 HAVE_EPOLL
 #cmakedefine01 HAVE_ACCEPT4
 #cmakedefine01 HAVE_KQUEUE

--- a/src/Native/Unix/System.Native/CMakeLists.txt
+++ b/src/Native/Unix/System.Native/CMakeLists.txt
@@ -54,6 +54,10 @@ endif ()
 
 if (CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
     target_link_libraries(System.Native pthread)
+if (HAVE_INOTIFY)
+    find_library(INOTIFY_LIBRARY inotify HINTS /usr/local/lib)
+    target_link_libraries(System.Native ${INOTIFY_LIBRARY})
+endif()
 endif ()
 
 install_library_and_symbols (System.Native)

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -18,6 +18,7 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL Darwin)
 elseif (CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
     set(PAL_UNIX_NAME \"FREEBSD\")
     include_directories(SYSTEM /usr/local/include)
+    set(CMAKE_REQUIRED_INCLUDES /usr/local/include)
 elseif (CMAKE_SYSTEM_NAME STREQUAL NetBSD)
     set(PAL_UNIX_NAME \"NETBSD\")
 elseif (CMAKE_SYSTEM_NAME STREQUAL Emscripten)
@@ -492,6 +493,10 @@ check_c_source_compiles(
     IPV6MR_INTERFACE_UNSIGNED
 )
 
+check_include_files(
+    "sys/inotify.h"
+    HAVE_SYS_INOTIFY_H)
+
 check_c_source_compiles(
     "
     #include <sys/inotify.h>
@@ -672,6 +677,11 @@ check_c_source_compiles(
 )
 set (CMAKE_REQUIRED_FLAGS ${PREVIOUS_CMAKE_REQUIRED_FLAGS})
 
+set (PREVIOUS_CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES})
+if (HAVE_SYS_INOTIFY_H AND CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
+set (CMAKE_REQUIRED_LIBRARIES "-linotify -L/usr/local/lib")
+endif()
+
 check_function_exists(
     inotify_init
     HAVE_INOTIFY_INIT)
@@ -683,6 +693,7 @@ check_function_exists(
 check_function_exists(
     inotify_rm_watch
     HAVE_INOTIFY_RM_WATCH)
+set (CMAKE_REQUIRED_LIBRARIES ${PREVIOUS_CMAKE_REQUIRED_LIBRARIES})
 
 set (HAVE_INOTIFY 0)
 if (HAVE_INOTIFY_INIT AND HAVE_INOTIFY_ADD_WATCH AND HAVE_INOTIFY_RM_WATCH)


### PR DESCRIPTION
this is follow-up on discussion in #39680
This change allows to detect if libinotify is present and if so use it. I did not run tests (yet) but this sets HAVE_INOTIFY appropriately and links with library:
```
[furt@FreeBSD-11 ~/git/wfurt-corefx]$ ldd artifacts/bin/native/FreeBSD-x64-Debug/System.Native.so
artifacts/bin/native/FreeBSD-x64-Debug/System.Native.so:
	libthr.so.3 => /lib/libthr.so.3 (0x801000000)
	libinotify.so.0 => /usr/local/lib/libinotify.so.0 (0x801228000)
	libc.so.7 => /lib/libc.so.7 (0x800825000)
```

I also verify that detection still works and HAVE_INOTIFY is set. 

cc: @rootwyrm @joperator