### PR TITLE
[release/3.0] JsonSerializerOptions.GetConverter() tests

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterKeyValuePair.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterKeyValuePair.cs
@@ -94,7 +94,7 @@ namespace System.Text.Json.Serialization.Converters
 
             // Attempt to use existing converter first before re-entering through JsonSerializer.Deserialize().
             // The default converter for objects does not parse null objects as null, so it is not used here.
-            if (typeToConvert != typeof(object) && (options.GetConverter(typeToConvert) is JsonConverter<T> keyConverter))
+            if (typeToConvert != typeof(object) && (options?.GetConverter(typeToConvert) is JsonConverter<T> keyConverter))
             {
                 reader.Read();
                 k = keyConverter.Read(ref reader, typeToConvert, options);
@@ -115,7 +115,7 @@ namespace System.Text.Json.Serialization.Converters
 
             // Attempt to use existing converter first before re-entering through JsonSerializer.Serialize().
             // The default converter for object does not support writing.
-            if (typeToConvert != typeof(object) && (options.GetConverter(typeToConvert) is JsonConverter<T> keyConverter))
+            if (typeToConvert != typeof(object) && (options?.GetConverter(typeToConvert) is JsonConverter<T> keyConverter))
             {
                 keyConverter.Write(writer, value, options);
             }

--- a/src/System.Text.Json/tests/Serialization/CustomConverterTests.Array.cs
+++ b/src/System.Text.Json/tests/Serialization/CustomConverterTests.Array.cs
@@ -10,7 +10,7 @@ namespace System.Text.Json.Serialization.Tests
     public static partial class CustomConverterTests
     {
         // A custom long[] converter as comma-delimited string "1,2,3".
-        private class LongArrayConverter : JsonConverter<long[]>
+        internal class LongArrayConverter : JsonConverter<long[]>
         {
             public LongArrayConverter() { }
 

--- a/src/System.Text.Json/tests/Serialization/CustomConverterTests.Dictionary.cs
+++ b/src/System.Text.Json/tests/Serialization/CustomConverterTests.Dictionary.cs
@@ -11,7 +11,7 @@ namespace System.Text.Json.Serialization.Tests
     public static partial class CustomConverterTests
     {
         // Demonstrates custom Dictionary<string, long>; Adds offset to each integer or long to verify converter ran.
-        private class DictionaryConverter : JsonConverter<Dictionary<string, long>>
+        internal class DictionaryConverter : JsonConverter<Dictionary<string, long>>
         {
             private long _offset;
 

--- a/src/System.Text.Json/tests/Serialization/OptionsTests.cs
+++ b/src/System.Text.Json/tests/Serialization/OptionsTests.cs
@@ -337,22 +337,20 @@ namespace System.Text.Json.Serialization.Tests
 
             JsonConverter<T> converter = (JsonConverter<T>)options.GetConverter(typeof(T));
             Assert.Equal(converterName, converter.GetType().Name);
-            
+
             ReadOnlySpan<byte> data = Encoding.UTF8.GetBytes(stringValue);
             Utf8JsonReader reader = new Utf8JsonReader(data);
-            reader.Read();
+            Assert.True(reader.Read());
+
             T readValue = converter.Read(ref reader, typeof(T), null);
 
+            Assert.True(readValue is JsonElement, "Must be JsonElement");
             if (readValue is JsonElement element)
             {
                 Assert.Equal(JsonValueKind.Array, element.ValueKind);
                 JsonElement.ArrayEnumerator iterator = element.EnumerateArray();
                 Assert.True(iterator.MoveNext());
                 Assert.Equal(3, iterator.Current.GetInt32());
-            }
-            else
-            {
-                Assert.True(false, "Must be JsonElement");
             }
 
             using (var stream = new MemoryStream())


### PR DESCRIPTION
#### Description
Test improvements for built-in JsonConverters.
Code update:  null check added to JsonValueConverterKeyValuePair.cs to fix test failure with NRE 
Port of #39750
Fixes #39457
		
#### Customer Impact
Low
#### Regression?
No		
#### Risk
No