### PR TITLE
Use Count in Enumerable.Any if available

### DIFF
--- a/src/System.Linq/src/System/Linq/AnyAll.cs
+++ b/src/System.Linq/src/System/Linq/AnyAll.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
 using System.Collections.Generic;
 
 namespace System.Linq
@@ -13,6 +14,29 @@ namespace System.Linq
             if (source == null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            }
+
+            if (source is ICollection<TSource> collectionoft)
+            {
+                return collectionoft.Count != 0;
+            }
+            else if (source is IIListProvider<TSource> listProv)
+            {
+                // Note that this check differs from the corresponding check in
+                // Count (whereas otherwise this method parallels it).  If the count
+                // can't be retrieved cheaply, that likely means we'd need to iterate
+                // through the entire sequence in order to get the count, and in that
+                // case, we'll generally be better off falling through to the logic
+                // below that only enumerates at most a single element.
+                int count = listProv.GetCount(onlyIfCheap: true);
+                if (count >= 0)
+                {
+                    return count != 0;
+                }
+            }
+            else if (source is ICollection collection)
+            {
+                return collection.Count != 0;
             }
 
             using (IEnumerator<TSource> e = source.GetEnumerator())

--- a/src/System.Linq/tests/AnyTests.cs
+++ b/src/System.Linq/tests/AnyTests.cs
@@ -32,6 +32,40 @@ namespace System.Linq.Tests
 
         public static IEnumerable<object[]> TestData()
         {
+            foreach (int count in new[] { 0, 1, 2 })
+            {
+                bool expected = count > 0;
+
+                var arr = new int[count];
+                var collectionTypes = new IEnumerable<int>[]
+                {
+                    arr,
+                    new List<int>(arr),
+                    new TestCollection<int>(arr),
+                    new TestNonGenericCollection<int>(arr),
+                    NumberRangeGuaranteedNotCollectionType(0, count),
+                };
+
+                foreach (IEnumerable<int> source in collectionTypes)
+                {
+                    yield return new object[] { source, expected };
+                    yield return new object[] { source.Select(i => i), expected };
+                    yield return new object[] { source.Where(i => true), expected };
+
+                    yield return new object[] { source.Where(i => false), false };
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TestData))]
+        public void Any(IEnumerable<int> source, bool expected)
+        {
+            Assert.Equal(expected, source.Any());
+        }
+
+        public static IEnumerable<object[]> TestDataWithPredicate()
+        {
             yield return new object[] { new int[0], null, false };
             yield return new object[] { new int[] { 3 }, null, true };
 
@@ -52,7 +86,7 @@ namespace System.Linq.Tests
         }
 
         [Theory]
-        [MemberData(nameof(TestData))]
+        [MemberData(nameof(TestDataWithPredicate))]
         public void Any(IEnumerable<int> source, Func<int, bool> predicate, bool expected)
         {
             if (predicate == null)
@@ -65,7 +99,7 @@ namespace System.Linq.Tests
             }
         }
 
-        [Theory, MemberData(nameof(TestData))]
+        [Theory, MemberData(nameof(TestDataWithPredicate))]
         public void AnyRunOnce(IEnumerable<int> source, Func<int, bool> predicate, bool expected)
         {
             if (predicate == null)

--- a/src/System.Linq/tests/EnumerableTests.cs
+++ b/src/System.Linq/tests/EnumerableTests.cs
@@ -11,7 +11,7 @@ namespace System.Linq.Tests
     {
         protected class TestCollection<T> : ICollection<T>
         {
-            public T[] Items = new T[0];
+            public T[] Items;
             public int CountTouched = 0;
             public int CopyToTouched = 0;
             public TestCollection(T[] items) { Items = items; }
@@ -27,9 +27,25 @@ namespace System.Linq.Tests
             IEnumerator IEnumerable.GetEnumerator() => Items.GetEnumerator();
         }
 
+        protected class TestNonGenericCollection<T> : ICollection, IEnumerable<T>
+        {
+            public T[] Items;
+            public int CountTouched = 0;
+
+            public TestNonGenericCollection(T[] items) => Items = items;
+
+            public virtual int Count { get { CountTouched++; return Items.Length; } }
+            public bool IsSynchronized => false;
+            public object SyncRoot => this;
+            public void CopyTo(Array array, int index) => throw new NotImplementedException();
+
+            public IEnumerator<T> GetEnumerator() => ((IEnumerable<T>)Items).GetEnumerator();
+            IEnumerator IEnumerable.GetEnumerator() => Items.GetEnumerator();
+        }
+
         protected class TestEnumerable<T> : IEnumerable<T>
         {
-            public T[] Items = new T[0];
+            public T[] Items;
             public TestEnumerable(T[] items) { Items = items; }
 
             public IEnumerator<T> GetEnumerator() => ((IEnumerable<T>)Items).GetEnumerator();
@@ -38,7 +54,7 @@ namespace System.Linq.Tests
 
         protected class TestReadOnlyCollection<T> : IReadOnlyCollection<T>
         {
-            public T[] Items = new T[0];
+            public T[] Items;
             public int CountTouched = 0;
             public TestReadOnlyCollection(T[] items) { Items = items; }
 


### PR DESCRIPTION
We've been hesitant to make this change in the past, as it adds several interface checks which do show up in microbenchmarks (as is evidenced below).

However, wide-spread "wisdom" is that `Any()` is as fast or faster than `Count() > 0`, and there are even FxCop rules/analyzers that warn about using the latter instead of the former, but in its current form that can frequently be incorrect: if the source does implement `ICollection<T>`, generally its `Count` is O(1) and allocation-free, whereas `Any()` will almost always end up allocating an enumerator.

On balance, it seems better to just have `Any()` map closely to `Count()` so that their performance can be reasoned about in parallel. I'd like a second opinion, though. @cston? @ahsonkhan? @bartonjs?

```C#
using System.Collections.Generic;
using System.Linq;
using System.Runtime.CompilerServices;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

[MemoryDiagnoser]
public class Program
{
    public static void Main(string[] args) => BenchmarkSwitcher.FromTypes(new[] { typeof(Program) }).Run(args);

    private static IEnumerable<int> Iterator() { yield return 1; }

    public IEnumerable<object[]> Sources()
    {
        yield return new object[] { "Empty", Enumerable.Empty<int>() };
        yield return new object[] { "Range", Enumerable.Range(0, 10) };
        yield return new object[] { "List", new List<int>() { 1, 2, 3 } };
        yield return new object[] { "int[]", new int[] { 1, 2, 3 } };
        yield return new object[] { "int[].Select", new int[] { 1, 2, 3 }.Select(i => i) };
        yield return new object[] { "int[].Select.Where", new int[] { 1, 2, 3 }.Select(i => i).Where(i => i % 2 == 0) };
        yield return new object[] { "Iterator", Iterator() };
        yield return new object[] { "Iterator.Select", Iterator().Select(i => i) };
        yield return new object[] { "Iterator.Select.Where", Iterator().Select(i => i).Where(i => i % 2 == 0) };
    }

    [Benchmark]
    [ArgumentsSource(nameof(Sources))]
    public void Any(string name, object source) => Unsafe.As<IEnumerable<int>>(source).Any();
}
```
produces:

| Method |                   Toolchain |                 name |               source |      Mean | Allocated |
|------- |---------------------------- |--------------------- |--------------------- |----------:|----------:|
|    Any | New |                Empty | Syste(...)nt32] [42] |  6.966 ns |         - |
|    Any |    Old |                Empty | Syste(...)nt32] [42] |  5.421 ns |         - |
|        |                             |                      |                      |           |           |
|    Any | New |             Iterator | Progr(...)>d__1 [22] | 20.192 ns |      32 B |
|    Any |    Old |             Iterator | Progr(...)>d__1 [22] | 13.645 ns |      32 B |
|        |                             |                      |                      |           |           |
|    Any | New |      Iterator.Select | Syste(...)nt32] [76] | 42.764 ns |      88 B |
|    Any |    Old |      Iterator.Select | Syste(...)nt32] [76] | 35.661 ns |      88 B |
|        |                             |                      |                      |           |           |
|    Any | New | Itera(...)Where [21] | Syste(...)nt32] [62] | 74.852 ns |     144 B |
|    Any |    Old | Itera(...)Where [21] | Syste(...)nt32] [62] | 65.916 ns |     144 B |
|        |                             |                      |                      |           |           |
|    Any | New |                 List | Syste(...)nt32] [47] |  3.979 ns |         - |
|    Any |    Old |                 List | Syste(...)nt32] [47] | 12.500 ns |      40 B |
|        |                             |                      |                      |           |           |
|    Any | New |                Range | Syste(...)rator [36] |  7.972 ns |         - |
|    Any |    Old |                Range | Syste(...)rator [36] | 15.880 ns |      40 B |
|        |                             |                      |                      |           |           |
|    Any | New |                int[] |       System.Int32[] | 11.606 ns |         - |
|    Any |    Old |                int[] |       System.Int32[] |  9.594 ns |      32 B |
|        |                             |                      |                      |           |           |
|    Any | New |         int[].Select | Syste(...)nt32] [71] |  8.505 ns |         - |
|    Any |    Old |         int[].Select | Syste(...)nt32] [71] | 19.888 ns |      48 B |
|        |                             |                      |                      |           |           |
|    Any | New |   int[].Select.Where | Syste(...)nt32] [62] | 59.662 ns |     104 B |
|    Any |    Old |   int[].Select.Where | Syste(...)nt32] [62] | 48.749 ns |     104 B |

ps @adamsitnik, I could not figure out how to get the benchmark to take an `IEnumerable<int>`; everything I tried resulted in errors like `error CS0266: Cannot implicitly convert type 'object' to 'System.Collections.Generic.IEnumerable<int>'`.  This is with benchmarkdotnet 11.5.