### PR TITLE
Avoid WeakReference race with GC in LdapSessionOptions

### DIFF
--- a/src/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.cs
+++ b/src/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.cs
@@ -971,10 +971,10 @@ namespace System.DirectoryServices.Protocols
                     {
                         // Check whether we have save it in the handle table before.
                         WeakReference reference = (WeakReference)(LdapConnection.s_handleTable[referralFromConnection]);
-                        if (reference != null && reference.IsAlive && null != ((LdapConnection)reference.Target)._ldapHandle)
+                        if (reference != null && reference.Target is LdapConnection conn && conn._ldapHandle != null)
                         {
                             // Save this before and object has not been garbage collected yet.
-                            tempReferralConnection = (LdapConnection)reference.Target;
+                            tempReferralConnection = conn;
                         }
                         else
                         {


### PR DESCRIPTION
The GC could run between the check of IsAlive and the access to Target.  Better to just access Target and use the result if it's non-null.