### PR TITLE
Support PinChangedEvent on Unix

### DIFF
--- a/src/Native/Unix/System.IO.Ports.Native/pal_termios.c
+++ b/src/Native/Unix/System.IO.Ports.Native/pal_termios.c
@@ -32,11 +32,12 @@ enum
 /* Interop/Unix/Interop.Termios.cs */
 enum
 {
-    SignalDtr = 1,
-    SignalDsr = 2,
-    SignalRts = 3,
-    SignalCts = 4,
-    SignalDcd = 5,
+    SignalDtr = 1 << 0,
+    SignalDsr = 1 << 1,
+    SignalRts = 1 << 2,
+    SignalCts = 1 << 3,
+    SignalDcd = 1 << 4,
+    SignalRng = 1 << 5,
 };
 
 enum
@@ -81,6 +82,31 @@ int32_t SystemIoPortsNative_TermiosGetSignal(intptr_t handle, int32_t signal)
     default:
         return -1;
    }
+}
+
+int32_t SystemIoPortsNative_TermiosGetAllSignals(intptr_t handle)
+{
+    int32_t status = SystemIoPortsNative_TermiosGetStatus(handle);
+    if (status == -1)
+    {
+        return -1;
+    }
+
+    int32_t signals = 0;
+
+    if (status & TIOCM_CTS)
+        signals |= SignalCts;
+
+    if (status & TIOCM_DSR)
+        signals |= SignalDsr;
+
+    if (status & TIOCM_CAR)
+        signals |= SignalDcd;
+
+    if (status & TIOCM_RNG)
+        signals |= SignalRng;
+
+    return signals;
 }
 
 int32_t SystemIoPortsNative_TermiosSetSignal(intptr_t handle, int32_t signal, int32_t set)

--- a/src/Native/Unix/System.IO.Ports.Native/pal_termios.h
+++ b/src/Native/Unix/System.IO.Ports.Native/pal_termios.h
@@ -7,6 +7,7 @@
 
 DLLEXPORT int32_t SystemIoPortsNative_TermiosGetSignal(intptr_t fd, int32_t signal);
 DLLEXPORT int32_t SystemIoPortsNative_TermiosSetSignal(intptr_t fd, int32_t signal, int32_t set);
+DLLEXPORT int32_t SystemIoPortsNative_TermiosGetAllSignals(intptr_t fd);
 
 DLLEXPORT int32_t SystemIoPortsNative_TermiosGetSpeed(intptr_t fd);
 DLLEXPORT int32_t SystemIoPortsNative_TermiosSetSpeed(intptr_t fd, int32_t speed);

--- a/src/System.IO.Ports/src/Interop/Unix/Interop.Termios.cs
+++ b/src/System.IO.Ports/src/Interop/Unix/Interop.Termios.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.IO.Ports;
 using System.Runtime.InteropServices;
 using Microsoft.Win32.SafeHandles;
@@ -10,13 +11,17 @@ internal static partial class Interop
 {
     internal static partial class Termios
     {
+        [Flags]
         internal enum Signals
         {
-            SignalDtr = 1,
-            SignalDsr = 2,
-            SignalRts = 3,
-            SignalCts = 4,
-            SignalDcd = 5,
+            None = 0,
+            SignalDtr = 0b000001,
+            SignalDsr = 0b000010,
+            SignalRts = 0b000100,
+            SignalCts = 0b001000,
+            SignalDcd = 0b010000,
+            SignalRng = 0b100000,
+            Error = -1,
         }
 
         internal enum Queue
@@ -34,6 +39,9 @@ internal static partial class Interop
 
         [DllImport(Libraries.IOPortsNative, EntryPoint = "SystemIoPortsNative_TermiosSetSignal", SetLastError = true)]
         internal static extern int TermiosGetSignal(SafeSerialDeviceHandle handle, Signals signal, int set);
+
+        [DllImport(Libraries.IOPortsNative, EntryPoint = "SystemIoPortsNative_TermiosGetAllSignals")]
+        internal static extern Signals TermiosGetAllSignals(SafeSerialDeviceHandle handle);
 
         [DllImport(Libraries.IOPortsNative, EntryPoint = "SystemIoPortsNative_TermiosSetSpeed", SetLastError = true)]
         internal static extern int TermiosSetSpeed(SafeSerialDeviceHandle handle, int speed);

--- a/src/System.IO.Ports/src/Interop/Unix/Interop.Termios.cs
+++ b/src/System.IO.Ports/src/Interop/Unix/Interop.Termios.cs
@@ -15,12 +15,12 @@ internal static partial class Interop
         internal enum Signals
         {
             None = 0,
-            SignalDtr = 0b000001,
-            SignalDsr = 0b000010,
-            SignalRts = 0b000100,
-            SignalCts = 0b001000,
-            SignalDcd = 0b010000,
-            SignalRng = 0b100000,
+            SignalDtr = 1 << 0,
+            SignalDsr = 1 << 1,
+            SignalRts = 1 << 2,
+            SignalCts = 1 << 3,
+            SignalDcd = 1 << 4,
+            SignalRng = 1 << 5,
             Error = -1,
         }
 

--- a/src/System.IO.Ports/src/System/IO/Ports/SerialStream.Unix.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/SerialStream.Unix.cs
@@ -650,11 +650,7 @@ namespace System.IO.Ports
             {
                 ThreadPool.QueueUserWorkItem(s => {
                         var thisRef = (SerialStream)s;
-                        SerialDataReceivedEventHandler dataReceived = thisRef._dataReceived;
-                        if (dataReceived != null)
-                        {
-                            dataReceived(thisRef, new SerialDataReceivedEventArgs(SerialData.Chars));
-                        }
+                        thisRef._dataReceived?.Invoke(thisRef, new SerialDataReceivedEventArgs(SerialData.Chars));
                     }, this);
             }
         }
@@ -665,11 +661,7 @@ namespace System.IO.Ports
             {
                 ThreadPool.QueueUserWorkItem(s => {
                         var thisRef = (SerialStream)s;
-                        SerialPinChangedEventHandler pinChangedHandler = thisRef._pinChanged;
-                        if (pinChangedHandler != null)
-                        {
-                            pinChangedHandler(thisRef, new SerialPinChangedEventArgs(pinChanged));
-                        }
+                        thisRef._pinChanged?.Invoke(thisRef, new SerialPinChangedEventArgs(pinChanged));
                     }, this);
             }
         }
@@ -892,8 +884,6 @@ namespace System.IO.Ports
                     // user didn't have time to respond.
                     // Diffing seems like a better solution.
                     Signals current = Interop.Termios.TermiosGetAllSignals(_handle);
-                    if (current != lastSignals)
-                        Console.WriteLine($"{lastSignals} => {current}");
 
                     // There is no really good action we can take when this errors so just ignore
                     // a sinle event.

--- a/src/System.IO.Ports/src/System/IO/Ports/SerialStream.Unix.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/SerialStream.Unix.cs
@@ -655,7 +655,7 @@ namespace System.IO.Ports
             }
         }
 
-        private void RaisePingChanged(SerialPinChange pinChanged)
+        private void RaisePinChanged(SerialPinChange pinChanged)
         {
             if (_pinChanged != null)
             {
@@ -893,7 +893,7 @@ namespace System.IO.Ports
                         if (changed != Signals.None)
                         {
                             SerialPinChange pinChanged = SignalsToPinChanges(changed);
-                            RaisePingChanged(pinChanged);
+                            RaisePinChanged(pinChanged);
                         }
                     }
 

--- a/src/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
@@ -36,6 +36,9 @@ namespace System.IO.Ports
         // called when one character is received.
         internal event SerialDataReceivedEventHandler DataReceived;
 
+        // called when any of the pin/ring-related triggers occurs
+        internal event SerialPinChangedEventHandler PinChanged;
+
         private SafeFileHandle _handle = null;
 
         // members supporting properties exposed to SerialPort

--- a/src/System.IO.Ports/src/System/IO/Ports/SerialStream.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/SerialStream.cs
@@ -22,8 +22,6 @@ namespace System.IO.Ports
         private Handshake _handshake;
 
 #pragma warning disable CS0067 // Events shared by Windows and Linux, on Linux we currently never call them
-        // called when any of the pin/ring-related triggers occurs
-        internal event SerialPinChangedEventHandler PinChanged;
         // called when any runtime error occurs on the port (frame, overrun, parity, etc.)
         internal event SerialErrorReceivedEventHandler ErrorReceived;
 #pragma warning restore CS0067


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/39814

I've tested the code with:

```csharp
            using (SerialPort spA = new SerialPort(devA))
            using (SerialPort spB =new SerialPort(devB))
            {
                spB.PinChanged += (s, e) =>
                {
                    Console.WriteLine($"Pin state changed {e.EventType}");
                };

                spA.Open();
                spB.Open();

                spA.RtsEnable = true;
                Console.ReadLine();
                spA.RtsEnable = false;
                Console.ReadLine();
            }
```

there is currently a test testing this but seems we are hitting [similar issue as python](https://github.com/pyserial/pyserial/issues/124) where RTS/DTR randomly change for some short period of time after openning the port which makes it very difficult to test in the automated way - it could be related to our detection logic or driver issue (i.e. buffering pin change request from previous time this run).