### PR TITLE
Remove unnecessary null check from ConstraintCollection

### DIFF
--- a/src/System.Data.Common/src/System/Data/ConstraintCollection.cs
+++ b/src/System.Data.Common/src/System/Data/ConstraintCollection.cs
@@ -27,6 +27,7 @@ namespace System.Data
         /// </summary>
         internal ConstraintCollection(DataTable table)
         {
+            Debug.Assert(table != null);
             _table = table;
         }
 
@@ -420,18 +421,15 @@ namespace System.Data
         /// </summary>
         public void Clear()
         {
-            if (_table != null)
-            {
-                _table.PrimaryKey = null;
+            _table.PrimaryKey = null;
 
-                for (int i = 0; i < _table.ParentRelations.Count; i++)
-                {
-                    _table.ParentRelations[i].SetChildKeyConstraint(null);
-                }
-                for (int i = 0; i < _table.ChildRelations.Count; i++)
-                {
-                    _table.ChildRelations[i].SetParentKeyConstraint(null);
-                }
+            for (int i = 0; i < _table.ParentRelations.Count; i++)
+            {
+                _table.ParentRelations[i].SetChildKeyConstraint(null);
+            }
+            for (int i = 0; i < _table.ChildRelations.Count; i++)
+            {
+                _table.ChildRelations[i].SetParentKeyConstraint(null);
             }
 
             if (_table.fInitInProgress && _delayLoadingConstraints != null)


### PR DESCRIPTION
`_table` will never be null.  The `ConstraintCollection` is only constructed in one place, where it's passed `this` by `DataTable`.  It's used in many other places without a guard check, as well (and later in this method, unguarded).

cc: @roji (sorry if you're not the right person to tag :smile:)