### PR TITLE
Remove duplicate _wrapped.WriteBase64 call in QueryOutputWriterV1

### DIFF
--- a/src/System.Private.Xml/src/System/Xml/Core/QueryOutputWriterV1.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/QueryOutputWriterV1.cs
@@ -239,10 +239,12 @@ namespace System.Xml
 
         public override void WriteBase64(byte[] buffer, int index, int count)
         {
-            if (!_inAttr && (_inCDataSection || StartCDataSection()))
-                _wrapped.WriteBase64(buffer, index, count);
-            else
-                _wrapped.WriteBase64(buffer, index, count);
+            if (!_inAttr && !_inCDataSection)
+            {
+                StartCDataSection();
+            }
+
+            _wrapped.WriteBase64(buffer, index, count);
         }
 
         public override void WriteEntityRef(string name)


### PR DESCRIPTION
The same expression is used for both the if and the else branches.  But the if branch does make a mutating method call, which we keep.

cc: @krwq 