### PR TITLE
Renaming Microsoft.Framework.WebEncoders namespace

### DIFF
--- a/src/System.Text.Encodings.Web/tests/AllowedCharsBitmapTests.cs
+++ b/src/System.Text.Encodings.Web/tests/AllowedCharsBitmapTests.cs
@@ -8,7 +8,7 @@ using System.Text.Internal;
 using System.Text.Unicode;
 using Xunit;
 
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tests
 {
     public class AllowedCharsBitmapTests
     {

--- a/src/System.Text.Encodings.Web/tests/AllowedCharsBitmapTests.cs
+++ b/src/System.Text.Encodings.Web/tests/AllowedCharsBitmapTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Text.Encodings.Web;
 using System.Text.Internal;
 using System.Text.Unicode;
 using Xunit;

--- a/src/System.Text.Encodings.Web/tests/ConfigurableScalarTextEncoder.cs
+++ b/src/System.Text.Encodings.Web/tests/ConfigurableScalarTextEncoder.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Text.Encodings.Web;
 
 namespace System.Text.Encodings.Web.Tests
 {

--- a/src/System.Text.Encodings.Web/tests/ConfigurableScalarTextEncoder.cs
+++ b/src/System.Text.Encodings.Web/tests/ConfigurableScalarTextEncoder.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Text.Encodings.Web;
 
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tests
 {
     /// <summary>
     /// Dummy encoder used for unit testing.

--- a/src/System.Text.Encodings.Web/tests/EncoderCommon.cs
+++ b/src/System.Text.Encodings.Web/tests/EncoderCommon.cs
@@ -4,7 +4,7 @@
 
 using System;
 
-namespace System.Text.Encodings.Web
+namespace System.Text.Encodings.Web.Tests
 {
     internal static class EncoderCommon
     {

--- a/src/System.Text.Encodings.Web/tests/EncoderCommonTests.cs
+++ b/src/System.Text.Encodings.Web/tests/EncoderCommonTests.cs
@@ -6,7 +6,7 @@ using System;
 using System.Text.Encodings.Web;
 using Xunit;
 
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tests
 {
     public class EncoderCommonTests
     {

--- a/src/System.Text.Encodings.Web/tests/EncoderCommonTests.cs
+++ b/src/System.Text.Encodings.Web/tests/EncoderCommonTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Text.Encodings.Web;
 using Xunit;
 
 namespace System.Text.Encodings.Web.Tests

--- a/src/System.Text.Encodings.Web/tests/EncoderExtensionsTests.cs
+++ b/src/System.Text.Encodings.Web/tests/EncoderExtensionsTests.cs
@@ -2,14 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using NewHtmlEncoder = System.Text.Encodings.Web.HtmlEncoder;
-using NewUrlEncoder = System.Text.Encodings.Web.UrlEncoder;
+using System.Text.Encodings.Web.Tests;
 using System;
 using System.IO;
 using Xunit;
 using System.Text.Unicode;
 
-namespace System.Text.Encodings.Web.Tests
+namespace System.Text.Encodings.Web
 {
     public class EncoderExtensionsTests
     {
@@ -23,7 +22,7 @@ namespace System.Text.Encodings.Web.Tests
         public void HtmlEncode_PositiveTestCase()
         {
             // Arrange
-            NewHtmlEncoder encoder = NewHtmlEncoder.Create(UnicodeRanges.All);
+            HtmlEncoder encoder = HtmlEncoder.Create(UnicodeRanges.All);
             StringWriter writer = new StringWriter();
 
             // Act
@@ -38,7 +37,7 @@ namespace System.Text.Encodings.Web.Tests
         {
             // Arrange
             TextEncoderSettings settings = new TextEncoderSettings(UnicodeRanges.All);
-            NewHtmlEncoder encoder = NewHtmlEncoder.Create(settings);
+            HtmlEncoder encoder = HtmlEncoder.Create(settings);
             StringWriter writer = new StringWriter();
 
             // Act
@@ -51,20 +50,20 @@ namespace System.Text.Encodings.Web.Tests
         [Fact]
         public void HtmlEncode_CreateNullRanges()
         {
-            Assert.Throws<ArgumentNullException>("allowedRanges", () => NewHtmlEncoder.Create(default(UnicodeRange[])));
+            Assert.Throws<ArgumentNullException>("allowedRanges", () => HtmlEncoder.Create(default(UnicodeRange[])));
         }
 
         [Fact]
         public void HtmlEncode_CreateNullSettings()
         {
-            Assert.Throws<ArgumentNullException>("settings", () => NewHtmlEncoder.Create(default(TextEncoderSettings)));
+            Assert.Throws<ArgumentNullException>("settings", () => HtmlEncoder.Create(default(TextEncoderSettings)));
         }
 
 
         [Fact]
         public unsafe void TryEncodeUnicodeScalar_Null_Buffer()
         {
-            Assert.Throws<ArgumentNullException>("buffer", () => NewHtmlEncoder.Default.TryEncodeUnicodeScalar(2, null, 1, out int _));
+            Assert.Throws<ArgumentNullException>("buffer", () => HtmlEncoder.Default.TryEncodeUnicodeScalar(2, null, 1, out int _));
         }
 
         [Fact]
@@ -72,7 +71,7 @@ namespace System.Text.Encodings.Web.Tests
         {
             char* buffer = stackalloc char[1];
             int numberWritten;
-            Assert.False(NewHtmlEncoder.Default.TryEncodeUnicodeScalar(0x10000, buffer, 1, out numberWritten));
+            Assert.False(HtmlEncoder.Default.TryEncodeUnicodeScalar(0x10000, buffer, 1, out numberWritten));
             Assert.Equal(0, numberWritten);
         }
 
@@ -106,7 +105,7 @@ namespace System.Text.Encodings.Web.Tests
         public void UrlEncode_PositiveTestCase()
         {
             // Arrange
-            NewUrlEncoder encoder = NewUrlEncoder.Create(UnicodeRanges.All);
+            UrlEncoder encoder = UrlEncoder.Create(UnicodeRanges.All);
             StringWriter writer = new StringWriter();
 
             // Act

--- a/src/System.Text.Encodings.Web/tests/EncoderExtensionsTests.cs
+++ b/src/System.Text.Encodings.Web/tests/EncoderExtensionsTests.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using newHtmlEncoder = System.Text.Encodings.Web.HtmlEncoder;
-using newUrlEncoder = System.Text.Encodings.Web.UrlEncoder;
+using NewHtmlEncoder = System.Text.Encodings.Web.HtmlEncoder;
+using NewUrlEncoder = System.Text.Encodings.Web.UrlEncoder;
 using System;
 using System.IO;
 using Xunit;
@@ -23,7 +23,7 @@ namespace System.Text.Encodings.Web.Tests
         public void HtmlEncode_PositiveTestCase()
         {
             // Arrange
-            newHtmlEncoder encoder = newHtmlEncoder.Create(UnicodeRanges.All);
+            NewHtmlEncoder encoder = NewHtmlEncoder.Create(UnicodeRanges.All);
             StringWriter writer = new StringWriter();
 
             // Act
@@ -38,7 +38,7 @@ namespace System.Text.Encodings.Web.Tests
         {
             // Arrange
             TextEncoderSettings settings = new TextEncoderSettings(UnicodeRanges.All);
-            newHtmlEncoder encoder = newHtmlEncoder.Create(settings);
+            NewHtmlEncoder encoder = NewHtmlEncoder.Create(settings);
             StringWriter writer = new StringWriter();
 
             // Act
@@ -51,20 +51,20 @@ namespace System.Text.Encodings.Web.Tests
         [Fact]
         public void HtmlEncode_CreateNullRanges()
         {
-            Assert.Throws<ArgumentNullException>("allowedRanges", () => newHtmlEncoder.Create(default(UnicodeRange[])));
+            Assert.Throws<ArgumentNullException>("allowedRanges", () => NewHtmlEncoder.Create(default(UnicodeRange[])));
         }
 
         [Fact]
         public void HtmlEncode_CreateNullSettings()
         {
-            Assert.Throws<ArgumentNullException>("settings", () => newHtmlEncoder.Create(default(TextEncoderSettings)));
+            Assert.Throws<ArgumentNullException>("settings", () => NewHtmlEncoder.Create(default(TextEncoderSettings)));
         }
 
 
         [Fact]
         public unsafe void TryEncodeUnicodeScalar_Null_Buffer()
         {
-            Assert.Throws<ArgumentNullException>("buffer", () => newHtmlEncoder.Default.TryEncodeUnicodeScalar(2, null, 1, out int _));
+            Assert.Throws<ArgumentNullException>("buffer", () => NewHtmlEncoder.Default.TryEncodeUnicodeScalar(2, null, 1, out int _));
         }
 
         [Fact]
@@ -72,7 +72,7 @@ namespace System.Text.Encodings.Web.Tests
         {
             char* buffer = stackalloc char[1];
             int numberWritten;
-            Assert.False(newHtmlEncoder.Default.TryEncodeUnicodeScalar(0x10000, buffer, 1, out numberWritten));
+            Assert.False(NewHtmlEncoder.Default.TryEncodeUnicodeScalar(0x10000, buffer, 1, out numberWritten));
             Assert.Equal(0, numberWritten);
         }
 
@@ -106,7 +106,7 @@ namespace System.Text.Encodings.Web.Tests
         public void UrlEncode_PositiveTestCase()
         {
             // Arrange
-            newUrlEncoder encoder = newUrlEncoder.Create(UnicodeRanges.All);
+            NewUrlEncoder encoder = NewUrlEncoder.Create(UnicodeRanges.All);
             StringWriter writer = new StringWriter();
 
             // Act

--- a/src/System.Text.Encodings.Web/tests/EncoderExtensionsTests.cs
+++ b/src/System.Text.Encodings.Web/tests/EncoderExtensionsTests.cs
@@ -2,13 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Framework.WebEncoders;
+using newHtmlEncoder = System.Text.Encodings.Web.HtmlEncoder;
+using newUrlEncoder = System.Text.Encodings.Web.UrlEncoder;
 using System;
 using System.IO;
 using Xunit;
 using System.Text.Unicode;
 
-namespace System.Text.Encodings.Web
+namespace System.Text.Encodings.Web.Tests
 {
     public class EncoderExtensionsTests
     {
@@ -22,7 +23,7 @@ namespace System.Text.Encodings.Web
         public void HtmlEncode_PositiveTestCase()
         {
             // Arrange
-            HtmlEncoder encoder = HtmlEncoder.Create(UnicodeRanges.All);
+            newHtmlEncoder encoder = newHtmlEncoder.Create(UnicodeRanges.All);
             StringWriter writer = new StringWriter();
 
             // Act
@@ -37,7 +38,7 @@ namespace System.Text.Encodings.Web
         {
             // Arrange
             TextEncoderSettings settings = new TextEncoderSettings(UnicodeRanges.All);
-            HtmlEncoder encoder = HtmlEncoder.Create(settings);
+            newHtmlEncoder encoder = newHtmlEncoder.Create(settings);
             StringWriter writer = new StringWriter();
 
             // Act
@@ -50,20 +51,20 @@ namespace System.Text.Encodings.Web
         [Fact]
         public void HtmlEncode_CreateNullRanges()
         {
-            Assert.Throws<ArgumentNullException>("allowedRanges", () => HtmlEncoder.Create(default(UnicodeRange[])));
+            Assert.Throws<ArgumentNullException>("allowedRanges", () => newHtmlEncoder.Create(default(UnicodeRange[])));
         }
 
         [Fact]
         public void HtmlEncode_CreateNullSettings()
         {
-            Assert.Throws<ArgumentNullException>("settings", () => HtmlEncoder.Create(default(TextEncoderSettings)));
+            Assert.Throws<ArgumentNullException>("settings", () => newHtmlEncoder.Create(default(TextEncoderSettings)));
         }
 
 
         [Fact]
         public unsafe void TryEncodeUnicodeScalar_Null_Buffer()
         {
-            Assert.Throws<ArgumentNullException>("buffer", () => HtmlEncoder.Default.TryEncodeUnicodeScalar(2, null, 1, out int _));
+            Assert.Throws<ArgumentNullException>("buffer", () => newHtmlEncoder.Default.TryEncodeUnicodeScalar(2, null, 1, out int _));
         }
 
         [Fact]
@@ -71,7 +72,7 @@ namespace System.Text.Encodings.Web
         {
             char* buffer = stackalloc char[1];
             int numberWritten;
-            Assert.False(HtmlEncoder.Default.TryEncodeUnicodeScalar(0x10000, buffer, 1, out numberWritten));
+            Assert.False(newHtmlEncoder.Default.TryEncodeUnicodeScalar(0x10000, buffer, 1, out numberWritten));
             Assert.Equal(0, numberWritten);
         }
 
@@ -105,7 +106,7 @@ namespace System.Text.Encodings.Web
         public void UrlEncode_PositiveTestCase()
         {
             // Arrange
-            UrlEncoder encoder = UrlEncoder.Create(UnicodeRanges.All);
+            newUrlEncoder encoder = newUrlEncoder.Create(UnicodeRanges.All);
             StringWriter writer = new StringWriter();
 
             // Act

--- a/src/System.Text.Encodings.Web/tests/Extensions.cs
+++ b/src/System.Text.Encodings.Web/tests/Extensions.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tests
 {
     public static class Extensions
     {

--- a/src/System.Text.Encodings.Web/tests/HtmlEncoderTests.cs
+++ b/src/System.Text.Encodings.Web/tests/HtmlEncoderTests.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Globalization;
 using System.IO;
-using System.Text.Encodings.Web;
 using System.Text.Unicode;
 using Xunit;
 

--- a/src/System.Text.Encodings.Web/tests/HtmlEncoderTests.cs
+++ b/src/System.Text.Encodings.Web/tests/HtmlEncoderTests.cs
@@ -9,7 +9,7 @@ using System.Text.Encodings.Web;
 using System.Text.Unicode;
 using Xunit;
 
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tests
 {
     public class HtmlEncoderTests
     {

--- a/src/System.Text.Encodings.Web/tests/IHtmlEncoder.cs
+++ b/src/System.Text.Encodings.Web/tests/IHtmlEncoder.cs
@@ -5,7 +5,7 @@
 using System;
 using System.IO;
 
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tests
 {
     /// <summary>
     /// Provides services for HTML-encoding input.

--- a/src/System.Text.Encodings.Web/tests/IJavaScriptStringEncoder.cs
+++ b/src/System.Text.Encodings.Web/tests/IJavaScriptStringEncoder.cs
@@ -4,7 +4,7 @@
 
 using System.IO;
 
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tests
 {
     /// <summary>
     /// Provides services for JavaScript-escaping strings.

--- a/src/System.Text.Encodings.Web/tests/IUrlEncoder.cs
+++ b/src/System.Text.Encodings.Web/tests/IUrlEncoder.cs
@@ -4,7 +4,7 @@
 
 using System.IO;
 
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tests
 {
     /// <summary>
     /// Provides services for URL-escaping strings.

--- a/src/System.Text.Encodings.Web/tests/JavaScriptStringEncoderTests.Relaxed.cs
+++ b/src/System.Text.Encodings.Web/tests/JavaScriptStringEncoderTests.Relaxed.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Globalization;
 using System.IO;
-using System.Text.Encodings.Web;
 using System.Text.Unicode;
 using Xunit;
 

--- a/src/System.Text.Encodings.Web/tests/JavaScriptStringEncoderTests.Relaxed.cs
+++ b/src/System.Text.Encodings.Web/tests/JavaScriptStringEncoderTests.Relaxed.cs
@@ -9,7 +9,7 @@ using System.Text.Encodings.Web;
 using System.Text.Unicode;
 using Xunit;
 
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tests
 {
     public partial class JavaScriptStringEncoderTests
     {

--- a/src/System.Text.Encodings.Web/tests/JavaScriptStringEncoderTests.cs
+++ b/src/System.Text.Encodings.Web/tests/JavaScriptStringEncoderTests.cs
@@ -7,7 +7,6 @@ using System.Buffers;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Text.Encodings.Web;
 using System.Text.Unicode;
 using Xunit;
 

--- a/src/System.Text.Encodings.Web/tests/JavaScriptStringEncoderTests.cs
+++ b/src/System.Text.Encodings.Web/tests/JavaScriptStringEncoderTests.cs
@@ -11,7 +11,7 @@ using System.Text.Encodings.Web;
 using System.Text.Unicode;
 using Xunit;
 
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tests
 {
     public partial class JavaScriptStringEncoderTests
     {

--- a/src/System.Text.Encodings.Web/tests/PerformanceTests.cs
+++ b/src/System.Text.Encodings.Web/tests/PerformanceTests.cs
@@ -6,7 +6,6 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
-using System.Text.Encodings.Web;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/src/System.Text.Encodings.Web/tests/PerformanceTests.cs
+++ b/src/System.Text.Encodings.Web/tests/PerformanceTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 using Xunit.Abstractions;
 
 #if RELEASE
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tests
 {
     public class PerformanceTests
     {

--- a/src/System.Text.Encodings.Web/tests/ScalarTestEncoder.cs
+++ b/src/System.Text.Encodings.Web/tests/ScalarTestEncoder.cs
@@ -8,7 +8,7 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Text.Encodings.Web;
 
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tests
 {
     /// <summary>
     /// Dummy encoder used for unit testing.

--- a/src/System.Text.Encodings.Web/tests/ScalarTestEncoder.cs
+++ b/src/System.Text.Encodings.Web/tests/ScalarTestEncoder.cs
@@ -6,7 +6,6 @@ using System;
 using System.Globalization;
 using System.IO;
 using System.Runtime.CompilerServices;
-using System.Text.Encodings.Web;
 
 namespace System.Text.Encodings.Web.Tests
 {

--- a/src/System.Text.Encodings.Web/tests/TemporaryEncoderAdapters.cs
+++ b/src/System.Text.Encodings.Web/tests/TemporaryEncoderAdapters.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.IO;
-using System.Text.Encodings.Web;
 using System.Text.Unicode;
 
 namespace System.Text.Encodings.Web.Tests

--- a/src/System.Text.Encodings.Web/tests/TemporaryEncoderAdapters.cs
+++ b/src/System.Text.Encodings.Web/tests/TemporaryEncoderAdapters.cs
@@ -7,7 +7,7 @@ using System.IO;
 using System.Text.Encodings.Web;
 using System.Text.Unicode;
 
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tests
 {
     // These implement ASP.NET interfaces. They will be removed once we transition ASP.NET
     internal sealed class HtmlEncoder : IHtmlEncoder

--- a/src/System.Text.Encodings.Web/tests/TemporaryEncoderExtensions.cs
+++ b/src/System.Text.Encodings.Web/tests/TemporaryEncoderExtensions.cs
@@ -5,7 +5,7 @@
 using System;
 using System.IO;
 
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tests
 {
     /// <summary>
     /// Helpful extension methods for the encoder classes.

--- a/src/System.Text.Encodings.Web/tests/TemporaryInternalTypes.cs
+++ b/src/System.Text.Encodings.Web/tests/TemporaryInternalTypes.cs
@@ -10,7 +10,7 @@ using System.Text.Encodings.Web;
 using System.Text.Unicode;
 using System.Threading;
 
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tests
 {
     /// <summary>
     /// A class which can perform HTML encoding given an allow list of characters which

--- a/src/System.Text.Encodings.Web/tests/TemporaryInternalTypes.cs
+++ b/src/System.Text.Encodings.Web/tests/TemporaryInternalTypes.cs
@@ -6,7 +6,6 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
-using System.Text.Encodings.Web;
 using System.Text.Unicode;
 using System.Threading;
 

--- a/src/System.Text.Encodings.Web/tests/TextEncoderSettingsTests.cs
+++ b/src/System.Text.Encodings.Web/tests/TextEncoderSettingsTests.cs
@@ -11,7 +11,7 @@ using System.Text.Internal;
 using System.Text.Unicode;
 using Xunit;
 
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tests
 {
     internal static class TextEncoderSettingsExtensions
     {

--- a/src/System.Text.Encodings.Web/tests/TextEncoderSettingsTests.cs
+++ b/src/System.Text.Encodings.Web/tests/TextEncoderSettingsTests.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text.Encodings.Web;
 using System.Text.Internal;
 using System.Text.Unicode;
 using Xunit;

--- a/src/System.Text.Encodings.Web/tests/TextEncoderTests.cs
+++ b/src/System.Text.Encodings.Web/tests/TextEncoderTests.cs
@@ -7,7 +7,6 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Text.Encodings.Web;
 using Xunit;
 
 namespace System.Text.Encodings.Web.Tests

--- a/src/System.Text.Encodings.Web/tests/TextEncoderTests.cs
+++ b/src/System.Text.Encodings.Web/tests/TextEncoderTests.cs
@@ -10,7 +10,7 @@ using System.Text;
 using System.Text.Encodings.Web;
 using Xunit;
 
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tests
 {
     public class TextEncoderTests
     {

--- a/src/System.Text.Encodings.Web/tests/UnicodeEncoderBase.cs
+++ b/src/System.Text.Encodings.Web/tests/UnicodeEncoderBase.cs
@@ -11,7 +11,7 @@ using System.Text.Encodings.Web;
 using System.Text.Internal;
 using System.Text.Unicode;
 
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tests
 {
     internal unsafe abstract class UnicodeEncoderBase
     {

--- a/src/System.Text.Encodings.Web/tests/UnicodeEncoderBase.cs
+++ b/src/System.Text.Encodings.Web/tests/UnicodeEncoderBase.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Text;
-using System.Text.Encodings.Web;
 using System.Text.Internal;
 using System.Text.Unicode;
 

--- a/src/System.Text.Encodings.Web/tests/UnicodeEncoderBaseTests.cs
+++ b/src/System.Text.Encodings.Web/tests/UnicodeEncoderBaseTests.cs
@@ -10,7 +10,7 @@ using System.Text.Encodings.Web;
 using System.Text.Unicode;
 using Xunit;
 
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tests
 {
     public class UnicodeEncoderBaseTests
     {

--- a/src/System.Text.Encodings.Web/tests/UnicodeEncoderBaseTests.cs
+++ b/src/System.Text.Encodings.Web/tests/UnicodeEncoderBaseTests.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Text.Encodings.Web;
 using System.Text.Unicode;
 using Xunit;
 

--- a/src/System.Text.Encodings.Web/tests/UnicodeHelpersTests.cs
+++ b/src/System.Text.Encodings.Web/tests/UnicodeHelpersTests.cs
@@ -11,7 +11,7 @@ using System.Text;
 using System.Text.Unicode;
 using Xunit;
 
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tests
 {
     public unsafe class UnicodeHelpersTests
     {

--- a/src/System.Text.Encodings.Web/tests/UnicodeRangeTests.cs
+++ b/src/System.Text.Encodings.Web/tests/UnicodeRangeTests.cs
@@ -7,7 +7,7 @@ using System.Text.Encodings.Web;
 using System.Text.Unicode;
 using Xunit;
 
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tests
 {
     public class UnicodeRangeTests
     {

--- a/src/System.Text.Encodings.Web/tests/UnicodeRangeTests.cs
+++ b/src/System.Text.Encodings.Web/tests/UnicodeRangeTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Text.Encodings.Web;
 using System.Text.Unicode;
 using Xunit;
 

--- a/src/System.Text.Encodings.Web/tests/UrlEncoderTests.cs
+++ b/src/System.Text.Encodings.Web/tests/UrlEncoderTests.cs
@@ -11,7 +11,7 @@ using System.Text.Encodings.Web;
 using System.Text.Unicode;
 using Xunit;
 
-namespace Microsoft.Framework.WebEncoders
+namespace System.Text.Encodings.Web.Tests
 {
     public class UrlEncoderTests
     {

--- a/src/System.Text.Encodings.Web/tests/UrlEncoderTests.cs
+++ b/src/System.Text.Encodings.Web/tests/UrlEncoderTests.cs
@@ -7,7 +7,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Text.Encodings.Web;
 using System.Text.Unicode;
 using Xunit;
 


### PR DESCRIPTION
Renamed `Microsoft.Framework.WebEncoders` namespace to `System.Text.Encodings.Web.Tests`

cc @ahsonkhan @GrabYourPitchforks 

Fix #40073 