### PR TITLE
Fix outerloop cron job

### DIFF
--- a/eng/pipelines/outerloop.yml
+++ b/eng/pipelines/outerloop.yml
@@ -6,7 +6,8 @@ schedules:
   branches:
     include:
     - master
-    - releases/3.0
+    - release/3.0
+  condition: endsWith(variables['Build.DefinitionName'], 'outerloop')
 
 resources:
   containers:


### PR DESCRIPTION
I'm keeping the `release/3.0` branch here as it makes sense to run outerloop tests there. By default it only runs if sources changed so we avoid tons of builds.