### PR TITLE
Add Perf Pipeline

### DIFF
--- a/.azure-perf-ci.yml
+++ b/.azure-perf-ci.yml
@@ -1,0 +1,32 @@
+trigger:
+  batch: true
+  branches:
+    include:
+    - master
+  paths:
+    exclude:
+    - Documentation/*
+    - /*.md
+
+pr: none
+
+resources:
+  containers:
+  - container: centos_7_perf
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-3e800f1-20190501005343
+
+jobs:
+
+# Performance legs
+  - template: /eng/pipelines/performance.yml
+    parameters:
+      targetOS: Windows_NT
+      pool: 
+        name: Hosted VS2017
+
+  - template: /eng/pipelines/performance.yml
+    parameters:
+      targetOS: Linux
+      pool: 
+        name: Hosted Ubuntu 1604
+      container: centos_7_perf

--- a/eng/pipelines/performance.yml
+++ b/eng/pipelines/performance.yml
@@ -1,0 +1,42 @@
+parameters:
+  targetOS: ''
+  architecture: 'x64'
+  framework: 'netcoreapp'
+  isOfficialBuild: false
+  pool: ''
+  container: ''
+
+jobs:
+- template: ../common/templates/job/performance.yml
+  parameters:
+    variables:
+    - name: _commonArguments
+      value: -configuration Release -ci -arch ${{ parameters.architecture }} -framework ${{ parameters.framework }}
+
+    # Windows variables
+    - ${{ if eq(parameters.targetOS, 'Windows_NT') }}:
+      - name: _buildScript
+        value: build.cmd
+
+    # Non-Windows variables
+    - ${{ if ne(parameters.targetOS, 'Windows_NT') }}:
+      - name: _buildScript
+        value: ./build.sh
+
+    jobName: ${{ format('performance_{0}_{1}', parameters.targetOS, parameters.architecture) }}
+    pool: ${{ parameters.pool }}
+    container: ${{ parameters.container }}
+
+    ${{ if eq(parameters.targetOS, 'Windows_NT') }}:
+      extraSetupParameters: -CoreRootDirectory $(Build.SourcesDirectory)\artifacts\bin\runtime\${{ parameters.framework }}-${{ parameters.targetOS }}-Release-${{ parameters.architecture }} -Architecture ${{ parameters.architecture }} -Framework netcoreapp5.0
+    ${{ if ne(parameters.targetOS, 'Windows_NT') }}:
+      extraSetupParameters: --corerootdirectory $(Build.SourcesDirectory)/artifacts/bin/runtime/${{ parameters.framework }}-${{ parameters.targetOS }}-Release-${{ parameters.architecture }} --architecture ${{ parameters.architecture }} -Framework netcoreapp5.0
+
+    steps:
+      - script: $(_buildScript) -restore $(_commonArguments)
+        displayName: Restore Build Tools
+
+      - script: $(_buildScript)
+              -build
+              $(_commonArguments)
+        displayName: Build Sources and Tests


### PR DESCRIPTION
This change will add a performance pipeline to run performance testing on internal builds. After this change is checked in, we will need to create a perf pipeline in AzDO.

This change enables performance testing per-commit on internal builds for Windows x64 and Ubuntu x64 (if desired, I can quickly add x86 testing).

This change was tested as part of #39083, and has been tested in the performance repo to make sure the change works on internal runs.

This change will need to wait until dotnet/arcade#3680 has propagated to corefx before we can enable perf testing (that change updates the default framework to netcoreapp5.0 and fixes a bug in the linux build).

Note: this change is only for (internal) ci testing. I have only enabled it for master, but we can discuss enabling it for release/3.0 until we ship (at which point, we will disable it, and enable release/3.1). Enabling per-commit perf testing for release/3.0 will require us to set the framework to netcoreapp3.0. Enabling release/3.1 will require some additional changes in the performance repo.