### PR TITLE
Prevent race condition issues with warm-up of property caching

### DIFF
--- a/src/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/System.Text.Json/src/System.Text.Json.csproj
@@ -205,6 +205,7 @@
     <Reference Include="System.Numerics.Vectors" />
     <Reference Include="System.Runtime.CompilerServices.Unsafe" />
     <Reference Include="System.Text.Encodings.Web" />
+    <Reference Include="System.Threading" />
     <Reference Include="System.Threading.Tasks" />
     <Reference Include="System.Threading.Tasks.Extensions" />
   </ItemGroup>

--- a/src/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/System.Text.Json/src/System.Text.Json.csproj
@@ -205,7 +205,6 @@
     <Reference Include="System.Numerics.Vectors" />
     <Reference Include="System.Runtime.CompilerServices.Unsafe" />
     <Reference Include="System.Text.Encodings.Web" />
-    <Reference Include="System.Threading" />
     <Reference Include="System.Threading.Tasks" />
     <Reference Include="System.Threading.Tasks.Extensions" />
   </ItemGroup>

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleObject.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleObject.cs
@@ -56,7 +56,11 @@ namespace System.Text.Json
         {
             Debug.Assert(!state.Current.IsProcessingDictionary && !state.Current.IsProcessingIDictionaryConstructible);
 
-            state.Current.JsonClassInfo.UpdateSortedPropertyCache(ref state.Current);
+            // Check if we are trying to build the sorted cache.
+            if (state.Current.PropertyRefCache != null)
+            {
+                state.Current.JsonClassInfo.UpdateSortedPropertyCache(ref state.Current);
+            }
 
             object value = state.Current.ReturnValue;
 

--- a/src/System.Text.Json/tests/Serialization/CacheTests.cs
+++ b/src/System.Text.Json/tests/Serialization/CacheTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using System.Reflection;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -9,40 +11,63 @@ namespace System.Text.Json.Serialization.Tests
 {
     public static class CacheTests
     {
-        // Use a new type that is not used in other tests so we can attempt race conditions on cached global state.
-        public class TestClassForCachingTest : SimpleTestClass { }
+        [Fact, OuterLoop]
+        public static void MultipleThreadsLooping()
+        {
+            const int Iterations = 100;
+
+            for (int i = 0; i < Iterations; i++)
+            {
+                MultipleThreads();
+            }
+        }
 
         [Fact]
         public static void MultipleThreads()
         {
+            // Use local options to avoid obtaining already cached metadata from the default options.
+            var options = new JsonSerializerOptions();
+
+            // Verify the test class has >64 properties since that is a threshold for using the fallback dictionary.
+            Assert.True(typeof(SimpleTestClass).GetProperties(BindingFlags.Instance | BindingFlags.Public).Length > 64);
+
+            void DeserializeObjectMinimal()
+            {
+                SimpleTestClass obj = JsonSerializer.Deserialize<SimpleTestClass>(@"{""MyDecimal"" : 3.3}", options);
+            };
+
             void DeserializeObjectFlipped()
             {
-                TestClassForCachingTest obj = JsonSerializer.Deserialize<TestClassForCachingTest>(SimpleTestClass.s_json_flipped);
+                SimpleTestClass obj = JsonSerializer.Deserialize<SimpleTestClass>(SimpleTestClass.s_json_flipped, options);
                 obj.Verify();
             };
 
             void DeserializeObjectNormal()
             {
-                TestClassForCachingTest obj = JsonSerializer.Deserialize<TestClassForCachingTest>(SimpleTestClass.s_json);
+                SimpleTestClass obj = JsonSerializer.Deserialize<SimpleTestClass>(SimpleTestClass.s_json, options);
                 obj.Verify();
             };
 
             void SerializeObject()
             {
-                var obj = new TestClassForCachingTest();
+                var obj = new SimpleTestClass();
                 obj.Initialize();
-                JsonSerializer.Serialize(obj);
+                JsonSerializer.Serialize(obj, options);
             };
 
-            Task[] tasks = new Task[4 * 3];
-            for (int i = 0; i < tasks.Length; i += 3)
+            const int ThreadCount = 8;
+            const int ConcurrentTestsCount = 4;
+            Task[] tasks = new Task[ThreadCount * ConcurrentTestsCount];
+
+            for (int i = 0; i < tasks.Length; i += ConcurrentTestsCount)
             {
                 // Create race condition to populate the sorted property cache with different json ordering.
-                tasks[i + 0] = Task.Run(() => DeserializeObjectFlipped());
-                tasks[i + 1] = Task.Run(() => DeserializeObjectNormal());
+                tasks[i + 0] = Task.Run(() => DeserializeObjectMinimal());
+                tasks[i + 1] = Task.Run(() => DeserializeObjectFlipped());
+                tasks[i + 2] = Task.Run(() => DeserializeObjectNormal());
 
                 // Ensure no exceptions on serialization
-                tasks[i + 2] = Task.Run(() => SerializeObject());
+                tasks[i + 3] = Task.Run(() => SerializeObject());
             };
 
             Task.WaitAll(tasks);
@@ -51,8 +76,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void PropertyCacheWithMinInputsFirst()
         {
-            // Use localized caching
-            // Todo: localized caching not implemented yet. When implemented, add a run-time attribute to JsonSerializerOptions as that will create a separate cache held by JsonSerializerOptions.
+            // Use local options to avoid obtaining already cached metadata from the default options.
             var options = new JsonSerializerOptions();
 
             string json = "{}";
@@ -70,8 +94,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void PropertyCacheWithMinInputsLast()
         {
-            // Use localized caching
-            // Todo: localized caching not implemented yet. When implemented, add a run-time attribute to JsonSerializerOptions as that will create a separate cache held by JsonSerializerOptions.
+            // Use local options to avoid obtaining already cached metadata from the default options.
             var options = new JsonSerializerOptions();
 
             SimpleTestClass testObj = new SimpleTestClass();
@@ -84,6 +107,56 @@ namespace System.Text.Json.Serialization.Tests
 
             json = "{}";
             JsonSerializer.Deserialize<SimpleTestClass>(json, options);
+        }
+
+        // Use a common options instance to encourage additional metadata collisions across types. Also since
+        // this options is not the default options instance the tests will not use previously cached metadata.
+        private static JsonSerializerOptions s_options = new JsonSerializerOptions();
+
+        [Theory]
+        [MemberData(nameof(WriteSuccessCases))]
+        public static void MultipleTypes(ITestClass testObj)
+        {
+            Type type = testObj.GetType();
+
+            // Get the test json with the default options to avoid cache pollution of Deserialize() below.
+            testObj.Initialize();
+            testObj.Verify();
+            string json = JsonSerializer.Serialize(testObj, type);
+
+            void Serialize()
+            {
+                ITestClass localTestObj = (ITestClass)Activator.CreateInstance(type);
+                localTestObj.Initialize();
+                localTestObj.Verify();
+                string json = JsonSerializer.Serialize(localTestObj, type, s_options);
+            };
+
+            void Deserialize()
+            {
+                ITestClass obj = (ITestClass)JsonSerializer.Deserialize(json, type, s_options);
+                obj.Verify();
+            };
+
+            const int ThreadCount = 12;
+            const int ConcurrentTestsCount = 2;
+            Task[] tasks = new Task[ThreadCount * ConcurrentTestsCount];
+
+            for (int i = 0; i < tasks.Length; i += ConcurrentTestsCount)
+            {
+                tasks[i + 0] = Task.Run(() => Deserialize());
+                tasks[i + 1] = Task.Run(() => Serialize());
+            };
+
+            Task.WaitAll(tasks);
+        }
+
+        public static IEnumerable<object[]> WriteSuccessCases
+        {
+            get
+            {
+                return TestData.WriteSuccessCases;
+            }
         }
     }
 }


### PR DESCRIPTION
After stress testing it was determined that there is an issue with the warm-up phase where property metadata is cached, so this PR fixes that.

Fixes https://github.com/dotnet/corefx/issues/38802

The new OuterLoop test `MultipleThreadsLooping` had about a 33% chance of failure before the changes here (the test would fail with `IndexOutOfRangeException`). After the changes that test was run 1,000 times without failure.

No performance degradation was found; this area is highly perf-sensitive since it is used during deserialization to match JSON property names to the cached metadata.

After this is in master, a PR will be created for 3.0 ask mode.

More detail on the design and changes by this PR:

### Flow: stage 1 - `JsonClassInfo.PropertyCache` (cache of all properties)
_Note this logic didn't change in this PR._

1. Deserialization starts for a given type given some JSON.
2. An attempt is made to find the metadata (`JsonClassInfo`) for the given type.
3. If no metadata is found, all of the type's properties are reflected. This is placed into a `Dictionary<string, JsonPropertyInfo>` member on `JsonClassInfo` called `PropertyCache`.

There are no threading issues here because the dictionary entry for `JsonClassInfo` is overwritten in race conditions. That dictionary is `_classes` (which is a `ConcurrentDictionary<Type, JsonClassInfo>`) on `JsonSerializerOptions`.

### Flow: stage 2 - `GetProperty` and reading `_propertyRefsSorted`
After this `PropertyCache` is built, the first property is deserialized. For performance, a "sorted cache" is used (`PropertyRef[] _propertyRefsSorted`) which is owned by `JsonClassInfo`. This `_propertyRefsSorted` is accessed before the (slower) `PropertyCache` metadata.

To obtain the metadata for the property during deserialization this method is called:
```cs
JsonPropertyInfo JsonClassInfo.GetProperty(ReadOnlySpan<byte> propertyName, ref ReadStackFrame frame)
````
1. The `_propertyRefsSorted` cache is checked for the property. If found, the method exits. `_propertyRefsSorted` can be accessed by multiple threads.
2. If not found, then the `PropertyCache` is accessed to find the property. One of two outcomes:
 - If `_propertyRefsSorted` is at its upper bound (64 items\properties) then the property is just returned.
 - If not at upper bound then the property is added to `ReadStackFrame` in a simple `List<>` called `PropertyRefCache` before the property is returned. An instance of `ReadStackFrame` is only accessed by a single thread. Subsequent missing properties are also added to the `ReadStackFrame` instance for the same object being deserialized (on the same call stack \ object \ JSON).

**Step 1 was changed in this PR to hold onto a local reference to `_propertyRefsSorted` so it always sees a consistent version of the cache** (the cache contents are immutable). That field is always replaced so a different instance is created every time the contents change. Previously, an `IndexOutOfRangeException` could occur if another thread changed the cache reference.

In step 2 the check for the upper bounds is a point-in-time check since `_propertyRefsSorted` is accessed by multiple threads. Thus two different threads may both be adding, say 50 properties, to their local `PropertyRefCache`.

### Flow: stage 3 - Writing `_propertyRefsSorted` using lock()
After deserialization is done for the object, the `ReadStackFrame.PropertyRefCache` is checked for any elements. If there are elements then they are added to `_propertyRefsSorted` in the method `UpdateSortedPropertyCache()`.

`_propertyRefsSorted` can be accessed by multiple threads but the instance is replaced when modified, so no `lock` is necessary (also the field is marked volatile).

**This PR modifies the code to ensure the upper bound (64) is not going to be surpassed by adding the elements from `ReadStackFrame.PropertyRefCache`**.

Note that JSON during deserialization may only contain a subset of the properties for a given type\POCO and they may be in any order. Thus `_propertyRefsSorted` is not always built up in an orderly fashion -- it can span multiple deserializations and even contain duplicate entries.

A couple design points:
- The design is "lock free" due to the immutable contents of `_propertyRefsSorted`.
- The temporary cache on `ReadStackFrame` only creates a lock for an entire object, instead of per-property. This minimizes the number of lock statements and the number of conversions to the fast sorted array `_propertyRefsSorted`.

