### PR TITLE
Avoid non documented exceptions in BinaryFormatter.Deserialize

### DIFF
--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryFormatter.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryFormatter.cs
@@ -63,9 +63,21 @@ namespace System.Runtime.Serialization.Formatters.Binary
             {
                 _crossAppDomainArray = _crossAppDomainArray
             };
-            var parser = new BinaryParser(serializationStream, reader);
-            return reader.Deserialize(parser, check);
+            try
+            {
+                var parser = new BinaryParser(serializationStream, reader);
+                return reader.Deserialize(parser, check);
+            }
+            catch (SerializationException)
+            {
+                throw;
+            }
+            catch (Exception e)
+            {
+                throw new SerializationException(SR.Serialization_CorruptedStream, e);
+            }
         }
+
         public void Serialize(Stream serializationStream, object graph) =>
             Serialize(serializationStream, graph, true);
 

--- a/src/System.Runtime.Serialization.Formatters/tests/SerializationGuardTests.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/SerializationGuardTests.cs
@@ -66,7 +66,7 @@ namespace System.Runtime.Serialization.Formatters.Tests
         }
 
         private static void TryPayload(object payload)
-        {   
+        {
             MemoryStream ms = new MemoryStream();
             BinaryFormatter writer = new BinaryFormatter();
             writer.Serialize(ms, payload);

--- a/src/System.Runtime.Serialization.Formatters/tests/SerializationGuardTests.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/SerializationGuardTests.cs
@@ -73,8 +73,8 @@ namespace System.Runtime.Serialization.Formatters.Tests
             ms.Position = 0;
 
             BinaryFormatter reader = new BinaryFormatter();
-            SerializationException tie = Assert.Throws<SerializationException>(() => reader.Deserialize(ms));
-            Assert.IsAssignableFrom<TargetInvocationException>(tie.InnerException);
+            SerializationException se = Assert.Throws<SerializationException>(() => reader.Deserialize(ms));
+            Assert.IsAssignableFrom<TargetInvocationException>(se.InnerException);
         }
     }
 

--- a/src/System.Runtime.Serialization.Formatters/tests/SerializationGuardTests.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/SerializationGuardTests.cs
@@ -66,15 +66,15 @@ namespace System.Runtime.Serialization.Formatters.Tests
         }
 
         private static void TryPayload(object payload)
-        {
+        {   
             MemoryStream ms = new MemoryStream();
             BinaryFormatter writer = new BinaryFormatter();
             writer.Serialize(ms, payload);
             ms.Position = 0;
 
             BinaryFormatter reader = new BinaryFormatter();
-            TargetInvocationException tie = Assert.Throws<TargetInvocationException>(() => reader.Deserialize(ms));
-            Assert.IsAssignableFrom<SerializationException>(tie.InnerException);
+            SerializationException tie = Assert.Throws<SerializationException>(() => reader.Deserialize(ms));
+            Assert.IsAssignableFrom<TargetInvocationException>(tie.InnerException);
         }
     }
 

--- a/src/System.Runtime/tests/System/UnitySerializationHolderTests.cs
+++ b/src/System.Runtime/tests/System/UnitySerializationHolderTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Tests;
 using Xunit;
 
@@ -13,8 +14,9 @@ namespace System.Tests
         public void UnitySerializationHolderWithAssemblySingleton()
         {
             const string UnitySerializationHolderAssemblyBase64String = "AAEAAAD/////AQAAAAAAAAAEAQAAAB9TeXN0ZW0uVW5pdHlTZXJpYWxpemF0aW9uSG9sZGVyAwAAAAREYXRhCVVuaXR5VHlwZQxBc3NlbWJseU5hbWUBAAEIBgIAAABLbXNjb3JsaWIsIFZlcnNpb249NC4wLjAuMCwgQ3VsdHVyZT1uZXV0cmFsLCBQdWJsaWNLZXlUb2tlbj1iNzdhNWM1NjE5MzRlMDg5BgAAAAkCAAAACw==";
-            AssertExtensions.Throws<ArgumentException>(() =>
+            SerializationException se = AssertExtensions.Throws<SerializationException>(() =>
               BinaryFormatterHelpers.FromBase64String(UnitySerializationHolderAssemblyBase64String));
+            Assert.IsAssignableFrom<ArgumentException>(se.InnerException);
         }
     }
 }


### PR DESCRIPTION
Fixes #35491. BinaryFormatter.Deserialize can throw other exceptions than those specified in the documentation (SerializationException, SecurityException & ArgumentNullException) in cases of corrupt input. This update changes the BinaryFormatter.Deserialize method to wrap those "internal" exception inside an SerializationException.