### PR TITLE
Delete dead code from XMLDiffLoader.ReadOldRowData

### DIFF
--- a/src/System.Data.Common/src/System/Data/DataException.cs
+++ b/src/System.Data.Common/src/System/Data/DataException.cs
@@ -673,7 +673,6 @@ namespace System.Data
         public static Exception CircularComplexType(string name) => _Data(SR.Format(SR.Xml_CircularComplexType, name));
         public static Exception CannotInstantiateAbstract(string name) => _Data(SR.Format(SR.Xml_CannotInstantiateAbstract, name));
         public static Exception InvalidKey(string name) => _Data(SR.Format(SR.Xml_InvalidKey, name));
-        public static Exception DiffgramMissingTable(string name) => _Data(SR.Format(SR.Xml_MissingTable, name));
         public static Exception DiffgramMissingSQL() => _Data(SR.Xml_MissingSQL);
         public static Exception DuplicateConstraintRead(string str) => _Data(SR.Format(SR.Xml_DuplicateConstraint, str));
         public static Exception ColumnTypeConflict(string name) => _Data(SR.Format(SR.Xml_ColumnConflict, name));

--- a/src/System.Data.Common/src/System/Data/XMLDiffLoader.cs
+++ b/src/System.Data.Common/src/System/Data/XMLDiffLoader.cs
@@ -303,10 +303,6 @@ namespace System.Data
             int iRowDepth = row.Depth;
             string value = null;
 
-            if (table == null)
-                throw ExceptionBuilder.DiffgramMissingTable(XmlConvert.DecodeName(row.LocalName));
-
-
             value = row.GetAttribute(Keywords.ROWORDER, Keywords.MSDNS);
             if (!string.IsNullOrEmpty(value))
             {


### PR DESCRIPTION
We already exited out of the method a few lines earlier if table == null.
cc: @roji