### PR TITLE
Don't attempt to add to readonly collections and dictionaries

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoCommon.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoCommon.cs
@@ -164,8 +164,11 @@ namespace System.Text.Json
 
             // TODO: Use reflection to support types implementing Stack or Queue.
 
-            ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(collectionPropertyInfo.DeclaredPropertyType, jsonPath, exception);
-            return null;
+            throw ThrowHelper.GetNotSupportedException_SerializationNotSupportedCollection(
+                collectionPropertyInfo.DeclaredPropertyType,
+                collectionPropertyInfo.ParentClassType,
+                collectionPropertyInfo.PropertyInfo,
+                exception);
         }
 
         public override object CreateDerivedDictionaryInstance(JsonPropertyInfo collectionPropertyInfo, IDictionary sourceDictionary, string jsonPath, JsonSerializerOptions options)
@@ -200,8 +203,11 @@ namespace System.Text.Json
             // TODO: Use reflection to support types implementing SortedList and maybe immutable dictionaries.
 
             // Types implementing SortedList and immutable dictionaries will fail here.
-            ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(collectionPropertyInfo.DeclaredPropertyType, jsonPath, exception);
-            return null;
+            throw ThrowHelper.GetNotSupportedException_SerializationNotSupportedCollection(
+                collectionPropertyInfo.DeclaredPropertyType,
+                collectionPropertyInfo.ParentClassType,
+                collectionPropertyInfo.PropertyInfo,
+                exception);
         }
 
         public override IEnumerable CreateIEnumerableInstance(Type parentType, IList sourceList, string jsonPath, JsonSerializerOptions options)

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoCommon.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoCommon.cs
@@ -121,7 +121,7 @@ namespace System.Text.Json
         {
             object instance = collectionPropertyInfo.DeclaredTypeClassInfo.CreateObject();
 
-            if (instance is IList instanceOfIList)
+            if (instance is IList instanceOfIList && !instanceOfIList.IsReadOnly)
             {
                 foreach (object item in sourceList)
                 {
@@ -129,7 +129,7 @@ namespace System.Text.Json
                 }
                 return instanceOfIList;
             }
-            else if (instance is ICollection<TRuntimeProperty> instanceOfICollection)
+            else if (instance is ICollection<TRuntimeProperty> instanceOfICollection && !instanceOfICollection.IsReadOnly)
             {
                 foreach (TRuntimeProperty item in sourceList)
                 {
@@ -164,7 +164,7 @@ namespace System.Text.Json
         {
             object instance = collectionPropertyInfo.DeclaredTypeClassInfo.CreateObject();
 
-            if (instance is IDictionary instanceOfIDictionary)
+            if (instance is IDictionary instanceOfIDictionary && !instanceOfIDictionary.IsReadOnly)
             {
                 foreach (DictionaryEntry entry in sourceDictionary)
                 {
@@ -172,7 +172,7 @@ namespace System.Text.Json
                 }
                 return instanceOfIDictionary;
             }
-            else if (instance is IDictionary<string, TRuntimeProperty> instanceOfGenericIDictionary)
+            else if (instance is IDictionary<string, TRuntimeProperty> instanceOfGenericIDictionary && !instanceOfGenericIDictionary.IsReadOnly)
             {
                 foreach (DictionaryEntry entry in sourceDictionary)
                 {

--- a/src/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -18,14 +18,14 @@ namespace System.Text.Json
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static NotSupportedException GetNotSupportedException_SerializationNotSupportedCollection(Type propertyType, Type parentType, MemberInfo memberInfo)
+        public static NotSupportedException GetNotSupportedException_SerializationNotSupportedCollection(Type propertyType, Type parentType, MemberInfo memberInfo, Exception innerException = null)
         {
             if (parentType != null && parentType != typeof(object) && memberInfo != null)
             {
-                return new NotSupportedException(SR.Format(SR.SerializationNotSupportedCollection, propertyType, $"{parentType}.{memberInfo.Name}"));
+                return new NotSupportedException(SR.Format(SR.SerializationNotSupportedCollection, propertyType, $"{parentType}.{memberInfo.Name}"), innerException);
             }
 
-            return new NotSupportedException(SR.Format(SR.SerializationNotSupportedCollectionType, propertyType));
+            return new NotSupportedException(SR.Format(SR.SerializationNotSupportedCollectionType, propertyType), innerException);
         }
 
         public static void ThrowInvalidOperationException_SerializerCycleDetected(int maxDepth)

--- a/src/System.Text.Json/tests/Serialization/TestClasses.GenericCollections.cs
+++ b/src/System.Text.Json/tests/Serialization/TestClasses.GenericCollections.cs
@@ -199,7 +199,7 @@ namespace System.Text.Json.Serialization.Tests
 
         public int Count => _list.Count;
 
-        public bool IsReadOnly => ((ICollection<string>)_list).IsReadOnly;
+        public virtual bool IsReadOnly => ((ICollection<string>)_list).IsReadOnly;
 
         public void Add(string item)
         {
@@ -237,6 +237,11 @@ namespace System.Text.Json.Serialization.Tests
         }
     }
 
+    public class ReadOnlyStringICollectionWrapper : StringICollectionWrapper
+    {
+        public override bool IsReadOnly => true;
+    }
+
     public class StringIListWrapper : IList<string>
     {
         private readonly List<string> _list = new List<string>();
@@ -245,7 +250,7 @@ namespace System.Text.Json.Serialization.Tests
 
         public int Count => _list.Count;
 
-        public bool IsReadOnly => ((IList<string>)_list).IsReadOnly;
+        public virtual bool IsReadOnly => ((IList<string>)_list).IsReadOnly;
 
         public void Add(string item)
         {
@@ -296,6 +301,11 @@ namespace System.Text.Json.Serialization.Tests
         {
             return ((IList<string>)_list).GetEnumerator();
         }
+    }
+
+    public class ReadOnlyStringIListWrapper : StringIListWrapper
+    {
+        public override bool IsReadOnly => true;
     }
 
     public class GenericIListWrapper<T> : IList<T>
@@ -714,7 +724,7 @@ namespace System.Text.Json.Serialization.Tests
 
         public int Count => ((IDictionary<string, string>)_dictionary).Count;
 
-        public bool IsReadOnly => ((IDictionary<string, string>)_dictionary).IsReadOnly;
+        public virtual bool IsReadOnly => ((IDictionary<string, string>)_dictionary).IsReadOnly;
 
         public void Add(string key, string value)
         {
@@ -770,6 +780,11 @@ namespace System.Text.Json.Serialization.Tests
         {
             return ((IDictionary<string, string>)_dictionary).GetEnumerator();
         }
+    }
+
+    public class ReadOnlyStringToStringIDictionaryWrapper : StringToStringIDictionaryWrapper
+    {
+        public override bool IsReadOnly => true;
     }
 
     public class StringToObjectIDictionaryWrapper : IDictionary<string, object>

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
@@ -1145,5 +1145,13 @@ namespace System.Text.Json.Serialization.Tests
         {
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<StringCollection>(@"[""1"", ""2""]"));
         }
+
+        [Fact]
+        public static void ReadReadOnlyCollections_Throws()
+        {
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ReadOnlyStringIListWrapper>(@"[""1"", ""2""]"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ReadOnlyStringICollectionWrapper>(@"[""1"", ""2""]"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ReadOnlyStringToStringIDictionaryWrapper>(@"{""Key"":""key"",""Value"":""value""}"));
+        }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
@@ -1143,7 +1143,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadPrimitiveStringCollection_Throws()
         {
-            Assert.Throws<InvalidCastException>(() => JsonSerializer.Deserialize<StringCollection>(@"[""1"", ""2""]"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<StringCollection>(@"[""1"", ""2""]"));
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
+using System;
 using Xunit;
 
 namespace System.Text.Json.Serialization.Tests
@@ -1143,15 +1144,15 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadPrimitiveStringCollection_Throws()
         {
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<StringCollection>(@"[""1"", ""2""]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<StringCollection>(@"[""1"", ""2""]"));
         }
 
         [Fact]
         public static void ReadReadOnlyCollections_Throws()
         {
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ReadOnlyStringIListWrapper>(@"[""1"", ""2""]"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ReadOnlyStringICollectionWrapper>(@"[""1"", ""2""]"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ReadOnlyStringToStringIDictionaryWrapper>(@"{""Key"":""key"",""Value"":""value""}"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ReadOnlyStringIListWrapper>(@"[""1"", ""2""]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ReadOnlyStringICollectionWrapper>(@"[""1"", ""2""]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ReadOnlyStringToStringIDictionaryWrapper>(@"{""Key"":""key"",""Value"":""value""}"));
         }
     }
 }


### PR DESCRIPTION
Also added try/catch blocks to properly catch potential exceptions that could occur when calling `Add` and wrap them in a `JsonException`.

Closes #40237