### PR TITLE
[WIP] Throw HttpRequestException from HttpClient instead of TaskCanceledException on Timeouts

### DIFF
--- a/src/System.Net.Http/src/Resources/Strings.resx
+++ b/src/System.Net.Http/src/Resources/Strings.resx
@@ -528,4 +528,7 @@
   <data name="net_http_server_shutdown" xml:space="preserve">
     <value>The server shut down the connection.</value>
   </data>
+  <data name="net_http_timeout" xml:space="preserve">
+    <value>The operation has timed out.</value>
+  </data>
 </root>

--- a/src/System.Net.Http/src/System/Net/Http/HttpClient.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClient.cs
@@ -544,7 +544,7 @@ namespace System.Net.Http
             catch (OperationCanceledException e) when (isTimeout(e))
             {
                 HandleFinishSendAsyncError(e, cts);
-                throw new TimeoutException(SR.net_http_timeout, e);
+                throw CreateTimeoutException(e);
             }
             catch (Exception e)
             {
@@ -575,7 +575,7 @@ namespace System.Net.Http
             catch (OperationCanceledException e) when (isTimeout(e))
             {
                 HandleFinishSendAsyncError(e, cts);
-                throw new TimeoutException(SR.net_http_timeout, e);
+                throw CreateTimeoutException(e);
             }
             catch (Exception e)
             {
@@ -768,6 +768,15 @@ namespace System.Net.Http
 
         private HttpRequestMessage CreateRequestMessage(HttpMethod method, Uri uri) =>
             new HttpRequestMessage(method, uri) { Version = _defaultRequestVersion };
+
+        private Exception CreateTimeoutException(Exception innerException)
+        {
+            return new HttpRequestException(
+                SR.net_http_timeout,
+                new TimeoutException(SR.net_http_timeout, innerException),
+                true);
+        }
+
         #endregion Private Helpers
     }
 }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -391,7 +391,11 @@ namespace System.Net.Http.Functional.Tests
             {
                 client.Timeout = TimeSpan.FromMilliseconds(1);
                 Task<HttpResponseMessage>[] tasks = Enumerable.Range(0, 3).Select(_ => client.GetAsync(CreateFakeUri(), completionOption)).ToArray();
-                Assert.All(tasks, task => Assert.Throws<TimeoutException>(() => task.GetAwaiter().GetResult()));
+                Assert.All(tasks, task =>
+                {
+                    var ex = Assert.Throws<HttpRequestException>(() => task.GetAwaiter().GetResult());
+                    Assert.IsType<TimeoutException>(ex.InnerException);
+                });
             }
         }
 


### PR DESCRIPTION
Fixes #20296

WIP because @karelz mentioned several possible options to solve the problem in https://github.com/dotnet/corefx/issues/20296#issuecomment-397846112, and I don't know which one will be chosen. I implemented my favorite option, but I can change the code as requested.