### PR TITLE
[release/3.0] Bump IntelliSense nupkg version to Preview 8 in eng/Versions.props (40364)

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -77,7 +77,7 @@
     <CoverletConsolePackageVersion>1.5.0</CoverletConsolePackageVersion>
     <DotNetReportGeneratorGlobalToolPackageVersion>4.1.4</DotNetReportGeneratorGlobalToolPackageVersion>
     <!-- Docs -->
-    <MicrosoftPrivateIntellisensePackageVersion>3.0.0-preview3-190305-0</MicrosoftPrivateIntellisensePackageVersion>
+    <MicrosoftPrivateIntellisensePackageVersion>3.0.0-preview8-190815-0</MicrosoftPrivateIntellisensePackageVersion>
     <!-- ILLink -->
     <ILLinkTasksPackageVersion>0.1.5-preview-1461378</ILLinkTasksPackageVersion>
   </PropertyGroup>


### PR DESCRIPTION
IntelliSense drop from the Docs team Live build generated on 08/15 for Preview 8, which will be part of 3.0 Preview 9. English only.