### PR TITLE
Re-enable StyleCop warning SA1400 (elements should specify access)

### DIFF
--- a/src/Common/src/CoreLib/CodeAnalysis.ruleset
+++ b/src/Common/src/CoreLib/CodeAnalysis.ruleset
@@ -146,7 +146,6 @@
     <Rule Id="SA1312" Action="None" /> <!-- Variable should begin with lower-case letter -->
     <Rule Id="SA1313" Action="None" /> <!-- Parameter should begin with lower-case letter -->
     <Rule Id="SA1314" Action="None" /> <!-- Type parameter names should begin with T -->
-    <Rule Id="SA1400" Action="None" /> <!-- Element should declare an access modifier -->
     <Rule Id="SA1401" Action="None" /> <!-- Fields should be private -->
     <Rule Id="SA1402" Action="None" /> <!-- File may only contain a single type -->
     <Rule Id="SA1403" Action="None" /> <!-- File may only contain a single namespace -->

--- a/src/Common/src/CoreLib/System/Diagnostics/Tracing/ActivityTracker.cs
+++ b/src/Common/src/CoreLib/System/Diagnostics/Tracing/ActivityTracker.cs
@@ -440,7 +440,7 @@ namespace System.Diagnostics.Tracing
             /// the value is either encoded into nibble itself or it can spill over into the
             /// bytes that follow.
             /// </summary>
-            enum NumberListCodes : byte
+            private enum NumberListCodes : byte
             {
                 End = 0x0,             // ends the list.   No valid value has this prefix.
                 LastImmediateValue = 0xA,
@@ -565,7 +565,7 @@ namespace System.Diagnostics.Tracing
         // This callback is used to initialize the m_current AsyncLocal Variable.
         // Its job is to keep the ETW Activity ID (part of thread local storage) in sync
         // with m_current.ActivityID
-        void ActivityChanging(AsyncLocalValueChangedArgs<ActivityInfo?> args)
+        private void ActivityChanging(AsyncLocalValueChangedArgs<ActivityInfo?> args)
         {
             ActivityInfo? cur = args.CurrentValue;
             ActivityInfo? prev = args.PreviousValue;
@@ -609,14 +609,14 @@ namespace System.Diagnostics.Tracing
         ///
         /// This variable points to a linked list that represents all Activities that have started but have not stopped.
         /// </summary>
-        AsyncLocal<ActivityInfo?>? m_current;
-        bool m_checkedForEnable;
+        private AsyncLocal<ActivityInfo?>? m_current;
+        private bool m_checkedForEnable;
 
         // Singleton
         private static ActivityTracker s_activityTrackerInstance = new ActivityTracker();
 
         // Used to create unique IDs at the top level.  Not used for nested Ids (each activity has its own id generator)
-        static long m_nextId = 0;
+        private static long m_nextId = 0;
         private const ushort MAX_ACTIVITY_DEPTH = 100;            // Limit maximum depth of activities to be tracked at 100.
                                                                   // This will avoid leaking memory in case of activities that are never stopped.
 

--- a/src/Common/src/CoreLib/System/Diagnostics/Tracing/EventCounter.cs
+++ b/src/Common/src/CoreLib/System/Diagnostics/Tracing/EventCounter.cs
@@ -190,7 +190,7 @@ namespace System.Diagnostics.Tracing
     /// This is the payload that is sent in the with EventSource.Write
     /// </summary>
     [EventData]
-    class CounterPayloadType
+    internal class CounterPayloadType
     {
         public CounterPayloadType(CounterPayload payload) { Payload = payload; }
         public CounterPayload Payload { get; set; }

--- a/src/Common/src/CoreLib/System/Diagnostics/Tracing/EventProvider.cs
+++ b/src/Common/src/CoreLib/System/Diagnostics/Tracing/EventProvider.cs
@@ -94,7 +94,7 @@ namespace System.Diagnostics.Tracing
         }
 
         internal IEventProvider m_eventProvider;         // The interface that implements the specific logging mechanism functions.
-        Interop.Advapi32.EtwEnableCallback? m_etwCallback;     // Trace Callback function
+        private Interop.Advapi32.EtwEnableCallback? m_etwCallback;     // Trace Callback function
         private long m_regHandle;                        // Trace Registration Handle
         private byte m_level;                            // Tracing Level
         private long m_anyKeywordMask;                   // Trace Enable Flags
@@ -260,7 +260,7 @@ namespace System.Diagnostics.Tracing
         // <UsesUnsafeCode Name="Parameter filterData of type: Void*" />
         // <UsesUnsafeCode Name="Parameter callbackContext of type: Void*" />
         // </SecurityKernel>
-        unsafe void EtwEnableCallBack(
+        private unsafe void EtwEnableCallBack(
                         in System.Guid sourceId,
                         int controlCode,
                         byte setLevel,

--- a/src/Common/src/CoreLib/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/Common/src/CoreLib/System/Diagnostics/Tracing/EventSource.cs
@@ -3950,7 +3950,7 @@ namespace System.Diagnostics.Tracing
 
         // We use a single instance of ActivityTracker for all EventSources instances to allow correlation between multiple event providers.
         // We have m_activityTracker field simply because instance field is more efficient than static field fetch.
-        ActivityTracker m_activityTracker = null!;
+        private ActivityTracker m_activityTracker = null!;
         internal const string s_ActivityStartSuffix = "Start";
         internal const string s_ActivityStopSuffix = "Stop";
 
@@ -5083,7 +5083,7 @@ namespace System.Diagnostics.Tracing
         public EventActivityOptions ActivityOptions { get; set; }
 
 #region private
-        EventOpcode m_opcode;
+        private EventOpcode m_opcode;
         private bool m_opcodeSet;
 #endregion
     }
@@ -5122,7 +5122,7 @@ namespace System.Diagnostics.Tracing
 #if FEATURE_ADVANCED_MANAGED_ETW_CHANNELS
     public
 #endif
-    class EventChannelAttribute : Attribute
+    internal class EventChannelAttribute : Attribute
     {
         /// <summary>
         /// Specified whether the channel is enabled by default
@@ -5162,7 +5162,7 @@ namespace System.Diagnostics.Tracing
 #if FEATURE_ADVANCED_MANAGED_ETW_CHANNELS
     public
 #endif
-    enum EventChannelType
+    internal enum EventChannelType
     {
         /// <summary>The admin channel</summary>
         Admin = 1,
@@ -6268,7 +6268,7 @@ namespace System.Diagnostics.Tracing
         }
 
 #if FEATURE_MANAGED_ETW_CHANNELS
-        class ChannelInfo
+        private class ChannelInfo
         {
             public string? Name;
             public ulong Keywords;
@@ -6276,15 +6276,15 @@ namespace System.Diagnostics.Tracing
         }
 #endif
 
-        Dictionary<int, string> opcodeTab;
-        Dictionary<int, string>? taskTab;
+        private Dictionary<int, string> opcodeTab;
+        private Dictionary<int, string>? taskTab;
 #if FEATURE_MANAGED_ETW_CHANNELS
-        Dictionary<int, ChannelInfo>? channelTab;
+        private Dictionary<int, ChannelInfo>? channelTab;
 #endif
-        Dictionary<ulong, string>? keywordTab;
-        Dictionary<string, Type>? mapsTab;
+        private Dictionary<ulong, string>? keywordTab;
+        private Dictionary<string, Type>? mapsTab;
 
-        Dictionary<string, string> stringTab;       // Maps unlocalized strings to localized ones
+        private Dictionary<string, string> stringTab;       // Maps unlocalized strings to localized ones
 
 #if FEATURE_MANAGED_ETW_CHANNELS
         // WCF used EventSource to mimic a existing ETW manifest.   To support this
@@ -6293,26 +6293,26 @@ namespace System.Diagnostics.Tracing
         // this set of channel keywords that we allow to be explicitly set.  You
         // can ignore these bits otherwise.
         internal const ulong ValidPredefinedChannelKeywords = 0xF000000000000000;
-        ulong nextChannelKeywordBit = 0x8000000000000000;   // available Keyword bit to be used for next channel definition, grows down
-        const int MaxCountChannels = 8; // a manifest can defined at most 8 ETW channels
+        private ulong nextChannelKeywordBit = 0x8000000000000000;   // available Keyword bit to be used for next channel definition, grows down
+        private const int MaxCountChannels = 8; // a manifest can defined at most 8 ETW channels
 #endif
 
-        StringBuilder sb;               // Holds the provider information.
-        StringBuilder events;           // Holds the events.
-        StringBuilder templates;
+        private StringBuilder sb;               // Holds the provider information.
+        private StringBuilder events;           // Holds the events.
+        private StringBuilder templates;
 
 #if FEATURE_MANAGED_ETW_CHANNELS
-        string providerName;
+        private string providerName;
 #endif
-        ResourceManager? resources;      // Look up localized strings here.
-        EventManifestOptions flags;
-        IList<string> errors;           // list of currently encountered errors
-        Dictionary<string, List<int>> perEventByteArrayArgIndices;  // "event_name" -> List_of_Indices_of_Byte[]_Arg
+        private ResourceManager? resources;      // Look up localized strings here.
+        private EventManifestOptions flags;
+        private IList<string> errors;           // list of currently encountered errors
+        private Dictionary<string, List<int>> perEventByteArrayArgIndices;  // "event_name" -> List_of_Indices_of_Byte[]_Arg
 
         // State we track between StartEvent and EndEvent.
-        string? eventName;               // Name of the event currently being processed.
-        int numParams;                  // keeps track of the number of args the event has.
-        List<int>? byteArrArgIndices;   // keeps track of the index of each byte[] argument
+        private string? eventName;               // Name of the event currently being processed.
+        private int numParams;                  // keeps track of the number of args the event has.
+        private List<int>? byteArrArgIndices;   // keeps track of the index of each byte[] argument
 #endregion
     }
 

--- a/src/Common/src/CoreLib/System/Diagnostics/Tracing/IncrementingEventCounter.cs
+++ b/src/Common/src/CoreLib/System/Diagnostics/Tracing/IncrementingEventCounter.cs
@@ -89,7 +89,7 @@ namespace System.Diagnostics.Tracing
     /// This is the payload that is sent in the with EventSource.Write
     /// </summary>
     [EventData]
-    class IncrementingEventCounterPayloadType
+    internal class IncrementingEventCounterPayloadType
     {
         public IncrementingEventCounterPayloadType(IncrementingCounterPayload payload) { Payload = payload; }
         public IncrementingCounterPayload Payload { get; set; }

--- a/src/Common/src/CoreLib/System/Diagnostics/Tracing/IncrementingPollingCounter.cs
+++ b/src/Common/src/CoreLib/System/Diagnostics/Tracing/IncrementingPollingCounter.cs
@@ -93,7 +93,7 @@ namespace System.Diagnostics.Tracing
     /// This is the payload that is sent in the with EventSource.Write
     /// </summary>
     [EventData]
-    class IncrementingPollingCounterPayloadType
+    internal class IncrementingPollingCounterPayloadType
     {
         public IncrementingPollingCounterPayloadType(IncrementingCounterPayload payload) { Payload = payload; }
         public IncrementingCounterPayload Payload { get; set; }

--- a/src/Common/src/CoreLib/System/Diagnostics/Tracing/PollingCounter.cs
+++ b/src/Common/src/CoreLib/System/Diagnostics/Tracing/PollingCounter.cs
@@ -82,7 +82,7 @@ namespace System.Diagnostics.Tracing
     /// This is the payload that is sent in the with EventSource.Write
     /// </summary>
     [EventData]
-    class PollingPayloadType
+    internal class PollingPayloadType
     {
         public PollingPayloadType(CounterPayload payload) { Payload = payload; }
         public CounterPayload Payload { get; set; }

--- a/src/Common/src/CoreLib/System/Diagnostics/Tracing/StubEnvironment.cs
+++ b/src/Common/src/CoreLib/System/Diagnostics/Tracing/StubEnvironment.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Reflection
         String = 18,                // Unicode character string
     }
 #endif
-    static class ReflectionExtensions
+    internal static class ReflectionExtensions
     {
 #if (!ES_BUILD_PCL && !ES_BUILD_PN)
 

--- a/src/Common/src/CoreLib/System/Diagnostics/Tracing/TraceLogging/PropertyValue.cs
+++ b/src/Common/src/CoreLib/System/Diagnostics/Tracing/TraceLogging/PropertyValue.cs
@@ -80,9 +80,9 @@ namespace System.Diagnostics.Tracing
         }
 
         // Anything not covered by the Scalar union gets stored in this reference.
-        readonly object? _reference;
-        readonly Scalar _scalar;
-        readonly int _scalarLength;
+        private readonly object? _reference;
+        private readonly Scalar _scalar;
+        private readonly int _scalarLength;
 
         private PropertyValue(object? value)
         {

--- a/src/Common/src/CoreLib/System/Diagnostics/Tracing/TraceLogging/SimpleTypeInfos.cs
+++ b/src/Common/src/CoreLib/System/Diagnostics/Tracing/TraceLogging/SimpleTypeInfos.cs
@@ -48,10 +48,10 @@ namespace System.Diagnostics.Tracing
     /// <summary>
     /// Type handler for simple scalar types.
     /// </summary>
-    sealed class ScalarTypeInfo : TraceLoggingTypeInfo
+    internal sealed class ScalarTypeInfo : TraceLoggingTypeInfo
     {
-        Func<EventFieldFormat, TraceLoggingDataType, TraceLoggingDataType> formatFunc;
-        TraceLoggingDataType nativeFormat;
+        private Func<EventFieldFormat, TraceLoggingDataType, TraceLoggingDataType> formatFunc;
+        private TraceLoggingDataType nativeFormat;
 
         private ScalarTypeInfo(
             Type type,
@@ -96,9 +96,9 @@ namespace System.Diagnostics.Tracing
     /// </summary>
     internal sealed class ScalarArrayTypeInfo : TraceLoggingTypeInfo
     {
-        Func<EventFieldFormat, TraceLoggingDataType, TraceLoggingDataType> formatFunc;
-        TraceLoggingDataType nativeFormat;
-        int elementSize;
+        private Func<EventFieldFormat, TraceLoggingDataType, TraceLoggingDataType> formatFunc;
+        private TraceLoggingDataType nativeFormat;
+        private int elementSize;
 
         private ScalarArrayTypeInfo(
             Type type,

--- a/src/Common/src/Interop/FreeBSD/Interop.Process.cs
+++ b/src/Common/src/Interop/FreeBSD/Interop.Process.cs
@@ -86,7 +86,7 @@ internal static partial class Interop
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        struct vnode
+        private struct vnode
         {
             public long tv_sec;
             public long tv_usec;

--- a/src/Common/src/Interop/Windows/BCrypt/Interop.Blobs.cs
+++ b/src/Common/src/Interop/Windows/BCrypt/Interop.Blobs.cs
@@ -286,8 +286,8 @@ internal partial class Interop
         [StructLayout(LayoutKind.Sequential)]
         internal unsafe struct BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO
         {
-            int cbSize;
-            uint dwInfoVersion;
+            private int cbSize;
+            private uint dwInfoVersion;
             internal byte* pbNonce;
             internal int cbNonce;
             internal byte* pbAuthData;

--- a/src/Common/src/Interop/Windows/Kernel32/Interop.MoveFileEx.cs
+++ b/src/Common/src/Interop/Windows/Kernel32/Interop.MoveFileEx.cs
@@ -10,8 +10,8 @@ internal partial class Interop
 {
     internal partial class Kernel32
     {
-        const uint MOVEFILE_REPLACE_EXISTING = 0x01;
-        const uint MOVEFILE_COPY_ALLOWED = 0x02;
+        private const uint MOVEFILE_REPLACE_EXISTING = 0x01;
+        private const uint MOVEFILE_COPY_ALLOWED = 0x02;
 
         /// <summary>
         /// WARNING: This method does not implicitly handle long paths. Use MoveFile.

--- a/src/Common/src/Interop/Windows/Kernel32/Interop.ReadConsoleOutput.cs
+++ b/src/Common/src/Interop/Windows/Kernel32/Interop.ReadConsoleOutput.cs
@@ -12,8 +12,8 @@ internal partial class Interop
         [StructLayout(LayoutKind.Sequential)]
         internal struct CHAR_INFO
         {
-            ushort charData;
-            short attributes;
+            private ushort charData;
+            private short attributes;
         }
 
         [DllImport(Libraries.Kernel32, SetLastError = true, CharSet = CharSet.Unicode, EntryPoint = "ReadConsoleOutputW")]

--- a/src/Common/src/Interop/Windows/SspiCli/Interop.LSAStructs.cs
+++ b/src/Common/src/Interop/Windows/SspiCli/Interop.LSAStructs.cs
@@ -23,7 +23,7 @@ internal static partial class Interop
         internal int Use;
         internal IntPtr Sid;
         internal int DomainIndex;
-        uint Flags;
+        private uint Flags;
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/src/Common/src/System/Net/Security/NegotiateStreamPal.Unix.cs
+++ b/src/Common/src/System/Net/Security/NegotiateStreamPal.Unix.cs
@@ -38,7 +38,7 @@ namespace System.Net.Security
             return negoContext.IsNtlmUsed ? NegotiationInfoClass.NTLM : NegotiationInfoClass.Kerberos;
         }
 
-        static byte[] GssWrap(
+        private static byte[] GssWrap(
             SafeGssContextHandle context,
             bool encrypt,
             byte[] buffer,

--- a/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
+++ b/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
@@ -497,7 +497,7 @@ namespace Microsoft.XmlSerializer.Generator
             }
         }
 
-        static void WriteWarning(Exception e, bool parsableerrors)
+        private static void WriteWarning(Exception e, bool parsableerrors)
         {
             Console.Out.WriteLine(FormatMessage(parsableerrors, true, e.Message));
             if (e.InnerException != null)

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -2041,7 +2041,7 @@ namespace System.Collections.Concurrent
         /// </summary>
         private sealed class DictionaryEnumerator : IDictionaryEnumerator
         {
-            IEnumerator<KeyValuePair<TKey, TValue>> _enumerator; // Enumerator over the dictionary.
+            private IEnumerator<KeyValuePair<TKey, TValue>> _enumerator; // Enumerator over the dictionary.
 
             internal DictionaryEnumerator(ConcurrentDictionary<TKey, TValue> dictionary)
             {

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/PartitionerStatic.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/PartitionerStatic.cs
@@ -491,8 +491,8 @@ namespace System.Collections.Concurrent
         /// <typeparam name="TSource">Type of elements in the source data</typeparam>
         private class DynamicPartitionerForIEnumerable<TSource> : OrderablePartitioner<TSource>
         {
-            IEnumerable<TSource> _source;
-            readonly bool _useSingleChunking;
+            private IEnumerable<TSource> _source;
+            private readonly bool _useSingleChunking;
 
             //constructor
             internal DynamicPartitionerForIEnumerable(IEnumerable<TSource> source, EnumerablePartitionerOptions partitionerOptions)
@@ -1003,7 +1003,7 @@ namespace System.Collections.Concurrent
         {
             // TCollection can be: IList<TSource>, TSource[] and IEnumerable<TSource>
             // Derived classes specify TCollection, and implement the abstract method GetOrderableDynamicPartitions_Factory accordingly
-            TCollection _data;
+            private TCollection _data;
 
             /// <summary>
             /// Constructs a new orderable partitioner
@@ -1510,7 +1510,7 @@ namespace System.Collections.Concurrent
         /// <typeparam name="TSource"></typeparam>
         private class StaticIndexRangePartitionerForIList<TSource> : StaticIndexRangePartitioner<TSource, IList<TSource>>
         {
-            IList<TSource> _list;
+            private IList<TSource> _list;
             internal StaticIndexRangePartitionerForIList(IList<TSource> list)
                 : base()
             {
@@ -1568,7 +1568,7 @@ namespace System.Collections.Concurrent
         /// </summary>
         private class StaticIndexRangePartitionerForArray<TSource> : StaticIndexRangePartitioner<TSource, TSource[]>
         {
-            TSource[] _array;
+            private TSource[] _array;
             internal StaticIndexRangePartitionerForArray(TSource[] array)
                 : base()
             {

--- a/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/CatalogReflectionContextAttribute.cs
+++ b/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/CatalogReflectionContextAttribute.cs
@@ -15,7 +15,7 @@ namespace System.ComponentModel.Composition
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false,Inherited = true)]
     public class CatalogReflectionContextAttribute : Attribute
     {
-        Type _reflectionContextType;
+        private Type _reflectionContextType;
 
         public CatalogReflectionContextAttribute(Type reflectionContextType)
         {

--- a/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/CompositionContainer.CompositionServiceShim.cs
+++ b/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/CompositionContainer.CompositionServiceShim.cs
@@ -10,7 +10,7 @@ namespace System.ComponentModel.Composition.Hosting
     {
         private class CompositionServiceShim : ICompositionService
         {
-            CompositionContainer _innerContainer = null;
+            private CompositionContainer _innerContainer = null;
 
             public CompositionServiceShim(CompositionContainer innerContainer)
             {

--- a/src/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigXmlDocument.cs
+++ b/src/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigXmlDocument.cs
@@ -17,9 +17,9 @@ namespace System.Configuration
     // the UserData property to hang any info off of any node.
     public sealed class ConfigXmlDocument : XmlDocument, IConfigErrorInfo
     {
-        XmlTextReader _reader;
-        int _lineOffset;
-        string _filename;
+        private XmlTextReader _reader;
+        private int _lineOffset;
+        private string _filename;
 
         int IConfigErrorInfo.LineNumber
         {

--- a/src/System.Configuration.ConfigurationManager/src/System/Configuration/IdnElement.cs
+++ b/src/System.Configuration.ConfigurationManager/src/System/Configuration/IdnElement.cs
@@ -37,7 +37,7 @@ namespace System.Configuration
             set { this[_enabled] = value; }
         }
 
-        class UriIdnScopeTypeConverter : TypeConverter
+        private class UriIdnScopeTypeConverter : TypeConverter
         {
             public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
             {

--- a/src/System.Console/src/System/ConsolePal.Windows.cs
+++ b/src/System.Console/src/System/ConsolePal.Windows.cs
@@ -1116,7 +1116,7 @@ namespace System
         {
             // We know that if we are using console APIs rather than file APIs, then the encoding
             // is Encoding.Unicode implying 2 bytes per character:
-            const int BytesPerWChar = 2;
+            private const int BytesPerWChar = 2;
 
             private readonly bool _isPipe; // When reading from pipes, we need to properly handle EOF cases.
             private IntPtr _handle;

--- a/src/System.Data.Common/src/System/Data/SortExpressionBuilder.cs
+++ b/src/System.Data.Common/src/System/Data/SortExpressionBuilder.cs
@@ -38,11 +38,11 @@ namespace System.Data
         // Selectors and comparers are mapped using the index in the list.
         // E.g: _comparers[i] is used with _selectors[i]
 
-        LinkedList<Func<T, object>> _selectors = new LinkedList<Func<T, object>>();
-        LinkedList<Comparison<object>> _comparers = new LinkedList<Comparison<object>>();
+        private LinkedList<Func<T, object>> _selectors = new LinkedList<Func<T, object>>();
+        private LinkedList<Comparison<object>> _comparers = new LinkedList<Comparison<object>>();
 
-        LinkedListNode<Func<T, object>> _currentSelector = null;
-        LinkedListNode<Comparison<object>> _currentComparer = null;
+        private LinkedListNode<Func<T, object>> _currentSelector = null;
+        private LinkedListNode<Comparison<object>> _currentComparer = null;
 
         /// <summary>
         /// Adds a sorting selector/comparer in the correct order

--- a/src/System.Data.OleDb/src/OleDbDataReader.cs
+++ b/src/System.Data.OleDb/src/OleDbDataReader.cs
@@ -36,8 +36,8 @@ namespace System.Data.OleDb
         private int _depth;
         private bool _isClosed, _isRead, _hasRows, _hasRowsReadCheck;
 
-        long _sequentialBytesRead;
-        int _sequentialOrdinal;
+        private long _sequentialBytesRead;
+        private int _sequentialOrdinal;
 
         private Bindings[] _bindings; // _metdata contains the ColumnBinding
 

--- a/src/System.Data.OleDb/src/System/Data/Common/AdapterUtil.cs
+++ b/src/System.Data.OleDb/src/System/Data/Common/AdapterUtil.cs
@@ -34,7 +34,7 @@ namespace System.Data.Common
             }
         }
 
-        static void TraceException(string trace, Exception e)
+        private static void TraceException(string trace, Exception e)
         {
             Debug.Assert(e != null, "TraceException: null Exception");
             if (e != null)

--- a/src/System.Data.OleDb/src/System/Data/ProviderBase/DbConnectionFactory.cs
+++ b/src/System.Data.OleDb/src/System/Data/ProviderBase/DbConnectionFactory.cs
@@ -23,9 +23,9 @@ namespace System.Data.ProviderBase
 
         // s_pendingOpenNonPooled is an array of tasks used to throttle creation of non-pooled connections to
         // a maximum of Environment.ProcessorCount at a time.
-        static int s_pendingOpenNonPooledNext = 0;
-        static Task<DbConnectionInternal>[] s_pendingOpenNonPooled = new Task<DbConnectionInternal>[Environment.ProcessorCount];
-        static Task<DbConnectionInternal> s_completedTask;
+        private static int s_pendingOpenNonPooledNext = 0;
+        private static Task<DbConnectionInternal>[] s_pendingOpenNonPooled = new Task<DbConnectionInternal>[Environment.ProcessorCount];
+        private static Task<DbConnectionInternal> s_completedTask;
 
         protected DbConnectionFactory() : this(DbConnectionPoolCountersNoCounters.SingletonInstance) { }
 
@@ -113,7 +113,7 @@ namespace System.Data.ProviderBase
         }
 
         // GetCompletedTask must be called from within s_pendingOpenPooled lock
-        static Task<DbConnectionInternal> GetCompletedTask()
+        private static Task<DbConnectionInternal> GetCompletedTask()
         {
             if (s_completedTask == null)
             {

--- a/src/System.Data.OleDb/src/System/Data/ProviderBase/DbConnectionPool.cs
+++ b/src/System.Data.OleDb/src/System/Data/ProviderBase/DbConnectionPool.cs
@@ -46,7 +46,7 @@ namespace System.Data.ProviderBase
             }
         }
 
-        sealed class PendingGetConnection
+        private sealed class PendingGetConnection
         {
             public PendingGetConnection(long dueTime, DbConnection owner, TaskCompletionSource<DbConnectionInternal> completion, DbConnectionOptions userOptions)
             {
@@ -62,9 +62,9 @@ namespace System.Data.ProviderBase
 
         private sealed class TransactedConnectionPool
         {
-            Dictionary<SysTx.Transaction, TransactedConnectionList> _transactedCxns;
+            private Dictionary<SysTx.Transaction, TransactedConnectionList> _transactedCxns;
 
-            DbConnectionPool _pool;
+            private DbConnectionPool _pool;
 
             internal TransactedConnectionPool(DbConnectionPool pool)
             {
@@ -943,7 +943,7 @@ namespace System.Data.ProviderBase
             return _resError;
         }
 
-        void WaitForPendingOpen()
+        private void WaitForPendingOpen()
         {
             Debug.Assert(!Thread.CurrentThread.IsThreadPoolThread, "This thread may block for a long time.  Threadpool threads should not be used.");
 

--- a/src/System.Data.OleDb/src/System/Data/ProviderBase/DbConnectionPoolCounters.cs
+++ b/src/System.Data.OleDb/src/System/Data/ProviderBase/DbConnectionPoolCounters.cs
@@ -151,7 +151,7 @@ namespace System.Data.ProviderBase
             }
         };
 
-        const int CounterInstanceNameMaxLength = 127;
+        private const int CounterInstanceNameMaxLength = 127;
 
         internal readonly Counter HardConnectsPerSecond;
         internal readonly Counter HardDisconnectsPerSecond;
@@ -312,7 +312,7 @@ namespace System.Data.ProviderBase
             }
         }
 
-        void ExceptionEventHandler(object sender, UnhandledExceptionEventArgs e)
+        private void ExceptionEventHandler(object sender, UnhandledExceptionEventArgs e)
         {
             if ((null != e) && e.IsTerminating)
             {
@@ -320,12 +320,12 @@ namespace System.Data.ProviderBase
             }
         }
 
-        void ExitEventHandler(object sender, EventArgs e)
+        private void ExitEventHandler(object sender, EventArgs e)
         {
             Dispose();
         }
 
-        void UnloadEventHandler(object sender, EventArgs e)
+        private void UnloadEventHandler(object sender, EventArgs e)
         {
             Dispose();
         }

--- a/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionInternal.cs
@@ -442,7 +442,7 @@ namespace System.Data.ProviderBase
             }
         }
 
-        void TransactionCompletedEvent(object sender, TransactionEventArgs e)
+        private void TransactionCompletedEvent(object sender, TransactionEventArgs e)
         {
             Transaction transaction = e.Transaction;
 

--- a/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPool.cs
+++ b/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPool.cs
@@ -61,9 +61,9 @@ namespace System.Data.ProviderBase
 
         private sealed class TransactedConnectionPool
         {
-            Dictionary<Transaction, TransactedConnectionList> _transactedCxns;
+            private Dictionary<Transaction, TransactedConnectionList> _transactedCxns;
 
-            DbConnectionPool _pool;
+            private DbConnectionPool _pool;
 
             private static int _objectTypeCount; // Bid counter
             internal readonly int _objectID = System.Threading.Interlocked.Increment(ref _objectTypeCount);

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCredential.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCredential.cs
@@ -9,8 +9,8 @@ namespace System.Data.SqlClient
 {
     public sealed class SqlCredential
     {
-        string _userId;
-        SecureString _password;
+        private string _userId;
+        private SecureString _password;
 
         public SqlCredential(string userId, SecureString password)
         {

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -130,7 +130,7 @@ namespace System.Diagnostics
         ///     Returns whether this process component is associated with a real process.
         /// </devdoc>
         /// <internalonly/>
-        bool Associated
+        private bool Associated
         {
             get { return _haveProcessId || _haveProcessHandle; }
         }

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
@@ -614,7 +614,7 @@ namespace System.Diagnostics
                 return (long)MemoryMarshal.Read<int>(data);
         }
 
-        enum ValueId
+        private enum ValueId
         {
             Unknown = -1,
             HandleCount,

--- a/src/System.Diagnostics.TraceSource/src/System/Diagnostics/SwitchAttribute.cs
+++ b/src/System.Diagnostics.TraceSource/src/System/Diagnostics/SwitchAttribute.cs
@@ -67,7 +67,7 @@ namespace System.Diagnostics
             return ret;
         }
 
-        static void GetAllRecursive(Type type, List<object> switchAttribs)
+        private static void GetAllRecursive(Type type, List<object> switchAttribs)
         {
             GetAllRecursive((MemberInfo)type, switchAttribs);
             MemberInfo[] members = type.GetMembers(BindingFlags.Public | BindingFlags.NonPublic |
@@ -82,7 +82,7 @@ namespace System.Diagnostics
             }
         }
 
-        static void GetAllRecursive(MemberInfo member, List<object> switchAttribs)
+        private static void GetAllRecursive(MemberInfo member, List<object> switchAttribs)
         {
             object[] attribs = member.GetCustomAttributes(typeof(SwitchAttribute), false);
             switchAttribs.AddRange(attribs);

--- a/src/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPath.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPath.Unix.cs
@@ -46,7 +46,7 @@ namespace System.Drawing.Drawing2D
 
         internal IntPtr _nativePath = IntPtr.Zero;
 
-        GraphicsPath(IntPtr ptr)
+        private GraphicsPath(IntPtr ptr)
         {
             _nativePath = ptr;
         }
@@ -116,7 +116,7 @@ namespace System.Drawing.Drawing2D
             Dispose(false);
         }
 
-        void Dispose(bool disposing)
+        private void Dispose(bool disposing)
         {
             int status;
             if (_nativePath != IntPtr.Zero)

--- a/src/System.Drawing.Common/src/System/Drawing/ImageAnimator.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/ImageAnimator.Unix.cs
@@ -38,7 +38,7 @@ using System.Threading;
 namespace System.Drawing
 {
 
-    class AnimateEventArgs : EventArgs
+    internal class AnimateEventArgs : EventArgs
     {
 
         private int frameCount;
@@ -70,7 +70,7 @@ namespace System.Drawing
     public sealed class ImageAnimator
     {
 
-        static Hashtable ht = Hashtable.Synchronized(new Hashtable());
+        private static Hashtable ht = Hashtable.Synchronized(new Hashtable());
 
         private ImageAnimator()
         {
@@ -161,7 +161,7 @@ namespace System.Drawing
         }
     }
 
-    class WorkerThread
+    internal class WorkerThread
     {
 
         private EventHandler frameChangeHandler;

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/MetafileHeader.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/MetafileHeader.Unix.cs
@@ -37,7 +37,7 @@ namespace System.Drawing.Imaging
 {
 
     [StructLayout(LayoutKind.Sequential, Pack = 2)]
-    struct EnhMetafileHeader
+    internal struct EnhMetafileHeader
     {
         public int type;
         public int size;
@@ -58,7 +58,7 @@ namespace System.Drawing.Imaging
 
     // hack: keep public type as Sequential while making it possible to get the required union
     [StructLayout(LayoutKind.Explicit)]
-    struct MonoMetafileHeader
+    internal struct MonoMetafileHeader
     {
         [FieldOffset(0)]
         public MetafileType type;

--- a/src/System.Drawing.Common/src/System/Drawing/NativeStructs.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/NativeStructs.Unix.cs
@@ -68,8 +68,8 @@ namespace System.Drawing
         internal int Version;
         internal int SigCount;
         internal int SigSize;
-        IntPtr SigPattern;
-        IntPtr SigMask;
+        private IntPtr SigPattern;
+        private IntPtr SigMask;
 
         internal static void MarshalTo(GdipImageCodecInfo gdipcodec, ImageCodecInfo codec)
         {
@@ -119,7 +119,7 @@ namespace System.Drawing
     [StructLayout(LayoutKind.Sequential)]
     internal struct IconInfo
     {
-        int fIcon;
+        private int fIcon;
         public int xHotspot;
         public int yHotspot;
         public IntPtr hbmMask;

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PageSettings.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PageSettings.Unix.cs
@@ -49,12 +49,12 @@ namespace System.Drawing.Printing
         internal PrinterResolution printerResolution;
 
         // create a new default Margins object (is 1 inch for all margins)
-        Margins margins = new Margins();
+        private Margins margins = new Margins();
 #pragma warning disable 649
-        float hardMarginX;
-        float hardMarginY;
-        RectangleF printableArea;
-        PrinterSettings printerSettings;
+        private float hardMarginX;
+        private float hardMarginY;
+        private RectangleF printableArea;
+        private PrinterSettings printerSettings;
 #pragma warning restore 649
 
         public PageSettings() : this(new PrinterSettings())

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PreviewPrintController.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PreviewPrintController.Unix.cs
@@ -40,8 +40,8 @@ namespace System.Drawing.Printing
 {
     public class PreviewPrintController : PrintController
     {
-        bool useantialias;
-        ArrayList pageInfoList;
+        private bool useantialias;
+        private ArrayList pageInfoList;
 
         public PreviewPrintController()
         {

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PrintPageEventArgs.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PrintPageEventArgs.Unix.cs
@@ -41,13 +41,13 @@ namespace System.Drawing.Printing
     /// </summary>
     public class PrintPageEventArgs : EventArgs
     {
-        bool cancel;
-        Graphics graphics;
-        bool hasmorePages;
-        Rectangle marginBounds;
-        Rectangle pageBounds;
-        PageSettings pageSettings;
-        GraphicsPrinter graphics_context;
+        private bool cancel;
+        private Graphics graphics;
+        private bool hasmorePages;
+        private Rectangle marginBounds;
+        private Rectangle pageBounds;
+        private PageSettings pageSettings;
+        private GraphicsPrinter graphics_context;
 
         public PrintPageEventArgs(Graphics graphics, Rectangle marginBounds,
             Rectangle pageBounds, PageSettings pageSettings)

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PrinterSettings.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PrinterSettings.Unix.cs
@@ -379,7 +379,7 @@ namespace System.Drawing.Printing
 
         public class PaperSourceCollection : ICollection, IEnumerable
         {
-            ArrayList _PaperSources = new ArrayList();
+            private ArrayList _PaperSources = new ArrayList();
 
             public PaperSourceCollection(PaperSource[] array)
             {
@@ -424,7 +424,7 @@ namespace System.Drawing.Printing
 
         public class PaperSizeCollection : ICollection, IEnumerable
         {
-            ArrayList _PaperSizes = new ArrayList();
+            private ArrayList _PaperSizes = new ArrayList();
 
             public PaperSizeCollection(PaperSize[] array)
             {
@@ -468,7 +468,7 @@ namespace System.Drawing.Printing
 
         public class PrinterResolutionCollection : ICollection, IEnumerable
         {
-            ArrayList _PrinterResolutions = new ArrayList();
+            private ArrayList _PrinterResolutions = new ArrayList();
 
             public PrinterResolutionCollection(PrinterResolution[] array)
             {
@@ -512,7 +512,7 @@ namespace System.Drawing.Printing
 
         public class StringCollection : ICollection, IEnumerable
         {
-            ArrayList _Strings = new ArrayList();
+            private ArrayList _Strings = new ArrayList();
 
             public StringCollection(string[] array)
             {

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PrintingServices.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PrintingServices.Unix.cs
@@ -797,7 +797,7 @@ namespace System.Drawing.Printing
 
         #region Print job methods
 
-        static string tmpfile;
+        private static string tmpfile;
 
         /// <summary>
         /// Gets a pointer to an options list parsed from the printer's current settings, to use when setting up the printing job

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs
@@ -217,7 +217,7 @@ namespace System.IO
             /// The size of the native struct inotify_event.  4 32-bit integer values, the last of which is a length
             /// that indicates how many bytes follow to form the string name.
             /// </summary>
-            const int c_INotifyEventSize = 16;
+            private const int c_INotifyEventSize = 16;
 
             /// <summary>
             /// Weak reference to the associated watcher.  A weak reference is used so that the FileSystemWatcher may be collected and finalized,

--- a/src/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
@@ -1544,10 +1544,10 @@ namespace System.IO.Ports
             internal bool endEventLoop;
             private int eventsOccurred;
 
-            WaitCallback callErrorEvents;
-            WaitCallback callReceiveEvents;
-            WaitCallback callPinEvents;
-            IOCompletionCallback freeNativeOverlappedCallback;
+            private WaitCallback callErrorEvents;
+            private WaitCallback callReceiveEvents;
+            private WaitCallback callPinEvents;
+            private IOCompletionCallback freeNativeOverlappedCallback;
 
 #if DEBUG
             private readonly string portName;

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Enumerables/EnumerableWrapperWeakToStrong.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Enumerables/EnumerableWrapperWeakToStrong.cs
@@ -47,7 +47,7 @@ namespace System.Linq.Parallel
         // A wrapper over IEnumerator that provides IEnumerator<object> interface
         //
 
-        class WrapperEnumeratorWeakToStrong : IEnumerator<object>
+        private class WrapperEnumeratorWeakToStrong : IEnumerator<object>
         {
             private IEnumerator _wrappedEnumerator; // The weakly typed enumerator we've wrapped.
 

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Enumerables/RangeEnumerable.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Enumerables/RangeEnumerable.cs
@@ -72,7 +72,7 @@ namespace System.Linq.Parallel
         // The actual enumerator that walks over the specified range.
         //
 
-        class RangeEnumerator : QueryOperatorEnumerator<int, int>
+        private class RangeEnumerator : QueryOperatorEnumerator<int, int>
         {
             private readonly int _from; // The initial value.
             private readonly int _count; // How many values to yield.

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Enumerables/RepeatEnumerable.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Enumerables/RepeatEnumerable.cs
@@ -77,7 +77,7 @@ namespace System.Linq.Parallel
         // The actual enumerator that produces a set of repeated elements.
         //
 
-        class RepeatEnumerator : QueryOperatorEnumerator<TResult, int>
+        private class RepeatEnumerator : QueryOperatorEnumerator<TResult, int>
         {
             private readonly TResult _element; // The element to repeat.
             private readonly int _count; // The number of times to repeat it.

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Helpers.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Helpers.cs
@@ -86,7 +86,7 @@ namespace System.Linq.Parallel
             return false;
         }
 
-        bool Find(TElement value, bool add)
+        private bool Find(TElement value, bool add)
         {
             int hashCode = InternalGetHashCode(value);
             for (int i = _buckets[hashCode % _buckets.Length] - 1; i >= 0; i = _slots[i].next)
@@ -107,7 +107,7 @@ namespace System.Linq.Parallel
             return false;
         }
 
-        void Resize()
+        private void Resize()
         {
             int newSize = checked(_count * 2 + 1);
             int[] newBuckets = new int[newSize];

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Partitioning/HashRepartitionEnumerator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Partitioning/HashRepartitionEnumerator.cs
@@ -36,7 +36,7 @@ namespace System.Linq.Parallel
         private readonly CancellationToken _cancellationToken; // A token for canceling the process.
         private Mutables _mutables; // Mutable fields for this enumerator.
 
-        class Mutables
+        private class Mutables
         {
             internal int _currentBufferIndex; // Current buffer index.
             internal ListChunk<Pair<TInputOutput,THashKey>> _currentBuffer; // The buffer we're currently enumerating.

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Partitioning/IPartitionedStreamRecipient.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Partitioning/IPartitionedStreamRecipient.cs
@@ -15,7 +15,7 @@ namespace System.Linq.Parallel
     /// whose generic type parameter is the type of the order keys in the partitioned stream.
     /// </summary>
     /// <typeparam name="TElement"></typeparam>
-    interface IPartitionedStreamRecipient<TElement>
+    internal interface IPartitionedStreamRecipient<TElement>
     {
         void Receive<TKey>(PartitionedStream<TElement, TKey> partitionedStream);
     }

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Partitioning/OrderedHashRepartitionEnumerator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Partitioning/OrderedHashRepartitionEnumerator.cs
@@ -37,7 +37,7 @@ namespace System.Linq.Parallel
         private readonly CancellationToken _cancellationToken; // A token for canceling the process.
         private Mutables _mutables; // Mutable fields for this enumerator.
 
-        class Mutables
+        private class Mutables
         {
             internal int _currentBufferIndex; // Current buffer index.
             internal ListChunk<Pair<TInputOutput, THashKey>> _currentBuffer; // The buffer we're currently enumerating.

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Partitioning/PartitionedDataSource.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Partitioning/PartitionedDataSource.cs
@@ -221,7 +221,7 @@ namespace System.Linq.Parallel
             private readonly int _sectionCount; // Precomputed in ctor: the number of sections the range is split into.
             private Mutables _mutables; // Lazily allocated mutable variables.
 
-            class Mutables
+            private class Mutables
             {
                 internal Mutables()
                 {
@@ -399,7 +399,7 @@ namespace System.Linq.Parallel
             private readonly int _sectionCount; // Precomputed in ctor: the number of sections the range is split into.
             private Mutables _mutables; // Lazily allocated mutable variables.
 
-            class Mutables
+            private class Mutables
             {
                 internal Mutables()
                 {
@@ -581,7 +581,7 @@ namespace System.Linq.Parallel
             private readonly Shared<bool> _exceptionTracker;
             private Mutables _mutables; // Any mutable fields on this enumerator. These mutables are local and persistent
 
-            class Mutables
+            private class Mutables
             {
                 internal Mutables()
                 {

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Binary/ConcatQueryOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Binary/ConcatQueryOperator.cs
@@ -155,7 +155,7 @@ namespace System.Linq.Parallel
         // The enumerator type responsible for concatenating two data sources.
         //
 
-        sealed class ConcatQueryOperatorEnumerator<TLeftKey, TRightKey> : QueryOperatorEnumerator<TSource, ConcatKey<TLeftKey, TRightKey>>
+        private sealed class ConcatQueryOperatorEnumerator<TLeftKey, TRightKey> : QueryOperatorEnumerator<TSource, ConcatKey<TLeftKey, TRightKey>>
         {
             private QueryOperatorEnumerator<TSource, TLeftKey> _firstSource; // The first data source to enumerate.
             private QueryOperatorEnumerator<TSource, TRightKey> _secondSource; // The second data source to enumerate.
@@ -226,7 +226,7 @@ namespace System.Linq.Parallel
         // results were indexable.
         //
 
-        class ConcatQueryOperatorResults : BinaryQueryOperatorResults
+        private class ConcatQueryOperatorResults : BinaryQueryOperatorResults
         {
             private int _leftChildCount; // The number of elements in the left child result set
             private int _rightChildCount; // The number of elements in the right child result set

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Binary/ExceptQueryOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Binary/ExceptQueryOperator.cs
@@ -134,7 +134,7 @@ namespace System.Linq.Parallel
         // elements that have not yet been seen.
         //
 
-        class ExceptQueryOperatorEnumerator<TLeftKey> : QueryOperatorEnumerator<TInputOutput, int>
+        private class ExceptQueryOperatorEnumerator<TLeftKey> : QueryOperatorEnumerator<TInputOutput, int>
         {
             private QueryOperatorEnumerator<Pair<TInputOutput, NoKeyMemoizationRequired>, TLeftKey> _leftSource; // Left data source.
             private QueryOperatorEnumerator<Pair<TInputOutput, NoKeyMemoizationRequired>, int> _rightSource; // Right data source.
@@ -223,7 +223,7 @@ namespace System.Linq.Parallel
             }
         }
 
-        class OrderedExceptQueryOperatorEnumerator<TLeftKey> : QueryOperatorEnumerator<TInputOutput, TLeftKey>
+        private class OrderedExceptQueryOperatorEnumerator<TLeftKey> : QueryOperatorEnumerator<TInputOutput, TLeftKey>
         {
             private QueryOperatorEnumerator<Pair<TInputOutput, NoKeyMemoizationRequired>, TLeftKey> _leftSource; // Left data source.
             private QueryOperatorEnumerator<Pair<TInputOutput, NoKeyMemoizationRequired>, int> _rightSource; // Right data source.

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Binary/GroupJoinQueryOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Binary/GroupJoinQueryOperator.cs
@@ -279,7 +279,7 @@ namespace System.Linq.Parallel
         /// </summary>
         private class GroupJoinHashLookup : GroupJoinHashLookup<THashKey, TElement, ListChunk<TElement>, int>
         {
-            const int OrderKey = unchecked((int)0xdeadbeef);
+            private const int OrderKey = unchecked((int)0xdeadbeef);
 
             internal GroupJoinHashLookup(HashLookup<THashKey, ListChunk<TElement>> lookup)
                 : base(lookup)

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Binary/IntersectQueryOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Binary/IntersectQueryOperator.cs
@@ -123,7 +123,7 @@ namespace System.Linq.Parallel
         // only returns elements that are seen twice (returning each one only once).
         //
 
-        class IntersectQueryOperatorEnumerator<TLeftKey> : QueryOperatorEnumerator<TInputOutput, int>
+        private class IntersectQueryOperatorEnumerator<TLeftKey> : QueryOperatorEnumerator<TInputOutput, int>
         {
             private QueryOperatorEnumerator<Pair<TInputOutput, NoKeyMemoizationRequired>, TLeftKey> _leftSource; // Left data source.
             private QueryOperatorEnumerator<Pair<TInputOutput, NoKeyMemoizationRequired>, int> _rightSource; // Right data source.
@@ -224,7 +224,7 @@ namespace System.Linq.Parallel
         }
 
 
-        class OrderedIntersectQueryOperatorEnumerator<TLeftKey> : QueryOperatorEnumerator<TInputOutput, TLeftKey>
+        private class OrderedIntersectQueryOperatorEnumerator<TLeftKey> : QueryOperatorEnumerator<TInputOutput, TLeftKey>
         {
             private QueryOperatorEnumerator<Pair<TInputOutput, NoKeyMemoizationRequired>, TLeftKey> _leftSource; // Left data source.
             private QueryOperatorEnumerator<Pair<TInputOutput, NoKeyMemoizationRequired>, int> _rightSource; // Right data source.

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Binary/UnionQueryOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Binary/UnionQueryOperator.cs
@@ -180,7 +180,7 @@ namespace System.Linq.Parallel
         // return any duplicates.
         //
 
-        class UnionQueryOperatorEnumerator<TLeftKey, TRightKey> : QueryOperatorEnumerator<TInputOutput, int>
+        private class UnionQueryOperatorEnumerator<TLeftKey, TRightKey> : QueryOperatorEnumerator<TInputOutput, int>
         {
             private QueryOperatorEnumerator<Pair<TInputOutput, NoKeyMemoizationRequired>, TLeftKey> _leftSource; // Left data source.
             private QueryOperatorEnumerator<Pair<TInputOutput, NoKeyMemoizationRequired>, TRightKey> _rightSource; // Right data source.
@@ -294,7 +294,7 @@ namespace System.Linq.Parallel
             }
         }
 
-        class OrderedUnionQueryOperatorEnumerator<TLeftKey, TRightKey> : QueryOperatorEnumerator<TInputOutput, ConcatKey<TLeftKey, TRightKey>>
+        private class OrderedUnionQueryOperatorEnumerator<TLeftKey, TRightKey> : QueryOperatorEnumerator<TInputOutput, ConcatKey<TLeftKey, TRightKey>>
         {
             private QueryOperatorEnumerator<Pair<TInputOutput, NoKeyMemoizationRequired>, TLeftKey> _leftSource; // Left data source.
             private QueryOperatorEnumerator<Pair<TInputOutput, NoKeyMemoizationRequired>, TRightKey> _rightSource; // Right data source.

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/QueryOperatorEnumerator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/QueryOperatorEnumerator.cs
@@ -50,7 +50,7 @@ namespace System.Linq.Parallel
             return new QueryOperatorClassicEnumerator(this);
         }
 
-        class QueryOperatorClassicEnumerator : IEnumerator<TElement>
+        private class QueryOperatorClassicEnumerator : IEnumerator<TElement>
         {
             private QueryOperatorEnumerator<TElement, TKey> _operatorEnumerator;
             private TElement _current;

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/ContainsSearchOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/ContainsSearchOperator.cs
@@ -133,7 +133,7 @@ namespace System.Linq.Parallel
         // requested.
         //
 
-        class ContainsSearchOperatorEnumerator<TKey> : QueryOperatorEnumerator<bool, int>
+        private class ContainsSearchOperatorEnumerator<TKey> : QueryOperatorEnumerator<bool, int>
         {
             private readonly QueryOperatorEnumerator<TInput, TKey> _source; // The source data.
             private readonly TInput _searchValue; // The value for which we are searching.

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/DistinctQueryOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/DistinctQueryOperator.cs
@@ -116,7 +116,7 @@ namespace System.Linq.Parallel
         // then doesn't return elements it has already seen before.
         //
 
-        class DistinctQueryOperatorEnumerator<TKey> : QueryOperatorEnumerator<TInputOutput, int>
+        private class DistinctQueryOperatorEnumerator<TKey> : QueryOperatorEnumerator<TInputOutput, int>
         {
             private QueryOperatorEnumerator<Pair<TInputOutput, NoKeyMemoizationRequired>, TKey> _source; // The data source.
             private Set<TInputOutput> _hashLookup; // The hash lookup, used to produce the distinct set.
@@ -189,7 +189,7 @@ namespace System.Linq.Parallel
             return wrappedChild.Distinct(_comparer);
         }
 
-        class OrderedDistinctQueryOperatorEnumerator<TKey> : QueryOperatorEnumerator<TInputOutput, TKey>
+        private class OrderedDistinctQueryOperatorEnumerator<TKey> : QueryOperatorEnumerator<TInputOutput, TKey>
         {
             private QueryOperatorEnumerator<Pair<TInputOutput, NoKeyMemoizationRequired>, TKey> _source; // The data source.
             private Dictionary<Wrapper<TInputOutput>, TKey> _hashLookup; // The hash lookup, used to produce the distinct set.

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/ElementAtQueryOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/ElementAtQueryOperator.cs
@@ -165,7 +165,7 @@ namespace System.Linq.Parallel
         // This enumerator performs the search for the element at the specified index.
         //
 
-        class ElementAtQueryOperatorEnumerator : QueryOperatorEnumerator<TSource, int>
+        private class ElementAtQueryOperatorEnumerator : QueryOperatorEnumerator<TSource, int>
         {
             private QueryOperatorEnumerator<TSource, int> _source; // The source data.
             private int _index; // The index of the element to seek.

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/FirstQueryOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/FirstQueryOperator.cs
@@ -117,7 +117,7 @@ namespace System.Linq.Parallel
         // The enumerator type responsible for executing the first operation.
         //
 
-        class FirstQueryOperatorEnumerator<TKey> : QueryOperatorEnumerator<TSource, int>
+        private class FirstQueryOperatorEnumerator<TKey> : QueryOperatorEnumerator<TSource, int>
         {
             private QueryOperatorEnumerator<TSource, TKey> _source; // The data source to enumerate.
             private Func<TSource, bool> _predicate; // The optional predicate used during the search.
@@ -232,7 +232,7 @@ namespace System.Linq.Parallel
             }
         }
 
-        class FirstQueryOperatorState<TKey>
+        private class FirstQueryOperatorState<TKey>
         {
             internal TKey _key;
             internal int _partitionId = -1;

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/GroupByQueryOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/GroupByQueryOperator.cs
@@ -226,7 +226,7 @@ namespace System.Linq.Parallel
         protected readonly CancellationToken _cancellationToken;
         private Mutables _mutables; // All of the mutable state.
 
-        class Mutables
+        private class Mutables
         {
             internal HashLookup<Wrapper<TGroupKey>, ListChunk<TElement>> _hashLookup; // The lookup with key-value mappings.
             internal int _hashLookupIndex; // The current index within the lookup.
@@ -429,7 +429,7 @@ namespace System.Linq.Parallel
         protected readonly CancellationToken _cancellationToken;
         private Mutables _mutables; // All the mutable state.
 
-        class Mutables
+        private class Mutables
         {
             internal HashLookup<Wrapper<TGroupKey>, GroupKeyData> _hashLookup; // The lookup with key-value mappings.
             internal int _hashLookupIndex; // The current index within the lookup.
@@ -724,7 +724,7 @@ namespace System.Linq.Parallel
     /// </summary>
     internal class OrderedGroupByGrouping<TGroupKey, TOrderKey, TElement> : IGrouping<TGroupKey, TElement>
     {
-        const int INITIAL_CHUNK_SIZE = 2;
+        private const int INITIAL_CHUNK_SIZE = 2;
 
         private TGroupKey _groupKey; // The group key for this grouping
         private ListChunk<Pair<TOrderKey, TElement>> _values; // Values in this group

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/IndexedSelectQueryOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/IndexedSelectQueryOperator.cs
@@ -131,7 +131,7 @@ namespace System.Linq.Parallel
         // The enumerator type responsible for projecting elements as it is walked.
         //
 
-        class IndexedSelectQueryOperatorEnumerator : QueryOperatorEnumerator<TOutput, int>
+        private class IndexedSelectQueryOperatorEnumerator : QueryOperatorEnumerator<TOutput, int>
         {
             private readonly QueryOperatorEnumerator<TInput, int> _source; // The data source to enumerate.
             private readonly Func<TInput, int, TOutput> _selector;  // The actual select function.
@@ -187,7 +187,7 @@ namespace System.Linq.Parallel
         // results were indexable.
         //
 
-        class IndexedSelectQueryOperatorResults : UnaryQueryOperatorResults
+        private class IndexedSelectQueryOperatorResults : UnaryQueryOperatorResults
         {
             private IndexedSelectQueryOperator<TInput, TOutput> _selectOp;  // Operator that generated the results
             private int _childCount; // The number of elements in child results

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/LastQueryOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/LastQueryOperator.cs
@@ -113,7 +113,7 @@ namespace System.Linq.Parallel
         // The enumerator type responsible for executing the last operation.
         //
 
-        class LastQueryOperatorEnumerator<TKey> : QueryOperatorEnumerator<TSource, int>
+        private class LastQueryOperatorEnumerator<TKey> : QueryOperatorEnumerator<TSource, int>
         {
             private QueryOperatorEnumerator<TSource, TKey> _source; // The data source to enumerate.
             private Func<TSource, bool> _predicate; // The optional predicate used during the search.
@@ -235,7 +235,7 @@ namespace System.Linq.Parallel
         }
 
 
-        class LastQueryOperatorState<TKey>
+        private class LastQueryOperatorState<TKey>
         {
             internal TKey _key;
             internal int _partitionId = -1;

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/ReverseQueryOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/ReverseQueryOperator.cs
@@ -101,7 +101,7 @@ namespace System.Linq.Parallel
         // The enumerator type responsible for executing the reverse operation.
         //
 
-        class ReverseQueryOperatorEnumerator<TKey> : QueryOperatorEnumerator<TSource, TKey>
+        private class ReverseQueryOperatorEnumerator<TKey> : QueryOperatorEnumerator<TSource, TKey>
         {
             private readonly QueryOperatorEnumerator<TSource, TKey> _source; // The data source to reverse.
             private readonly CancellationToken _cancellationToken;
@@ -167,7 +167,7 @@ namespace System.Linq.Parallel
         // results were indexable.
         //
 
-        class ReverseQueryOperatorResults : UnaryQueryOperatorResults
+        private class ReverseQueryOperatorResults : UnaryQueryOperatorResults
         {
             private int _count; // The number of elements in child results
 

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/SelectManyQueryOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/SelectManyQueryOperator.cs
@@ -230,7 +230,7 @@ namespace System.Linq.Parallel
         // The enumerator type responsible for executing the SelectMany logic.
         //
 
-        class IndexedSelectManyQueryOperatorEnumerator : QueryOperatorEnumerator<TOutput, Pair<int, int>>
+        private class IndexedSelectManyQueryOperatorEnumerator : QueryOperatorEnumerator<TOutput, Pair<int, int>>
         {
             private readonly QueryOperatorEnumerator<TLeftInput, int> _leftSource; // The left data source to enumerate.
             private readonly SelectManyQueryOperator<TLeftInput, TRightInput, TOutput> _selectManyOperator; // The select many operator to use.
@@ -360,7 +360,7 @@ namespace System.Linq.Parallel
         // The enumerator type responsible for executing the SelectMany logic.
         //
 
-        class SelectManyQueryOperatorEnumerator<TLeftKey> : QueryOperatorEnumerator<TOutput, Pair<TLeftKey, int>>
+        private class SelectManyQueryOperatorEnumerator<TLeftKey> : QueryOperatorEnumerator<TOutput, Pair<TLeftKey, int>>
         {
             private readonly QueryOperatorEnumerator<TLeftInput, TLeftKey> _leftSource; // The left data source to enumerate.
             private readonly SelectManyQueryOperator<TLeftInput, TRightInput, TOutput> _selectManyOperator; // The select many operator to use.

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/SelectQueryOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/SelectQueryOperator.cs
@@ -90,7 +90,7 @@ namespace System.Linq.Parallel
         // The enumerator type responsible for projecting elements as it is walked.
         //
 
-        class SelectQueryOperatorEnumerator<TKey> : QueryOperatorEnumerator<TOutput, TKey>
+        private class SelectQueryOperatorEnumerator<TKey> : QueryOperatorEnumerator<TOutput, TKey>
         {
             private readonly QueryOperatorEnumerator<TInput, TKey> _source; // The data source to enumerate.
             private readonly Func<TInput, TOutput> _selector;  // The actual select function.
@@ -136,7 +136,7 @@ namespace System.Linq.Parallel
         // results were indexable.
         //
 
-        class SelectQueryOperatorResults : UnaryQueryOperatorResults
+        private class SelectQueryOperatorResults : UnaryQueryOperatorResults
         {
             private Func<TInput, TOutput> _selector; // Selector function
             private int _childCount; // The number of elements in child results

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/SingleQueryOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/SingleQueryOperator.cs
@@ -94,7 +94,7 @@ namespace System.Linq.Parallel
         // The enumerator type responsible for executing the Single operation.
         //
 
-        class SingleQueryOperatorEnumerator<TKey> : QueryOperatorEnumerator<TSource, int>
+        private class SingleQueryOperatorEnumerator<TKey> : QueryOperatorEnumerator<TSource, int>
         {
             private QueryOperatorEnumerator<TSource, TKey> _source; // The data source to enumerate.
             private Func<TSource, bool> _predicate; // The optional predicate used during the search.

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/TakeOrSkipQueryOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/TakeOrSkipQueryOperator.cs
@@ -145,7 +145,7 @@ namespace System.Linq.Parallel
         // The enumerator type responsible for executing the Take or Skip.
         //
 
-        class TakeOrSkipQueryOperatorEnumerator<TKey> : QueryOperatorEnumerator<TResult, TKey>
+        private class TakeOrSkipQueryOperatorEnumerator<TKey> : QueryOperatorEnumerator<TResult, TKey>
         {
             private readonly QueryOperatorEnumerator<TResult, TKey> _source; // The data source to enumerate.
             private readonly int _count; // The number of elements to take or skip.
@@ -323,7 +323,7 @@ namespace System.Linq.Parallel
         // results were indexable.
         //
 
-        class TakeOrSkipQueryOperatorResults : UnaryQueryOperatorResults
+        private class TakeOrSkipQueryOperatorResults : UnaryQueryOperatorResults
         {
             private TakeOrSkipQueryOperator<TResult> _takeOrSkipOp; // The operator that generated the results
             private int _childCount; // The number of elements in child results

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/TakeOrSkipWhileQueryOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/TakeOrSkipWhileQueryOperator.cs
@@ -198,7 +198,7 @@ namespace System.Linq.Parallel
         // The enumerator type responsible for executing the take- or skip-while.
         //
 
-        class TakeOrSkipWhileQueryOperatorEnumerator<TKey> : QueryOperatorEnumerator<TResult, TKey>
+        private class TakeOrSkipWhileQueryOperatorEnumerator<TKey> : QueryOperatorEnumerator<TResult, TKey>
         {
             private readonly QueryOperatorEnumerator<TResult, TKey> _source; // The data source to enumerate.
             private readonly Func<TResult, bool> _predicate;  // The actual predicate function.
@@ -394,7 +394,7 @@ namespace System.Linq.Parallel
             }
         }
 
-        class OperatorState<TKey>
+        private class OperatorState<TKey>
         {
             internal volatile int _updatesDone = 0;
             internal TKey _currentLowKey;

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Scheduling/OrderPreservingPipeliningSpoolingTask.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Scheduling/OrderPreservingPipeliningSpoolingTask.cs
@@ -19,7 +19,7 @@ using System.Diagnostics;
 
 namespace System.Linq.Parallel
 {
-    class OrderPreservingPipeliningSpoolingTask<TOutput, TKey> : SpoolingTaskBase
+    internal class OrderPreservingPipeliningSpoolingTask<TOutput, TKey> : SpoolingTaskBase
     {
         private readonly QueryTaskGroupState _taskGroupState; // State shared among tasks.
         private readonly QueryOperatorEnumerator<TOutput, TKey> _partition; // The source partition.

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Utils/HashLookup.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Utils/HashLookup.cs
@@ -123,7 +123,7 @@ namespace System.Linq.Parallel
             return false;
         }
 
-        void Resize()
+        private void Resize()
         {
             int newSize = checked(count * 2 + 1);
             int[] newBuckets = new int[newSize];

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Utils/Util.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Utils/Util.cs
@@ -62,7 +62,7 @@ namespace System.Linq.Parallel
 
         private static FastIntComparer s_fastIntComparer = new FastIntComparer();
 
-        class FastIntComparer : Comparer<int>
+        private class FastIntComparer : Comparer<int>
         {
             public override int Compare(int x, int y)
             {
@@ -72,7 +72,7 @@ namespace System.Linq.Parallel
 
         private static FastLongComparer s_fastLongComparer = new FastLongComparer();
 
-        class FastLongComparer : Comparer<long>
+        private class FastLongComparer : Comparer<long>
         {
             public override int Compare(long x, long y)
             {
@@ -82,7 +82,7 @@ namespace System.Linq.Parallel
 
         private static FastFloatComparer s_fastFloatComparer = new FastFloatComparer();
 
-        class FastFloatComparer : Comparer<float>
+        private class FastFloatComparer : Comparer<float>
         {
             public override int Compare(float x, float y)
             {
@@ -92,7 +92,7 @@ namespace System.Linq.Parallel
 
         private static FastDoubleComparer s_fastDoubleComparer = new FastDoubleComparer();
 
-        class FastDoubleComparer : Comparer<double>
+        private class FastDoubleComparer : Comparer<double>
         {
             public override int Compare(double x, double y)
             {
@@ -102,7 +102,7 @@ namespace System.Linq.Parallel
 
         private static FastDateTimeComparer s_fastDateTimeComparer = new FastDateTimeComparer();
 
-        class FastDateTimeComparer : Comparer<DateTime>
+        private class FastDateTimeComparer : Comparer<DateTime>
         {
             public override int Compare(DateTime x, DateTime y)
             {

--- a/src/System.Management/src/System/Management/InteropClasses/WMIInterop.cs
+++ b/src/System.Management/src/System/Management/InteropClasses/WMIInterop.cs
@@ -16,7 +16,7 @@ namespace WbemUtilities_v1 {}
 namespace System.Management
 {
     #region FreeThreadedInterfaces
-    sealed class IWbemClassObjectFreeThreaded : IDisposable, ISerializable
+    internal sealed class IWbemClassObjectFreeThreaded : IDisposable, ISerializable
     {
         //
         // This is to force load wminet_utils.dll as a COM component. Since wminet_utils.dll
@@ -27,10 +27,10 @@ namespace System.Management
         // the correct path and succeed in loading the DLL. Once the DllImport occurs, the DLL will
         // already be in the cache.
         //
-        static readonly string name = typeof(IWbemClassObjectFreeThreaded).FullName;
+        private static readonly string name = typeof(IWbemClassObjectFreeThreaded).FullName;
         public static Guid IID_IWbemClassObject = new Guid("DC12A681-737F-11CF-884D-00AA004B2E24");
 
-        IntPtr pWbemClassObject = IntPtr.Zero;
+        private IntPtr pWbemClassObject = IntPtr.Zero;
 
         public IWbemClassObjectFreeThreaded(IntPtr pWbemClassObject)
         {
@@ -75,7 +75,7 @@ namespace System.Management
             Dispose_(true);
         }
 
-        void DeserializeFromBlob(byte [] rg)
+        private void DeserializeFromBlob(byte [] rg)
         {
             IntPtr hGlobal = IntPtr.Zero;
             System.Runtime.InteropServices.ComTypes.IStream stream = null;
@@ -98,7 +98,7 @@ namespace System.Management
             }
         }
 
-        byte[] SerializeToBlob()
+        private byte[] SerializeToBlob()
         {
             byte [] rg = null;
             System.Runtime.InteropServices.ComTypes.IStream stream = null;
@@ -398,13 +398,13 @@ namespace System.Management
             return res ;
         }
 
-        enum STATFLAG
+        private enum STATFLAG
         {
             STATFLAG_DEFAULT    = 0,
             STATFLAG_NONAME     = 1
         }
 
-        enum MSHCTX
+        private enum MSHCTX
         {
             MSHCTX_LOCAL               = 0,
             MSHCTX_NOSHAREDMEM         = 1,
@@ -412,7 +412,7 @@ namespace System.Management
             MSHCTX_INPROC              = 3
         }
 
-        enum MSHLFLAGS
+        private enum MSHLFLAGS
         {
             MSHLFLAGS_NORMAL         = 0,
             MSHLFLAGS_TABLESTRONG    = 1,
@@ -421,12 +421,12 @@ namespace System.Management
         }
     }
 
-    sealed class IWbemQualifierSetFreeThreaded : IDisposable
+    internal sealed class IWbemQualifierSetFreeThreaded : IDisposable
     {
-        static readonly string name = typeof(IWbemQualifierSetFreeThreaded).FullName;
+        private static readonly string name = typeof(IWbemQualifierSetFreeThreaded).FullName;
         public static Guid IID_IWbemClassObject = new Guid("DC12A681-737F-11CF-884D-00AA004B2E24");
 
-        IntPtr pWbemQualifierSet = IntPtr.Zero;
+        private IntPtr pWbemQualifierSet = IntPtr.Zero;
         public IWbemQualifierSetFreeThreaded(IntPtr pWbemQualifierSet)
         {
             // This instance will now own a single ref count on pWbemClassObject
@@ -517,15 +517,15 @@ namespace System.Management
         }
     }
 
-    class MarshalWbemObject : ICustomMarshaler
+    internal class MarshalWbemObject : ICustomMarshaler
     {
         public static ICustomMarshaler GetInstance(string cookie)
         {
             return new MarshalWbemObject(cookie);
         }
 
-        string cookie;
-        MarshalWbemObject(string cookie)
+        private string cookie;
+        private MarshalWbemObject(string cookie)
         {
             this.cookie = cookie;
         }
@@ -560,7 +560,7 @@ namespace System.Management
     //[TypeLibTypeAttribute(0x0200)]
     [GuidAttribute("DC12A681-737F-11CF-884D-00AA004B2E24")]
     [ComImport]
-    interface IWbemClassObject_DoNotMarshal
+    internal interface IWbemClassObject_DoNotMarshal
     {
         [PreserveSig] int GetQualifierSet_([Out][MarshalAs(UnmanagedType.Interface)]  out IWbemQualifierSet_DoNotMarshal   ppQualSet);
         [PreserveSig] int Get_([In][MarshalAs(UnmanagedType.LPWStr)]  string   wszName, [In] int lFlags, [In][Out] ref object pVal, [In][Out] ref int pType, [In][Out] ref int plFlavor);
@@ -592,7 +592,7 @@ namespace System.Management
     [GuidAttribute("DC12A680-737F-11CF-884D-00AA004B2E24")]
     //[TypeLibTypeAttribute(0x0200)]
     [ComImport]
-    interface IWbemQualifierSet_DoNotMarshal
+    internal interface IWbemQualifierSet_DoNotMarshal
     {
         [PreserveSig] int Get_([In][MarshalAs(UnmanagedType.LPWStr)]  string   wszName, [In] int lFlags, [In][Out] ref object pVal, [In][Out] ref int plFlavor);
         [PreserveSig] int Put_([In][MarshalAs(UnmanagedType.LPWStr)]  string   wszName, [In] ref object pVal, [In] int lFlavor);
@@ -607,7 +607,7 @@ namespace System.Management
     //[TypeLibTypeAttribute(0x0200)]
     [GuidAttribute("DC12A687-737F-11CF-884D-00AA004B2E24")]
     [ComImport]
-    interface IWbemLocator
+    internal interface IWbemLocator
     {
         [PreserveSig] int ConnectServer_([In][MarshalAs(UnmanagedType.BStr)]  string   strNetworkResource, [In][MarshalAs(UnmanagedType.BStr)]  string   strUser, [In]IntPtr   strPassword, [In][MarshalAs(UnmanagedType.BStr)]  string   strLocale, [In] int lSecurityFlags, [In][MarshalAs(UnmanagedType.BStr)]  string   strAuthority, [In][MarshalAs(UnmanagedType.Interface)]  IWbemContext   pCtx, [Out][MarshalAs(UnmanagedType.Interface)]  out IWbemServices   ppNamespace);
     }
@@ -616,7 +616,7 @@ namespace System.Management
     //[TypeLibTypeAttribute(0x0200)]
     [InterfaceTypeAttribute(0x0001)]
     [ComImport]
-    interface IWbemContext
+    internal interface IWbemContext
     {
         [PreserveSig] int Clone_([Out][MarshalAs(UnmanagedType.Interface)]  out IWbemContext   ppNewCopy);
         [PreserveSig] int GetNames_([In] int lFlags, [Out][MarshalAs(UnmanagedType.SafeArray, SafeArraySubType=VarEnum.VT_BSTR)]  out string[]   pNames);
@@ -633,7 +633,7 @@ namespace System.Management
     //[TypeLibTypeAttribute(0x0200)]
     [GuidAttribute("9556DC99-828C-11CF-A37E-00AA003240C7")]
     [ComImport]
-    interface IWbemServices
+    internal interface IWbemServices
     {
         [PreserveSig] int OpenNamespace_([In][MarshalAs(UnmanagedType.BStr)]  string   strNamespace, [In] int lFlags, [In][MarshalAs(UnmanagedType.Interface)]  IWbemContext   pCtx, [In][Out][MarshalAs(UnmanagedType.Interface)]  ref IWbemServices   ppWorkingNamespace, [In] IntPtr ppCallResult);
         [PreserveSig] int CancelAsyncCall_([In][MarshalAs(UnmanagedType.Interface)]  IWbemObjectSink   pSink);
@@ -664,7 +664,7 @@ namespace System.Management
     //[TypeLibTypeAttribute(0x0200)]
     [GuidAttribute("9556DC99-828C-11CF-A37E-00AA003240C7")]
     [ComImport]
-    interface IWbemServices_Old
+    internal interface IWbemServices_Old
     {
         [PreserveSig] int OpenNamespace_([In][MarshalAs(UnmanagedType.BStr)]  string   strNamespace, [In] int lFlags, [In][MarshalAs(UnmanagedType.Interface)]  IWbemContext   pCtx, [In][Out][MarshalAs(UnmanagedType.Interface)]  ref IWbemServices   ppWorkingNamespace, [In] IntPtr ppCallResult);
         [PreserveSig] int CancelAsyncCall_([In][MarshalAs(UnmanagedType.Interface)]  IWbemObjectSink   pSink);
@@ -695,7 +695,7 @@ namespace System.Management
     //[TypeLibTypeAttribute(0x0200)]
     [InterfaceTypeAttribute(0x0001)]
     [ComImport]
-    interface IWbemCallResult
+    internal interface IWbemCallResult
     {
         [PreserveSig] int GetResultObject_([In] int lTimeout, [Out][MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef=typeof(MarshalWbemObject))] out IWbemClassObjectFreeThreaded ppResultObject);
         [PreserveSig] int GetResultString_([In] int lTimeout, [Out][MarshalAs(UnmanagedType.BStr)]  out string   pstrResultString);
@@ -707,7 +707,7 @@ namespace System.Management
     [GuidAttribute("7C857801-7381-11CF-884D-00AA004B2E24")]
     [InterfaceTypeAttribute(0x0001)]
     [ComImport]
-    interface IWbemObjectSink
+    internal interface IWbemObjectSink
     {
         [PreserveSig] int Indicate_([In] int lObjectCount, [In][MarshalAs(UnmanagedType.LPArray)] IntPtr[] apObjArray);
         [PreserveSig] int SetStatus_([In] int lFlags, [In][MarshalAs(UnmanagedType.Error)]  int   hResult, [In][MarshalAs(UnmanagedType.BStr)]  string   strParam, [In] IntPtr pObjParam);
@@ -717,7 +717,7 @@ namespace System.Management
     //[TypeLibTypeAttribute(0x0200)]
     [GuidAttribute("027947E1-D731-11CE-A357-000000000001")]
     [ComImport]
-    interface IEnumWbemClassObject
+    internal interface IEnumWbemClassObject
     {
         [PreserveSig] int Reset_();
         [PreserveSig] int Next_([In] int lTimeout, [In] uint uCount, [In][Out][MarshalAs(UnmanagedType.LPArray)] IWbemClassObject_DoNotMarshal[] apObjects, [Out] out uint puReturned);
@@ -729,7 +729,7 @@ namespace System.Management
     [InterfaceTypeAttribute(0x0001)]
     [GuidAttribute("B7B31DF9-D515-11D3-A11C-00105A1F515A")]
     [ComImport]
-    interface IWbemShutdown
+    internal interface IWbemShutdown
     {
         [PreserveSig] int Shutdown_([In] int uReason, [In] uint uMaxMilliseconds, [In][MarshalAs(UnmanagedType.Interface)]  IWbemContext   pCtx);
     }
@@ -738,7 +738,7 @@ namespace System.Management
     //[TypeLibTypeAttribute(0x0200)]
     [GuidAttribute("BFBF883A-CAD7-11D3-A11B-00105A1F515A")]
     [ComImport]
-    interface IWbemObjectTextSrc
+    internal interface IWbemObjectTextSrc
     {
         [PreserveSig] int GetText_([In] int lFlags, [In][MarshalAs(UnmanagedType.Interface)]  IWbemClassObject_DoNotMarshal   pObj, [In] uint uObjTextFormat, [In][MarshalAs(UnmanagedType.Interface)]  IWbemContext   pCtx, [Out][MarshalAs(UnmanagedType.BStr)]  out string   strText);
         [PreserveSig] int CreateFromText_([In] int lFlags, [In][MarshalAs(UnmanagedType.BStr)]  string   strText, [In] uint uObjTextFormat, [In][MarshalAs(UnmanagedType.Interface)]  IWbemContext   pCtx, [Out][MarshalAs(UnmanagedType.Interface)]  out IWbemClassObject_DoNotMarshal   pNewObj);
@@ -748,7 +748,7 @@ namespace System.Management
     //[TypeLibTypeAttribute(0x0200)]
     [InterfaceTypeAttribute(0x0001)]
     [ComImport]
-    interface IWbemObjectAccess
+    internal interface IWbemObjectAccess
     {
         [PreserveSig] int GetQualifierSet_([Out][MarshalAs(UnmanagedType.Interface)]  out IWbemQualifierSet_DoNotMarshal   ppQualSet);
         [PreserveSig] int Get_([In][MarshalAs(UnmanagedType.LPWStr)]  string   wszName, [In] int lFlags, [In][Out] ref object pVal, [In][Out] ref int pType, [In][Out] ref int plFlavor);
@@ -790,7 +790,7 @@ namespace System.Management
     //[TypeLibTypeAttribute(0x0200)]
     [InterfaceTypeAttribute(0x0001)]
     [ComImport]
-    interface IUnsecuredApartment
+    internal interface IUnsecuredApartment
     {
         [PreserveSig] int CreateObjectStub_([In][MarshalAs(UnmanagedType.IUnknown)]  object   pObject, [Out][MarshalAs(UnmanagedType.IUnknown)]  out object   ppStub);
     }
@@ -798,7 +798,7 @@ namespace System.Management
     [GuidAttribute("EB87E1BC-3233-11D2-AEC9-00C04FB68820")]
     [InterfaceTypeAttribute(0x0001)]
     [ComImport]
-    interface IWbemStatusCodeText
+    internal interface IWbemStatusCodeText
     {
         [PreserveSig] int GetErrorCodeText_([In][MarshalAs(UnmanagedType.Error)]  int   hRes, [In] uint LocaleId, [In] int lFlags, [Out][MarshalAs(UnmanagedType.BStr)]  out string   MessageText);
         [PreserveSig] int GetFacilityCodeText_([In][MarshalAs(UnmanagedType.Error)]  int   hRes, [In] uint LocaleId, [In] int lFlags, [Out][MarshalAs(UnmanagedType.BStr)]  out string   MessageText);
@@ -808,7 +808,7 @@ namespace System.Management
     //[TypeLibTypeAttribute(0x0200)]
     [GuidAttribute("E246107B-B06E-11D0-AD61-00C04FD8FDFF")]
     [ComImport]
-    interface IWbemUnboundObjectSink
+    internal interface IWbemUnboundObjectSink
     {
         [PreserveSig] int IndicateToConsumer_([In][MarshalAs(UnmanagedType.Interface)]  IWbemClassObject_DoNotMarshal   pLogicalConsumer, [In] int lNumObjects, [In][MarshalAs(UnmanagedType.Interface)]  ref IWbemClassObject_DoNotMarshal   apObjects);
     }
@@ -817,7 +817,7 @@ namespace System.Management
     [GuidAttribute("CE61E841-65BC-11D0-B6BD-00AA003240C7")]
     //[TypeLibTypeAttribute(0x0200)]
     [ComImport]
-    interface IWbemPropertyProvider
+    internal interface IWbemPropertyProvider
     {
         [PreserveSig] int GetProperty_([In] int lFlags, [In][MarshalAs(UnmanagedType.BStr)]  string   strLocale, [In][MarshalAs(UnmanagedType.BStr)]  string   strClassMapping, [In][MarshalAs(UnmanagedType.BStr)]  string   strInstMapping, [In][MarshalAs(UnmanagedType.BStr)]  string   strPropMapping, [Out] out object pvValue);
         [PreserveSig] int PutProperty_([In] int lFlags, [In][MarshalAs(UnmanagedType.BStr)]  string   strLocale, [In][MarshalAs(UnmanagedType.BStr)]  string   strClassMapping, [In][MarshalAs(UnmanagedType.BStr)]  string   strInstMapping, [In][MarshalAs(UnmanagedType.BStr)]  string   strPropMapping, [In] ref object pvValue);
@@ -827,7 +827,7 @@ namespace System.Management
     //[TypeLibTypeAttribute(0x0200)]
     [GuidAttribute("E245105B-B06E-11D0-AD61-00C04FD8FDFF")]
     [ComImport]
-    interface IWbemEventProvider
+    internal interface IWbemEventProvider
     {
         [PreserveSig] int ProvideEvents_([In][MarshalAs(UnmanagedType.Interface)]  IWbemObjectSink   pSink, [In] int lFlags);
     }
@@ -836,7 +836,7 @@ namespace System.Management
     //[TypeLibTypeAttribute(0x0200)]
     [InterfaceTypeAttribute(0x0001)]
     [ComImport]
-    interface IWbemEventProviderQuerySink
+    internal interface IWbemEventProviderQuerySink
     {
         [PreserveSig] int NewQuery_([In] uint dwId, [In][MarshalAs(UnmanagedType.LPWStr)]  string   wszQueryLanguage, [In][MarshalAs(UnmanagedType.LPWStr)]  string   wszQuery);
         [PreserveSig] int CancelQuery_([In] uint dwId);
@@ -846,7 +846,7 @@ namespace System.Management
     //[TypeLibTypeAttribute(0x0200)]
     [GuidAttribute("631F7D96-D993-11D2-B339-00105A1F4AAF")]
     [ComImport]
-    interface IWbemEventProviderSecurity
+    internal interface IWbemEventProviderSecurity
     {
         [PreserveSig] int AccessCheck_([In][MarshalAs(UnmanagedType.LPWStr)]  string   wszQueryLanguage, [In][MarshalAs(UnmanagedType.LPWStr)]  string   wszQuery, [In] int lSidLength, [In] ref byte pSid);
     }
@@ -855,7 +855,7 @@ namespace System.Management
     //[TypeLibTypeAttribute(0x0200)]
     [InterfaceTypeAttribute(0x0001)]
     [ComImport]
-    interface IWbemProviderIdentity
+    internal interface IWbemProviderIdentity
     {
         [PreserveSig] int SetRegistrationObject_([In] int lFlags, [In][MarshalAs(UnmanagedType.Interface)]  IWbemClassObject_DoNotMarshal   pProvReg);
     }
@@ -864,7 +864,7 @@ namespace System.Management
     //[TypeLibTypeAttribute(0x0200)]
     [GuidAttribute("E246107A-B06E-11D0-AD61-00C04FD8FDFF")]
     [ComImport]
-    interface IWbemEventConsumerProvider
+    internal interface IWbemEventConsumerProvider
     {
         [PreserveSig] int FindConsumer_([In][MarshalAs(UnmanagedType.Interface)]  IWbemClassObject_DoNotMarshal   pLogicalConsumer, [Out][MarshalAs(UnmanagedType.Interface)]  out IWbemUnboundObjectSink   ppConsumer);
     }
@@ -872,7 +872,7 @@ namespace System.Management
     [GuidAttribute("1BE41571-91DD-11D1-AEB2-00C04FB68820")]
     [InterfaceTypeAttribute(0x0001)]
     [ComImport]
-    interface IWbemProviderInitSink
+    internal interface IWbemProviderInitSink
     {
         [PreserveSig] int SetStatus_([In] int lStatus, [In] int lFlags);
     }
@@ -880,7 +880,7 @@ namespace System.Management
     [GuidAttribute("1BE41572-91DD-11D1-AEB2-00C04FB68820")]
     [InterfaceTypeAttribute(0x0001)]
     [ComImport]
-    interface IWbemProviderInit
+    internal interface IWbemProviderInit
     {
         [PreserveSig] int Initialize_([In][MarshalAs(UnmanagedType.LPWStr)]  string   wszUser, [In] int lFlags, [In][MarshalAs(UnmanagedType.LPWStr)]  string   wszNamespace, [In][MarshalAs(UnmanagedType.LPWStr)]  string   wszLocale, [In][MarshalAs(UnmanagedType.Interface)]  IWbemServices   pNamespace, [In][MarshalAs(UnmanagedType.Interface)]  IWbemContext   pCtx, [In][MarshalAs(UnmanagedType.Interface)]  IWbemProviderInitSink   pInitSink);
     }
@@ -888,7 +888,7 @@ namespace System.Management
     [InterfaceTypeAttribute(0x0001)]
     [GuidAttribute("1005CBCF-E64F-4646-BCD3-3A089D8A84B4")]
     [ComImport]
-    interface IWbemDecoupledRegistrar
+    internal interface IWbemDecoupledRegistrar
     {
         [PreserveSig] int Register_([In] int flags, [In][MarshalAs(UnmanagedType.Interface)]  IWbemContext   context, [In][MarshalAs(UnmanagedType.LPWStr)]  string   user, [In][MarshalAs(UnmanagedType.LPWStr)]  string   locale, [In][MarshalAs(UnmanagedType.LPWStr)]  string   scope, [In][MarshalAs(UnmanagedType.LPWStr)]  string   registration, [In][MarshalAs(UnmanagedType.IUnknown)]  object   unknown);
         [PreserveSig] int UnRegister_();
@@ -898,7 +898,7 @@ namespace System.Management
     //[TypeLibTypeAttribute(0x0200)]
     [GuidAttribute("3AE0080A-7E3A-4366-BF89-0FEEDC931659")]
     [ComImport]
-    interface IWbemEventSink
+    internal interface IWbemEventSink
     {
         [PreserveSig] int Indicate_([In] int lObjectCount, [In][MarshalAs(UnmanagedType.Interface)]  ref IWbemClassObject_DoNotMarshal   apObjArray);
         [PreserveSig] int SetStatus_([In] int lFlags, [In][MarshalAs(UnmanagedType.Error)]  int   hResult, [In][MarshalAs(UnmanagedType.BStr)]  string   strParam, [In][MarshalAs(UnmanagedType.Interface)]  IWbemClassObject_DoNotMarshal   pObjParam);
@@ -913,7 +913,7 @@ namespace System.Management
     /*[ComConversionLossAttribute]*/
     [InterfaceTypeAttribute(0x0001)]
     [ComImport]
-    interface IWbemPathKeyList
+    internal interface IWbemPathKeyList
     {
         [PreserveSig] int GetCount_([Out] out uint puKeyCount);
         [PreserveSig] int SetKey_([In][MarshalAs(UnmanagedType.LPWStr)]  string   wszName, [In] uint uFlags, [In] uint uCimType, [In] IntPtr pKeyVal);
@@ -930,7 +930,7 @@ namespace System.Management
     [GuidAttribute("3BC15AF2-736C-477E-9E51-238AF8667DCC")]
     [InterfaceTypeAttribute(0x0001)]
     [ComImport]
-    interface IWbemPath
+    internal interface IWbemPath
     {
         [PreserveSig] int SetText_([In] uint uMode, [In][MarshalAs(UnmanagedType.LPWStr)]  string   pszPath);
         [PreserveSig] int GetText_([In] int lFlags, [In][Out] ref uint puBuffLength, [Out][MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeParamIndex = 1)]  char[]   pszText);
@@ -963,13 +963,13 @@ namespace System.Management
     #endregion
 
     #region Enums
-    enum tag_WBEM_GENUS_TYPE
+    internal enum tag_WBEM_GENUS_TYPE
     {
         WBEM_GENUS_CLASS = unchecked((int)0x00000001),
         WBEM_GENUS_INSTANCE = unchecked((int)0x00000002),
     }
 
-    enum tag_WBEM_CHANGE_FLAG_TYPE
+    internal enum tag_WBEM_CHANGE_FLAG_TYPE
     {
         WBEM_FLAG_CREATE_OR_UPDATE = unchecked((int)0x00000000),
         WBEM_FLAG_UPDATE_ONLY = unchecked((int)0x00000001),
@@ -981,7 +981,7 @@ namespace System.Management
         WBEM_FLAG_ADVISORY = unchecked((int)0x00010000),
     }
 
-    enum tag_WBEM_GENERIC_FLAG_TYPE
+    internal enum tag_WBEM_GENERIC_FLAG_TYPE
     {
         WBEM_FLAG_RETURN_IMMEDIATELY = unchecked((int)0x00000010),
         WBEM_FLAG_RETURN_WBEM_COMPLETE = unchecked((int)0x00000000),
@@ -1001,20 +1001,20 @@ namespace System.Management
         WBEM_FLAG_STRONG_VALIDATION = unchecked((int)0x00100000),
     }
 
-    enum tag_WBEM_STATUS_TYPE
+    internal enum tag_WBEM_STATUS_TYPE
     {
         WBEM_STATUS_COMPLETE = unchecked((int)0x00000000),
         WBEM_STATUS_REQUIREMENTS = unchecked((int)0x00000001),
         WBEM_STATUS_PROGRESS = unchecked((int)0x00000002),
     }
 
-    enum tag_WBEM_TIMEOUT_TYPE
+    internal enum tag_WBEM_TIMEOUT_TYPE
     {
         WBEM_NO_WAIT = unchecked((int)0x00000000),
         WBEM_INFINITE = unchecked((int)0xFFFFFFFF),
     }
 
-    enum tag_WBEM_CONDITION_FLAG_TYPE
+    internal enum tag_WBEM_CONDITION_FLAG_TYPE
     {
         WBEM_FLAG_ALWAYS = unchecked((int)0x00000000),
         WBEM_FLAG_ONLY_IF_TRUE = unchecked((int)0x00000001),
@@ -1032,7 +1032,7 @@ namespace System.Management
         WBEM_FLAG_CLASS_LOCAL_AND_OVERRIDES = unchecked((int)0x00000200),
         WBEM_MASK_CLASS_CONDITION = unchecked((int)0x00000300),
     }
-    enum tag_WBEM_FLAVOR_TYPE
+    internal enum tag_WBEM_FLAVOR_TYPE
     {
         WBEM_FLAVOR_DONT_PROPAGATE = unchecked((int)0x00000000),
         WBEM_FLAVOR_FLAG_PROPAGATE_TO_INSTANCE = unchecked((int)0x00000001),
@@ -1050,14 +1050,14 @@ namespace System.Management
         WBEM_FLAVOR_MASK_AMENDED = unchecked((int)0x00000080),
     }
 
-    enum tag_WBEM_QUERY_FLAG_TYPE
+    internal enum tag_WBEM_QUERY_FLAG_TYPE
     {
         WBEM_FLAG_DEEP = unchecked((int)0x00000000),
         WBEM_FLAG_SHALLOW = unchecked((int)0x00000001),
         WBEM_FLAG_PROTOTYPE = unchecked((int)0x00000002),
     }
 
-    enum tag_CIMTYPE_ENUMERATION
+    internal enum tag_CIMTYPE_ENUMERATION
     {
         CIM_ILLEGAL = unchecked((int)0x00000FFF),
         CIM_EMPTY = unchecked((int)0x00000000),
@@ -1080,7 +1080,7 @@ namespace System.Management
         CIM_FLAG_ARRAY = unchecked((int)0x00002000),
     }
 
-    enum tag_WBEMSTATUS
+    internal enum tag_WBEMSTATUS
     {
         WBEM_NO_ERROR = unchecked((int)0x00000000),
         WBEM_S_NO_ERROR = unchecked((int)0x00000000),
@@ -1281,13 +1281,13 @@ namespace System.Management
         WBEMMOF_E_INVALID_DELETECLASS_SYNTAX = unchecked((int)0x80044031),
     }
 
-    enum tag_WBEM_CONNECT_OPTIONS
+    internal enum tag_WBEM_CONNECT_OPTIONS
     {
         WBEM_FLAG_CONNECT_REPOSITORY_ONLY = 0X40,
         WBEM_FLAG_CONNECT_USE_MAX_WAIT = 0X80,
     }
 
-    enum tag_WBEM_PATH_STATUS_FLAG
+    internal enum tag_WBEM_PATH_STATUS_FLAG
     {
         WBEMPATH_INFO_ANON_LOCAL_MACHINE = unchecked((int)0x00000001),
         WBEMPATH_INFO_HAS_MACHINE_NAME = unchecked((int)0x00000002),
@@ -1309,7 +1309,7 @@ namespace System.Management
         WBEMPATH_INFO_PATH_HAD_SERVER = unchecked((int)0x00020000),
     }
 
-    enum tag_WBEM_PATH_CREATE_FLAG
+    internal enum tag_WBEM_PATH_CREATE_FLAG
     {
         WBEMPATH_CREATE_ACCEPT_RELATIVE = unchecked((int)0x00000001),
         WBEMPATH_CREATE_ACCEPT_ABSOLUTE = unchecked((int)0x00000002),
@@ -1317,7 +1317,7 @@ namespace System.Management
         WBEMPATH_TREAT_SINGLE_IDENT_AS_NS = unchecked((int)0x00000008),
     }
 
-    enum tag_WBEM_GET_TEXT_FLAGS
+    internal enum tag_WBEM_GET_TEXT_FLAGS
     {
         WBEMPATH_COMPRESSED = unchecked((int)0x00000001),
         WBEMPATH_GET_RELATIVE_ONLY = unchecked((int)0x00000002),
@@ -1337,7 +1337,7 @@ namespace System.Management
     [GuidAttribute("4590F811-1D3A-11D0-891F-00AA004B2E24")]
     //[TypeLibTypeAttribute(0x0202)]
     [ComImport]
-    class WbemLocator
+    internal class WbemLocator
     {
     }
 
@@ -1345,7 +1345,7 @@ namespace System.Management
     [GuidAttribute("674B6698-EE92-11D0-AD71-00C04FD8FDFF")]
     //[TypeLibTypeAttribute(0x0202)]
     [ComImport]
-    class WbemContext
+    internal class WbemContext
     {
     }
 
@@ -1353,7 +1353,7 @@ namespace System.Management
     [GuidAttribute("49BD2028-1523-11D1-AD79-00C04FD8FDFF")]
     //[TypeLibTypeAttribute(0x0002)]
     [ComImport]
-    class UnsecuredApartment
+    internal class UnsecuredApartment
     {
     }
 
@@ -1361,7 +1361,7 @@ namespace System.Management
     [ClassInterfaceAttribute((short)0x0000)]
     //[TypeLibTypeAttribute(0x0002)]
     [ComImport]
-    class WbemClassObject
+    internal class WbemClassObject
     {
     }
 
@@ -1369,7 +1369,7 @@ namespace System.Management
     [GuidAttribute("6DAF9757-2E37-11D2-AEC9-00C04FB68820")]
     //[TypeLibTypeAttribute(0x0002)]
     [ComImport]
-    class MofCompiler
+    internal class MofCompiler
     {
     }
 
@@ -1377,7 +1377,7 @@ namespace System.Management
     //[TypeLibTypeAttribute(0x0002)]
     [GuidAttribute("EB87E1BD-3233-11D2-AEC9-00C04FB68820")]
     [ComImport]
-    class WbemStatusCodeText
+    internal class WbemStatusCodeText
     {
     }
 
@@ -1385,7 +1385,7 @@ namespace System.Management
     [ClassInterfaceAttribute((short)0x0000)]
     //[TypeLibTypeAttribute(0x0002)]
     [ComImport]
-    class WbemBackupRestore
+    internal class WbemBackupRestore
     {
     }
 
@@ -1393,7 +1393,7 @@ namespace System.Management
     //[TypeLibTypeAttribute(0x0202)]
     [GuidAttribute("8D1C559D-84F0-4BB3-A7D5-56A7435A9BA6")]
     [ComImport]
-    class WbemObjectTextSrc
+    internal class WbemObjectTextSrc
     {
     }
 
@@ -1401,7 +1401,7 @@ namespace System.Management
     //[TypeLibTypeAttribute(0x0002)]
     [ClassInterfaceAttribute((short)0x0000)]
     [ComImport]
-    class WbemDecoupledRegistrar
+    internal class WbemDecoupledRegistrar
     {
     }
 
@@ -1409,7 +1409,7 @@ namespace System.Management
     //[TypeLibTypeAttribute(0x0002)]
     [ClassInterfaceAttribute((short)0x0000)]
     [ComImport]
-    class WbemDecoupledBasicEventProvider
+    internal class WbemDecoupledBasicEventProvider
     {
     }
 
@@ -1417,7 +1417,7 @@ namespace System.Management
     [GuidAttribute("CF4CC405-E2C5-4DDD-B3CE-5E7582D8C9FA")]
     //[TypeLibTypeAttribute(0x0202)]
     [ComImport]
-    class WbemDefPath
+    internal class WbemDefPath
     {
     }
 
@@ -1425,12 +1425,12 @@ namespace System.Management
     [ClassInterfaceAttribute((short)0x0000)]
     //[TypeLibTypeAttribute(0x0002)]
     [ComImport]
-    class WbemQuery
+    internal class WbemQuery
     {
     }
     #endregion
 
-    class MTAHelper
+    internal class MTAHelper
     {
 
         private class MTARequest
@@ -1446,15 +1446,15 @@ namespace System.Management
             }
         }
 
-        static ArrayList reqList = new ArrayList(3);
-        static object critSec = new object();
+        private static ArrayList reqList = new ArrayList(3);
+        private static object critSec = new object();
 
-        static AutoResetEvent evtGo = new AutoResetEvent(false); // tells the worker to create an object on our behalf
+        private static AutoResetEvent evtGo = new AutoResetEvent(false); // tells the worker to create an object on our behalf
 
-        static bool workerThreadInitialized = false;
+        private static bool workerThreadInitialized = false;
         // Initialize worker thread
         // This is not done in a static constructor so that we don't do this in an MTA only application
-        static void InitWorkerThread()
+        private static void InitWorkerThread()
         {
             // Create the worker thread
             Thread thread = new Thread(new ThreadStart(WorkerThread));
@@ -1505,7 +1505,7 @@ namespace System.Management
             return myReq.createdObject;
         }
 
-        static void WorkerThread()
+        private static void WorkerThread()
         {
             // The worker thread will be a background thread, so we never have
             // to worry about killing it.  There is no chance that we will
@@ -1555,12 +1555,12 @@ namespace System.Management
         }
 
         // Interfaces that we need to use
-        static Guid IID_IObjectContext = new Guid("51372AE0-CAE7-11CF-BE81-00AA00A2FA25");
-        static Guid IID_IComThreadingInfo = new Guid("000001ce-0000-0000-C000-000000000046");
+        private static Guid IID_IObjectContext = new Guid("51372AE0-CAE7-11CF-BE81-00AA00A2FA25");
+        private static Guid IID_IComThreadingInfo = new Guid("000001ce-0000-0000-C000-000000000046");
 
         // A variable that is initialized once to tell us if we are on
         // a Win2k platform or above.
-        static bool CanCallCoGetObjectContext = IsWindows2000OrHigher();
+        private static bool CanCallCoGetObjectContext = IsWindows2000OrHigher();
 
         // This method will tell us if the calling thread is in the MTA and we are not in a 'context'
         public static bool IsNoContextMTA()
@@ -1614,7 +1614,7 @@ namespace System.Management
             return true;
         }
 
-        static bool IsWindows2000OrHigher()
+        private static bool IsWindows2000OrHigher()
         {
             // If we are on Win2k or above, we are OK
             // - Platform == Win32NT and OS version >= 5.0.0.0

--- a/src/System.Management/src/System/Management/ManagementEventWatcher.cs
+++ b/src/System.Management/src/System/Management/ManagementEventWatcher.cs
@@ -647,7 +647,7 @@ namespace System.Management
 
         }
 
-        void HackToCreateStubInMTA(object param)
+        private void HackToCreateStubInMTA(object param)
         {
             SinkForEventQuery obj = (SinkForEventQuery) param ;
             object dmuxStub = null;
@@ -701,7 +701,7 @@ namespace System.Management
 
         // On Win2k, we get a deadlock if we do a Cancel within a SetStatus
         // Instead of calling it from SetStatus, we use ThreadPool.QueueUserWorkItem
-        void Cancel2(object o)
+        private void Cancel2(object o)
         {
             //
             // Try catch the call to cancel. In this case the cancel is being done without the client

--- a/src/System.Management/src/System/Management/ManagementObject.cs
+++ b/src/System.Management/src/System/Management/ManagementObject.cs
@@ -375,7 +375,7 @@ namespace System.Management
             ManagementObjectCTOR(scope, path, options);
         }
 
-        void ManagementObjectCTOR(ManagementScope scope, ManagementPath path, ObjectGetOptions options)
+        private void ManagementObjectCTOR(ManagementScope scope, ManagementPath path, ObjectGetOptions options)
         {
             // We may use this to set the scope path
             string nsPath = string.Empty;

--- a/src/System.Management/src/System/Management/ManagementPath.cs
+++ b/src/System.Management/src/System/Management/ManagementPath.cs
@@ -1047,7 +1047,7 @@ namespace System.Management
     /// <summary>
     /// Converts a String to a ManagementPath
     /// </summary>
-    class ManagementPathConverter : ExpandableObjectConverter
+    internal class ManagementPathConverter : ExpandableObjectConverter
     {
 
         /// <summary>

--- a/src/System.Management/src/System/Management/ManagementQuery.cs
+++ b/src/System.Management/src/System/Management/ManagementQuery.cs
@@ -3154,7 +3154,7 @@ namespace System.Management
     /// <summary>
     /// Converts a String to a ManagementQuery
     /// </summary>
-    class ManagementQueryConverter : ExpandableObjectConverter
+    internal class ManagementQueryConverter : ExpandableObjectConverter
     {
 
         /// <summary>

--- a/src/System.Management/src/System/Management/ManagementScope.cs
+++ b/src/System.Management/src/System/Management/ManagementScope.cs
@@ -378,14 +378,14 @@ namespace System.Management
                 LoadPlatformNotSupportedDelegates(SR.Format(SR.PlatformNotSupported_FrameworkUpdatedRequired, wminet_utilsPath));
             }
         }
-        static bool LoadDelegate<TDelegate>(ref TDelegate delegate_f, IntPtr hModule, string procName) where TDelegate : class
+        private static bool LoadDelegate<TDelegate>(ref TDelegate delegate_f, IntPtr hModule, string procName) where TDelegate : class
         {
             IntPtr procAddr = Interop.Kernel32.GetProcAddress(hModule, procName);
             return procAddr != IntPtr.Zero &&
                 (delegate_f = Marshal.GetDelegateForFunctionPointer<TDelegate>(procAddr)) != null;
         }
 
-        static void LoadPlatformNotSupportedDelegates(string exceptionMessage)
+        private static void LoadPlatformNotSupportedDelegates(string exceptionMessage)
         {
             ResetSecurity_f = (_) => throw new PlatformNotSupportedException(exceptionMessage);
             SetSecurity_f = (ref bool _, ref IntPtr __) => throw new PlatformNotSupportedException(exceptionMessage);
@@ -968,7 +968,7 @@ namespace System.Management
             }
         }
 
-        void InitializeGuts(object o)
+        private void InitializeGuts(object o)
         {
             ManagementScope threadParam = (ManagementScope) o ;
             IWbemLocator loc = (IWbemLocator) new WbemLocator();
@@ -1486,7 +1486,7 @@ namespace System.Management
     /// <summary>
     /// Converts a String to a ManagementScope
     /// </summary>
-    class ManagementScopeConverter : ExpandableObjectConverter
+    internal class ManagementScopeConverter : ExpandableObjectConverter
     {
 
         /// <summary>

--- a/src/System.Management/src/System/Management/Property.cs
+++ b/src/System.Management/src/System/Management/Property.cs
@@ -17,7 +17,7 @@ namespace System.Management
     // RuntimeHelpers.GetObjectValue.  This returns reference types right back to the caller, but if passed
     // a boxed non-primitive value type, it will return a boxed copy.  We cannot use GetObjectValue for primitives
     // because its implementation does not copy boxed primitives.
-    class ValueTypeSafety
+    internal class ValueTypeSafety
     {
         public static object GetSafeObject(object theValue)
         {

--- a/src/System.Management/src/System/Management/PropertySet.cs
+++ b/src/System.Management/src/System/Management/PropertySet.cs
@@ -51,7 +51,7 @@ namespace System.Management
     public class PropertyDataCollection : ICollection, IEnumerable
     {
         private ManagementBaseObject parent;
-        bool isSystem;
+        private bool isSystem;
 
         internal PropertyDataCollection(ManagementBaseObject parent, bool isSystem) : base()
         {

--- a/src/System.Management/src/System/Management/WMIGenerator.cs
+++ b/src/System.Management/src/System/Management/WMIGenerator.cs
@@ -192,7 +192,7 @@ namespace System.Management
         /// <summary>
         /// Checks if mandatory properties are properly initialized.
         /// </summary>
-        void CheckIfClassIsProperlyInitialized()
+        private void CheckIfClassIsProperlyInitialized()
         {
             if (classobj == null)
             {
@@ -477,7 +477,7 @@ namespace System.Management
             return cc;
         }
 
-        bool GenerateAndWriteCode(CodeLanguage lang)
+        private bool GenerateAndWriteCode(CodeLanguage lang)
         {
 
             if (InitializeCodeGenerator(lang) == false)
@@ -601,7 +601,7 @@ namespace System.Management
         /// This functrion initializes the public attributes and private variables
         /// list that will be used in the generated code.
         /// </summary>
-        void InitilializePublicPrivateMembers()
+        private void InitilializePublicPrivateMembers()
         {
             //Initialize the public members
             PublicNamesUsed.Add("SystemPropertiesProperty","SystemProperties");
@@ -680,7 +680,7 @@ namespace System.Management
         /// due to the collision between the local objects of the generated
         /// class and the properties/methos of the original WMI Class.
         /// </summary>
-        void ProcessNamingCollisions()
+        private void ProcessNamingCollisions()
         {
             if (classobj.Properties != null)
             {
@@ -1008,7 +1008,7 @@ namespace System.Management
             }
         }
 
-        void GeneratePathProperty()
+        private void GeneratePathProperty()
         {
             cmp = new CodeMemberProperty();
             cmp.Name = PublicNamesUsed["PathProperty"].ToString();
@@ -1082,7 +1082,7 @@ namespace System.Management
         /// used for seperating the system properties from the other properties. This is used
         /// just to make the drop down list in the editor to look good.
         /// </summary>
-        CodeTypeDeclaration GenerateSystemPropertiesClass()
+        private CodeTypeDeclaration GenerateSystemPropertiesClass()
         {
             CodeTypeDeclaration SysPropsClass = new CodeTypeDeclaration(PublicNamesUsed["SystemPropertiesClass"].ToString());
             SysPropsClass.TypeAttributes =TypeAttributes.NestedPublic;
@@ -1168,7 +1168,7 @@ namespace System.Management
         /// of the WMI class and will generate them as properties of the managed code
         /// wrapper class.
         /// </summary>
-        void GenerateProperties()
+        private void GenerateProperties()
         {
             bool bRead;
             bool bWrite;
@@ -1569,7 +1569,7 @@ namespace System.Management
         /// This function will process the qualifiers for a given WMI property and set the
         /// attributes of the generated property accordingly.
         /// </summary>
-        string ProcessPropertyQualifiers(PropertyData prop,ref bool bRead, ref bool bWrite, ref bool bStatic,bool bDynamicClass,out bool nullable)
+        private string ProcessPropertyQualifiers(PropertyData prop,ref bool bRead, ref bool bWrite, ref bool bStatic,bool bDynamicClass,out bool nullable)
         {
             bool hasWrite = false;
             bool writeValue = false;
@@ -1788,7 +1788,7 @@ namespace System.Management
         /// <returns>
         /// returns if the property is an enum. This is checked by if enum is added or not
         /// </returns>
-        bool GeneratePropertyHelperEnums(PropertyData prop, string strPropertyName, bool bNullable)
+        private bool GeneratePropertyHelperEnums(PropertyData prop, string strPropertyName, bool bNullable)
         {
             bool isEnumAdded = false;
             bool bZeroFieldInEnum = false;
@@ -2031,7 +2031,7 @@ namespace System.Management
         ///            return "\\&lt;defNameSpace&gt;:&lt;defClassName&gt;=@";
         ///        }
         /// </summary>
-        void GenerateConstructPath()
+        private void GenerateConstructPath()
         {
             string strType;
             cmm = new CodeMemberMethod();
@@ -2096,7 +2096,7 @@ namespace System.Management
         ///     _privSystemProps = new ManagementSystemProperties(_privObject);
         /// }
         /// </summary>
-        void GenerateDefaultConstructor()
+        private void GenerateDefaultConstructor()
         {
             cctor = new CodeConstructor();
             cctor.Attributes = MemberAttributes.Public;
@@ -2136,7 +2136,7 @@ namespace System.Management
         ///public cons(UInt32 key_Key1, String key_Key2) :this(null,&lt;ClassName&gt;.ConstructPath(&lt;key1,key2&gt;),null) {
         /// }
         ///</summary>
-        void GenerateConstructorWithKeys()
+        private void GenerateConstructorWithKeys()
         {
             if (arrKeyType.Count > 0)
             {
@@ -2194,7 +2194,7 @@ namespace System.Management
         ///public cons(ManagementScope scope,UInt32 key_Key1, String key_Key2) :this(scope,&lt;ClassName&gt;.ConstructPath(&lt;key1,key2&gt;),null) {
         /// }
         ///</summary>
-        void GenerateConstructorWithScopeKeys()
+        private void GenerateConstructorWithScopeKeys()
         {
             cctor = new CodeConstructor();
             cctor.Attributes = MemberAttributes.Public;
@@ -2256,7 +2256,7 @@ namespace System.Management
         ///        public Cons(ManagementPath path) : this (null, path,null){
         ///        }
         /// </summary>
-        void GenerateConstructorWithPath()
+        private void GenerateConstructorWithPath()
         {
             string strPathObject = "path";
             cctor = new CodeConstructor();
@@ -2288,7 +2288,7 @@ namespace System.Management
         ///        public Cons(ManagementPath path, ObjectGetOptions options) : this (null, path,options){
         ///        }
         /// </summary>
-        void GenerateConstructorWithPathOptions()
+        private void GenerateConstructorWithPathOptions()
         {
             string strPathObject = "path";
             string strGetOptions = "getOptions";
@@ -2317,7 +2317,7 @@ namespace System.Management
         ///                            this (new ManagementScope(scope), new ManagementPath(path),options){
         ///        }
         /// </summary>
-        void GenerateConstructorWithScopePath()
+        private void GenerateConstructorWithScopePath()
         {
             string strPathObject = "path";
 
@@ -2343,7 +2343,7 @@ namespace System.Management
         ///        public Cons(ManagementScope scope, ObjectGetOptions options) : this (scope, &lt;ClassName&gt;.ConstructPath(),null){
         ///        }
         /// </summary>
-        void GenerateConstructorWithScope()
+        private void GenerateConstructorWithScope()
         {
 
             cctor = new CodeConstructor();
@@ -2379,7 +2379,7 @@ namespace System.Management
         ///        public Cons(ObjectGetOptions options) : this (null, &lt;ClassName&gt;.ConstructPath(),options){
         ///        }
         /// </summary>
-        void GenerateConstructorWithOptions()
+        private void GenerateConstructorWithOptions()
         {
             string strGetOptions = "getOptions";
 
@@ -2414,7 +2414,7 @@ namespace System.Management
         ///        public Cons(ManagementScope scope, ObjectGetOptions options) : this (scope, &lt;ClassName&gt;.ConstructPath(),options){
         ///        }
         /// </summary>
-        void GenerateConstructorWithScopeOptions()
+        private void GenerateConstructorWithScopeOptions()
         {
             string strGetOptions = "getOptions";
 
@@ -2457,7 +2457,7 @@ namespace System.Management
         ///            PrivateSystemProperties = new ManagementSystemProperties(PrivateObject);
         ///        }
         /// </summary>
-        void GenerateConstructorWithScopePathOptions()
+        private void GenerateConstructorWithScopePathOptions()
         {
             string strPathObject = "path";
             string strGetOptions = "getOptions";
@@ -2510,7 +2510,7 @@ namespace System.Management
         ///            }
         ///        }
         /// </summary>
-        void GenarateConstructorWithLateBound()
+        private void GenarateConstructorWithLateBound()
         {
             string strLateBoundObject = "theObject";
             string LateBoundSystemProperties = "SystemProperties";
@@ -2581,7 +2581,7 @@ namespace System.Management
         ///    }
         ///
         /// </summary>
-        void GenarateConstructorWithLateBoundForEmbedded()
+        private void GenarateConstructorWithLateBoundForEmbedded()
         {
             string strLateBoundObject = "theObject";
 
@@ -2642,7 +2642,7 @@ namespace System.Management
         ///            PrivateSystemProperties = new ManagementSystemProperties(PrivateObject);
         ///        }
         /// </summary>
-        void GenerateInitializeObject()
+        private void GenerateInitializeObject()
         {
             string strPathObject = "path";
             string strGetOptions = "getOptions";
@@ -2773,7 +2773,7 @@ namespace System.Management
         ///     }
         ///
         /// </summary>
-        void GenerateMethods()
+        private void GenerateMethods()
         {
             string strInParams = "inParams";
             string strOutParams = "outParams";
@@ -3274,7 +3274,7 @@ namespace System.Management
         ///            return GetInstances((System.Management.ManagementScope)null,(System.Management.EnumerateionOptions)null);
         ///        }
         /// </summary>
-        void GenerateGetInstancesWithNoParameters()
+        private void GenerateGetInstancesWithNoParameters()
         {
             cmm = new CodeMemberMethod();
 
@@ -3303,7 +3303,7 @@ namespace System.Management
         ///            return GetInstances(null,Condition,null);
         ///     }
         /// </summary>
-        void GenerateGetInstancesWithCondition()
+        private void GenerateGetInstancesWithCondition()
         {
             string strCondition = "condition";
             cmm = new CodeMemberMethod();
@@ -3334,7 +3334,7 @@ namespace System.Management
         ///            return GetInstances(null,null,selectedProperties);
         ///        }
         /// </summary>
-        void GenerateGetInstancesWithProperties()
+        private void GenerateGetInstancesWithProperties()
         {
             string strSelectedProperties = "selectedProperties";
             cmm = new CodeMemberMethod();
@@ -3364,7 +3364,7 @@ namespace System.Management
         ///            return GetInstances(null,condition,selectedProperties);
         ///        }
         /// </summary>
-        void GenerateGetInstancesWithWhereProperties()
+        private void GenerateGetInstancesWithWhereProperties()
         {
             string strSelectedProperties = "selectedProperties";
             string strCondition = "condition";
@@ -3413,7 +3413,7 @@ namespace System.Management
         ///    }
         ///    This method takes the scope which is useful for connection to remote machine
         /// </summary>
-        void GenerateGetInstancesWithScope()
+        private void GenerateGetInstancesWithScope()
         {
             cmm = new CodeMemberMethod();
 
@@ -3523,7 +3523,7 @@ namespace System.Management
         ///            return GetInstances(scope,Condition,null);
         ///     }
         /// </summary>
-        void GenerateGetInstancesWithScopeCondition()
+        private void GenerateGetInstancesWithScopeCondition()
         {
             string strCondition = "condition";
             cmm = new CodeMemberMethod();
@@ -3554,7 +3554,7 @@ namespace System.Management
         ///            return GetInstances(scope,null,selectedProperties);
         ///        }
         /// </summary>
-        void GenerateGetInstancesWithScopeProperties()
+        private void GenerateGetInstancesWithScopeProperties()
         {
             string strSelectedProperties = "selectedProperties";
             cmm = new CodeMemberMethod();
@@ -3593,7 +3593,7 @@ namespace System.Management
         ///            return new ServiceCollection(ObjectSearcher.Get());
         ///        }
         /// </summary>
-        void GenerateGetInstancesWithScopeWhereProperties()
+        private void GenerateGetInstancesWithScopeWhereProperties()
         {
             string strCondition = "condition";
             string strSelectedProperties = "selectedProperties";
@@ -3685,7 +3685,7 @@ namespace System.Management
         /// The generated code will look like this
         ///         private &lt;MemberType&gt; &lt;MemberName&gt;;
         /// </summary>
-        void GeneratePrivateMember(string memberName,string MemberType,string Comment)
+        private void GeneratePrivateMember(string memberName,string MemberType,string Comment)
         {
             GeneratePrivateMember(memberName,MemberType,null,false,Comment);
         }
@@ -3695,7 +3695,7 @@ namespace System.Management
         /// The generated code will look like this
         ///         private &lt;MemberType&gt; &lt;MemberName&gt; = &lt;initValue&gt;;
         /// </summary>
-        void GeneratePrivateMember(string memberName,string MemberType,CodeExpression initExpression,bool isStatic,string Comment)
+        private void GeneratePrivateMember(string memberName,string MemberType,CodeExpression initExpression,bool isStatic,string Comment)
         {
             cf = new CodeMemberField();
             cf.Name = memberName;
@@ -3717,7 +3717,7 @@ namespace System.Management
             }
         }
 
-        CodeTypeDeclaration GenerateTypeConverterClass()
+        private CodeTypeDeclaration GenerateTypeConverterClass()
         {
             string TypeDescriptorContextClass = "System.ComponentModel.ITypeDescriptorContext";
             string contextObject = "context";
@@ -4514,7 +4514,7 @@ namespace System.Management
         /// This function will find a given string in the passed
         /// in a case insensitive manner and will return true if the string is found.
         /// </summary>
-        int IsContainedIn(string strToFind, ref SortedList sortedList)
+        private int IsContainedIn(string strToFind, ref SortedList sortedList)
         {
             int nIndex = -1;
             for (int i=0; i < sortedList.Count; i++)
@@ -4719,7 +4719,7 @@ namespace System.Management
         /// <summary>
         /// Function to convert a given ValueMap or BitMap name to propert enum name
         /// </summary>
-        static string ConvertValuesToName(string str)
+        private static string ConvertValuesToName(string str)
         {
             string strRet = string.Empty;
             string strToReplace = "_";
@@ -4771,7 +4771,7 @@ namespace System.Management
         /// This function goes thru the names in array list and resolves any duplicates
         /// if any so that these names can be added as values of enum
         /// </summary>
-        void ResolveEnumNameValues(ArrayList arrIn,ref ArrayList arrayOut)
+        private void ResolveEnumNameValues(ArrayList arrIn,ref ArrayList arrayOut)
         {
             arrayOut.Clear();
             int        nCurIndex = 0;
@@ -4802,7 +4802,7 @@ namespace System.Management
         /// This function will find a given string in the passed
         /// array list.
         /// </summary>
-        static bool IsContainedInArray(string strToFind, ArrayList arrToSearch)
+        private static bool IsContainedInArray(string strToFind, ArrayList arrToSearch)
         {
             for (int i=0; i < arrToSearch.Count; i++)
             {
@@ -4817,7 +4817,7 @@ namespace System.Management
         /// <summary>
         /// Function to create a appropriate generator
         /// </summary>
-        bool InitializeCodeGenerator(CodeLanguage lang)
+        private bool InitializeCodeGenerator(CodeLanguage lang)
         {
             string strProvider = "";
             Assembly asm = null;
@@ -4911,7 +4911,7 @@ namespace System.Management
         /// Function which checks if the language supports Unsigned numbers
         /// </summary>
         /// <param name="Language">Language</param>
-        void GetUnsignedSupport(CodeLanguage Language)
+        private void GetUnsignedSupport(CodeLanguage Language)
         {
             switch(Language)
             {
@@ -4932,7 +4932,7 @@ namespace System.Management
         /// Function which adds commit function to commit all the changes
         /// to the object to WMI
         /// </summary>
-        void GenerateCommitMethod()
+        private void GenerateCommitMethod()
         {
             cmm = new CodeMemberMethod();
             cmm.Name = PublicNamesUsed["CommitMethod"].ToString();
@@ -5001,7 +5001,7 @@ namespace System.Management
         /// Function to convert a value in format "0x..." to a integer
         /// to the object to WMI
         /// </summary>
-        static int ConvertBitMapValueToInt32(string bitMap)
+        private static int ConvertBitMapValueToInt32(string bitMap)
         {
             string strTemp = "0x";
             int ret = 0;
@@ -5029,7 +5029,7 @@ namespace System.Management
         /// <summary>
         /// Function to get the Converstion function to be used for Numeric datatypes
         /// </summary>
-        string GetConversionFunction(CimType cimType)
+        private string GetConversionFunction(CimType cimType)
         {
             string retFunctionName = string.Empty;
 
@@ -5127,7 +5127,7 @@ namespace System.Management
         /// <summary>
         /// Checks if a given property is to be visible for Designer seriliazation
         /// </summary>
-        static bool IsDesignerSerializationVisibilityToBeSet(string propName)
+        private static bool IsDesignerSerializationVisibilityToBeSet(string propName)
         {
             if (!string.Equals(propName,"Path",StringComparison.OrdinalIgnoreCase))
             {
@@ -5305,7 +5305,7 @@ namespace System.Management
         /// <summary>
         /// Adds comments at the begining of the class defination
         /// </summary>
-        void AddClassComments(CodeTypeDeclaration cc)
+        private void AddClassComments(CodeTypeDeclaration cc)
         {
             cc.Comments.Add(new CodeCommentStatement(SR.CommentShouldSerialize));
             cc.Comments.Add(new CodeCommentStatement(SR.CommentIsPropNull));
@@ -5401,7 +5401,7 @@ namespace System.Management
         /// Generates the functions CheckIfProperClass() which checks if the given path
         /// can be represented with the generated code
         /// </summary>
-        void GenerateIfClassvalidFuncWithAllParams()
+        private void GenerateIfClassvalidFuncWithAllParams()
         {
             string strPathParam = "path";
             string strGetOptions = "OptionsParam";
@@ -5469,7 +5469,7 @@ namespace System.Management
         /// Generates the functions CheckIfProperClass() which checks if the given path
         /// can be represented with the generated code
         /// </summary>
-        void GenerateIfClassvalidFunction()
+        private void GenerateIfClassvalidFunction()
         {
             // Call this function to generate the first overload of this function
             GenerateIfClassvalidFuncWithAllParams();
@@ -5591,7 +5591,7 @@ namespace System.Management
         /// Generates code for Property Get for Cimtype.Reference and CimType.DateTime type property
         /// Also generated code to initialize a variable after converting a property to DateTime and ManagementPathProperty
         /// </summary>
-        void GenerateCodeForRefAndDateTimeTypes(CodeIndexerExpression prop,bool bArray,CodeStatementCollection statColl,string strType,CodeVariableReferenceExpression varToAssign,bool bIsValueProprequired)
+        private void GenerateCodeForRefAndDateTimeTypes(CodeIndexerExpression prop,bool bArray,CodeStatementCollection statColl,string strType,CodeVariableReferenceExpression varToAssign,bool bIsValueProprequired)
         {
 
             if(bArray == false)
@@ -5779,7 +5779,7 @@ namespace System.Management
         /// <summary>
         /// Generates code for Property Set for Cimtype.DateTime and CimType.Reference type property
         /// </summary>
-        void AddPropertySet(CodeIndexerExpression prop,bool bArray,CodeStatementCollection statColl,string strType,CodeVariableReferenceExpression varValue)
+        private void AddPropertySet(CodeIndexerExpression prop,bool bArray,CodeStatementCollection statColl,string strType,CodeVariableReferenceExpression varValue)
         {
             if(varValue == null)
             {
@@ -5880,7 +5880,7 @@ namespace System.Management
         /// <summary>
         /// Internal function used to create object. Used in adding code for Property Get for DateTime and Reference properties
         /// </summary>
-        CodeExpression CreateObjectForProperty(string strType, CodeExpression param)
+        private CodeExpression CreateObjectForProperty(string strType, CodeExpression param)
         {
             switch(strType)
             {
@@ -5932,7 +5932,7 @@ namespace System.Management
         /// Internal function used to create code to convert DateTime or ManagementPath to String
         /// convert a expression. Used in adding code for Property Set for DateTime and Reference properties
         /// </summary>
-        CodeExpression ConvertPropertyToString(string strType,CodeExpression beginingExpression)
+        private CodeExpression ConvertPropertyToString(string strType,CodeExpression beginingExpression)
         {
             switch(strType)
             {
@@ -6018,7 +6018,7 @@ namespace System.Management
             cmp.Comments.Add(new CodeCommentStatement(SR.CommentManagementScope));
         }
 
-        void AddGetStatementsForEnumArray(CodeIndexerExpression ciProp,CodeMemberProperty cmProp)
+        private void AddGetStatementsForEnumArray(CodeIndexerExpression ciProp,CodeMemberProperty cmProp)
         {
             string strArray = "arrEnumVals";
             string ArrToRet = "enumToRet";
@@ -6183,7 +6183,7 @@ namespace System.Management
         ///        return new GenClass(new ManagementClass(new System.Management.ManagementClass(CreatedWmiNamespace, CreatedClassName, null).CreateInstance()));
         /// }
         /// </summary>
-        void GenerateCreateInstance()
+        private void GenerateCreateInstance()
         {
             string strTemp = "tmpMgmtClass";
             cmm = new CodeMemberMethod();
@@ -6266,7 +6266,7 @@ namespace System.Management
         ///        PrivateLateBoundObject.Delete();
         /// }
         /// </summary>
-        void GenerateDeleteInstance()
+        private void GenerateDeleteInstance()
         {
             cmm = new CodeMemberMethod();
 
@@ -6295,7 +6295,7 @@ namespace System.Management
         /// <summary>
         /// Function to genreate helper function for DMTF to DateTime and DateTime to DMTF
         /// </summary>
-        void GenerateDateTimeConversionFunction()
+        private void GenerateDateTimeConversionFunction()
         {
             AddToDateTimeFunction();
             AddToDMTFDateTimeFunction();
@@ -6304,7 +6304,7 @@ namespace System.Management
         /// <summary>
         /// Function to genreate helper function for DMTF Time interval to TimeSpan and vice versa
         /// </summary>
-        void GenerateTimeSpanConversionFunction()
+        private void GenerateTimeSpanConversionFunction()
         {
             AddToTimeSpanFunction();
             AddToDMTFTimeIntervalFunction();
@@ -6315,7 +6315,7 @@ namespace System.Management
         /// <summary>
         /// Generated code for function to do conversion of date from DMTF format to DateTime format
         /// </summary>
-        void AddToDateTimeFunction()
+        private void AddToDateTimeFunction()
         {
             string dmtfParam = "dmtfDate";
             string year    = "year";
@@ -6735,7 +6735,7 @@ namespace System.Management
         /// <summary>
         /// Generates some common code used in conversion function for DateTime
         /// </summary>
-        static void DateTimeConversionFunctionHelper(CodeStatementCollection cmmdt ,
+        private static void DateTimeConversionFunctionHelper(CodeStatementCollection cmmdt ,
             string toCompare,
             string tempVarName,
             string dmtfVarName,
@@ -6767,7 +6767,7 @@ namespace System.Management
             cmmdt.Add(cis);
         }
 
-        void AddToDMTFTimeIntervalFunction()
+        private void AddToDMTFTimeIntervalFunction()
         {
             string dmtfTimeSpan = "dmtftimespan";
             string timespan    = "timespan";
@@ -7030,7 +7030,7 @@ namespace System.Management
 
         }
 
-        void AddToDMTFDateTimeFunction()
+        private void AddToDMTFDateTimeFunction()
         {
             string strUtc = "utcString";
             string dateParam    = "date";
@@ -7330,7 +7330,7 @@ namespace System.Management
         }
 
         // Helper function exclusively added to be used from AddToDMTFFunction function
-        void ToDMTFDateHelper(string dateTimeMember,CodeMemberMethod cmmdt,string strType)
+        private void ToDMTFDateHelper(string dateTimeMember,CodeMemberMethod cmmdt,string strType)
         {
             string dmtfDateTime = "dmtfDateTime";
             string dateParam = "date";
@@ -7355,7 +7355,7 @@ namespace System.Management
                 cmie2)));
         }
 
-        void AddToTimeSpanFunction()
+        private void AddToTimeSpanFunction()
         {
             string tsParam    = "dmtfTimespan";
             string days = "days";
@@ -7663,7 +7663,7 @@ namespace System.Management
         }
 
         // Exclusive helper function to be used from AddToTimeSpanFunction
-        static void ToTimeSpanHelper(int start,int numOfCharacters,string strVarToAssign,CodeStatementCollection statCol)
+        private static void ToTimeSpanHelper(int start,int numOfCharacters,string strVarToAssign,CodeStatementCollection statCol)
         {
             string strTemp = "tempString";
             string tsParam    = "dmtfTimespan";
@@ -7682,7 +7682,7 @@ namespace System.Management
             statCol.Add(new CodeAssignStatement(new CodeVariableReferenceExpression(strVarToAssign),cmie));
         }
 
-        void InitPrivateMemberVariables(CodeMemberMethod cmMethod)
+        private void InitPrivateMemberVariables(CodeMemberMethod cmMethod)
         {
             CodeMethodInvokeExpression cmieInit = new CodeMethodInvokeExpression();
             cmieInit.Method.MethodName = PrivateNamesUsed["initVariable"].ToString();
@@ -7690,7 +7690,7 @@ namespace System.Management
             cmMethod.Statements.Add(cmieInit);
         }
 
-        void GenerateMethodToInitializeVariables()
+        private void GenerateMethodToInitializeVariables()
         {
 
             CodeMemberMethod cmmInit = new CodeMemberMethod ();
@@ -7709,7 +7709,7 @@ namespace System.Management
 
 
         //
-        static CodeMethodInvokeExpression GenerateConcatStrings(CodeExpression ce1,CodeExpression ce2)
+        private static CodeMethodInvokeExpression GenerateConcatStrings(CodeExpression ce1,CodeExpression ce2)
         {
             CodeExpression []cmieParams = {ce1,ce2 };
 

--- a/src/System.Management/src/System/Management/WmiEventSink.cs
+++ b/src/System.Management/src/System/Management/WmiEventSink.cs
@@ -23,12 +23,12 @@ internal class WmiEventSink : IWmiEventSource
     private bool                            isLocal;
 
 
-    static ManagementOperationObserver watcherParameter;
-    static object contextParameter;
-    static ManagementScope scopeParameter;
-    static string pathParameter;
-    static string classNameParameter;
-    static WmiEventSink wmiEventSinkNew;
+    private static ManagementOperationObserver watcherParameter;
+    private static object contextParameter;
+    private static ManagementScope scopeParameter;
+    private static string pathParameter;
+    private static string classNameParameter;
+    private static WmiEventSink wmiEventSinkNew;
 
     internal static WmiEventSink GetWmiEventSink(
         ManagementOperationObserver watcher,
@@ -55,7 +55,7 @@ internal class WmiEventSink : IWmiEventSource
         return wmiEventSinkNew;
     }
 
-    static void HackToCreateWmiEventSink()
+    private static void HackToCreateWmiEventSink()
     {
         wmiEventSinkNew = new WmiEventSink(watcherParameter, contextParameter, scopeParameter, pathParameter, classNameParameter);
     }
@@ -222,12 +222,12 @@ internal class WmiGetEventSink : WmiEventSink
 {
     private ManagementObject    managementObject;
 
-    static ManagementOperationObserver watcherParameter;
-    static object contextParameter;
-    static ManagementScope scopeParameter;
-    static ManagementObject managementObjectParameter;
+    private static ManagementOperationObserver watcherParameter;
+    private static object contextParameter;
+    private static ManagementScope scopeParameter;
+    private static ManagementObject managementObjectParameter;
 
-    static WmiGetEventSink wmiGetEventSinkNew;
+    private static WmiGetEventSink wmiGetEventSinkNew;
 
     internal static WmiGetEventSink GetWmiGetEventSink(
         ManagementOperationObserver watcher,
@@ -252,7 +252,7 @@ internal class WmiGetEventSink : WmiEventSink
         return wmiGetEventSinkNew;
     }
 
-    static void HackToCreateWmiGetEventSink()
+    private static void HackToCreateWmiGetEventSink()
     {
         wmiGetEventSinkNew = new WmiGetEventSink(watcherParameter, contextParameter, scopeParameter, managementObjectParameter);
     }

--- a/src/System.Management/src/System/Management/wmiutil.cs
+++ b/src/System.Management/src/System/Management/wmiutil.cs
@@ -22,7 +22,7 @@ namespace System.Management
     }
 
     //Class for calling GetErrorInfo from managed code
-    class WbemErrorInfo
+    internal class WbemErrorInfo
     {
         public static IWbemClassObjectFreeThreaded GetErrorInfo()
         {

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestState.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestState.cs
@@ -101,7 +101,7 @@ namespace System.Net.Http
 
         public WinHttpHandler Handler { get; set; }
 
-        SafeWinHttpHandle _requestHandle;
+        private SafeWinHttpHandle _requestHandle;
         public SafeWinHttpHandle RequestHandle
         {
             get

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/DecompressionHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/DecompressionHandler.cs
@@ -94,8 +94,8 @@ namespace System.Net.Http
 
         private abstract class DecompressedContent : HttpContent
         {
-            HttpContent _originalContent;
-            bool _contentConsumed;
+            private readonly HttpContent _originalContent;
+            private bool _contentConsumed;
 
             public DecompressedContent(HttpContent originalContent)
             {

--- a/src/System.Net.Http/src/uap/System/Net/cookie.cs
+++ b/src/System.Net.Http/src/uap/System/Net/cookie.cs
@@ -71,26 +71,26 @@ namespace System.Net
 
         // fields
 
-        string m_comment = string.Empty;
-        Uri m_commentUri = null;
-        CookieVariant m_cookieVariant = CookieVariant.Plain;
-        bool m_discard = false;
-        string m_domain = string.Empty;
-        bool m_domain_implicit = true;
-        DateTime m_expires = DateTime.MinValue;
-        string m_name = string.Empty;
-        string m_path = string.Empty;
-        bool m_path_implicit = true;
-        string m_port = string.Empty;
-        bool m_port_implicit = true;
-        int[] m_port_list = null;
-        bool m_secure = false;
-        bool m_httpOnly = false;
-        DateTime m_timeStamp = DateTime.Now;
-        string m_value = string.Empty;
-        int m_version = 0;
+        private string m_comment = string.Empty;
+        private Uri m_commentUri = null;
+        private CookieVariant m_cookieVariant = CookieVariant.Plain;
+        private bool m_discard = false;
+        private string m_domain = string.Empty;
+        private bool m_domain_implicit = true;
+        private DateTime m_expires = DateTime.MinValue;
+        private string m_name = string.Empty;
+        private string m_path = string.Empty;
+        private bool m_path_implicit = true;
+        private string m_port = string.Empty;
+        private bool m_port_implicit = true;
+        private int[] m_port_list = null;
+        private bool m_secure = false;
+        private bool m_httpOnly = false;
+        private DateTime m_timeStamp = DateTime.Now;
+        private string m_value = string.Empty;
+        private int m_version = 0;
 
-        string m_domainKey = string.Empty;
+        private string m_domainKey = string.Empty;
         internal bool IsQuotedVersion = false;
         internal bool IsQuotedDomain = false;
 
@@ -1018,18 +1018,18 @@ namespace System.Net
     {
         // fields
 
-        bool m_eofCookie;
-        int m_index;
-        int m_length;
-        string m_name;
-        bool m_quoted;
-        int m_start;
-        CookieToken m_token;
-        int m_tokenLength;
-        string m_tokenStream;
-        string m_value;
-        int m_cookieStartIndex;
-        int m_cookieLength;
+        private bool m_eofCookie;
+        private int m_index;
+        private int m_length;
+        private string m_name;
+        private bool m_quoted;
+        private int m_start;
+        private CookieToken m_token;
+        private int m_tokenLength;
+        private string m_tokenStream;
+        private string m_value;
+        private int m_cookieStartIndex;
+        private int m_cookieLength;
 
         // constructors
 
@@ -1436,8 +1436,8 @@ namespace System.Net
 
         private struct RecognizedAttribute
         {
-            string m_name;
-            CookieToken m_token;
+            private string m_name;
+            private CookieToken m_token;
 
             internal RecognizedAttribute(string name, CookieToken token)
             {
@@ -1463,7 +1463,7 @@ namespace System.Net
         // recognized attributes in order of expected commonality
         //
 
-        static RecognizedAttribute[] RecognizedAttributes = {
+        private static RecognizedAttribute[] RecognizedAttributes = {
             new RecognizedAttribute(Cookie.PathAttributeName, CookieToken.Path),
             new RecognizedAttribute(Cookie.MaxAgeAttributeName, CookieToken.MaxAge),
             new RecognizedAttribute(Cookie.ExpiresAttributeName, CookieToken.Expires),
@@ -1477,7 +1477,7 @@ namespace System.Net
             new RecognizedAttribute(Cookie.HttpOnlyAttributeName, CookieToken.HttpOnly),
         };
 
-        static RecognizedAttribute[] RecognizedServerAttributes = {
+        private static RecognizedAttribute[] RecognizedServerAttributes = {
             new RecognizedAttribute('$' + Cookie.PathAttributeName, CookieToken.Path),
             new RecognizedAttribute('$' + Cookie.VersionAttributeName, CookieToken.Version),
             new RecognizedAttribute('$' + Cookie.DomainAttributeName, CookieToken.Domain),
@@ -1521,8 +1521,8 @@ namespace System.Net
     {
         // fields
 
-        CookieTokenizer m_tokenizer;
-        Cookie m_savedCookie;
+        private CookieTokenizer m_tokenizer;
+        private Cookie m_savedCookie;
 
         // constructors
 

--- a/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
@@ -1475,7 +1475,7 @@ namespace System.Numerics
         }
 
 
-        struct CanonicalBasis
+        private struct CanonicalBasis
         {
             public Vector3 Row0;
             public Vector3 Row1;
@@ -1483,7 +1483,7 @@ namespace System.Numerics
         };
 
 
-        struct VectorBasis
+        private struct VectorBasis
         {
             public unsafe Vector3* Element0;
             public unsafe Vector3* Element1;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatReaderGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatReaderGenerator.cs
@@ -248,7 +248,7 @@ namespace System.Runtime.Serialization.Json
                 }
             }
 
-            bool HasFactoryMethod(ClassDataContract classContract)
+            private bool HasFactoryMethod(ClassDataContract classContract)
             {
                 return Globals.TypeOfIObjectReference.IsAssignableFrom(classContract.UnderlyingType);
             }

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ReflectionFeature.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ReflectionFeature.cs
@@ -4,7 +4,7 @@
 
 namespace System.Runtime.Serialization
 {
-    class ReflectionBasedSerializationFeature
+    internal class ReflectionBasedSerializationFeature
     {
         public const string Name = "System.Runtime.Serialization.ReflectionBasedSerialization";
     }

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/SchemaHelper.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/SchemaHelper.cs
@@ -82,7 +82,7 @@ namespace System.Runtime.Serialization
             return CreateSchema(ns, schemas);
         }
 
-        static XmlSchema CreateSchema(string ns, XmlSchemaSet schemas)
+        private static XmlSchema CreateSchema(string ns, XmlSchemaSet schemas)
         {
             XmlSchema schema = new XmlSchema();
 

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/SurrogateDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/SurrogateDataContract.cs
@@ -76,7 +76,7 @@ namespace System.Runtime.Serialization
 
         private class SurrogateDataContractCriticalHelper : DataContract.DataContractCriticalHelper
         {
-            ISerializationSurrogate serializationSurrogate;
+            private ISerializationSurrogate serializationSurrogate;
 
             internal SurrogateDataContractCriticalHelper(Type type, ISerializationSurrogate serializationSurrogate)
                 : base(type)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XPathQueryGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XPathQueryGenerator.cs
@@ -15,8 +15,8 @@ namespace System.Runtime.Serialization
 
     public static class XPathQueryGenerator
     {
-        const string XPathSeparator = "/";
-        const string NsSeparator = ":";
+        private const string XPathSeparator = "/";
+        private const string NsSeparator = ":";
 
         public static string CreateFromDataContractSerializer(Type type, MemberInfo[] pathToMember, out XmlNamespaceManager namespaces)
         {
@@ -57,7 +57,7 @@ namespace System.Runtime.Serialization
             return context.XPath;
         }
 
-        static DataContract ProcessDataContract(DataContract contract, ExportContext context, MemberInfo memberNode)
+        private static DataContract ProcessDataContract(DataContract contract, ExportContext context, MemberInfo memberNode)
         {
             if (contract is ClassDataContract)
             {
@@ -66,7 +66,7 @@ namespace System.Runtime.Serialization
             throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlObjectSerializer.CreateSerializationException(SR.QueryGeneratorPathToMemberNotFound));
         }
 
-        static DataContract ProcessClassDataContract(ClassDataContract contract, ExportContext context, MemberInfo memberNode)
+        private static DataContract ProcessClassDataContract(ClassDataContract contract, ExportContext context, MemberInfo memberNode)
         {
             string prefix = context.SetNamespace(contract.Namespace.Value);
             foreach (DataMember member in GetDataMembers(contract))
@@ -80,7 +80,7 @@ namespace System.Runtime.Serialization
             throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlObjectSerializer.CreateSerializationException(SR.QueryGeneratorPathToMemberNotFound));
         }
 
-        static IEnumerable<DataMember> GetDataMembers(ClassDataContract contract)
+        private static IEnumerable<DataMember> GetDataMembers(ClassDataContract contract)
         {
             if (contract.BaseContract != null)
             {
@@ -98,7 +98,7 @@ namespace System.Runtime.Serialization
             }
         }
 
-        class ExportContext
+        private class ExportContext
         {
             private XmlNamespaceManager _namespaces;
             private int _nextPrefix;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XsdDataContractExporter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XsdDataContractExporter.cs
@@ -40,7 +40,7 @@ namespace System.Runtime.Serialization
             }
         }
 
-        XmlSchemaSet GetSchemaSet()
+        private XmlSchemaSet GetSchemaSet()
         {
             if (_schemas == null)
             {
@@ -50,7 +50,7 @@ namespace System.Runtime.Serialization
             return _schemas;
         }
 
-        DataContractSet DataContractSet
+        private DataContractSet DataContractSet
         {
             get
             {
@@ -61,15 +61,15 @@ namespace System.Runtime.Serialization
             }
         }
 
-        void TraceExportBegin()
+        private void TraceExportBegin()
         {
         }
 
-        void TraceExportEnd()
+        private void TraceExportEnd()
         {
         }
 
-        void TraceExportError(Exception exception)
+        private void TraceExportError(Exception exception)
         {
         }
 

--- a/src/System.Private.Xml.Linq/src/System/Xml/Linq/XDocument.cs
+++ b/src/System.Private.Xml.Linq/src/System/Xml/Linq/XDocument.cs
@@ -479,7 +479,7 @@ namespace System.Xml.Linq
         /// <summary>
         /// Performs shared initialization between Load and LoadAsync.
         /// </summary>
-        static XDocument InitLoad(XmlReader reader, LoadOptions options)
+        private static XDocument InitLoad(XmlReader reader, LoadOptions options)
         {
             XDocument d = new XDocument();
             if ((options & LoadOptions.SetBaseUri) != 0)

--- a/src/System.Private.Xml.Linq/src/System/Xml/Linq/XLinq.cs
+++ b/src/System.Private.Xml.Linq/src/System/Xml/Linq/XLinq.cs
@@ -387,7 +387,7 @@ namespace System.Xml.Linq
             }
         }
 
-        async Task WriteStartElementAsync(XElement e, CancellationToken cancellationToken)
+        private async Task WriteStartElementAsync(XElement e, CancellationToken cancellationToken)
         {
             PushElement(e);
             XNamespace ns = e.Name.Namespace;
@@ -409,7 +409,7 @@ namespace System.Xml.Linq
 
     internal struct NamespaceResolver
     {
-        class NamespaceDeclaration
+        private class NamespaceDeclaration
         {
             public string prefix;
             public XNamespace ns;

--- a/src/System.Private.Xml.Linq/src/System/Xml/Schema/XNodeValidator.cs
+++ b/src/System.Private.Xml.Linq/src/System/Xml/Schema/XNodeValidator.cs
@@ -14,18 +14,18 @@ namespace System.Xml.Schema
 {
     internal class XNodeValidator
     {
-        XmlSchemaSet schemas;
-        ValidationEventHandler validationEventHandler;
+        private XmlSchemaSet schemas;
+        private ValidationEventHandler validationEventHandler;
 
-        XObject source;
-        bool addSchemaInfo;
-        XmlNamespaceManager namespaceManager;
-        XmlSchemaValidator validator;
+        private XObject source;
+        private bool addSchemaInfo;
+        private XmlNamespaceManager namespaceManager;
+        private XmlSchemaValidator validator;
 
-        Dictionary<XmlSchemaInfo, XmlSchemaInfo> schemaInfos;
-        ArrayList defaultAttributes;
-        XName xsiTypeName;
-        XName xsiNilName;
+        private Dictionary<XmlSchemaInfo, XmlSchemaInfo> schemaInfos;
+        private ArrayList defaultAttributes;
+        private XName xsiTypeName;
+        private XName xsiNilName;
 
         public XNodeValidator(XmlSchemaSet schemas, ValidationEventHandler validationEventHandler)
         {
@@ -86,7 +86,7 @@ namespace System.Xml.Schema
             RestoreLineInfo(orginal);
         }
 
-        XmlSchemaInfo GetDefaultAttributeSchemaInfo(XmlSchemaAttribute sa)
+        private XmlSchemaInfo GetDefaultAttributeSchemaInfo(XmlSchemaAttribute sa)
         {
             XmlSchemaInfo si = new XmlSchemaInfo();
             si.IsDefault = true;
@@ -118,7 +118,7 @@ namespace System.Xml.Schema
             return si;
         }
 
-        string GetDefaultValue(XmlSchemaAttribute sa)
+        private string GetDefaultValue(XmlSchemaAttribute sa)
         {
             XmlQualifiedName name = sa.RefName;
             if (!name.IsEmpty)
@@ -131,7 +131,7 @@ namespace System.Xml.Schema
             return sa.DefaultValue;
         }
 
-        string GetDefaultValue(XmlSchemaElement se)
+        private string GetDefaultValue(XmlSchemaElement se)
         {
             XmlQualifiedName name = se.RefName;
             if (!name.IsEmpty)
@@ -144,7 +144,7 @@ namespace System.Xml.Schema
             return se.DefaultValue;
         }
 
-        void ReplaceSchemaInfo(XObject o, XmlSchemaInfo schemaInfo)
+        private void ReplaceSchemaInfo(XObject o, XmlSchemaInfo schemaInfo)
         {
             if (schemaInfos == null)
             {
@@ -167,7 +167,7 @@ namespace System.Xml.Schema
             o.AddAnnotation(si);
         }
 
-        void PushAncestorsAndSelf(XElement e)
+        private void PushAncestorsAndSelf(XElement e)
         {
             while (e != null)
             {
@@ -195,7 +195,7 @@ namespace System.Xml.Schema
             }
         }
 
-        void PushElement(XElement e, ref string xsiType, ref string xsiNil)
+        private void PushElement(XElement e, ref string xsiType, ref string xsiNil)
         {
             namespaceManager.PushScope();
             XAttribute a = e.lastAttr;
@@ -229,20 +229,20 @@ namespace System.Xml.Schema
             }
         }
 
-        IXmlLineInfo SaveLineInfo(XObject source)
+        private IXmlLineInfo SaveLineInfo(XObject source)
         {
             IXmlLineInfo previousLineInfo = validator.LineInfoProvider;
             validator.LineInfoProvider = source as IXmlLineInfo;
             return previousLineInfo;
         }
 
-        void RestoreLineInfo(IXmlLineInfo originalLineInfo)
+        private void RestoreLineInfo(IXmlLineInfo originalLineInfo)
         {
             validator.LineInfoProvider = originalLineInfo;
         }
 
 
-        void ValidateAttribute(XAttribute a)
+        private void ValidateAttribute(XAttribute a)
         {
             IXmlLineInfo original = SaveLineInfo(a);
             XmlSchemaInfo si = addSchemaInfo ? new XmlSchemaInfo() : null;
@@ -255,7 +255,7 @@ namespace System.Xml.Schema
             RestoreLineInfo(original);
         }
 
-        void ValidateAttributes(XElement e)
+        private void ValidateAttributes(XElement e)
         {
             XAttribute a = e.lastAttr;
             IXmlLineInfo orginal = SaveLineInfo(a);
@@ -292,7 +292,7 @@ namespace System.Xml.Schema
             RestoreLineInfo(orginal);
         }
 
-        void ValidateElement(XElement e)
+        private void ValidateElement(XElement e)
         {
             XmlSchemaInfo si = addSchemaInfo ? new XmlSchemaInfo() : null;
             string xsiType = null;
@@ -317,7 +317,7 @@ namespace System.Xml.Schema
             namespaceManager.PopScope();
         }
 
-        void ValidateNodes(XElement e)
+        private void ValidateNodes(XElement e)
         {
             XNode n = e.content as XNode;
             IXmlLineInfo orginal = SaveLineInfo(n);
@@ -358,7 +358,7 @@ namespace System.Xml.Schema
             RestoreLineInfo(orginal);
         }
 
-        void ValidationCallback(object sender, ValidationEventArgs e)
+        private void ValidationCallback(object sender, ValidationEventArgs e)
         {
             if (validationEventHandler != null)
             {

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlReaderSettings.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlReaderSettings.cs
@@ -60,7 +60,7 @@ namespace System.Xml
         // Creation of validating readers is hidden behind a delegate which is only initialized if the ValidationType
         // property is set. This is for AOT builds where the tree shaker can reduce the validating readers away
         // if nobody calls the ValidationType setter. Might also help with non-AOT build when ILLinker is used.
-        delegate XmlReader AddValidationFunc(XmlReader reader, XmlResolver resolver, bool addConformanceWrapper);
+        private delegate XmlReader AddValidationFunc(XmlReader reader, XmlResolver resolver, bool addConformanceWrapper);
         private AddValidationFunc _addValidationFunc;
 
         //

--- a/src/System.Resources.Extensions/src/System/Resources/Extensions/PreserializedResourceWriter.cs
+++ b/src/System.Resources.Extensions/src/System/Resources/Extensions/PreserializedResourceWriter.cs
@@ -16,7 +16,7 @@ namespace System.Resources.Extensions
     {
         // indicates if the types of resources saved will require the DeserializingResourceReader
         // in order to read them.
-        bool _requiresDeserializingResourceReader = false;
+        private bool _requiresDeserializingResourceReader = false;
 
         // use hard-coded strings rather than typeof so that the version doesn't leak into resources files
         internal const string DeserializingResourceReaderFullyQualifiedName = "System.Resources.Extensions.DeserializingResourceReader, System.Resources.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51";

--- a/src/System.Runtime.WindowsRuntime/src/System/Runtime/InteropServices/WindowsRuntime/MarshalingHelpers.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Runtime/InteropServices/WindowsRuntime/MarshalingHelpers.cs
@@ -105,9 +105,9 @@ namespace System.Runtime.InteropServices.WindowsRuntime
 
     internal static class NotifyCollectionChangedEventArgsMarshaler
     {
-        const string WinRTNotifyCollectionChangedEventArgsName = "Windows.UI.Xaml.Interop.NotifyCollectionChangedEventArgs";
+        private const string WinRTNotifyCollectionChangedEventArgsName = "Windows.UI.Xaml.Interop.NotifyCollectionChangedEventArgs";
 
-        static INotifyCollectionChangedEventArgsFactory s_EventArgsFactory;
+        private static INotifyCollectionChangedEventArgsFactory s_EventArgsFactory;
 
         // Extracts properties from a managed NotifyCollectionChangedEventArgs and passes them to
         // a VM-implemented helper that creates a WinRT NotifyCollectionChangedEventArgs instance.
@@ -178,9 +178,9 @@ namespace System.Runtime.InteropServices.WindowsRuntime
 
     internal static class PropertyChangedEventArgsMarshaler
     {
-        const string WinRTPropertyChangedEventArgsName = "Windows.UI.Xaml.Data.PropertyChangedEventArgs";
+        private const string WinRTPropertyChangedEventArgsName = "Windows.UI.Xaml.Data.PropertyChangedEventArgs";
 
-        static IPropertyChangedEventArgsFactory s_pPCEventArgsFactory;
+        private static IPropertyChangedEventArgsFactory s_pPCEventArgsFactory;
 
         // Extracts PropertyName from a managed PropertyChangedEventArgs and passes them to
         // a VM-implemented helper that creates a WinRT PropertyChangedEventArgs instance.

--- a/src/System.Security.AccessControl/src/System/Security/AccessControl/SecurityDescriptor.cs
+++ b/src/System.Security.AccessControl/src/System/Security/AccessControl/SecurityDescriptor.cs
@@ -822,8 +822,8 @@ nameof(sddlForm));
     {
         #region Private Members
 
-        bool _isContainer;
-        bool _isDS;
+        private bool _isContainer;
+        private bool _isDS;
         private RawSecurityDescriptor _rawSd;
         private SystemAcl _sacl;
         private DiscretionaryAcl _dacl;

--- a/src/System.Security.Claims/src/System/Security/Claims/GenericIdentity.cs
+++ b/src/System.Security.Claims/src/System/Security/Claims/GenericIdentity.cs
@@ -36,7 +36,7 @@ namespace System.Security.Principal
             AddNameClaim();
         }
 
-        GenericIdentity()
+        private GenericIdentity()
             : base()
         { }
 

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/X509Pal.PublicKey.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/X509Pal.PublicKey.cs
@@ -22,8 +22,8 @@ namespace Internal.Cryptography.Pal
     /// </summary>
     internal sealed partial class X509Pal : IX509Pal
     {
-        const string BCRYPT_ECC_CURVE_NAME_PROPERTY = "ECCCurveName";
-        const string BCRYPT_ECC_PARAMETERS_PROPERTY = "ECCParameters";
+        private const string BCRYPT_ECC_CURVE_NAME_PROPERTY = "ECCCurveName";
+        private const string BCRYPT_ECC_PARAMETERS_PROPERTY = "ECCParameters";
 
         public AsymmetricAlgorithm DecodePublicKey(Oid oid, byte[] encodedKeyValue, byte[] encodedParameters, ICertificatePal certificatePal)
         {

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/DSASignatureDescription.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/DSASignatureDescription.cs
@@ -8,7 +8,7 @@ namespace System.Security.Cryptography.Xml
 {
     internal class DSASignatureDescription : SignatureDescription
     {
-        const string HashAlgorithm = "SHA1";
+        private const string HashAlgorithm = "SHA1";
 
         public DSASignatureDescription()
         {

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/HtmlEncoder.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/HtmlEncoder.cs
@@ -97,10 +97,10 @@ namespace System.Text.Encodings.Web
             get { return 10; } // "&#x10FFFF;" is the longest encoded form
         }
 
-        static readonly char[] s_quote = "&quot;".ToCharArray();
-        static readonly char[] s_ampersand = "&amp;".ToCharArray();
-        static readonly char[] s_lessthan = "&lt;".ToCharArray();
-        static readonly char[] s_greaterthan = "&gt;".ToCharArray();
+        private static readonly char[] s_quote = "&quot;".ToCharArray();
+        private static readonly char[] s_ampersand = "&amp;".ToCharArray();
+        private static readonly char[] s_lessthan = "&lt;".ToCharArray();
+        private static readonly char[] s_greaterthan = "&gt;".ToCharArray();
 
         public unsafe override bool TryEncodeUnicodeScalar(int unicodeScalar, char* buffer, int bufferLength, out int numberOfCharactersWritten)
         {

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/JavaScriptEncoder.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/JavaScriptEncoder.cs
@@ -131,12 +131,12 @@ namespace System.Text.Encodings.Web
             get { return 12; } // "\uFFFF\uFFFF" is the longest encoded form
         }
 
-        static readonly char[] s_b = new char[] { '\\', 'b' };
-        static readonly char[] s_t = new char[] { '\\', 't' };
-        static readonly char[] s_n = new char[] { '\\', 'n' };
-        static readonly char[] s_f = new char[] { '\\', 'f' };
-        static readonly char[] s_r = new char[] { '\\', 'r' };
-        static readonly char[] s_back = new char[] { '\\', '\\' };
+        private static readonly char[] s_b = new char[] { '\\', 'b' };
+        private static readonly char[] s_t = new char[] { '\\', 't' };
+        private static readonly char[] s_n = new char[] { '\\', 'n' };
+        private static readonly char[] s_f = new char[] { '\\', 'f' };
+        private static readonly char[] s_r = new char[] { '\\', 'r' };
+        private static readonly char[] s_back = new char[] { '\\', '\\' };
 
         // Writes a scalar value as a JavaScript-escaped character (or sequence of characters).
         // See ECMA-262, Sec. 7.8.4, and ECMA-404, Sec. 9

--- a/src/System.Threading.Channels/src/System/Threading/Channels/IDebugEnumerator.cs
+++ b/src/System.Threading.Channels/src/System/Threading/Channels/IDebugEnumerator.cs
@@ -7,7 +7,7 @@ using System.Diagnostics;
 
 namespace System.Threading.Channels
 {
-    interface IDebugEnumerable<T>
+    internal interface IDebugEnumerable<T>
     {
         IEnumerator<T> GetEnumerator();
     }

--- a/src/System.Threading.Tasks.Dataflow/src/Internal/Common.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Internal/Common.cs
@@ -594,7 +594,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
 
         /// <summary>Static class used to cache generic delegates the C# compiler doesn't cache by default.</summary>
         /// <remarks>Without this, we end up allocating the generic delegate each time the operation is used.</remarks>
-        static class CachedGenericDelegates<T>
+        private static class CachedGenericDelegates<T>
         {
             /// <summary>A function that returns the default value of T.</summary>
             internal static readonly Func<T> DefaultTResultFunc = () => default(T);

--- a/src/System.Threading.Tasks.Dataflow/src/Internal/ConcurrentQueue.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Internal/ConcurrentQueue.cs
@@ -907,7 +907,7 @@ namespace System.Threading.Tasks.Dataflow.Internal.Collections
     /// A wrapper struct for volatile bool, please note the copy of the struct it self will not be volatile
     /// for example this statement will not include in volatile operation volatileBool1 = volatileBool2 the jit will copy the struct and will ignore the volatile
     /// </summary>
-    struct VolatileBool
+    internal struct VolatileBool
     {
         public VolatileBool(bool value)
         {

--- a/src/System.Transactions.Local/src/System/Transactions/TransactionsEtwProvider.cs
+++ b/src/System.Transactions.Local/src/System/Transactions/TransactionsEtwProvider.cs
@@ -1156,7 +1156,7 @@ namespace System.Transactions
             public const EventKeywords TraceDistributed = (EventKeywords)0x0004;
         }
 
-        void SetActivityId(string str)
+        private void SetActivityId(string str)
         {
             Guid guid = Guid.Empty;
 

--- a/src/System.Windows.Extensions/src/System/Drawing/FontConverter.cs
+++ b/src/System.Windows.Extensions/src/System/Drawing/FontConverter.cs
@@ -394,7 +394,7 @@ namespace System.Drawing
 
         public sealed class FontNameConverter : TypeConverter, IDisposable
         {
-            FontFamily[] _fonts;
+            private FontFamily[] _fonts;
 
             public FontNameConverter()
             {


### PR DESCRIPTION
One of the more common things we "nit" in PRs.  Now the compiler will flag it for us.