### PR TITLE
Fix BytesConsumed when reading JSON numbers within a multi-segment ReadOnlySequence via Utf8JsonReader

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
@@ -88,8 +88,11 @@ namespace System.Text.Json
                 }
                 else
                 {
+                    // Make sure to advance _nextPosition in this case so that it is no longer the same as _currentPosition
                     _isLastSegment = !jsonData.TryGet(ref _nextPosition, out _, advance: true) && isFinalBlock; // Don't re-order to avoid short-circuiting
                 }
+
+                Debug.Assert(!_nextPosition.Equals(_currentPosition));
 
                 _isMultiSegment = true;
             }

--- a/src/System.Text.Json/tests/JsonTestHelper.cs
+++ b/src/System.Text.Json/tests/JsonTestHelper.cs
@@ -167,9 +167,7 @@ namespace System.Text.Json
             ReadOnlyMemory<byte> secondMem = dataMemory.Slice(splitLocation);
             BufferSegment<byte> secondSegment = firstSegment.Append(secondMem);
 
-            var sequence = new ReadOnlySequence<byte>(firstSegment, 0, secondSegment, secondMem.Length);
-            Debug.Assert(data.AsSpan().SequenceEqual(sequence.ToArray()));
-            return sequence;
+            return new ReadOnlySequence<byte>(firstSegment, 0, secondSegment, secondMem.Length);
         }
 
         public static ReadOnlySequence<byte> CreateSegments(byte[] data, int firstSplit, int secondSplit)
@@ -187,9 +185,7 @@ namespace System.Text.Json
             ReadOnlyMemory<byte> thirdMem = dataMemory.Slice(secondSplit);
             BufferSegment<byte> thirdSegment = secondSegment.Append(thirdMem);
 
-            var sequence = new ReadOnlySequence<byte>(firstSegment, 0, thirdSegment, thirdMem.Length);
-            Debug.Assert(data.AsSpan().SequenceEqual(sequence.ToArray()));
-            return sequence;
+            return new ReadOnlySequence<byte>(firstSegment, 0, thirdSegment, thirdMem.Length);
         }
 
         public static ReadOnlySequence<byte> GetSequence(byte[] dataUtf8, int segmentSize)
@@ -207,9 +203,7 @@ namespace System.Text.Json
             buffers[numberOfSegments - 1] = new byte[remaining];
             Array.Copy(dataUtf8, dataUtf8.Length - remaining, buffers[numberOfSegments - 1], 0, remaining);
 
-            ReadOnlySequence<byte> sequence = BufferFactory.Create(buffers);
-            Debug.Assert(dataUtf8.AsSpan().SequenceEqual(sequence.ToArray()));
-            return sequence;
+            return BufferFactory.Create(buffers);
         }
 
         public static List<ReadOnlySequence<byte>> GetSequences(ReadOnlyMemory<byte> dataMemory)

--- a/src/System.Text.Json/tests/JsonTestHelper.cs
+++ b/src/System.Text.Json/tests/JsonTestHelper.cs
@@ -161,6 +161,7 @@ namespace System.Text.Json
         public static ReadOnlySequence<byte> CreateSegments(byte[] data, int splitLocation)
         {
             Debug.Assert(splitLocation <= data.Length);
+
             ReadOnlyMemory<byte> dataMemory = data;
 
             var firstSegment = new BufferSegment<byte>(dataMemory.Slice(0, splitLocation));
@@ -172,9 +173,7 @@ namespace System.Text.Json
 
         public static ReadOnlySequence<byte> CreateSegments(byte[] data, int firstSplit, int secondSplit)
         {
-            Debug.Assert(firstSplit <= data.Length);
-            Debug.Assert(secondSplit <= data.Length);
-            Debug.Assert(firstSplit <= secondSplit);
+            Debug.Assert(firstSplit <= data.Length && secondSplit <= data.Length && firstSplit <= secondSplit);
 
             ReadOnlyMemory<byte> dataMemory = data;
 

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
@@ -38,6 +38,108 @@ namespace System.Text.Json.Tests
         }
 
         [Fact]
+        public static void EmptySequenceSegments()
+        {
+            ReadOnlyMemory<byte> dataMemory = Array.Empty<byte>();
+
+            var firstSegment = new BufferSegment<byte>(dataMemory.Slice(0, 0));
+            ReadOnlyMemory<byte> secondMem = dataMemory.Slice(0, 0);
+            BufferSegment<byte> secondSegment = firstSegment.Append(secondMem);
+
+            var sequence = new ReadOnlySequence<byte>(firstSegment, 0, secondSegment, secondMem.Length);
+
+            Assert.ThrowsAny<JsonException>(() =>
+            {
+                var json = new Utf8JsonReader(sequence, isFinalBlock: true, state: default);
+
+                Assert.Equal(0, json.BytesConsumed);
+                Assert.Equal(0, json.TokenStartIndex);
+                Assert.Equal(0, json.CurrentDepth);
+                Assert.Equal(JsonTokenType.None, json.TokenType);
+                Assert.NotEqual(default, json.Position);
+                Assert.False(json.HasValueSequence);
+                Assert.True(json.ValueSpan.SequenceEqual(default));
+                Assert.True(json.ValueSequence.IsEmpty);
+
+                Assert.Equal(64, json.CurrentState.Options.MaxDepth);
+                Assert.False(json.CurrentState.Options.AllowTrailingCommas);
+                Assert.Equal(JsonCommentHandling.Disallow, json.CurrentState.Options.CommentHandling);
+
+                json.Read();
+            });
+        }
+
+        [Theory]
+        [InlineData("2e2", 200)]
+        [InlineData("2e+2", 200)]
+        [InlineData("123e-01", 12.3)]
+        [InlineData("0", 0)]
+        [InlineData("0.1", 0.1)]
+        [InlineData("-0", 0)]
+        [InlineData("-0.1", -0.1)]
+        [InlineData("   2e2   ", 200)]
+        [InlineData("   2e+2   ", 200)]
+        [InlineData("   123e-01   ", 12.3)]
+        [InlineData("   0   ", 0)]
+        [InlineData("   0.1   ", 0.1)]
+        [InlineData("   -0   ", 0)]
+        [InlineData("   -0.1   ", -0.1)]
+        [InlineData("[2e2]", 200)]
+        [InlineData("[2e+2]", 200)]
+        [InlineData("[123e-01]", 12.3)]
+        [InlineData("[0]", 0)]
+        [InlineData("[0.1]", 0.1)]
+        [InlineData("[-0]", 0)]
+        [InlineData("[-0.1]", -0.1)]
+        [InlineData("{\"foo\": 2e2}", 200)]
+        [InlineData("{\"foo\": 2e+2}", 200)]
+        [InlineData("{\"foo\": 123e-01}", 12.3)]
+        [InlineData("{\"foo\": 0}", 0)]
+        [InlineData("{\"foo\": 0.1}", 0.1)]
+        [InlineData("{\"foo\": -0}", 0)]
+        [InlineData("{\"foo\": -0.1}", -0.1)]
+        public static void ReadDoubleVariousSegmentSizes(string input, double expectedValue)
+        {
+            byte[] utf8 = Encoding.UTF8.GetBytes(input);
+
+            var jsonReader = new Utf8JsonReader(utf8);
+            ReadDoubleHelper(ref jsonReader, utf8.Length, expectedValue);
+
+            ReadOnlySequence<byte> sequence = JsonTestHelper.GetSequence(utf8, 1);
+            jsonReader = new Utf8JsonReader(sequence);
+            ReadDoubleHelper(ref jsonReader, utf8.Length, expectedValue);
+
+            for (int splitLocation = 0; splitLocation < utf8.Length; splitLocation++)
+            {
+                sequence = JsonTestHelper.CreateSegments(utf8, splitLocation);
+                jsonReader = new Utf8JsonReader(sequence);
+                ReadDoubleHelper(ref jsonReader, utf8.Length, expectedValue);
+            }
+
+            for (int splitLocation = 0; splitLocation < utf8.Length; splitLocation++)
+            {
+                for (int j = splitLocation; j < utf8.Length; j++)
+                {
+                    sequence = JsonTestHelper.CreateSegments(utf8, splitLocation, j);
+                    jsonReader = new Utf8JsonReader(sequence);
+                    ReadDoubleHelper(ref jsonReader, utf8.Length, expectedValue);
+                }
+            }
+        }
+
+        private static void ReadDoubleHelper(ref Utf8JsonReader jsonReader, int expectedBytesConsumed, double expectedValue)
+        {
+            while (jsonReader.Read())
+            {
+                if (jsonReader.TokenType == JsonTokenType.Number)
+                {
+                    Assert.Equal(expectedValue, jsonReader.GetDouble());
+                }
+            }
+            Assert.Equal(expectedBytesConsumed, jsonReader.BytesConsumed);
+        }
+
+        [Fact]
         public static void InitialStateSimpleCtorMultiSegment()
         {
             byte[] utf8 = Encoding.UTF8.GetBytes("1");

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
@@ -65,7 +65,7 @@ namespace System.Text.Json.Tests
                 Assert.False(json.CurrentState.Options.AllowTrailingCommas);
                 Assert.Equal(JsonCommentHandling.Disallow, json.CurrentState.Options.CommentHandling);
 
-                json.Read();
+                json.Read(); // this should throw
             });
         }
 
@@ -98,7 +98,7 @@ namespace System.Text.Json.Tests
         [InlineData("{\"foo\": 0.1}", 0.1)]
         [InlineData("{\"foo\": -0}", 0)]
         [InlineData("{\"foo\": -0.1}", -0.1)]
-        public static void ReadDoubleVariousSegmentSizes(string input, double expectedValue)
+        public static void ReadJsonWithNumberVariousSegmentSizes(string input, double expectedValue)
         {
             byte[] utf8 = Encoding.UTF8.GetBytes(input);
 

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
@@ -116,11 +116,11 @@ namespace System.Text.Json.Tests
                 ReadDoubleHelper(ref jsonReader, utf8.Length, expectedValue);
             }
 
-            for (int splitLocation = 0; splitLocation < utf8.Length; splitLocation++)
+            for (int firstSplit = 0; firstSplit < utf8.Length; firstSplit++)
             {
-                for (int j = splitLocation; j < utf8.Length; j++)
+                for (int secondSplit = firstSplit; secondSplit < utf8.Length; secondSplit++)
                 {
-                    sequence = JsonTestHelper.CreateSegments(utf8, splitLocation, j);
+                    sequence = JsonTestHelper.CreateSegments(utf8, firstSplit, secondSplit);
                     jsonReader = new Utf8JsonReader(sequence);
                     ReadDoubleHelper(ref jsonReader, utf8.Length, expectedValue);
                 }

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
@@ -70,50 +70,50 @@ namespace System.Text.Json.Tests
         }
 
         [Theory]
-        [InlineData("2e2", 200)]
-        [InlineData("2e+2", 200)]
-        [InlineData("123e-01", 12.3)]
-        [InlineData("0", 0)]
-        [InlineData("0.1", 0.1)]
-        [InlineData("-0", 0)]
-        [InlineData("-0.1", -0.1)]
-        [InlineData("   2e2   ", 200)]
-        [InlineData("   2e+2   ", 200)]
-        [InlineData("   123e-01   ", 12.3)]
-        [InlineData("   0   ", 0)]
-        [InlineData("   0.1   ", 0.1)]
-        [InlineData("   -0   ", 0)]
-        [InlineData("   -0.1   ", -0.1)]
-        [InlineData("[2e2]", 200)]
-        [InlineData("[2e+2]", 200)]
-        [InlineData("[123e-01]", 12.3)]
-        [InlineData("[0]", 0)]
-        [InlineData("[0.1]", 0.1)]
-        [InlineData("[-0]", 0)]
-        [InlineData("[-0.1]", -0.1)]
-        [InlineData("{\"foo\": 2e2}", 200)]
-        [InlineData("{\"foo\": 2e+2}", 200)]
-        [InlineData("{\"foo\": 123e-01}", 12.3)]
-        [InlineData("{\"foo\": 0}", 0)]
-        [InlineData("{\"foo\": 0.1}", 0.1)]
-        [InlineData("{\"foo\": -0}", 0)]
-        [InlineData("{\"foo\": -0.1}", -0.1)]
-        public static void ReadJsonWithNumberVariousSegmentSizes(string input, double expectedValue)
+        [InlineData("2e2", 200, 3)]
+        [InlineData("2e+2", 200, 4)]
+        [InlineData("123e-01", 12.3, 7)]
+        [InlineData("0", 0, 1)]
+        [InlineData("0.1", 0.1, 3)]
+        [InlineData("-0", 0, 2)]
+        [InlineData("-0.1", -0.1, 4)]
+        [InlineData("   2e2   ", 200, 3)]
+        [InlineData("   2e+2   ", 200, 4)]
+        [InlineData("   123e-01   ", 12.3, 7)]
+        [InlineData("   0   ", 0, 1)]
+        [InlineData("   0.1   ", 0.1, 3)]
+        [InlineData("   -0   ", 0, 2)]
+        [InlineData("   -0.1   ", -0.1, 4)]
+        [InlineData("[2e2]", 200, 3)]
+        [InlineData("[2e+2]", 200, 4)]
+        [InlineData("[123e-01]", 12.3, 7)]
+        [InlineData("[0]", 0, 1)]
+        [InlineData("[0.1]", 0.1, 3)]
+        [InlineData("[-0]", 0, 2)]
+        [InlineData("[-0.1]", -0.1, 4)]
+        [InlineData("{\"foo\": 2e2}", 200, 3)]
+        [InlineData("{\"foo\": 2e+2}", 200, 4)]
+        [InlineData("{\"foo\": 123e-01}", 12.3, 7)]
+        [InlineData("{\"foo\": 0}", 0, 1)]
+        [InlineData("{\"foo\": 0.1}", 0.1, 3)]
+        [InlineData("{\"foo\": -0}", 0, 2)]
+        [InlineData("{\"foo\": -0.1}", -0.1, 4)]
+        public static void ReadJsonWithNumberVariousSegmentSizes(string input, double expectedValue, long expectedTokenLength)
         {
             byte[] utf8 = Encoding.UTF8.GetBytes(input);
 
             var jsonReader = new Utf8JsonReader(utf8);
-            ReadDoubleHelper(ref jsonReader, utf8.Length, expectedValue);
+            ReadDoubleHelper(ref jsonReader, utf8.Length, expectedValue, expectedTokenLength);
 
             ReadOnlySequence<byte> sequence = JsonTestHelper.GetSequence(utf8, 1);
             jsonReader = new Utf8JsonReader(sequence);
-            ReadDoubleHelper(ref jsonReader, utf8.Length, expectedValue);
+            ReadDoubleHelper(ref jsonReader, utf8.Length, expectedValue, expectedTokenLength);
 
             for (int splitLocation = 0; splitLocation < utf8.Length; splitLocation++)
             {
                 sequence = JsonTestHelper.CreateSegments(utf8, splitLocation);
                 jsonReader = new Utf8JsonReader(sequence);
-                ReadDoubleHelper(ref jsonReader, utf8.Length, expectedValue);
+                ReadDoubleHelper(ref jsonReader, utf8.Length, expectedValue, expectedTokenLength);
             }
 
             for (int firstSplit = 0; firstSplit < utf8.Length; firstSplit++)
@@ -122,17 +122,20 @@ namespace System.Text.Json.Tests
                 {
                     sequence = JsonTestHelper.CreateSegments(utf8, firstSplit, secondSplit);
                     jsonReader = new Utf8JsonReader(sequence);
-                    ReadDoubleHelper(ref jsonReader, utf8.Length, expectedValue);
+                    ReadDoubleHelper(ref jsonReader, utf8.Length, expectedValue, expectedTokenLength);
                 }
             }
         }
 
-        private static void ReadDoubleHelper(ref Utf8JsonReader jsonReader, int expectedBytesConsumed, double expectedValue)
+        private static void ReadDoubleHelper(ref Utf8JsonReader jsonReader, int expectedBytesConsumed, double expectedValue, long expectedTokenLength)
         {
             while (jsonReader.Read())
             {
                 if (jsonReader.TokenType == JsonTokenType.Number)
                 {
+                    long tokenLength = jsonReader.HasValueSequence ? jsonReader.ValueSequence.Length : jsonReader.ValueSpan.Length;
+                    Assert.Equal(expectedTokenLength, tokenLength);
+                    Assert.Equal(tokenLength, jsonReader.BytesConsumed - jsonReader.TokenStartIndex);
                     Assert.Equal(expectedValue, jsonReader.GetDouble());
                 }
             }

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
@@ -38,7 +38,7 @@ namespace System.Text.Json.Tests
         }
 
         [Fact]
-        public static void EmptySequenceSegments()
+        public static void EmptyJsonMultiSegmentIsInvalid()
         {
             ReadOnlyMemory<byte> dataMemory = Array.Empty<byte>();
 


### PR DESCRIPTION
Addressed the primary concern from https://github.com/dotnet/corefx/issues/39974.

cc @bartonjs, @stephentoub, @GSPP 