### PR TITLE
Store UserOptions in DbConnectionPool.PendingGetConnection

### DIFF
--- a/src/System.Data.Odbc/src/Common/System/Data/ProviderBase/DbConnectionPool.cs
+++ b/src/System.Data.Odbc/src/Common/System/Data/ProviderBase/DbConnectionPool.cs
@@ -28,6 +28,7 @@ namespace System.Data.ProviderBase
                 DueTime = dueTime;
                 Owner = owner;
                 Completion = completion;
+                UserOptions = userOptions;
             }
             public long DueTime { get; private set; }
             public DbConnection Owner { get; private set; }

--- a/src/System.Data.OleDb/src/System/Data/ProviderBase/DbConnectionPool.cs
+++ b/src/System.Data.OleDb/src/System/Data/ProviderBase/DbConnectionPool.cs
@@ -53,6 +53,7 @@ namespace System.Data.ProviderBase
                 DueTime = dueTime;
                 Owner = owner;
                 Completion = completion;
+                UserOptions = userOptions;
             }
             public long DueTime { get; private set; }
             public DbConnection Owner { get; private set; }

--- a/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPool.cs
+++ b/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPool.cs
@@ -52,6 +52,7 @@ namespace System.Data.ProviderBase
                 DueTime = dueTime;
                 Owner = owner;
                 Completion = completion;
+                UserOptions = userOptions;
             }
             public long DueTime { get; private set; }
             public DbConnection Owner { get; private set; }


### PR DESCRIPTION
@roji, is this worth fixing?  It does seem like these were supposed to be stored such that they'd be passed through to subsequent operations, but this code has also been around for a very long time.