### PR TITLE
Fixed Dispose in JsonDocument and JsonDocument.MetadataDb in order to guard against multiple calls to ArrayPool.Return

### DIFF
--- a/src/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/System.Text.Json/src/System.Text.Json.csproj
@@ -205,6 +205,7 @@
     <Reference Include="System.Numerics.Vectors" />
     <Reference Include="System.Runtime.CompilerServices.Unsafe" />
     <Reference Include="System.Text.Encodings.Web" />
+    <Reference Include="System.Threading" />
     <Reference Include="System.Threading.Tasks" />
     <Reference Include="System.Threading.Tasks.Extensions" />
   </ItemGroup>

--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.MetadataDb.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.MetadataDb.cs
@@ -5,6 +5,7 @@
 using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace System.Text.Json
 {
@@ -148,7 +149,7 @@ namespace System.Text.Json
 
             public void Dispose()
             {
-                byte[] data = Threading.Interlocked.Exchange(ref _data, null);
+                byte[] data = Interlocked.Exchange(ref _data, null);
                 if (data == null)
                 {
                     return;

--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.MetadataDb.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.MetadataDb.cs
@@ -162,7 +162,6 @@ namespace System.Text.Json
                 // lengths of tokens in a document, but no content; so it does not
                 // need to be cleared.
                 ArrayPool<byte>.Shared.Return(data);
-                _data = null;
                 Length = 0;
             }
 

--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.MetadataDb.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.MetadataDb.cs
@@ -148,7 +148,8 @@ namespace System.Text.Json
 
             public void Dispose()
             {
-                if (_data == null)
+                byte[] data = Threading.Interlocked.Exchange(ref _data, null);
+                if (data == null)
                 {
                     return;
                 }
@@ -160,7 +161,7 @@ namespace System.Text.Json
                 // The data in this rented buffer only conveys the positions and
                 // lengths of tokens in a document, but no content; so it does not
                 // need to be cleared.
-                ArrayPool<byte>.Shared.Return(_data);
+                ArrayPool<byte>.Shared.Return(data);
                 _data = null;
                 Length = 0;
             }

--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
@@ -73,8 +73,6 @@ namespace System.Text.Json
             {
                 extraRentedBytes.AsSpan(0, length).Clear();
                 ArrayPool<byte>.Shared.Return(extraRentedBytes);
-
-                _extraRentedBytes = null;
             }
         }
 

--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
@@ -8,6 +8,7 @@ using System.Buffers.Text;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
+using System.Threading;
 
 namespace System.Text.Json
 {
@@ -67,7 +68,7 @@ namespace System.Text.Json
 
             // When "extra rented bytes exist" they contain the document,
             // and thus need to be cleared before being returned.
-            byte[] extraRentedBytes = Threading.Interlocked.Exchange(ref _extraRentedBytes, null);
+            byte[] extraRentedBytes = Interlocked.Exchange(ref _extraRentedBytes, null);
 
             if (extraRentedBytes != null)
             {

--- a/src/System.Text.Json/tests/JsonDocumentTests.cs
+++ b/src/System.Text.Json/tests/JsonDocumentTests.cs
@@ -3737,6 +3737,7 @@ namespace System.Text.Json.Tests
 
             // When ArrayPool gets corrupted, the Rent method might return an already rented array, which is incorrect.
             // So we will rent as many arrays as calls to JsonElement.Dispose and check they are unique.
+            // The minimum length that we ask for is a mirror of the size of the string passed to JsonDocument.Parse.
             HashSet<byte[]> uniqueAddresses = new HashSet<byte[]>();
             while (count > 0)
             {


### PR DESCRIPTION
Fixes #39930 
* Fixed Dispose in JsonDocument and JsonDocument.MetadataDb in order to guard against multiple calls to ArrayPool.Return when invoking from several threads at once.
* Added condition to validate _utf8Json.Length is > 0 in order to prevent that `extraRentedBytes.AsSpan(0, length).Clear()` takes a zero length range in a race condition.
* Added test related to this scenario.