### PR TITLE
Introduce UInt32 versions of Skip(Last) and Take(Last) LINQ functions

### DIFF
--- a/src/System.Linq/src/System/Linq/Skip.cs
+++ b/src/System.Linq/src/System/Linq/Skip.cs
@@ -9,6 +9,11 @@ namespace System.Linq
 {
     public static partial class Enumerable
     {
+        public static IEnumerable<TSource> Skip<TSource>(this IEnumerable<TSource> source, uint count)
+        {
+            Skip( source, (int)count );
+        }
+
         public static IEnumerable<TSource> Skip<TSource>(this IEnumerable<TSource> source, int count)
         {
             if (source == null)
@@ -34,7 +39,7 @@ namespace System.Linq
 
             return SkipIterator(source, count);
         }
-
+        
         public static IEnumerable<TSource> SkipWhile<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
             if (source == null)
@@ -113,6 +118,11 @@ namespace System.Linq
             }
         }
 
+        public static IEnumerable<TSource> SkipLast<TSource>(this IEnumerable<TSource> source, uint count)
+        {
+            SkipLast( source, (int)count );
+        }
+        
         public static IEnumerable<TSource> SkipLast<TSource>(this IEnumerable<TSource> source, int count)
         {
             if (source == null)

--- a/src/System.Linq/src/System/Linq/Take.cs
+++ b/src/System.Linq/src/System/Linq/Take.cs
@@ -9,6 +9,11 @@ namespace System.Linq
 {
     public static partial class Enumerable
     {
+        public static IEnumerable<TSource> Take<TSource>(this IEnumerable<TSource> source, uint count)
+        {
+            Take( source, (int)count );
+        }
+            
         public static IEnumerable<TSource> Take<TSource>(this IEnumerable<TSource> source, int count)
         {
             if (source == null)
@@ -81,6 +86,11 @@ namespace System.Linq
 
                 yield return element;
             }
+        }
+
+        public static IEnumerable<TSource> TakeLast<TSource>(this IEnumerable<TSource> source, uint count)
+        {
+            TakeLast( source, (int)count );
         }
 
         public static IEnumerable<TSource> TakeLast<TSource>(this IEnumerable<TSource> source, int count)


### PR DESCRIPTION
I was working with a library that returned lots of UInt32 values for the size of the results and thought introducing these might be useful. They simply delegate the work to the existing codebase after a cast.

Is this a worthwhile addition? or does it simply pollute the Enumerable class