### PR TITLE
[release/3.0] Fixed Dispose in JsonDocument and JsonDocument.MetadataDb in order toguard against multiple calls to ArrayPool.Return (#40290)

### DIFF
--- a/src/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/System.Text.Json/src/System.Text.Json.csproj
@@ -205,6 +205,7 @@
     <Reference Include="System.Numerics.Vectors" />
     <Reference Include="System.Runtime.CompilerServices.Unsafe" />
     <Reference Include="System.Text.Encodings.Web" />
+    <Reference Include="System.Threading" />
     <Reference Include="System.Threading.Tasks" />
     <Reference Include="System.Threading.Tasks.Extensions" />
   </ItemGroup>

--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.MetadataDb.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.MetadataDb.cs
@@ -5,6 +5,7 @@
 using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace System.Text.Json
 {
@@ -148,7 +149,8 @@ namespace System.Text.Json
 
             public void Dispose()
             {
-                if (_data == null)
+                byte[] data = Interlocked.Exchange(ref _data, null);
+                if (data == null)
                 {
                     return;
                 }
@@ -160,8 +162,7 @@ namespace System.Text.Json
                 // The data in this rented buffer only conveys the positions and
                 // lengths of tokens in a document, but no content; so it does not
                 // need to be cleared.
-                ArrayPool<byte>.Shared.Return(_data);
-                _data = null;
+                ArrayPool<byte>.Shared.Return(data);
                 Length = 0;
             }
 

--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
@@ -8,6 +8,7 @@ using System.Buffers.Text;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
+using System.Threading;
 
 namespace System.Text.Json
 {
@@ -56,22 +57,23 @@ namespace System.Text.Json
         /// <inheritdoc />
         public void Dispose()
         {
-            if (_utf8Json.IsEmpty || !IsDisposable)
+            int length = _utf8Json.Length;
+            if (length == 0 || !IsDisposable)
             {
                 return;
             }
 
-            int length = _utf8Json.Length;
-            _utf8Json = ReadOnlyMemory<byte>.Empty;
             _parsedData.Dispose();
+            _utf8Json = ReadOnlyMemory<byte>.Empty;
 
             // When "extra rented bytes exist" they contain the document,
             // and thus need to be cleared before being returned.
-            if (_extraRentedBytes != null)
+            byte[] extraRentedBytes = Interlocked.Exchange(ref _extraRentedBytes, null);
+
+            if (extraRentedBytes != null)
             {
-                _extraRentedBytes.AsSpan(0, length).Clear();
-                ArrayPool<byte>.Shared.Return(_extraRentedBytes);
-                _extraRentedBytes = null;
+                extraRentedBytes.AsSpan(0, length).Clear();
+                ArrayPool<byte>.Shared.Return(extraRentedBytes);
             }
         }
 


### PR DESCRIPTION
This is a port of #40290 to 3.0 release branch.
Fixes #39930

## Description
* Fixed Dispose in JsonDocument and JsonDocument.MetadataDb in order to guard against multiple calls to ArrayPool.Return when invoking from several threads at once.
* Added condition to validate _utf8Json.Length is > 0 in order to prevent that `extraRentedBytes.AsSpan(0, length).Clear()` takes a zero length range in a race condition.
* Added test related to this scenario.

## Customer Impact
Without the fix, there is a chance that `ArrayPool.Shared` gets corrupted when disposing a `JsonDocument` on multiple threads simultaneously.

## Regression?
No.

## Risk
Low.

