### PR TITLE
Remove unnecessary null check from JsonClassInfo.CreatePolymorphicProperty

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.AddProperty.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.AddProperty.cs
@@ -174,7 +174,7 @@ namespace System.Text.Json
 
         internal JsonPropertyInfo CreatePolymorphicProperty(JsonPropertyInfo property, Type runtimePropertyType, JsonSerializerOptions options)
         {
-            JsonPropertyInfo runtimeProperty = CreateProperty(property.DeclaredPropertyType, runtimePropertyType, property.ImplementedPropertyType, property?.PropertyInfo, Type, options);
+            JsonPropertyInfo runtimeProperty = CreateProperty(property.DeclaredPropertyType, runtimePropertyType, property.ImplementedPropertyType, property.PropertyInfo, Type, options);
             property.CopyRuntimeSettingsTo(runtimeProperty);
 
             return runtimeProperty;


### PR DESCRIPTION
`property` will never be null in calls to this method, and even if it were, prior dereferences of it would result in exceptions.
cc: @steveharter, @ahsonkhan 