### PR TITLE
Avoid tracing-induced null ref in HttpListener when {Begin}Read/Write called with invalid buffer

### DIFF
--- a/src/System.Net.HttpListener/src/System/Net/HttpRequestStream.cs
+++ b/src/System.Net.HttpListener/src/System/Net/HttpRequestStream.cs
@@ -19,7 +19,7 @@ namespace System.Net
             if (NetEventSource.IsEnabled)
             {
                 NetEventSource.Enter(this);
-                NetEventSource.Info(this, "size:" + size + " offset:" + offset);
+                NetEventSource.Info(this, "buffer.Length:" + buffer?.Length + " size:" + size + " offset:" + offset);
             }
             if (buffer == null)
             {
@@ -48,7 +48,7 @@ namespace System.Net
             if (NetEventSource.IsEnabled)
             {
                 NetEventSource.Enter(this);
-                NetEventSource.Info(this, "buffer.Length:" + buffer.Length + " size:" + size + " offset:" + offset);
+                NetEventSource.Info(this, "buffer.Length:" + buffer?.Length + " size:" + size + " offset:" + offset);
             }
             if (buffer == null)
             {

--- a/src/System.Net.HttpListener/src/System/Net/HttpResponseStream.cs
+++ b/src/System.Net.HttpListener/src/System/Net/HttpResponseStream.cs
@@ -46,7 +46,7 @@ namespace System.Net
             if (NetEventSource.IsEnabled)
             {
                 NetEventSource.Enter(this);
-                NetEventSource.Info(this, "buffer.Length:" + buffer.Length + " size:" + size + " offset:" + offset);
+                NetEventSource.Info(this, "buffer.Length:" + buffer?.Length + " size:" + size + " offset:" + offset);
             }
             if (buffer == null)
             {
@@ -71,7 +71,7 @@ namespace System.Net
 
         public override IAsyncResult BeginWrite(byte[] buffer, int offset, int size, AsyncCallback callback, object state)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, "buffer.Length:" + buffer.Length + " size:" + size + " offset:" + offset);
+            if (NetEventSource.IsEnabled) NetEventSource.Info(this, "buffer.Length:" + buffer?.Length + " size:" + size + " offset:" + offset);
             if (buffer == null)
             {
                 throw new ArgumentNullException(nameof(buffer));


### PR DESCRIPTION
HttpRequest/ResponseStream's {Begin}Read/Write methods trace the length of the caller-supplied buffer.  If the caller erroneously passes null, with tracing enabled it'll end up throwing a NullReferenceException instead of an ArgumentNullException.  This should never happen in real-world code, but might as well clean it up.