### PR TITLE
[release/3.0]  Improve compatibility of new AddressFamily values

### DIFF
--- a/src/Common/src/System/Net/SocketAddressPal.Windows.cs
+++ b/src/Common/src/System/Net/SocketAddressPal.Windows.cs
@@ -18,6 +18,14 @@ namespace System.Net
 
         public static unsafe void SetAddressFamily(byte[] buffer, AddressFamily family)
         {
+            if ((int)(family) > (int)AddressFamily.Max)
+            {
+                // For legacy values up to AddressFamily.Max, family maps directly to Winsock value.
+                // Other values will need mapping if/when supported.
+                // Currently, that is Netlink, Packet and ControllerAreaNetwork, neither of them supported on Windows.
+                throw new PlatformNotSupportedException();
+            }
+
 #if BIGENDIAN
             buffer[0] = unchecked((byte)((int)family >> 8));
             buffer[1] = unchecked((byte)((int)family));

--- a/src/Common/src/System/Net/SocketAddressPal.Windows.cs
+++ b/src/Common/src/System/Net/SocketAddressPal.Windows.cs
@@ -18,9 +18,9 @@ namespace System.Net
 
         public static unsafe void SetAddressFamily(byte[] buffer, AddressFamily family)
         {
-            if ((int)(family) > (int)AddressFamily.Max)
+            if ((int)(family) > ushort.MaxValue)
             {
-                // For legacy values up to AddressFamily.Max, family maps directly to Winsock value.
+                // For legacy values family maps directly to Winsock value.
                 // Other values will need mapping if/when supported.
                 // Currently, that is Netlink, Packet and ControllerAreaNetwork, neither of them supported on Windows.
                 throw new PlatformNotSupportedException();

--- a/src/Common/src/System/Net/SocketAddressPal.Windows.cs
+++ b/src/Common/src/System/Net/SocketAddressPal.Windows.cs
@@ -22,7 +22,7 @@ namespace System.Net
             {
                 // For legacy values family maps directly to Winsock value.
                 // Other values will need mapping if/when supported.
-                // Currently, that is Netlink, Packet and ControllerAreaNetwork, neither of them supported on Windows.
+                // Currently, that is Packet and ControllerAreaNetwork, neither of them supported on Windows.
                 throw new PlatformNotSupportedException();
             }
 

--- a/src/Common/src/System/Net/Sockets/ProtocolFamily.cs
+++ b/src/Common/src/System/Net/Sockets/ProtocolFamily.cs
@@ -42,7 +42,6 @@ namespace System.Net.Internals
         Irda = AddressFamily.Irda,
         NetworkDesigners = AddressFamily.NetworkDesigners,
         Max = 29, //AddressFamily.Max
-        Netlink = AddressFamily.Netlink,
         Packet = AddressFamily.Packet,
         ControllerAreaNetwork = AddressFamily.ControllerAreaNetwork,
     }

--- a/src/Native/Unix/System.Native/pal_networking.c
+++ b/src/Native/Unix/System.Native/pal_networking.c
@@ -492,11 +492,6 @@ static bool TryConvertAddressFamilyPlatformToPal(sa_family_t platformAddressFami
         case AF_INET6:
             *palAddressFamily = AddressFamily_AF_INET6;
             return true;
-#ifdef AF_NETLINK
-        case AF_NETLINK:
-            *palAddressFamily = AddressFamily_AF_NETLINK;
-            return true;
-#endif
 #ifdef AF_PACKET
         case AF_PACKET:
             *palAddressFamily = AddressFamily_AF_PACKET;

--- a/src/Native/Unix/System.Native/pal_networking.h
+++ b/src/Native/Unix/System.Native/pal_networking.h
@@ -53,6 +53,8 @@ typedef enum
  *
  * NOTE: these values are taken from System.Net.AddressFamily. If you add
  *       new entries, be sure that the values are chosen accordingly.
+ *       Unix specific values have distinct offset to avoid conflict with
+ *       Windows values.
  */
 typedef enum
 {
@@ -60,9 +62,8 @@ typedef enum
     AddressFamily_AF_UNIX = 1,     // System.Net.AddressFamily.Unix
     AddressFamily_AF_INET = 2,     // System.Net.AddressFamily.InterNetwork
     AddressFamily_AF_INET6 = 23,   // System.Net.AddressFamily.InterNetworkV6
-    AddressFamily_AF_NETLINK = 30, // System.Net.AddressFamily.Netlink
-    AddressFamily_AF_PACKET = 31,  // System.Net.AddressFamily.Packet
-    AddressFamily_AF_CAN = 32,     // System.Net.AddressFamily.ControllerAreaNetwork
+    AddressFamily_AF_PACKET = 65536,  // System.Net.AddressFamily.Packet
+    AddressFamily_AF_CAN = 65537,     // System.Net.AddressFamily.ControllerAreaNetwork
 } AddressFamily;
 
 /*

--- a/src/System.Net.Primitives/ref/System.Net.Primitives.cs
+++ b/src/System.Net.Primitives/ref/System.Net.Primitives.cs
@@ -403,9 +403,8 @@ namespace System.Net.Sockets
         Irda = 26,
         NetworkDesigners = 28,
         Max = 29,
-        Netlink = 30,
-        Packet = 31,
-        ControllerAreaNetwork = 32,
+        Packet = 65536,
+        ControllerAreaNetwork = 65537,
     }
     public enum SocketError
     {

--- a/src/System.Net.Primitives/src/System/Net/Sockets/AddressFamily.cs
+++ b/src/System.Net.Primitives/src/System/Net/Sockets/AddressFamily.cs
@@ -43,8 +43,10 @@ namespace System.Net.Sockets
         Irda = 26,              // IrDA
         NetworkDesigners = 28,  // Network Designers OSI & gateway enabled protocols
         Max = 29,               // Max
-        Netlink = 30,           // Netlink protocol
-        Packet = 31,            // Linux Packet
-        ControllerAreaNetwork = 32, // Controller Area Network automotive bus protocol
+        // Unix specific values are past Uint16.MaxValue to avoid conflicts with Windows values.
+        // On Windows we pass values straight to OS and if we add new protocol supported by Windows,
+        // we should use actual OS value.
+        Packet = 65536,         // Linux Packet
+        ControllerAreaNetwork = 65537, // Controller Area Network automotive bus protocol
     }
 }

--- a/src/System.Net.Primitives/tests/FunctionalTests/SocketAddressTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/SocketAddressTest.cs
@@ -75,10 +75,49 @@ namespace System.Net.Primitives.Functional.Tests
             Assert.Equal(expected, sa.ToString());
         }
 
-        [ActiveIssue(37997, TestPlatforms.AnyUnix)]
-        [Theory] // recombine into ToString_Expected_Success when #37997 is fixed
-        [InlineData((AddressFamily)12345, -1, false, "12345:32:{0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}")]
-        public static void ToString_UnknownFamily_Success(AddressFamily family, int size, bool fillBytes, string expected) =>
-            ToString_Expected_Success(family, size, fillBytes, expected);
+        [Theory]
+        [InlineData((AddressFamily)12345, -1)]
+        [InlineData((AddressFamily)12345, 16)]
+        public static void ToString_UnknownFamily_Throws(AddressFamily family, int size)
+        {
+            Assert.Throws<PlatformNotSupportedException>(() => size >= 0 ? new SocketAddress(family, size) : new SocketAddress(family));
+        }
+
+        [Theory]
+        [InlineData(AddressFamily.Packet)]
+        [InlineData(AddressFamily.Netlink)]
+        [InlineData(AddressFamily.ControllerAreaNetwork)]
+        [PlatformSpecific(~TestPlatforms.Linux)]
+        public static void ToString_UnsupportedFamily_Throws(AddressFamily family)
+        {
+            Assert.Throws<PlatformNotSupportedException>(() => new SocketAddress(family));
+        }
+
+        [Theory]
+        [InlineData(AddressFamily.Packet)]
+        [InlineData(AddressFamily.ControllerAreaNetwork)]
+        [PlatformSpecific(TestPlatforms.Linux)]
+        public static void ToString_LinuxSpecificFamily_Success(AddressFamily family)
+        {
+            SocketAddress sa = new SocketAddress(family);
+            Assert.Equal(family, sa.Family);
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public static void ToString_AllFamilies_Success()
+        {
+            foreach (AddressFamily family in Enum.GetValues(typeof(AddressFamily)))
+            {
+                if ((int)family > (int)AddressFamily.Max)
+                {
+                    // Skip Linux specific protocols.
+                    continue;
+                }
+
+                var sa = new SocketAddress(family);
+                Assert.NotNull(sa.ToString());
+            }
+        }
     }
 }

--- a/src/System.Net.Sockets/ref/System.Net.Sockets.cs
+++ b/src/System.Net.Sockets/ref/System.Net.Sockets.cs
@@ -157,9 +157,8 @@ namespace System.Net.Sockets
         Irda = 26,
         NetworkDesigners = 28,
         Max = 29,
-        Netlink = 30,
-        Packet = 31,
-        ControllerAreaNetwork = 32,
+        Packet = 65536,
+        ControllerAreaNetwork = 65537,
     }
     public enum ProtocolType
     {

--- a/src/System.Net.Sockets/tests/FunctionalTests/CreateSocketTests.netcoreapp.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/CreateSocketTests.netcoreapp.cs
@@ -14,7 +14,6 @@ namespace System.Net.Sockets.Tests
     public partial class CreateSocket
     {
         [Theory]
-        [InlineData(AddressFamily.Netlink)]
         [InlineData(AddressFamily.Packet)]
         [InlineData(AddressFamily.ControllerAreaNetwork)]
         [PlatformSpecific(~TestPlatforms.Linux)]
@@ -25,7 +24,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Theory]
-        [InlineData(AddressFamily.Netlink)]
         [InlineData(AddressFamily.Packet)]
         [InlineData(AddressFamily.ControllerAreaNetwork)]
         [PlatformSpecific(TestPlatforms.Linux)]


### PR DESCRIPTION
This is port of #39785 and #40165 to 3.0 release branch.
fixes #37997

**Description**

This add corrections and validation to new AddressFamily enum values added in 3.0.
New values overlap with valid Windows address families and since .Net on Windows does not really have PAL mapping, this can create compatibility problems. 
Also since one can cast int, customers may use values supported on Windows outside of .Net enum values. 
This can get very confusing over time.

To avoid compatibility issues, this change essentially moves Unix specific enum values above ushort range used by Windows OS for address family. With that there will be no conflicts.      

**Customer Impact**

With code as it is now in 3.0, we can misbehave and for example create wrong socket on Windows when using new values.   

**Regression?**

No

**Risk**

This breaks binary compatibility with earlier 3.0 previews. 

**Test changes in this PR**

More tests were added to verify behavior on all supported OSes.