### PR TITLE
Fix potential null ref in RuntimeInformation.FrameworkDescription

### DIFF
--- a/src/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.cs
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Reflection;
-using System.Diagnostics;
 
 namespace System.Runtime.InteropServices
 {
@@ -26,12 +25,17 @@ namespace System.Runtime.InteropServices
                         versionString = typeof(object).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
 
                         // Strip the git hash if there is one
-                        int plusIndex = versionString.IndexOf('+');
-                        if (plusIndex != -1)
-                            versionString = versionString.Substring(0, plusIndex);
+                        if (versionString != null)
+                        {
+                            int plusIndex = versionString.IndexOf('+');
+                            if (plusIndex != -1)
+                            {
+                                versionString = versionString.Substring(0, plusIndex);
+                            }
+                        }
                     }
 
-                    s_frameworkDescription = $"{FrameworkName} {versionString}";
+                    s_frameworkDescription = !string.IsNullOrWhiteSpace(versionString) ? $"{FrameworkName} {versionString}" : FrameworkName;
                 }
 
                 return s_frameworkDescription;


### PR DESCRIPTION
If there's no FX_PRODUCT_VERSION and then if there's no AssemblyInformationalVersionAttribute on the assembly or its InformationVersion is null, we'll try to dereference a null string.