### PR TITLE
Re-enable scheduled outerloop runs

### DIFF
--- a/eng/pipelines/outerloop.yml
+++ b/eng/pipelines/outerloop.yml
@@ -1,5 +1,13 @@
 trigger: none
 
+schedules:
+- cron: "0 3 * * *"
+  displayName: Outerloop scheduled build
+  branches:
+    include:
+    - master
+    - releases/3.0
+
 resources:
   containers:
   - container: rhel7_container


### PR DESCRIPTION
I noticed that the scheduled outerloop builds aren't running since 8/9. As we need them in the CI council meeting this week adding the trigger back now.