### PR TITLE
Prevent threading issues with warm-up of property caching (#40261)

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
@@ -18,14 +18,15 @@ namespace System.Text.Json
         // The length of the property name embedded in the key (in bytes).
         private const int PropertyNameKeyLength = 6;
 
-        // The limit to how many property names from the JSON are cached before using PropertyCache.
+        // The limit to how many property names from the JSON are cached in _propertyRefsSorted before using PropertyCache.
         private const int PropertyNameCountCacheThreshold = 64;
 
-        // The properties on a POCO keyed on property name.
+        // All of the serializable properties on a POCO keyed on property name.
         public volatile Dictionary<string, JsonPropertyInfo> PropertyCache;
 
-        // Cache of properties by first JSON ordering. Use an array for highest performance.
-        private volatile PropertyRef[] _propertyRefsSorted = null;
+        // Fast cache of properties by first JSON ordering; may not contain all properties. Accessed before PropertyCache.
+        // Use an array (instead of List<T>) for highest performance.
+        private volatile PropertyRef[] _propertyRefsSorted;
 
         public delegate object ConstructorDelegate();
         public ConstructorDelegate CreateObject { get; private set; }
@@ -70,22 +71,35 @@ namespace System.Text.Json
 
         public void UpdateSortedPropertyCache(ref ReadStackFrame frame)
         {
-            // Check if we are trying to build the sorted cache.
-            if (frame.PropertyRefCache == null)
-            {
-                return;
-            }
+            Debug.Assert(frame.PropertyRefCache != null);
 
-            List<PropertyRef> newList;
+            // frame.PropertyRefCache is only read\written by a single thread -- the thread performing
+            // the deserialization for a given object instance.
+
+            List<PropertyRef> listToAppend = frame.PropertyRefCache;
+
+            // _propertyRefsSorted can be accessed by multiple threads, so replace the reference when
+            // appending to it. No lock() is necessary.
+
             if (_propertyRefsSorted != null)
             {
-                newList = new List<PropertyRef>(_propertyRefsSorted);
-                newList.AddRange(frame.PropertyRefCache);
-                _propertyRefsSorted = newList.ToArray();
+                List<PropertyRef> replacementList = new List<PropertyRef>(_propertyRefsSorted);
+                Debug.Assert(replacementList.Count <= PropertyNameCountCacheThreshold);
+
+                // Verify replacementList will not become too large.
+                while (replacementList.Count + listToAppend.Count > PropertyNameCountCacheThreshold)
+                {
+                    // This code path is rare; keep it simple by using RemoveAt() instead of RemoveRange() which requires calculating index\count.
+                    listToAppend.RemoveAt(listToAppend.Count - 1);
+                }
+
+                // Add the new items; duplicates are possible but that is tolerated during property lookup.
+                replacementList.AddRange(listToAppend);
+                _propertyRefsSorted = replacementList.ToArray();
             }
             else
             {
-                _propertyRefsSorted = frame.PropertyRefCache.ToArray();
+                _propertyRefsSorted = listToAppend.ToArray();
             }
 
             frame.PropertyRefCache = null;
@@ -247,55 +261,54 @@ namespace System.Text.Json
         {
             JsonPropertyInfo info = null;
 
-            // If we're not trying to build the cache locally, and there is an existing cache, then use it.
-            if (_propertyRefsSorted != null)
+            // Keep a local copy of the cache in case it changes by another thread.
+            PropertyRef[] localPropertyRefsSorted = _propertyRefsSorted;
+
+            // If there is an existing cache, then use it.
+            if (localPropertyRefsSorted != null)
             {
                 ulong key = GetKey(propertyName);
 
-                // First try sorted lookup.
+                // Start with the current property index, and then go forwards\backwards.
                 int propertyIndex = frame.PropertyIndex;
 
-                // This .Length is consistent no matter what json data intialized _propertyRefsSorted.
-                int count = _propertyRefsSorted.Length;
-                if (count != 0)
-                {
-                    int iForward = Math.Min(propertyIndex, count);
-                    int iBackward = iForward - 1;
-                    while (iForward < count || iBackward >= 0)
-                    {
-                        if (iForward < count)
-                        {
-                            if (TryIsPropertyRefEqual(_propertyRefsSorted[iForward], propertyName, key, ref info))
-                            {
-                                return info;
-                            }
-                            ++iForward;
-                        }
+                int count = localPropertyRefsSorted.Length;
+                int iForward = Math.Min(propertyIndex, count);
+                int iBackward = iForward - 1;
 
-                        if (iBackward >= 0)
+                while (iForward < count || iBackward >= 0)
+                {
+                    if (iForward < count)
+                    {
+                        if (TryIsPropertyRefEqual(localPropertyRefsSorted[iForward], propertyName, key, ref info))
                         {
-                            if (TryIsPropertyRefEqual(_propertyRefsSorted[iBackward], propertyName, key, ref info))
-                            {
-                                return info;
-                            }
-                            --iBackward;
+                            return info;
                         }
+                        ++iForward;
+                    }
+
+                    if (iBackward >= 0)
+                    {
+                        if (TryIsPropertyRefEqual(localPropertyRefsSorted[iBackward], propertyName, key, ref info))
+                        {
+                            return info;
+                        }
+                        --iBackward;
                     }
                 }
             }
 
-            // Try the main list which has all of the properties in a consistent order.
-            // We could get here even when hasPropertyCache==true if there is a race condition with different json
-            // property ordering and _propertyRefsSorted is re-assigned while in the loop above.
+            // No cached item was found. Try the main list which has all of the properties.
 
             string stringPropertyName = JsonHelpers.Utf8GetString(propertyName);
             if (PropertyCache.TryGetValue(stringPropertyName, out info))
             {
-                // For performance, only add to cache up to a threshold and then just use the dictionary.
+                // Check if we should add this to the cache.
+                // Only cache up to a threshold length and then just use the dictionary when an item is not found in the cache.
                 int count;
-                if (_propertyRefsSorted != null)
+                if (localPropertyRefsSorted != null)
                 {
-                    count = _propertyRefsSorted.Length;
+                    count = localPropertyRefsSorted.Length;
                 }
                 else
                 {
@@ -305,12 +318,13 @@ namespace System.Text.Json
                 // Do a quick check for the stable (after warm-up) case.
                 if (count < PropertyNameCountCacheThreshold)
                 {
+                    // Do a slower check for the warm-up case.
                     if (frame.PropertyRefCache != null)
                     {
                         count += frame.PropertyRefCache.Count;
                     }
 
-                    // Check again to fill up to the limit.
+                    // Check again to append the cache up to the threshold.
                     if (count < PropertyNameCountCacheThreshold)
                     {
                         if (frame.PropertyRefCache == null)

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleObject.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleObject.cs
@@ -56,7 +56,11 @@ namespace System.Text.Json
         {
             Debug.Assert(!state.Current.IsProcessingDictionary && !state.Current.IsProcessingIDictionaryConstructible);
 
-            state.Current.JsonClassInfo.UpdateSortedPropertyCache(ref state.Current);
+            // Check if we are trying to build the sorted cache.
+            if (state.Current.PropertyRefCache != null)
+            {
+                state.Current.JsonClassInfo.UpdateSortedPropertyCache(ref state.Current);
+            }
 
             object value = state.Current.ReturnValue;
 

--- a/src/System.Text.Json/tests/Serialization/CacheTests.cs
+++ b/src/System.Text.Json/tests/Serialization/CacheTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using System.Reflection;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -9,40 +11,63 @@ namespace System.Text.Json.Serialization.Tests
 {
     public static class CacheTests
     {
-        // Use a new type that is not used in other tests so we can attempt race conditions on cached global state.
-        public class TestClassForCachingTest : SimpleTestClass { }
+        [Fact, OuterLoop]
+        public static void MultipleThreadsLooping()
+        {
+            const int Iterations = 100;
+
+            for (int i = 0; i < Iterations; i++)
+            {
+                MultipleThreads();
+            }
+        }
 
         [Fact]
         public static void MultipleThreads()
         {
+            // Use local options to avoid obtaining already cached metadata from the default options.
+            var options = new JsonSerializerOptions();
+
+            // Verify the test class has >64 properties since that is a threshold for using the fallback dictionary.
+            Assert.True(typeof(SimpleTestClass).GetProperties(BindingFlags.Instance | BindingFlags.Public).Length > 64);
+
+            void DeserializeObjectMinimal()
+            {
+                SimpleTestClass obj = JsonSerializer.Deserialize<SimpleTestClass>(@"{""MyDecimal"" : 3.3}", options);
+            };
+
             void DeserializeObjectFlipped()
             {
-                TestClassForCachingTest obj = JsonSerializer.Deserialize<TestClassForCachingTest>(SimpleTestClass.s_json_flipped);
+                SimpleTestClass obj = JsonSerializer.Deserialize<SimpleTestClass>(SimpleTestClass.s_json_flipped, options);
                 obj.Verify();
             };
 
             void DeserializeObjectNormal()
             {
-                TestClassForCachingTest obj = JsonSerializer.Deserialize<TestClassForCachingTest>(SimpleTestClass.s_json);
+                SimpleTestClass obj = JsonSerializer.Deserialize<SimpleTestClass>(SimpleTestClass.s_json, options);
                 obj.Verify();
             };
 
             void SerializeObject()
             {
-                var obj = new TestClassForCachingTest();
+                var obj = new SimpleTestClass();
                 obj.Initialize();
-                JsonSerializer.Serialize(obj);
+                JsonSerializer.Serialize(obj, options);
             };
 
-            Task[] tasks = new Task[4 * 3];
-            for (int i = 0; i < tasks.Length; i += 3)
+            const int ThreadCount = 8;
+            const int ConcurrentTestsCount = 4;
+            Task[] tasks = new Task[ThreadCount * ConcurrentTestsCount];
+
+            for (int i = 0; i < tasks.Length; i += ConcurrentTestsCount)
             {
                 // Create race condition to populate the sorted property cache with different json ordering.
-                tasks[i + 0] = Task.Run(() => DeserializeObjectFlipped());
-                tasks[i + 1] = Task.Run(() => DeserializeObjectNormal());
+                tasks[i + 0] = Task.Run(() => DeserializeObjectMinimal());
+                tasks[i + 1] = Task.Run(() => DeserializeObjectFlipped());
+                tasks[i + 2] = Task.Run(() => DeserializeObjectNormal());
 
                 // Ensure no exceptions on serialization
-                tasks[i + 2] = Task.Run(() => SerializeObject());
+                tasks[i + 3] = Task.Run(() => SerializeObject());
             };
 
             Task.WaitAll(tasks);
@@ -51,8 +76,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void PropertyCacheWithMinInputsFirst()
         {
-            // Use localized caching
-            // Todo: localized caching not implemented yet. When implemented, add a run-time attribute to JsonSerializerOptions as that will create a separate cache held by JsonSerializerOptions.
+            // Use local options to avoid obtaining already cached metadata from the default options.
             var options = new JsonSerializerOptions();
 
             string json = "{}";
@@ -70,8 +94,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void PropertyCacheWithMinInputsLast()
         {
-            // Use localized caching
-            // Todo: localized caching not implemented yet. When implemented, add a run-time attribute to JsonSerializerOptions as that will create a separate cache held by JsonSerializerOptions.
+            // Use local options to avoid obtaining already cached metadata from the default options.
             var options = new JsonSerializerOptions();
 
             SimpleTestClass testObj = new SimpleTestClass();
@@ -84,6 +107,56 @@ namespace System.Text.Json.Serialization.Tests
 
             json = "{}";
             JsonSerializer.Deserialize<SimpleTestClass>(json, options);
+        }
+
+        // Use a common options instance to encourage additional metadata collisions across types. Also since
+        // this options is not the default options instance the tests will not use previously cached metadata.
+        private static JsonSerializerOptions s_options = new JsonSerializerOptions();
+
+        [Theory]
+        [MemberData(nameof(WriteSuccessCases))]
+        public static void MultipleTypes(ITestClass testObj)
+        {
+            Type type = testObj.GetType();
+
+            // Get the test json with the default options to avoid cache pollution of Deserialize() below.
+            testObj.Initialize();
+            testObj.Verify();
+            string json = JsonSerializer.Serialize(testObj, type);
+
+            void Serialize()
+            {
+                ITestClass localTestObj = (ITestClass)Activator.CreateInstance(type);
+                localTestObj.Initialize();
+                localTestObj.Verify();
+                string json = JsonSerializer.Serialize(localTestObj, type, s_options);
+            };
+
+            void Deserialize()
+            {
+                ITestClass obj = (ITestClass)JsonSerializer.Deserialize(json, type, s_options);
+                obj.Verify();
+            };
+
+            const int ThreadCount = 12;
+            const int ConcurrentTestsCount = 2;
+            Task[] tasks = new Task[ThreadCount * ConcurrentTestsCount];
+
+            for (int i = 0; i < tasks.Length; i += ConcurrentTestsCount)
+            {
+                tasks[i + 0] = Task.Run(() => Deserialize());
+                tasks[i + 1] = Task.Run(() => Serialize());
+            };
+
+            Task.WaitAll(tasks);
+        }
+
+        public static IEnumerable<object[]> WriteSuccessCases
+        {
+            get
+            {
+                return TestData.WriteSuccessCases;
+            }
         }
     }
 }


### PR DESCRIPTION
Port https://github.com/dotnet/corefx/pull/40261 to 3.0

cc: @eerhardt, @layomia, @ahsonkhan, @stephentoub 

## Description

After stress testing it was determined that there is a threading issue with the warm-up phase where property metadata is cached\read which can cause an `IndexOutOfRangeException`. There also have been intermittent test failures in CI.

## Regression?

No; the code is new in 3.0.

## Risk

Low. The core change to the code just keeps a local reference to an array, instead of accessing a global once that can change within the method scope. Tests added and expanded to hit the potential issue more aggressively.

