### PR TITLE
Use sealed securityContext in SecureChannel

### DIFF
--- a/src/Common/src/Interop/Windows/SspiCli/ISSPIInterface.cs
+++ b/src/Common/src/Interop/Windows/SspiCli/ISSPIInterface.cs
@@ -15,8 +15,8 @@ namespace System.Net
         int AcquireCredentialsHandle(string moduleName, Interop.SspiCli.CredentialUse usage, ref SafeSspiAuthDataHandle authdata, out SafeFreeCredentials outCredential);
         int AcquireCredentialsHandle(string moduleName, Interop.SspiCli.CredentialUse usage, ref Interop.SspiCli.SCHANNEL_CRED authdata, out SafeFreeCredentials outCredential);
         int AcquireDefaultCredential(string moduleName, Interop.SspiCli.CredentialUse usage, out SafeFreeCredentials outCredential);
-        int AcceptSecurityContext(SafeFreeCredentials credential, ref SafeDeleteContext context, ReadOnlySpan<SecurityBuffer> inputBuffers, Interop.SspiCli.ContextFlags inFlags, Interop.SspiCli.Endianness endianness, ref SecurityBuffer outputBuffer, ref Interop.SspiCli.ContextFlags outFlags);
-        int InitializeSecurityContext(ref SafeFreeCredentials credential, ref SafeDeleteContext context, string targetName, Interop.SspiCli.ContextFlags inFlags, Interop.SspiCli.Endianness endianness, ReadOnlySpan<SecurityBuffer> inputBuffers, ref SecurityBuffer outputBuffer, ref Interop.SspiCli.ContextFlags outFlags);
+        int AcceptSecurityContext(SafeFreeCredentials credential, ref SafeDeleteSslContext context, ReadOnlySpan<SecurityBuffer> inputBuffers, Interop.SspiCli.ContextFlags inFlags, Interop.SspiCli.Endianness endianness, ref SecurityBuffer outputBuffer, ref Interop.SspiCli.ContextFlags outFlags);
+        int InitializeSecurityContext(ref SafeFreeCredentials credential, ref SafeDeleteSslContext context, string targetName, Interop.SspiCli.ContextFlags inFlags, Interop.SspiCli.Endianness endianness, ReadOnlySpan<SecurityBuffer> inputBuffers, ref SecurityBuffer outputBuffer, ref Interop.SspiCli.ContextFlags outFlags);
         int EncryptMessage(SafeDeleteContext context, ref Interop.SspiCli.SecBufferDesc inputOutput, uint sequenceNumber);
         int DecryptMessage(SafeDeleteContext context, ref Interop.SspiCli.SecBufferDesc inputOutput, uint sequenceNumber);
         int MakeSignature(SafeDeleteContext context, ref Interop.SspiCli.SecBufferDesc inputOutput, uint sequenceNumber);
@@ -25,7 +25,7 @@ namespace System.Net
         int QueryContextChannelBinding(SafeDeleteContext phContext, Interop.SspiCli.ContextAttribute attribute, out SafeFreeContextBufferChannelBinding refHandle);
         int QueryContextAttributes(SafeDeleteContext phContext, Interop.SspiCli.ContextAttribute attribute, Span<byte> buffer, Type handleType, out SafeHandle refHandle);
         int QuerySecurityContextToken(SafeDeleteContext phContext, out SecurityContextTokenHandle phToken);
-        int CompleteAuthToken(ref SafeDeleteContext refContext, in SecurityBuffer inputBuffer);
+        int CompleteAuthToken(ref SafeDeleteSslContext refContext, in SecurityBuffer inputBuffer);
         int ApplyControlToken(ref SafeDeleteContext refContext, in SecurityBuffer inputBuffer);
     }
 }

--- a/src/Common/src/Interop/Windows/SspiCli/Interop.SSPI.cs
+++ b/src/Common/src/Interop/Windows/SspiCli/Interop.SSPI.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Net.Security;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 internal static partial class Interop
@@ -25,6 +26,7 @@ internal static partial class Interop
 
             public bool IsZero
             {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 get { return dwLower == IntPtr.Zero && dwUpper == IntPtr.Zero; }
             }
 

--- a/src/Common/src/Interop/Windows/SspiCli/Interop.SSPI.cs
+++ b/src/Common/src/Interop/Windows/SspiCli/Interop.SSPI.cs
@@ -29,9 +29,7 @@ internal static partial class Interop
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 get
                 {
-                    // Ternary operator returning true/false prevents redundant asm generation:
-                    // https://github.com/dotnet/coreclr/issues/914
-                    return dwLower == IntPtr.Zero && dwUpper == IntPtr.Zero ? true : false;
+                    return dwLower == IntPtr.Zero && dwUpper == IntPtr.Zero;
                 }
             }
 

--- a/src/Common/src/Interop/Windows/SspiCli/Interop.SSPI.cs
+++ b/src/Common/src/Interop/Windows/SspiCli/Interop.SSPI.cs
@@ -27,7 +27,12 @@ internal static partial class Interop
             public bool IsZero
             {
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                get { return dwLower == IntPtr.Zero && dwUpper == IntPtr.Zero; }
+                get
+                {
+                    // Ternary operator returning true/false prevents redundant asm generation:
+                    // https://github.com/dotnet/coreclr/issues/914
+                    return dwLower == IntPtr.Zero && dwUpper == IntPtr.Zero ? true : false;
+                }
             }
 
             internal void SetToInvalid()

--- a/src/Common/src/Interop/Windows/SspiCli/SSPIAuthType.cs
+++ b/src/Common/src/Interop/Windows/SspiCli/SSPIAuthType.cs
@@ -45,12 +45,12 @@ namespace System.Net
             return SafeFreeCredentials.AcquireCredentialsHandle(moduleName, usage, ref authdata, out outCredential);
         }
 
-        public int AcceptSecurityContext(SafeFreeCredentials credential, ref SafeDeleteContext context, ReadOnlySpan<SecurityBuffer> inputBuffers, Interop.SspiCli.ContextFlags inFlags, Interop.SspiCli.Endianness endianness, ref SecurityBuffer outputBuffer, ref Interop.SspiCli.ContextFlags outFlags)
+        public int AcceptSecurityContext(SafeFreeCredentials credential, ref SafeDeleteSslContext context, ReadOnlySpan<SecurityBuffer> inputBuffers, Interop.SspiCli.ContextFlags inFlags, Interop.SspiCli.Endianness endianness, ref SecurityBuffer outputBuffer, ref Interop.SspiCli.ContextFlags outFlags)
         {
             return SafeDeleteContext.AcceptSecurityContext(ref credential, ref context, inFlags, endianness, inputBuffers, ref outputBuffer, ref outFlags);
         }
 
-        public int InitializeSecurityContext(ref SafeFreeCredentials credential, ref SafeDeleteContext context, string targetName, Interop.SspiCli.ContextFlags inFlags, Interop.SspiCli.Endianness endianness, ReadOnlySpan<SecurityBuffer> inputBuffers, ref SecurityBuffer outputBuffer, ref Interop.SspiCli.ContextFlags outFlags)
+        public int InitializeSecurityContext(ref SafeFreeCredentials credential, ref SafeDeleteSslContext context, string targetName, Interop.SspiCli.ContextFlags inFlags, Interop.SspiCli.Endianness endianness, ReadOnlySpan<SecurityBuffer> inputBuffers, ref SecurityBuffer outputBuffer, ref Interop.SspiCli.ContextFlags outFlags)
         {
             return SafeDeleteContext.InitializeSecurityContext(ref credential, ref context, targetName, inFlags, endianness, inputBuffers, ref outputBuffer, ref outFlags);
         }
@@ -163,7 +163,7 @@ namespace System.Net
             return GetSecurityContextToken(phContext, out phToken);
         }
 
-        public int CompleteAuthToken(ref SafeDeleteContext refContext, in SecurityBuffer inputBuffer)
+        public int CompleteAuthToken(ref SafeDeleteSslContext refContext, in SecurityBuffer inputBuffer)
         {
             return SafeDeleteContext.CompleteAuthToken(ref refContext, in inputBuffer);
         }

--- a/src/Common/src/Interop/Windows/SspiCli/SSPISecureChannelType.cs
+++ b/src/Common/src/Interop/Windows/SspiCli/SSPISecureChannelType.cs
@@ -45,12 +45,12 @@ namespace System.Net
             return SafeFreeCredentials.AcquireCredentialsHandle(moduleName, usage, ref authdata, out outCredential);
         }
 
-        public int AcceptSecurityContext(SafeFreeCredentials credential, ref SafeDeleteContext context, ReadOnlySpan<SecurityBuffer> inputBuffers, Interop.SspiCli.ContextFlags inFlags, Interop.SspiCli.Endianness endianness, ref SecurityBuffer outputBuffer, ref Interop.SspiCli.ContextFlags outFlags)
+        public int AcceptSecurityContext(SafeFreeCredentials credential, ref SafeDeleteSslContext context, ReadOnlySpan<SecurityBuffer> inputBuffers, Interop.SspiCli.ContextFlags inFlags, Interop.SspiCli.Endianness endianness, ref SecurityBuffer outputBuffer, ref Interop.SspiCli.ContextFlags outFlags)
         {
             return SafeDeleteContext.AcceptSecurityContext(ref credential, ref context, inFlags, endianness, inputBuffers, ref outputBuffer, ref outFlags);
         }
 
-        public int InitializeSecurityContext(ref SafeFreeCredentials credential, ref SafeDeleteContext context, string targetName, Interop.SspiCli.ContextFlags inFlags, Interop.SspiCli.Endianness endianness, ReadOnlySpan<SecurityBuffer> inputBuffers, ref SecurityBuffer outputBuffer, ref Interop.SspiCli.ContextFlags outFlags)
+        public int InitializeSecurityContext(ref SafeFreeCredentials credential, ref SafeDeleteSslContext context, string targetName, Interop.SspiCli.ContextFlags inFlags, Interop.SspiCli.Endianness endianness, ReadOnlySpan<SecurityBuffer> inputBuffers, ref SecurityBuffer outputBuffer, ref Interop.SspiCli.ContextFlags outFlags)
         {
             return SafeDeleteContext.InitializeSecurityContext(ref credential, ref context, targetName, inFlags, endianness, inputBuffers, ref outputBuffer, ref outFlags);
         }
@@ -132,7 +132,7 @@ namespace System.Net
             throw new NotSupportedException();
         }
 
-        public int CompleteAuthToken(ref SafeDeleteContext refContext, in SecurityBuffer inputBuffer)
+        public int CompleteAuthToken(ref SafeDeleteSslContext refContext, in SecurityBuffer inputBuffer)
         {
             throw new NotSupportedException();
         }

--- a/src/Common/src/Interop/Windows/SspiCli/SSPIWrapper.cs
+++ b/src/Common/src/Interop/Windows/SspiCli/SSPIWrapper.cs
@@ -140,7 +140,7 @@ namespace System.Net
             return outCredential;
         }
 
-        internal static int InitializeSecurityContext(ISSPIInterface secModule, ref SafeFreeCredentials credential, ref SafeDeleteContext context, string targetName, Interop.SspiCli.ContextFlags inFlags, Interop.SspiCli.Endianness datarep, ReadOnlySpan<SecurityBuffer> inputBuffers, ref SecurityBuffer outputBuffer, ref Interop.SspiCli.ContextFlags outFlags)
+        internal static int InitializeSecurityContext(ISSPIInterface secModule, ref SafeFreeCredentials credential, ref SafeDeleteSslContext context, string targetName, Interop.SspiCli.ContextFlags inFlags, Interop.SspiCli.Endianness datarep, ReadOnlySpan<SecurityBuffer> inputBuffers, ref SecurityBuffer outputBuffer, ref Interop.SspiCli.ContextFlags outFlags)
         {
             if (NetEventSource.IsEnabled) NetEventSource.Log.InitializeSecurityContext(credential, context, targetName, inFlags);
 
@@ -151,7 +151,7 @@ namespace System.Net
             return errorCode;
         }
 
-        internal static int AcceptSecurityContext(ISSPIInterface secModule, SafeFreeCredentials credential, ref SafeDeleteContext context, Interop.SspiCli.ContextFlags inFlags, Interop.SspiCli.Endianness datarep, ReadOnlySpan<SecurityBuffer> inputBuffers, ref SecurityBuffer outputBuffer, ref Interop.SspiCli.ContextFlags outFlags)
+        internal static int AcceptSecurityContext(ISSPIInterface secModule, SafeFreeCredentials credential, ref SafeDeleteSslContext context, Interop.SspiCli.ContextFlags inFlags, Interop.SspiCli.Endianness datarep, ReadOnlySpan<SecurityBuffer> inputBuffers, ref SecurityBuffer outputBuffer, ref Interop.SspiCli.ContextFlags outFlags)
         {
             if (NetEventSource.IsEnabled) NetEventSource.Log.AcceptSecurityContext(credential, context, inFlags);
 
@@ -162,7 +162,7 @@ namespace System.Net
             return errorCode;
         }
 
-        internal static int CompleteAuthToken(ISSPIInterface secModule, ref SafeDeleteContext context, in SecurityBuffer inputBuffer)
+        internal static int CompleteAuthToken(ISSPIInterface secModule, ref SafeDeleteSslContext context, in SecurityBuffer inputBuffer)
         {
             int errorCode = secModule.CompleteAuthToken(ref context, in inputBuffer);
 

--- a/src/Common/src/Interop/Windows/SspiCli/SafeDeleteContext.cs
+++ b/src/Common/src/Interop/Windows/SspiCli/SafeDeleteContext.cs
@@ -5,6 +5,7 @@
 using Microsoft.Win32.SafeHandles;
 
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security.Authentication.ExtendedProtection;
 
@@ -33,6 +34,7 @@ namespace System.Net.Security
 
         public override bool IsInvalid
         {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
                 return IsClosed || _handle.IsZero;

--- a/src/Common/src/Interop/Windows/SspiCli/SafeDeleteContext.cs
+++ b/src/Common/src/Interop/Windows/SspiCli/SafeDeleteContext.cs
@@ -37,7 +37,9 @@ namespace System.Net.Security
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                return IsClosed || _handle.IsZero;
+                // Ternary operator returning true/false prevents redundant asm generation:
+                // https://github.com/dotnet/coreclr/issues/914
+                return IsClosed || _handle.IsZero ? true : false;
             }
         }
 

--- a/src/Common/src/Interop/Windows/SspiCli/SafeDeleteContext.cs
+++ b/src/Common/src/Interop/Windows/SspiCli/SafeDeleteContext.cs
@@ -37,9 +37,7 @@ namespace System.Net.Security
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                // Ternary operator returning true/false prevents redundant asm generation:
-                // https://github.com/dotnet/coreclr/issues/914
-                return IsClosed || _handle.IsZero ? true : false;
+                return IsClosed || _handle.IsZero;
             }
         }
 

--- a/src/Common/src/Interop/Windows/SspiCli/SecuritySafeHandles.cs
+++ b/src/Common/src/Interop/Windows/SspiCli/SecuritySafeHandles.cs
@@ -392,7 +392,7 @@ namespace System.Net.Security
         //-------------------------------------------------------------------
         internal static unsafe int InitializeSecurityContext(
             ref SafeFreeCredentials inCredentials,
-            ref SafeDeleteContext refContext,
+            ref SafeDeleteSslContext refContext,
             string targetName,
             Interop.SspiCli.ContextFlags inFlags,
             Interop.SspiCli.Endianness endianness,
@@ -483,7 +483,7 @@ namespace System.Net.Security
                             // incorrect arguments to InitializeSecurityContextW in cases where an "contextHandle" was
                             // already present and non-zero.
                             if (isContextAbsent)
-                                refContext = new SafeDeleteContext_SECURITY();
+                                refContext = new SafeDeleteSslContext();
                         }
 
                         if (targetName == null || targetName.Length == 0)
@@ -623,7 +623,7 @@ namespace System.Net.Security
         //-------------------------------------------------------------------
         internal static unsafe int AcceptSecurityContext(
             ref SafeFreeCredentials inCredentials,
-            ref SafeDeleteContext refContext,
+            ref SafeDeleteSslContext refContext,
             Interop.SspiCli.ContextFlags inFlags,
             Interop.SspiCli.Endianness endianness,
             ReadOnlySpan<SecurityBuffer> inSecBuffers,
@@ -715,7 +715,7 @@ namespace System.Net.Security
                             // incorrect arguments to AcceptSecurityContext in cases where an "contextHandle" was
                             // already present and non-zero.
                             if (isContextAbsent)
-                                refContext = new SafeDeleteContext_SECURITY();
+                                refContext = new SafeDeleteSslContext();
                         }
 
                         errorCode = MustRunAcceptSecurityContext_SECURITY(
@@ -840,7 +840,7 @@ namespace System.Net.Security
         }
 
         internal static unsafe int CompleteAuthToken(
-            ref SafeDeleteContext refContext,
+            ref SafeDeleteSslContext refContext,
             in SecurityBuffer inSecBuffer)
         {
             if (NetEventSource.IsEnabled)
@@ -879,7 +879,7 @@ namespace System.Net.Security
                     // build a new "refContext" in an attempt to maximize compat.
                     if (contextHandle.IsZero)
                     {
-                        refContext = new SafeDeleteContext_SECURITY();
+                        refContext = new SafeDeleteSslContext();
                     }
                 }
 
@@ -944,7 +944,7 @@ namespace System.Net.Security
                     // build a new "refContext" in an attempt to maximize compat.
                     if (contextHandle.IsZero)
                     {
-                        refContext = new SafeDeleteContext_SECURITY();
+                        refContext = new SafeDeleteSslContext();
                     }
                 }
 
@@ -968,9 +968,9 @@ namespace System.Net.Security
         }
     }
 
-    internal sealed class SafeDeleteContext_SECURITY : SafeDeleteContext
+    internal sealed class SafeDeleteSslContext : SafeDeleteContext
     {
-        internal SafeDeleteContext_SECURITY() : base() { }
+        internal SafeDeleteSslContext() : base() { }
 
         protected override bool ReleaseHandle()
         {

--- a/src/Common/src/System/Net/Security/NegotiateStreamPal.Windows.cs
+++ b/src/Common/src/System/Net/Security/NegotiateStreamPal.Windows.cs
@@ -109,17 +109,19 @@ namespace System.Net.Security
             var outSecurityBuffer = new SecurityBuffer(resultBlob, SecurityBufferType.SECBUFFER_TOKEN);
 
             Interop.SspiCli.ContextFlags outContextFlags = Interop.SspiCli.ContextFlags.Zero;
+            // There is only one SafeDeleteContext type on Windows which is SafeDeleteSslContext so this cast is safe.
+            SafeDeleteSslContext sslContext = (SafeDeleteSslContext)securityContext;
             Interop.SECURITY_STATUS winStatus = (Interop.SECURITY_STATUS)SSPIWrapper.InitializeSecurityContext(
                 GlobalSSPI.SSPIAuth,
                 ref credentialsHandle,
-                ref securityContext,
+                ref sslContext,
                 spn,
                 ContextFlagsAdapterPal.GetInteropFromContextFlagsPal(requestedContextFlags),
                 Interop.SspiCli.Endianness.SECURITY_NETWORK_DREP,
                 inSecurityBufferSpan,
                 ref outSecurityBuffer,
                 ref outContextFlags);
-
+            securityContext = sslContext;
             resultBlob = outSecurityBuffer.token;
             contextFlags = ContextFlagsAdapterPal.GetContextFlagsPalFromInterop(outContextFlags);
             return SecurityStatusAdapterPal.GetSecurityStatusPalFromInterop(winStatus);
@@ -129,11 +131,14 @@ namespace System.Net.Security
             ref SafeDeleteContext securityContext,
             byte[] incomingBlob)
         {
+            // There is only one SafeDeleteContext type on Windows which is SafeDeleteSslContext so this cast is safe.
+            SafeDeleteSslContext sslContext = (SafeDeleteSslContext)securityContext;
             var inSecurityBuffer = new SecurityBuffer(incomingBlob, SecurityBufferType.SECBUFFER_TOKEN);
             Interop.SECURITY_STATUS winStatus = (Interop.SECURITY_STATUS)SSPIWrapper.CompleteAuthToken(
                 GlobalSSPI.SSPIAuth,
-                ref securityContext,
+                ref sslContext,
                 in inSecurityBuffer);
+            securityContext = sslContext;
             return SecurityStatusAdapterPal.GetSecurityStatusPalFromInterop(winStatus);
         }
 
@@ -175,10 +180,12 @@ namespace System.Net.Security
             var outSecurityBuffer = new SecurityBuffer(resultBlob, SecurityBufferType.SECBUFFER_TOKEN);
 
             Interop.SspiCli.ContextFlags outContextFlags = Interop.SspiCli.ContextFlags.Zero;
+            // There is only one SafeDeleteContext type on Windows which is SafeDeleteSslContext so this cast is safe.
+            SafeDeleteSslContext sslContext = (SafeDeleteSslContext)securityContext;
             Interop.SECURITY_STATUS winStatus = (Interop.SECURITY_STATUS)SSPIWrapper.AcceptSecurityContext(
                 GlobalSSPI.SSPIAuth,
                 credentialsHandle,
-                ref securityContext,
+                ref sslContext,
                 ContextFlagsAdapterPal.GetInteropFromContextFlagsPal(requestedContextFlags),
                 Interop.SspiCli.Endianness.SECURITY_NETWORK_DREP,
                 inSecurityBufferSpan,
@@ -186,7 +193,7 @@ namespace System.Net.Security
                 ref outContextFlags);
 
             resultBlob = outSecurityBuffer.token;
-
+            securityContext = sslContext;
             contextFlags = ContextFlagsAdapterPal.GetContextFlagsPalFromInterop(outContextFlags);
             return SecurityStatusAdapterPal.GetSecurityStatusPalFromInterop(winStatus);
         }

--- a/src/System.Net.Security/src/System/Net/Security/NegoState.cs
+++ b/src/System.Net.Security/src/System/Net/Security/NegoState.cs
@@ -28,7 +28,6 @@ namespace System.Net.Security
         private static readonly AsyncCallback s_writeCallback = new AsyncCallback(WriteCallback);
 
         private readonly Stream _innerStream;
-        private readonly bool _leaveStreamOpen;
 
         private Exception _exception;
 
@@ -53,12 +52,11 @@ namespace System.Net.Security
         // This is a state variable used to gracefully handle auth confirmation.
         private bool _remoteOk = false;
 
-        internal NegoState(Stream innerStream, bool leaveStreamOpen)
+        internal NegoState(Stream innerStream)
         {
             Debug.Assert(innerStream != null);
 
             _innerStream = innerStream;
-            _leaveStreamOpen = leaveStreamOpen;
         }
 
         internal static string DefaultPackage
@@ -773,8 +771,7 @@ namespace System.Net.Security
 
         private unsafe byte[] GetOutgoingBlob(byte[] incomingBlob, ref Exception e)
         {
-            SecurityStatusPal statusCode;
-            byte[] message = _context.GetOutgoingBlob(incomingBlob, false, out statusCode);
+            byte[] message = _context.GetOutgoingBlob(incomingBlob, false, out SecurityStatusPal statusCode);
 
             if (IsError(statusCode))
             {

--- a/src/System.Net.Security/src/System/Net/Security/NegotiateStream.cs
+++ b/src/System.Net.Security/src/System/Net/Security/NegotiateStream.cs
@@ -41,7 +41,7 @@ namespace System.Net.Security
             using (DebugThreadTracking.SetThreadKind(ThreadKinds.User))
             {
 #endif
-                _negoState = new NegoState(innerStream, leaveInnerStreamOpen);
+                _negoState = new NegoState(innerStream);
                 _package = NegoState.DefaultPackage;
                 InitializeStreamPart();
 #if DEBUG

--- a/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -911,8 +911,7 @@ namespace System.Net.Security
         --*/
         internal SecurityStatusPal Encrypt(ReadOnlyMemory<byte> buffer, ref byte[] output, out int resultSize)
         {
-            bool logEnabled = NetEventSource.IsEnabled;
-            if (logEnabled)
+            if (NetEventSource.IsEnabled)
             {
                 NetEventSource.Enter(this, buffer, buffer.Length);
                 NetEventSource.DumpBuffer(this, buffer);
@@ -930,18 +929,14 @@ namespace System.Net.Security
 
             if (secStatus.ErrorCode != SecurityStatusPalErrorCode.OK)
             {
-                if (logEnabled)
-                {
+                if (NetEventSource.IsEnabled)
                     NetEventSource.Exit(this, $"ERROR {secStatus}");
-                }
             }
             else
             {
                 output = writeBuffer;
-                if (logEnabled)
-                {
+                if (NetEventSource.IsEnabled)
                     NetEventSource.Exit(this, $"OK data size:{resultSize}");
-                }
             }
 
             return secStatus;

--- a/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -143,9 +143,7 @@ namespace System.Net.Security
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                // Ternary operator returning true/false prevents redundant asm generation:
-                // https://github.com/dotnet/coreclr/issues/914
-                return (_securityContext == null || _securityContext.IsInvalid) ? false : true;
+                return !(_securityContext == null || _securityContext.IsInvalid);
             }
         }
 

--- a/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Security;
@@ -22,7 +23,7 @@ namespace System.Net.Security
         internal const int ReadHeaderSize = 5;
 
         private SafeFreeCredentials _credentialsHandle;
-        private SafeDeleteContext _securityContext;
+        private SafeDeleteSslContext _securityContext;
 
         private SslConnectionInfo _connectionInfo;
         private X509Certificate _selectedClientCertificate;
@@ -139,6 +140,7 @@ namespace System.Net.Security
 
         internal bool IsValidContext
         {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
                 return !(_securityContext == null || _securityContext.IsInvalid);
@@ -337,7 +339,7 @@ namespace System.Net.Security
             // Acquire possible Client Certificate information and set it on the handle.
             X509Certificate clientCertificate = null;        // This is a candidate that can come from the user callback or be guessed when targeting a session restart.
             List<X509Certificate> filteredCerts = null;      // This is an intermediate client certs collection that try to use if no selectedCert is available yet.
-            string[] issuers = null;                         // This is a list of issuers sent by the server, only valid is we do know what the server cert is.
+            string[] issuers;                                // This is a list of issuers sent by the server, only valid is we do know what the server cert is.
 
             bool sessionRestartAttempt = false; // If true and no cached creds we will use anonymous creds.
 
@@ -351,8 +353,7 @@ namespace System.Net.Security
                 X509Certificate2 remoteCert = null;
                 try
                 {
-                    X509Certificate2Collection dummyCollection;
-                    remoteCert = CertificateValidationPal.GetRemoteCertificate(_securityContext, out dummyCollection);
+                    remoteCert = CertificateValidationPal.GetRemoteCertificate(_securityContext, out X509Certificate2Collection dummyCollection);
                     if (_sslAuthenticationOptions.ClientCertificates == null)
                     {
                         _sslAuthenticationOptions.ClientCertificates = new X509CertificateCollection();
@@ -561,7 +562,7 @@ namespace System.Net.Security
                 //
                 // SECURITY: selectedCert ref if not null is a safe object that does not depend on possible **user** inherited X509Certificate type.
                 //
-                byte[] guessedThumbPrint = selectedCert == null ? null : selectedCert.GetCertHash();
+                byte[] guessedThumbPrint = selectedCert?.GetCertHash();
                 SafeFreeCredentials cachedCredentialHandle = SslSessionsCache.TryCachedCredential(guessedThumbPrint, _sslAuthenticationOptions.EnabledSslProtocols, _sslAuthenticationOptions.IsServer, _sslAuthenticationOptions.EncryptionPolicy);
 
                 // We can probably do some optimization here. If the selectedCert is returned by the delegate
@@ -908,7 +909,8 @@ namespace System.Net.Security
         --*/
         internal SecurityStatusPal Encrypt(ReadOnlyMemory<byte> buffer, ref byte[] output, out int resultSize)
         {
-            if (NetEventSource.IsEnabled)
+            bool logEnabled = NetEventSource.IsEnabled;
+            if (logEnabled)
             {
                 NetEventSource.Enter(this, buffer, buffer.Length);
                 NetEventSource.DumpBuffer(this, buffer);
@@ -926,14 +928,18 @@ namespace System.Net.Security
 
             if (secStatus.ErrorCode != SecurityStatusPalErrorCode.OK)
             {
-                if (NetEventSource.IsEnabled)
+                if (logEnabled)
+                {
                     NetEventSource.Exit(this, $"ERROR {secStatus}");
+                }
             }
             else
             {
                 output = writeBuffer;
-                if (NetEventSource.IsEnabled)
+                if (logEnabled)
+                {
                     NetEventSource.Exit(this, $"OK data size:{resultSize}");
+                }
             }
 
             return secStatus;
@@ -944,21 +950,19 @@ namespace System.Net.Security
             if (NetEventSource.IsEnabled)
                 NetEventSource.Enter(this, payload, offset, count);
 
-            if (offset < 0 || offset > (payload == null ? 0 : payload.Length))
+            if ((uint)offset > (uint)(payload == null ? 0 : payload.Length))
             {
                 NetEventSource.Fail(this, "Argument 'offset' out of range.");
                 throw new ArgumentOutOfRangeException(nameof(offset));
             }
 
-            if (count < 0 || count > (payload == null ? 0 : payload.Length - offset))
+            if ((uint)count > (uint)(payload == null ? 0 : payload.Length - offset))
             {
                 NetEventSource.Fail(this, "Argument 'count' out of range.");
                 throw new ArgumentOutOfRangeException(nameof(count));
             }
 
-            SecurityStatusPal secStatus = SslStreamPal.DecryptMessage(_securityContext, payload, ref offset, ref count);
-
-            return secStatus;
+            return SslStreamPal.DecryptMessage(_securityContext, payload, ref offset, ref count);
         }
 
         /*++
@@ -1313,7 +1317,7 @@ namespace System.Net.Security
         {
             // If it's not done, then there's got to be an error, even if it's
             // a Handshake message up, and we only have a Warning message.
-            return this.Done ? null : SslStreamPal.GetException(Status);
+            return Done ? null : SslStreamPal.GetException(Status);
         }
 
 #if TRACE_VERBOSE

--- a/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -143,7 +143,9 @@ namespace System.Net.Security
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                return !(_securityContext == null || _securityContext.IsInvalid);
+                // Ternary operator returning true/false prevents redundant asm generation:
+                // https://github.com/dotnet/coreclr/issues/914
+                return (_securityContext == null || _securityContext.IsInvalid) ? false : true;
             }
         }
 

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamPal.OSX.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamPal.OSX.cs
@@ -34,7 +34,7 @@ namespace System.Net.Security
 
         public static SecurityStatusPal AcceptSecurityContext(
             ref SafeFreeCredentials credential,
-            ref SafeDeleteContext context,
+            ref SafeDeleteSslContext context,
             ArraySegment<byte> inputBuffer,
             ref byte[] outputBuffer,
             SslAuthenticationOptions sslAuthenticationOptions)
@@ -44,7 +44,7 @@ namespace System.Net.Security
 
         public static SecurityStatusPal InitializeSecurityContext(
             ref SafeFreeCredentials credential,
-            ref SafeDeleteContext context,
+            ref SafeDeleteSslContext context,
             string targetName,
             ArraySegment<byte> inputBuffer,
             ref byte[] outputBuffer,
@@ -232,7 +232,7 @@ namespace System.Net.Security
 
         private static SecurityStatusPal HandshakeInternal(
             SafeFreeCredentials credential,
-            ref SafeDeleteContext context,
+            ref SafeDeleteSslContext context,
             ArraySegment<byte> inputBuffer,
             ref byte[] outputBuffer,
             SslAuthenticationOptions sslAuthenticationOptions)

--- a/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
@@ -27,13 +27,13 @@ namespace System.Net.Security
         {
         }
 
-        public static SecurityStatusPal AcceptSecurityContext(ref SafeFreeCredentials credential, ref SafeDeleteContext context,
+        public static SecurityStatusPal AcceptSecurityContext(ref SafeFreeCredentials credential, ref SafeDeleteSslContext context,
             ArraySegment<byte> inputBuffer, ref byte[] outputBuffer, SslAuthenticationOptions sslAuthenticationOptions)
         {
             return HandshakeInternal(credential, ref context, inputBuffer, ref outputBuffer, sslAuthenticationOptions);
         }
 
-        public static SecurityStatusPal InitializeSecurityContext(ref SafeFreeCredentials credential, ref SafeDeleteContext context, string targetName,
+        public static SecurityStatusPal InitializeSecurityContext(ref SafeFreeCredentials credential, ref SafeDeleteSslContext context, string targetName,
             ArraySegment<byte> inputBuffer, ref byte[] outputBuffer, SslAuthenticationOptions sslAuthenticationOptions)
         {
             return HandshakeInternal(credential, ref context, inputBuffer, ref outputBuffer, sslAuthenticationOptions);
@@ -99,7 +99,7 @@ namespace System.Net.Security
             return Interop.Ssl.ConvertAlpnProtocolListToByteArray(applicationProtocols);
         }
 
-        private static SecurityStatusPal HandshakeInternal(SafeFreeCredentials credential, ref SafeDeleteContext context,
+        private static SecurityStatusPal HandshakeInternal(SafeFreeCredentials credential, ref SafeDeleteSslContext context,
             ArraySegment<byte> inputBuffer, ref byte[] outputBuffer, SslAuthenticationOptions sslAuthenticationOptions)
         {
             Debug.Assert(!credential.IsInvalid);


### PR DESCRIPTION
Allows the virtual call in IsAuthenticated to become direct and inline and the method to be 2.5x faster (own time 35% -> 100%, Time 160ms -> 60ms)

Pre

![image](https://user-images.githubusercontent.com/1142958/62916245-7f95af80-bd8f-11e9-8d7f-162221150a86.png)

Post

![image](https://user-images.githubusercontent.com/1142958/62916257-90debc00-bd8f-11e9-9283-49f7154ddfd9.png)


Pre is preview8; Post also includes the improvements from https://github.com/dotnet/corefx/pull/39950; though that didn't effect IsAuthenticated.

Also now tailcalls into `DecryptMessage` which is why `SecureChannel.Decrypt` disappears from the trace


/cc @davidsh @wfurt @stephentoub