### PR TITLE
Fix regression in GetAsync_AllowedSSLVersion_Succeeds

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
@@ -139,7 +139,7 @@ namespace System.Net.Http.Functional.Tests
                     // restrictions on minimum TLS/SSL version
                     // We currently know that some platforms like Debian 10 OpenSSL
                     // will by default block < TLS 1.2
-                    handler.SslProtocols = SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12;
+                    handler.SslProtocols = SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12 | SslProtocols.Tls13;
                 }
 
                 var options = new LoopbackServer.Options { UseSsl = true, SslProtocols = acceptedProtocol };


### PR DESCRIPTION
When fixing debian failures here https://github.com/dotnet/corefx/pull/40259 I have accidentally broke Ubuntu 19.04, since it doesn't run on the CI it went unnoticed.

**Requires full test run to be green** (same as official run):
https://dnceng.visualstudio.com/public/_build/results?buildId=307602

The problem was that on Debian this specific test did not test TLS1.3 but on `PlatformDetection.IsUbuntu1810OrHigher` it does which caused that I incorrectly assumed that ALL means TLS1.0-TLS1.2