### PR TITLE
Disable two EventLog failing tests on Windows

### DIFF
--- a/src/System.Diagnostics.EventLog/tests/EventLogTraceListenerTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTraceListenerTests.cs
@@ -113,6 +113,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        [ActiveIssue(40224, TestPlatforms.Windows)]
         [ConditionalTheory(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         [InlineData(TraceEventType.Information, EventLogEntryType.Information, ushort.MaxValue + 1, ushort.MaxValue)]
         [InlineData(TraceEventType.Error, EventLogEntryType.Error, ushort.MinValue - 1, ushort.MinValue)]

--- a/src/System.Drawing.Common/tests/BitmapTests.cs
+++ b/src/System.Drawing.Common/tests/BitmapTests.cs
@@ -1149,6 +1149,7 @@ namespace System.Drawing.Tests
             yield return new object[] { new Bitmap(184, 184, PixelFormat.Format1bppIndexed), new Rectangle(0, 0, 184, 184), ImageLockMode.WriteOnly, PixelFormat.Format1bppIndexed, 24, 2 };
         }
 
+        [ActiveIssue(40224, TestPlatforms.Windows)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(LockBits_TestData))]
         public void LockBits_Invoke_Success(Bitmap bitmap, Rectangle rectangle, ImageLockMode lockMode, PixelFormat pixelFormat, int expectedStride, int expectedReserved)


### PR DESCRIPTION
Relates to https://github.com/dotnet/corefx/issues/40224

cc @stephentoub