### PR TITLE
Fix 2 System.Net.Http tests failing on debian

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.AcceptAllCerts.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.AcceptAllCerts.cs
@@ -28,7 +28,7 @@ namespace System.Net.Http.Functional.Tests
             Assert.True(HttpClientHandler.DangerousAcceptAnyServerCertificateValidator(null, null, null, SslPolicyErrors.None));
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotDebian10))] // [ActiveIssue(40175)]
+        [ConditionalTheory]
         [InlineData(SslProtocols.Tls, false)] // try various protocols to ensure we correctly set versions even when accepting all certs
         [InlineData(SslProtocols.Tls, true)]
         [InlineData(SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls, false)]
@@ -61,6 +61,14 @@ namespace System.Net.Http.Functional.Tests
                 if (requestOnlyThisProtocol)
                 {
                     handler.SslProtocols = acceptedProtocol;
+                }
+                else
+                {
+                    // Explicitly setting protocols clears implementation default
+                    // restrictions on minimum TLS/SSL version
+                    // We currently know that some platforms like Debian 10 OpenSSL
+                    // will by default block < TLS 1.2
+                    handler.SslProtocols = SslProtocols.Tls13 | SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls;
                 }
 
                 var options = new LoopbackServer.Options { UseSsl = true, SslProtocols = acceptedProtocol };

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
@@ -107,7 +107,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotDebian10))] // [ActiveIssue(40175)]
+        [ConditionalTheory]
         [MemberData(nameof(GetAsync_AllowedSSLVersion_Succeeds_MemberData))]
         public async Task GetAsync_AllowedSSLVersion_Succeeds(SslProtocols acceptedProtocol, bool requestOnlyThisProtocol)
         {
@@ -133,6 +133,15 @@ namespace System.Net.Http.Functional.Tests
                 {
                     handler.SslProtocols = acceptedProtocol;
                 }
+                else
+                {
+                    // Explicitly setting protocols clears implementation default
+                    // restrictions on minimum TLS/SSL version
+                    // We currently know that some platforms like Debian 10 OpenSSL
+                    // will by default block < TLS 1.2
+                    handler.SslProtocols = SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12;
+                }
+
                 var options = new LoopbackServer.Options { UseSsl = true, SslProtocols = acceptedProtocol };
                 await LoopbackServer.CreateServerAsync(async (server, url) =>
                 {


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/40175

Failures were caused by the fact that OpenSSL on Debian 10 is not allowing anything less than TLS 1.2 by default.

Currently in order to override that restriction protocols need to be explicitly set (which is what the fix is doing)