### PR TITLE
Use Strings.resx file for the exception messages

### DIFF
--- a/src/System.Composition.Hosting/src/Resources/Strings.resx
+++ b/src/System.Composition.Hosting/src/Resources/Strings.resx
@@ -130,4 +130,7 @@
   <data name="Diagnostic_InternalExceptionMessage" xml:space="preserve">
     <value>Internal error occurred. Additional information: '{0}'.</value>
   </data>
+  <data name="Update_already_executed" xml:space="preserve">
+    <value>The update has already executed.</value>
+  </data>
 </root>

--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/Core/ExportDescriptorPromise.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/Core/ExportDescriptorPromise.cs
@@ -85,7 +85,7 @@ namespace System.Composition.Hosting.Core
                 ExportDescriptor relay = _descriptor.Value;
                 if (relay == null)
                 {
-                    throw new ArgumentNullException("descriptor");
+                    throw new ArgumentNullException(nameof(_descriptor));
                 }
                 return relay;
             }

--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/Core/ExportDescriptorPromise.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/Core/ExportDescriptorPromise.cs
@@ -85,7 +85,7 @@ namespace System.Composition.Hosting.Core
                 ExportDescriptor relay = _descriptor.Value;
                 if (relay == null)
                 {
-                    throw new ArgumentNullException(nameof(_descriptor));
+                    throw new ArgumentNullException("descriptor");
                 }
                 return relay;
             }

--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/Core/ExportDescriptorRegistryUpdate.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/Core/ExportDescriptorRegistryUpdate.cs
@@ -32,7 +32,7 @@ namespace System.Composition.Hosting.Core
         {
             // Opportunism - we'll miss recursive calls to Execute(), but this will catch some problems
             // and the _updateFinished flag is required for other purposes anyway.
-            if (_updateFinished) throw new InvalidOperationException("The update has already executed.");
+            if (_updateFinished) throw new InvalidOperationException(SR.Update_already_executed);
 
             CompositionDependency initial;
             if (TryResolveOptionalDependency("initial request", contract, true, out initial))

--- a/src/System.Diagnostics.DiagnosticSource/src/Resources/Strings.resx
+++ b/src/System.Diagnostics.DiagnosticSource/src/Resources/Strings.resx
@@ -120,6 +120,9 @@
   <data name="ActivityIdFormatInvalid" xml:space="preserve">
     <value>"Value must be a valid ActivityIdFormat value"</value>
   </data>
+  <data name="ActivityNotRunning" xml:space="preserve">
+    <value>Trying to set an Activity that is not running</value>
+  </data>
   <data name="ActivityNotStarted" xml:space="preserve">
     <value>"Can not stop an Activity that was not started"</value>
   </data>

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -853,7 +853,7 @@ namespace System.Diagnostics
             bool canSet = activity == null || (activity.Id != null && !activity.IsFinished);
             if (!canSet)
             {
-                NotifyError(new InvalidOperationException("Trying to set an Activity that is not running"));
+                NotifyError(new InvalidOperationException(SR.ActivityNotRunning));
             }
 
             return canSet;

--- a/src/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ActiveDirectorySiteLinkCollection.cs
+++ b/src/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ActiveDirectorySiteLinkCollection.cs
@@ -122,7 +122,7 @@ namespace System.DirectoryServices.ActiveDirectory
         public void Insert(int index, ActiveDirectorySiteLink link)
         {
             if (link == null)
-                throw new ArgumentNullException("value");
+                throw new ArgumentNullException(nameof(link));
 
             if (!link.existing)
                 throw new InvalidOperationException(SR.Format(SR.SiteLinkNotCommitted , link.Name));

--- a/src/System.Drawing.Common/src/Resources/Strings.resx
+++ b/src/System.Drawing.Common/src/Resources/Strings.resx
@@ -410,4 +410,49 @@
   <data name="EntryPointNotFoundExceptionMessage" xml:space="preserve">
     <value>Unable to find an entry point named '{0}' in DLL '{1}'.</value>
   </data>
+  <data name="AvailableOnlyOnWMF" xml:space="preserve">
+    <value>{0} only available on WMF files.</value>
+  </data>
+  <data name="CannotCreateGraphics" xml:space="preserve">
+    <value>Cannot create Graphics from an indexed bitmap.</value>
+  </data>
+  <data name="CouldNotOpenDisplay" xml:space="preserve">
+    <value>Could not open display (X-Server required. Check your DISPLAY environment variable)</value>
+  </data>
+  <data name="CouldntFindSpecifiedFile" xml:space="preserve">
+    <value>Couldn't find specified file.</value>
+  </data>
+  <data name="IconInstanceWasDisposed" xml:space="preserve">
+    <value>Icon instance was disposed.</value>
+  </data>
+  <data name="InvalidGraphicsUnit" xml:space="preserve">
+    <value>Invalid GraphicsUnit</value>
+  </data>
+  <data name="InvalidThumbnailSize" xml:space="preserve">
+    <value>Invalid thumbnail size</value>
+  </data>
+  <data name="NoCodecAvailableForFormat" xml:space="preserve">
+    <value>No codec available for format:{0}</value>
+  </data>
+  <data name="NotImplementedUnderX11" xml:space="preserve">
+    <value>Operation not implemented under X11</value>
+  </data>
+  <data name="NoValidIconImageFound" xml:space="preserve">
+    <value>No valid icon image found</value>
+  </data>
+  <data name="NullOrEmptyPath" xml:space="preserve">
+    <value>Null or empty path.</value>
+  </data>
+  <data name="NumberOfPointsAndTypesMustBeSame" xml:space="preserve">
+    <value>Invalid parameter passed. Number of points and types must be same.</value>
+  </data>
+  <data name="ObjectDisposed" xml:space="preserve">
+    <value>Object has been disposed.</value>
+  </data>
+  <data name="ValueLessThenZero" xml:space="preserve">
+    <value>The value of the {0} property is less than zero.</value>
+  </data>
+  <data name="ValueNotOneOfValues" xml:space="preserve">
+    <value>The value of the {0} property is not one of the {1} values</value>
+  </data>
 </root>

--- a/src/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPath.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPath.Unix.cs
@@ -78,7 +78,7 @@ namespace System.Drawing.Drawing2D
             if (pts == null)
                 throw new ArgumentNullException(nameof(pts));
             if (pts.Length != types.Length)
-                throw new ArgumentException("Invalid parameter passed. Number of points and types must be same.");
+                throw new ArgumentException(SR.NumberOfPointsAndTypesMustBeSame);
 
             int status = Gdip.GdipCreatePath2I(pts, types, pts.Length, fillMode, out _nativePath);
             Gdip.CheckStatus(status);
@@ -89,7 +89,7 @@ namespace System.Drawing.Drawing2D
             if (pts == null)
                 throw new ArgumentNullException(nameof(pts));
             if (pts.Length != types.Length)
-                throw new ArgumentException("Invalid parameter passed. Number of points and types must be same.");
+                throw new ArgumentException(SR.NumberOfPointsAndTypesMustBeSame);
 
             int status = Gdip.GdipCreatePath2(pts, types, pts.Length, fillMode, out _nativePath);
             Gdip.CheckStatus(status);
@@ -141,7 +141,7 @@ namespace System.Drawing.Drawing2D
             set
             {
                 if ((value < FillMode.Alternate) || (value > FillMode.Winding))
-                    throw new InvalidEnumArgumentException("FillMode", (int)value, typeof(FillMode));
+                    throw new InvalidEnumArgumentException(nameof(FillMode), (int)value, typeof(FillMode));
 
                 int status = Gdip.GdipSetPathFillMode(_nativePath, value);
                 Gdip.CheckStatus(status);
@@ -185,7 +185,7 @@ namespace System.Drawing.Drawing2D
                 int status = Gdip.GdipGetPointCount(_nativePath, out count);
                 Gdip.CheckStatus(status);
                 if (count == 0)
-                    throw new ArgumentException("PathPoints");
+                    throw new ArgumentException(nameof(PathPoints));
 
                 PointF[] points = new PointF[count];
                 status = Gdip.GdipGetPathPoints(_nativePath, points, count);
@@ -203,7 +203,7 @@ namespace System.Drawing.Drawing2D
                 int status = Gdip.GdipGetPointCount(_nativePath, out count);
                 Gdip.CheckStatus(status);
                 if (count == 0)
-                    throw new ArgumentException("PathTypes");
+                    throw new ArgumentException(nameof(PathTypes));
 
                 byte[] types = new byte[count];
                 status = Gdip.GdipGetPathTypes(_nativePath, types, count);

--- a/src/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPath.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPath.Unix.cs
@@ -185,7 +185,7 @@ namespace System.Drawing.Drawing2D
                 int status = Gdip.GdipGetPointCount(_nativePath, out count);
                 Gdip.CheckStatus(status);
                 if (count == 0)
-                    throw new ArgumentException(nameof(PathPoints));
+                    throw new ArgumentException("PathPoints");
 
                 PointF[] points = new PointF[count];
                 status = Gdip.GdipGetPathPoints(_nativePath, points, count);
@@ -203,7 +203,7 @@ namespace System.Drawing.Drawing2D
                 int status = Gdip.GdipGetPointCount(_nativePath, out count);
                 Gdip.CheckStatus(status);
                 if (count == 0)
-                    throw new ArgumentException(nameof(PathTypes));
+                    throw new ArgumentException("PathTypes");
 
                 byte[] types = new byte[count];
                 status = Gdip.GdipGetPathTypes(_nativePath, types, count);

--- a/src/System.Drawing.Common/src/System/Drawing/Font.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Font.Unix.cs
@@ -100,7 +100,7 @@ namespace System.Drawing
                     inchs = nSrc / 72f;
                     break;
                 default:
-                    throw new ArgumentException("Invalid GraphicsUnit");
+                    throw new ArgumentException(SR.InvalidGraphicsUnit);
             }
 
             switch (toUnit)
@@ -125,7 +125,7 @@ namespace System.Drawing
                     nTrg = inchs * 72;
                     break;
                 default:
-                    throw new ArgumentException("Invalid GraphicsUnit");
+                    throw new ArgumentException(SR.InvalidGraphicsUnit);
             }
         }
 
@@ -215,7 +215,7 @@ namespace System.Drawing
         public IntPtr ToHfont()
         {
             if (_nativeFont == IntPtr.Zero)
-                throw new ArgumentException("Object has been disposed.");
+                throw new ArgumentException(SR.ObjectDisposed);
 
             return _nativeFont;
         }

--- a/src/System.Drawing.Common/src/System/Drawing/Graphics.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Graphics.Unix.cs
@@ -143,7 +143,7 @@ namespace System.Drawing
             int AllPlanes = ~0, nitems = 0, pixel;
 
             if (copyPixelOperation != CopyPixelOperation.SourceCopy)
-                throw new NotImplementedException("Operation not implemented under X11");
+                throw new NotImplementedException(SR.NotImplementedUnderX11);
 
             if (Gdip.Display == IntPtr.Zero)
             {
@@ -459,7 +459,7 @@ namespace System.Drawing
                 {
                     Gdip.Display = LibX11Functions.XOpenDisplay(IntPtr.Zero);
                     if (Gdip.Display == IntPtr.Zero)
-                        throw new NotSupportedException("Could not open display (X-Server required. Check your DISPLAY environment variable)");
+                        throw new NotSupportedException(SR.CouldNotOpenDisplay);
                 }
                 if (hwnd == IntPtr.Zero)
                 {
@@ -484,7 +484,7 @@ namespace System.Drawing
                 throw new ArgumentNullException(nameof(image));
 
             if ((image.PixelFormat & PixelFormat.Indexed) != 0)
-                throw new ArgumentException("Cannot create Graphics from an indexed bitmap.", nameof(image));
+                throw new ArgumentException(SR.CannotCreateGraphics, nameof(image));
 
             int status = Gdip.GdipGetImageGraphicsContext(image.nativeImage, out graphics);
             Gdip.CheckStatus(status);

--- a/src/System.Drawing.Common/src/System/Drawing/Icon.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Icon.Unix.cs
@@ -214,7 +214,7 @@ namespace System.Drawing
                 }
 
                 if (id == ushort.MaxValue)
-                    throw new ArgumentException("Icon", "No valid icon image found");
+                    throw new ArgumentException(SR.NoValidIconImageFound, "Icon");
 
                 iconSize.Height = iconDir.idEntries[id].height;
                 iconSize.Width = iconDir.idEntries[id].width;
@@ -322,9 +322,9 @@ namespace System.Drawing
             if (filePath == null)
                 throw new ArgumentNullException(nameof(filePath));
             if (string.IsNullOrEmpty(filePath))
-                throw new ArgumentException("Null or empty path.", "path");
+                throw new ArgumentException(SR.NullOrEmptyPath, "path");
             if (!File.Exists(filePath))
-                throw new FileNotFoundException("Couldn't find specified file.", filePath);
+                throw new FileNotFoundException(SR.CouldntFindSpecifiedFile, filePath);
 
             return SystemIcons.WinLogo;
         }
@@ -645,7 +645,7 @@ namespace System.Drawing
         public Bitmap ToBitmap()
         {
             if (disposed)
-                throw new ObjectDisposedException("Icon instance was disposed.");
+                throw new ObjectDisposedException(SR.IconInstanceWasDisposed);
 
             // note: we can't return the original image because
             // (a) we have no control over the bitmap instance we return (i.e. it could be disposed)

--- a/src/System.Drawing.Common/src/System/Drawing/Image.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Image.Unix.cs
@@ -133,7 +133,7 @@ namespace System.Drawing
         public Image GetThumbnailImage(int thumbWidth, int thumbHeight, Image.GetThumbnailImageAbort callback, IntPtr callbackData)
         {
             if ((thumbWidth <= 0) || (thumbHeight <= 0))
-                throw new OutOfMemoryException("Invalid thumbnail size");
+                throw new OutOfMemoryException(SR.InvalidThumbnailSize);
 
             Image ThumbNail = new Bitmap(thumbWidth, thumbHeight);
 
@@ -228,7 +228,7 @@ namespace System.Drawing
             ImageCodecInfo encoder = FindEncoderForFormat(format);
 
             if (encoder == null)
-                throw new ArgumentException("No codec available for format:" + format.Guid);
+                throw new ArgumentException(SR.Format(SR.NoCodecAvailableForFormat, format.Guid));
 
             Save(stream, encoder, null);
         }

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/MetafileHeader.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/MetafileHeader.Unix.cs
@@ -211,7 +211,7 @@ namespace System.Drawing.Imaging
             {
                 if (IsWmf())
                     return new MetaHeader(header.wmf_header);
-                throw new ArgumentException("WmfHeader only available on WMF files.");
+                throw new ArgumentException(SR.Format(SR.AvailableOnlyOnWMF, nameof(WmfHeader)));
             }
         }
     }

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PrinterSettings.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PrinterSettings.Unix.cs
@@ -102,7 +102,7 @@ namespace System.Drawing.Printing
             set
             {
                 if (value < 0)
-                    throw new ArgumentException("The value of the Copies property is less than zero.");
+                    throw new ArgumentException(SR.Format(SR.ValueLessThenZero, nameof(Copies)));
 
                 copies = value;
             }
@@ -139,7 +139,7 @@ namespace System.Drawing.Printing
             set
             {
                 if (value < 0)
-                    throw new ArgumentException("The value of the FromPage property is less than zero");
+                    throw new ArgumentException(SR.Format(SR.ValueLessThenZero, nameof(FromPage)));
 
                 from_page = value;
             }
@@ -182,7 +182,7 @@ namespace System.Drawing.Printing
             {
                 // This not documented but behaves like MinimumPage
                 if (value < 0)
-                    throw new ArgumentException("The value of the MaximumPage property is less than zero");
+                    throw new ArgumentException(SR.Format(SR.ValueLessThenZero, nameof(MaximumPage)));
 
                 maximum_page = value;
             }
@@ -194,7 +194,7 @@ namespace System.Drawing.Printing
             set
             {
                 if (value < 0)
-                    throw new ArgumentException("The value of the MaximumPage property is less than zero");
+                    throw new ArgumentException(SR.Format(SR.ValueLessThenZero, nameof(MinimumPage)));
 
                 minimum_page = value;
             }
@@ -264,7 +264,7 @@ namespace System.Drawing.Printing
             {
                 if (value != PrintRange.AllPages && value != PrintRange.Selection &&
                     value != PrintRange.SomePages)
-                    throw new InvalidEnumArgumentException("The value of the PrintRange property is not one of the PrintRange values");
+                    throw new InvalidEnumArgumentException(SR.Format(SR.ValueNotOneOfValues, nameof(PrintRange), nameof(PrintRange)));
 
                 print_range = value;
             }
@@ -287,7 +287,7 @@ namespace System.Drawing.Printing
             set
             {
                 if (value < 0)
-                    throw new ArgumentException("The value of the ToPage property is less than zero");
+                    throw new ArgumentException(SR.Format(SR.ValueLessThenZero, nameof(ToPage)));
 
                 to_page = value;
             }

--- a/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
+++ b/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
@@ -36,8 +36,7 @@ namespace System.IO
 
         private void Init(string originalPath, string fullPath = null, string fileName = null, bool isNormalized = false)
         {
-            // Want to throw the original argument name
-            OriginalPath = originalPath ?? throw new ArgumentNullException("path");
+            OriginalPath = originalPath ?? throw new ArgumentNullException(nameof(originalPath));
 
             fullPath = fullPath ?? originalPath;
             fullPath = isNormalized ? fullPath : Path.GetFullPath(fullPath);

--- a/src/System.IO.Packaging/src/Resources/Strings.resx
+++ b/src/System.IO.Packaging/src/Resources/Strings.resx
@@ -372,4 +372,7 @@
   <data name="UriShouldBeAbsolute" xml:space="preserve">
     <value>Must have absolute URI.</value>
   </data>
+  <data name="FileContainsCorruptedData" xml:space="preserve">
+    <value>File contains corrupted data.</value>
+  </data>
 </root>

--- a/src/System.IO.Packaging/src/System/IO/Packaging/ZipPackage.cs
+++ b/src/System.IO.Packaging/src/System/IO/Packaging/ZipPackage.cs
@@ -353,7 +353,7 @@ namespace System.IO.Packaging
             }
             catch (InvalidDataException)
             {
-                throw new FileFormatException("File contains corrupted data.");
+                throw new FileFormatException(SR.FileContainsCorruptedData);
             }
             catch
             {

--- a/src/System.Numerics.Tensors/src/Resources/Strings.resx
+++ b/src/System.Numerics.Tensors/src/Resources/Strings.resx
@@ -1,0 +1,168 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ArrayMustContainElements" xml:space="preserve">
+    <value>Array must contain elements.</value>
+  </data>
+  <data name="CannotCompare" xml:space="preserve">
+    <value>Cannot compare {0} to {1}.</value>
+  </data>
+  <data name="CannotCompareToWithDifferningDimension" xml:space="preserve">
+    <value>Cannot compare {0} to {1} with differning dimension {2}, {3} != {4}.</value>
+  </data>
+  <data name="CannotCompareWithDifferningDimension" xml:space="preserve">
+    <value>Cannot compare {0}s with differning dimension {1}, {2} != {3}.</value>
+  </data>
+  <data name="CannotCompareWithRank" xml:space="preserve">
+    <value>Cannot compare {0} with Rank {1} to {2} with Rank {3}.</value>
+  </data>
+  <data name="CannotComputeDiagonal" xml:space="preserve">
+    <value>Cannot compute diagonal of {0} with Rank less than 2.</value>
+  </data>
+  <data name="CannotComputeDiagonalWithOffset" xml:space="preserve">
+    <value>Cannot compute diagonal with offset {0}</value>
+  </data>
+  <data name="MustHaveAtLeastOneDimension" xml:space="preserve">
+    <value>Tensor {0} must have at least one dimension.</value>
+  </data>
+  <data name="CannotComputeTriangle" xml:space="preserve">
+    <value>Cannot compute triangle of {0} with Rank less than 2.</value>
+  </data>
+  <data name="CannotReshapeArrayDueToMismatchInLengths" xml:space="preserve">
+    <value>Cannot reshape array due to mismatch in lengths, currently {0} would become {1}.</value>
+  </data>
+  <data name="DimensionsMustBePositiveAndNonZero" xml:space="preserve">
+    <value>Dimensions must be positive and non-zero"</value>
+  </data>
+  <data name="DimensionsMustContainElements" xml:space="preserve">
+    <value>Dimensions must contain elements.</value>
+  </data>
+  <data name="LenghtMustMatch" xml:space="preserve">
+    <value>Length of {0} ({1}) must match product of {2} ({3}).</value>
+  </data>
+  <data name="NumberGreaterThenAvaliableSpace" xml:space="preserve">
+    <value>The number of elements in the Tensor is greater than the available space from index to the end of the destination array.</value>
+  </data>
+  <data name="OnlySingleDimensionalArraysSupported" xml:space="preserve">
+    <value>Only single dimensional arrays are supported for the requested action.</value>
+  </data>
+  <data name="ValueIsNotOfType" xml:space="preserve">
+    <value>The value "{0}" is not of type "{1}" and cannot be used in this generic collection.</value>
+  </data>
+</root>

--- a/src/System.Numerics.Tensors/src/Resources/Strings.resx
+++ b/src/System.Numerics.Tensors/src/Resources/Strings.resx
@@ -123,11 +123,11 @@
   <data name="CannotCompare" xml:space="preserve">
     <value>Cannot compare {0} to {1}.</value>
   </data>
-  <data name="CannotCompareToWithDifferningDimension" xml:space="preserve">
-    <value>Cannot compare {0} to {1} with differning dimension {2}, {3} != {4}.</value>
+  <data name="CannotCompareToWithDifferentDimension" xml:space="preserve">
+    <value>Cannot compare {0} to {1} with different dimension {2}, {3} != {4}.</value>
   </data>
-  <data name="CannotCompareWithDifferningDimension" xml:space="preserve">
-    <value>Cannot compare {0}s with differning dimension {1}, {2} != {3}.</value>
+  <data name="CannotCompareWithDifferentDimension" xml:space="preserve">
+    <value>Cannot compare {0} with different dimension {1}, {2} != {3}.</value>
   </data>
   <data name="CannotCompareWithRank" xml:space="preserve">
     <value>Cannot compare {0} with Rank {1} to {2} with Rank {3}.</value>
@@ -136,7 +136,7 @@
     <value>Cannot compute diagonal of {0} with Rank less than 2.</value>
   </data>
   <data name="CannotComputeDiagonalWithOffset" xml:space="preserve">
-    <value>Cannot compute diagonal with offset {0}</value>
+    <value>Cannot compute diagonal with offset {0}.</value>
   </data>
   <data name="MustHaveAtLeastOneDimension" xml:space="preserve">
     <value>Tensor {0} must have at least one dimension.</value>
@@ -148,15 +148,15 @@
     <value>Cannot reshape array due to mismatch in lengths, currently {0} would become {1}.</value>
   </data>
   <data name="DimensionsMustBePositiveAndNonZero" xml:space="preserve">
-    <value>Dimensions must be positive and non-zero"</value>
+    <value>Dimensions must be positive and non-zero.</value>
   </data>
   <data name="DimensionsMustContainElements" xml:space="preserve">
     <value>Dimensions must contain elements.</value>
   </data>
-  <data name="LenghtMustMatch" xml:space="preserve">
+  <data name="LengthMustMatch" xml:space="preserve">
     <value>Length of {0} ({1}) must match product of {2} ({3}).</value>
   </data>
-  <data name="NumberGreaterThenAvaliableSpace" xml:space="preserve">
+  <data name="NumberGreaterThenAvailableSpace" xml:space="preserve">
     <value>The number of elements in the Tensor is greater than the available space from index to the end of the destination array.</value>
   </data>
   <data name="OnlySingleDimensionalArraysSupported" xml:space="preserve">

--- a/src/System.Numerics.Tensors/src/System.Numerics.Tensors.csproj
+++ b/src/System.Numerics.Tensors/src/System.Numerics.Tensors.csproj
@@ -22,6 +22,7 @@
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.Linq" />
     <Reference Include="System.Memory" />
+    <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Runtime.InteropServices" />

--- a/src/System.Numerics.Tensors/src/System/Numerics/Tensors/DenseTensor.cs
+++ b/src/System.Numerics.Tensors/src/System/Numerics/Tensors/DenseTensor.cs
@@ -72,7 +72,7 @@ namespace System.Numerics.Tensors
 
             if (Length != memory.Length)
             {
-                throw new ArgumentException($"Length of {nameof(memory)} ({memory.Length}) must match product of {nameof(dimensions)} ({Length}).");
+                throw new ArgumentException(SR.Format(SR.LenghtMustMatch, nameof(memory), memory.Length, nameof(dimensions), Length));
             }
         }
 
@@ -109,7 +109,7 @@ namespace System.Numerics.Tensors
             }
             if (array.Length < arrayIndex + Length)
             {
-                throw new ArgumentException("The number of elements in the Tensor is greater than the available space from index to the end of the destination array.", nameof(array));
+                throw new ArgumentException(SR.NumberGreaterThenAvaliableSpace, nameof(array));
             }
 
             Buffer.Span.CopyTo(array.AsSpan(arrayIndex));
@@ -162,14 +162,14 @@ namespace System.Numerics.Tensors
         {
             if (dimensions.Length == 0)
             {
-                throw new ArgumentException("Dimensions must contain elements.", nameof(dimensions));
+                throw new ArgumentException(SR.DimensionsMustContainElements, nameof(dimensions));
             }
 
             var newSize = ArrayUtilities.GetProduct(dimensions);
 
             if (newSize != Length)
             {
-                throw new ArgumentException($"Cannot reshape array due to mismatch in lengths, currently {Length} would become {newSize}.", nameof(dimensions));
+                throw new ArgumentException(SR.Format(SR.CannotReshapeArrayDueToMismatchInLengths, Length, newSize), nameof(dimensions));
             }
 
             return new DenseTensor<T>(Buffer, dimensions, IsReversedStride);

--- a/src/System.Numerics.Tensors/src/System/Numerics/Tensors/DenseTensor.cs
+++ b/src/System.Numerics.Tensors/src/System/Numerics/Tensors/DenseTensor.cs
@@ -72,7 +72,7 @@ namespace System.Numerics.Tensors
 
             if (Length != memory.Length)
             {
-                throw new ArgumentException(SR.Format(SR.LenghtMustMatch, nameof(memory), memory.Length, nameof(dimensions), Length));
+                throw new ArgumentException(SR.Format(SR.LengthMustMatch, nameof(memory), memory.Length, nameof(dimensions), Length));
             }
         }
 
@@ -109,7 +109,7 @@ namespace System.Numerics.Tensors
             }
             if (array.Length < arrayIndex + Length)
             {
-                throw new ArgumentException(SR.NumberGreaterThenAvaliableSpace, nameof(array));
+                throw new ArgumentException(SR.NumberGreaterThenAvailableSpace, nameof(array));
             }
 
             Buffer.Span.CopyTo(array.AsSpan(arrayIndex));

--- a/src/System.Numerics.Tensors/src/System/Numerics/Tensors/Tensor.cs
+++ b/src/System.Numerics.Tensors/src/System/Numerics/Tensors/Tensor.cs
@@ -82,7 +82,7 @@ namespace System.Numerics.Tensors
         {
             if (diagonal.Rank < 1)
             {
-                throw new ArgumentException($"Tensor {nameof(diagonal)} must have at least one dimension.", nameof(diagonal));
+                throw new ArgumentException(SR.Format(SR.MustHaveAtLeastOneDimension, nameof(diagonal)), nameof(diagonal));
             }
 
             int diagonalLength = diagonal.dimensions[0];
@@ -283,7 +283,7 @@ namespace System.Numerics.Tensors
         {
             if (dimensions.Length == 0)
             {
-                throw new ArgumentException("Dimensions must contain elements.", nameof(dimensions));
+                throw new ArgumentException(SR.DimensionsMustContainElements, nameof(dimensions));
             }
 
             this.dimensions = new int[dimensions.Length];
@@ -292,7 +292,7 @@ namespace System.Numerics.Tensors
             {
                 if (dimensions[i] < 1)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(dimensions), "Dimensions must be positive and non-zero");
+                    throw new ArgumentOutOfRangeException(nameof(dimensions), SR.DimensionsMustBePositiveAndNonZero);
                 }
                 this.dimensions[i] = dimensions[i];
                 size *= dimensions[i];
@@ -318,7 +318,7 @@ namespace System.Numerics.Tensors
 
             if (fromArray.Rank == 0)
             {
-                throw new ArgumentException("Array must contain elements.", nameof(fromArray));
+                throw new ArgumentException(SR.ArrayMustContainElements, nameof(fromArray));
             }
 
             dimensions = new int[fromArray.Rank];
@@ -443,7 +443,7 @@ namespace System.Numerics.Tensors
 
             if (Rank < 2)
             {
-                throw new InvalidOperationException($"Cannot compute diagonal of {nameof(Tensor<T>)} with Rank less than 2.");
+                throw new InvalidOperationException(SR.Format(SR.CannotComputeDiagonal, nameof(Tensor<T>)));
             }
 
             // TODO: allow specification of axis1 and axis2?
@@ -470,7 +470,7 @@ namespace System.Numerics.Tensors
 
             if (diagonalLength <= 0)
             {
-                throw new ArgumentException($"Cannot compute diagonal with offset {offset}", nameof(offset));
+                throw new ArgumentException(SR.Format(SR.CannotComputeDiagonalWithOffset, offset), nameof(offset));
             }
 
             var newTensorRank = Rank - 1;
@@ -548,7 +548,7 @@ namespace System.Numerics.Tensors
         {
             if (Rank < 2)
             {
-                throw new InvalidOperationException($"Cannot compute triangle of {nameof(Tensor<T>)} with Rank less than 2.");
+                throw new InvalidOperationException(SR.Format(SR.CannotComputeTriangle, nameof(Tensor<T>)));
             }
 
             // Similar to get diagonal except it gets every element below and including the diagonal.
@@ -745,11 +745,11 @@ namespace System.Numerics.Tensors
                 }
                 if (array.Rank != 1)
                 {
-                    throw new ArgumentException("Only single dimensional arrays are supported for the requested action.", nameof(array));
+                    throw new ArgumentException(SR.OnlySingleDimensionalArraysSupported, nameof(array));
                 }
                 if (array.Length < index + Length)
                 {
-                    throw new ArgumentException("The number of elements in the Tensor is greater than the available space from index to the end of the destination array.", nameof(array));
+                    throw new ArgumentException(SR.NumberGreaterThenAvaliableSpace, nameof(array));
                 }
 
                 for (int i = 0; i < length; i++)
@@ -775,7 +775,7 @@ namespace System.Numerics.Tensors
                 }
                 catch (InvalidCastException)
                 {
-                    throw new ArgumentException($"The value \"{value}\" is not of type \"{typeof(T)}\" and cannot be used in this generic collection.");
+                    throw new ArgumentException(SR.Format(SR.ValueIsNotOfType, value, typeof(T)));
                 }
             }
         }
@@ -892,7 +892,7 @@ namespace System.Numerics.Tensors
             }
             if (array.Length < arrayIndex + Length)
             {
-                throw new ArgumentException("The number of elements in the Tensor is greater than the available space from index to the end of the destination array.", nameof(array));
+                throw new ArgumentException(SR.NumberGreaterThenAvaliableSpace, nameof(array));
             }
 
             for (int i = 0; i < length; i++)
@@ -980,21 +980,21 @@ namespace System.Numerics.Tensors
                 return CompareTo(otherArray, comparer);
             }
 
-            throw new ArgumentException($"Cannot compare {nameof(Tensor<T>)} to {other.GetType()}.", nameof(other));
+            throw new ArgumentException(SR.Format(SR.CannotCompare, nameof(Tensor<T>), other.GetType()), nameof(other));
         }
 
         private int CompareTo(Tensor<T> other, IComparer comparer)
         {
             if (Rank != other.Rank)
             {
-                throw new ArgumentException($"Cannot compare {nameof(Tensor<T>)} with Rank {Rank} to {nameof(other)} with Rank {other.Rank}.", nameof(other));
+                throw new ArgumentException(SR.Format(SR.CannotCompareWithRank, nameof(Tensor<T>), Rank, nameof(other), other.Rank), nameof(other));
             }
 
             for (int i = 0; i < dimensions.Length; i++)
             {
                 if (dimensions[i] != other.dimensions[i])
                 {
-                    throw new ArgumentException($"Cannot compare {nameof(Tensor<T>)}s with differning dimension {i}, {dimensions[i]} != {other.dimensions[i]}.", nameof(other));
+                    throw new ArgumentException(SR.Format(SR.CannotCompareWithDifferningDimension, nameof(Tensor<T>), i, dimensions[i], other.dimensions[i]), nameof(other));
                 }
             }
 
@@ -1032,7 +1032,7 @@ namespace System.Numerics.Tensors
         {
             if (Rank != other.Rank)
             {
-                throw new ArgumentException($"Cannot compare {nameof(Tensor<T>)} with Rank {Rank} to {nameof(Array)} with rank {other.Rank}.", nameof(other));
+                throw new ArgumentException(SR.Format(SR.CannotCompareWithRank, nameof(Tensor<T>), Rank, nameof(Array), other.Rank), nameof(other));
             }
 
             for (int i = 0; i < dimensions.Length; i++)
@@ -1040,7 +1040,7 @@ namespace System.Numerics.Tensors
                 var otherDimension = other.GetLength(i);
                 if (dimensions[i] != otherDimension)
                 {
-                    throw new ArgumentException($"Cannot compare {nameof(Tensor<T>)} to {nameof(Array)} with differning dimension {i}, {dimensions[i]} != {otherDimension}.", nameof(other));
+                    throw new ArgumentException(SR.Format(SR.CannotCompareToWithDifferningDimension, nameof(Tensor<T>), nameof(Array), i, dimensions[i], otherDimension), nameof(other));
                 }
             }
 
@@ -1082,21 +1082,21 @@ namespace System.Numerics.Tensors
                 return Equals(otherArray, comparer);
             }
 
-            throw new ArgumentException($"Cannot compare {nameof(Tensor<T>)} to {other.GetType()}.", nameof(other));
+            throw new ArgumentException(SR.Format(SR.CannotCompare, nameof(Tensor<T>), other.GetType()), nameof(other));
         }
 
         private bool Equals(Tensor<T> other, IEqualityComparer comparer)
         {
             if (Rank != other.Rank)
             {
-                throw new ArgumentException($"Cannot compare {nameof(Tensor<T>)} with Rank {Rank} to {nameof(other)} with Rank {other.Rank}.", nameof(other));
+                throw new ArgumentException(SR.Format(SR.CannotCompareWithRank, nameof(Tensor<T>), Rank, nameof(other), other.Rank), nameof(other));
             }
 
             for (int i = 0; i < dimensions.Length; i++)
             {
                 if (dimensions[i] != other.dimensions[i])
                 {
-                    throw new ArgumentException($"Cannot compare {nameof(Tensor<T>)}s with differning dimension {i}, {dimensions[i]} != {other.dimensions[i]}.", nameof(other));
+                    throw new ArgumentException(SR.Format(SR.CannotCompareWithDifferningDimension, nameof(Tensor<T>), i, dimensions[i], other.dimensions[i]), nameof(other));
                 }
             }
 
@@ -1131,7 +1131,7 @@ namespace System.Numerics.Tensors
         {
             if (Rank != other.Rank)
             {
-                throw new ArgumentException($"Cannot compare {nameof(Tensor<T>)} with Rank {Rank} to {nameof(Array)} with rank {other.Rank}.", nameof(other));
+                throw new ArgumentException(SR.Format(SR.CannotCompareWithRank, nameof(Tensor<T>), Rank, nameof(Array), other.Rank), nameof(other));
             }
 
             for (int i = 0; i < dimensions.Length; i++)
@@ -1139,7 +1139,7 @@ namespace System.Numerics.Tensors
                 var otherDimension = other.GetLength(i);
                 if (dimensions[i] != otherDimension)
                 {
-                    throw new ArgumentException($"Cannot compare {nameof(Tensor<T>)} to {nameof(Array)} with differning dimension {i}, {dimensions[i]} != {otherDimension}.", nameof(other));
+                    throw new ArgumentException(SR.Format(SR.CannotCompareToWithDifferningDimension, nameof(Tensor<T>), nameof(Array), i, dimensions[i], otherDimension), nameof(other));
                 }
             }
 

--- a/src/System.Numerics.Tensors/src/System/Numerics/Tensors/Tensor.cs
+++ b/src/System.Numerics.Tensors/src/System/Numerics/Tensors/Tensor.cs
@@ -749,7 +749,7 @@ namespace System.Numerics.Tensors
                 }
                 if (array.Length < index + Length)
                 {
-                    throw new ArgumentException(SR.NumberGreaterThenAvaliableSpace, nameof(array));
+                    throw new ArgumentException(SR.NumberGreaterThenAvailableSpace, nameof(array));
                 }
 
                 for (int i = 0; i < length; i++)
@@ -892,7 +892,7 @@ namespace System.Numerics.Tensors
             }
             if (array.Length < arrayIndex + Length)
             {
-                throw new ArgumentException(SR.NumberGreaterThenAvaliableSpace, nameof(array));
+                throw new ArgumentException(SR.NumberGreaterThenAvailableSpace, nameof(array));
             }
 
             for (int i = 0; i < length; i++)
@@ -994,7 +994,7 @@ namespace System.Numerics.Tensors
             {
                 if (dimensions[i] != other.dimensions[i])
                 {
-                    throw new ArgumentException(SR.Format(SR.CannotCompareWithDifferningDimension, nameof(Tensor<T>), i, dimensions[i], other.dimensions[i]), nameof(other));
+                    throw new ArgumentException(SR.Format(SR.CannotCompareWithDifferentDimension, nameof(Tensor<T>), i, dimensions[i], other.dimensions[i]), nameof(other));
                 }
             }
 
@@ -1040,7 +1040,7 @@ namespace System.Numerics.Tensors
                 var otherDimension = other.GetLength(i);
                 if (dimensions[i] != otherDimension)
                 {
-                    throw new ArgumentException(SR.Format(SR.CannotCompareToWithDifferningDimension, nameof(Tensor<T>), nameof(Array), i, dimensions[i], otherDimension), nameof(other));
+                    throw new ArgumentException(SR.Format(SR.CannotCompareToWithDifferentDimension, nameof(Tensor<T>), nameof(Array), i, dimensions[i], otherDimension), nameof(other));
                 }
             }
 
@@ -1096,7 +1096,7 @@ namespace System.Numerics.Tensors
             {
                 if (dimensions[i] != other.dimensions[i])
                 {
-                    throw new ArgumentException(SR.Format(SR.CannotCompareWithDifferningDimension, nameof(Tensor<T>), i, dimensions[i], other.dimensions[i]), nameof(other));
+                    throw new ArgumentException(SR.Format(SR.CannotCompareWithDifferentDimension, nameof(Tensor<T>), i, dimensions[i], other.dimensions[i]), nameof(other));
                 }
             }
 
@@ -1139,7 +1139,7 @@ namespace System.Numerics.Tensors
                 var otherDimension = other.GetLength(i);
                 if (dimensions[i] != otherDimension)
                 {
-                    throw new ArgumentException(SR.Format(SR.CannotCompareToWithDifferningDimension, nameof(Tensor<T>), nameof(Array), i, dimensions[i], otherDimension), nameof(other));
+                    throw new ArgumentException(SR.Format(SR.CannotCompareToWithDifferentDimension, nameof(Tensor<T>), nameof(Array), i, dimensions[i], otherDimension), nameof(other));
                 }
             }
 

--- a/src/System.Private.DataContractSerialization/src/Resources/Strings.resx
+++ b/src/System.Private.DataContractSerialization/src/Resources/Strings.resx
@@ -1157,4 +1157,7 @@
   <data name="FailedToCreateMethodDelegate" xml:space="preserve">
     <value>Failed to create Delegate for method '{0}' of type '{1}'.</value>
   </data>
+  <data name="CanOnlySetOnce" xml:space="preserve">
+    <value>Can only set once</value>
+  </data>
 </root>

--- a/src/System.Private.DataContractSerialization/src/Resources/Strings.resx
+++ b/src/System.Private.DataContractSerialization/src/Resources/Strings.resx
@@ -1110,7 +1110,7 @@
     <value>IExtensibleDataObject property setter '{1}' in type '{0}' must have a single parameter of type '{2}'.</value>
   </data>
   <data name="OnlyDataContractTypesCanHaveExtensionData" xml:space="preserve">
-    <value>Type '{0}' does not have DataContractAttribute attribute and therefore cannot support IExtensibleDataObject. </value>
+    <value>Type '{0}' does not have DataContractAttribute attribute and therefore cannot support IExtensibleDataObject.</value>
   </data>
   <data name="ParseJsonNumberReturnInvalidNumber" xml:space="preserve">
     <value>JsonObjectDataContract.ParseJsonNumber shouldn't return a TypeCode that we're not expecting.</value>
@@ -1157,7 +1157,10 @@
   <data name="FailedToCreateMethodDelegate" xml:space="preserve">
     <value>Failed to create Delegate for method '{0}' of type '{1}'.</value>
   </data>
-  <data name="CanOnlySetOnce" xml:space="preserve">
-    <value>Can only set once</value>
+  <data name="CannotSetTwice" xml:space="preserve">
+    <value>Cannot set option twice.</value>
+  </data>
+  <data name="MustBeGreaterThanZero" xml:space="preserve">
+    <value>'{0}' must be greater than 0.</value>
   </data>
 </root>

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSerializer.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSerializer.cs
@@ -43,7 +43,7 @@ namespace System.Runtime.Serialization
             {
                 if (_optionAlreadySet)
                 {
-                    throw new InvalidOperationException("Can only set once");
+                    throw new InvalidOperationException(SR.CanOnlySetOnce);
                 }
                 _optionAlreadySet = true;
                 _option = value;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSerializer.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSerializer.cs
@@ -43,7 +43,7 @@ namespace System.Runtime.Serialization
             {
                 if (_optionAlreadySet)
                 {
-                    throw new InvalidOperationException(SR.CanOnlySetOnce);
+                    throw new InvalidOperationException(SR.CannotSetTwice);
                 }
                 _optionAlreadySet = true;
                 _option = value;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/ReflectionJsonFormatReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/ReflectionJsonFormatReader.cs
@@ -218,7 +218,7 @@ namespace System.Runtime.Serialization.Json
 
                 if (keyTypeNullableDepth > 0)
                 {
-                    throw new NotImplementedException("keyTypeNullableDepth > 0");
+                    throw new NotImplementedException($"{nameof(keyTypeNullableDepth)} > 0");
                 }
 
                 object pairValue = ReflectionReadValue(xmlReader, context, valueType, string.Empty, string.Empty);

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/ReflectionJsonFormatReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/ReflectionJsonFormatReader.cs
@@ -218,7 +218,7 @@ namespace System.Runtime.Serialization.Json
 
                 if (keyTypeNullableDepth > 0)
                 {
-                    throw new NotImplementedException($"{nameof(keyTypeNullableDepth)} > 0");
+                    throw new NotImplementedException(SR.Format(SR.MustBeGreaterThanZero, keyTypeNullableDepth));
                 }
 
                 object pairValue = ReflectionReadValue(xmlReader, context, valueType, string.Empty, string.Empty);

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryReader.cs
@@ -1656,11 +1656,11 @@ namespace System.Xml
                 }
                 catch (ArgumentException exception)
                 {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException("Boolean", exception));
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException(nameof(Boolean), exception));
                 }
                 catch (FormatException exception)
                 {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException("Boolean", exception));
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException(nameof(Boolean), exception));
                 }
             }
 
@@ -1677,15 +1677,15 @@ namespace System.Xml
                 }
                 catch (ArgumentException exception)
                 {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException("Decimal", exception));
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException(nameof(Decimal), exception));
                 }
                 catch (FormatException exception)
                 {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException("Decimal", exception));
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException(nameof(Decimal), exception));
                 }
                 catch (OverflowException exception)
                 {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException("Decimal", exception));
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException(nameof(Decimal), exception));
                 }
             }
 
@@ -1697,15 +1697,15 @@ namespace System.Xml
                 }
                 catch (ArgumentException exception)
                 {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException("Double", exception));
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException(nameof(Double), exception));
                 }
                 catch (FormatException exception)
                 {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException("Double", exception));
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException(nameof(Double), exception));
                 }
                 catch (OverflowException exception)
                 {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException("Double", exception));
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException(nameof(Double), exception));
                 }
             }
 
@@ -1717,15 +1717,15 @@ namespace System.Xml
                 }
                 catch (ArgumentException exception)
                 {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException("Int32", exception));
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException(nameof(Int32), exception));
                 }
                 catch (FormatException exception)
                 {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException("Int32", exception));
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException(nameof(Int32), exception));
                 }
                 catch (OverflowException exception)
                 {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException("Int32", exception));
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException(nameof(Int32), exception));
                 }
             }
 
@@ -1737,15 +1737,15 @@ namespace System.Xml
                 }
                 catch (ArgumentException exception)
                 {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException("Int64", exception));
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException(nameof(Int64), exception));
                 }
                 catch (FormatException exception)
                 {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException("Int64", exception));
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException(nameof(Int64), exception));
                 }
                 catch (OverflowException exception)
                 {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException("Int64", exception));
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException(nameof(Int64), exception));
                 }
             }
 
@@ -1757,15 +1757,15 @@ namespace System.Xml
                 }
                 catch (ArgumentException exception)
                 {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException("Single", exception));
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException(nameof(Single), exception));
                 }
                 catch (FormatException exception)
                 {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException("Single", exception));
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException(nameof(Single), exception));
                 }
                 catch (OverflowException exception)
                 {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException("Single", exception));
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException(nameof(Single), exception));
                 }
             }
 
@@ -1777,11 +1777,11 @@ namespace System.Xml
                 }
                 catch (ArgumentException exception)
                 {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException("String", exception));
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException(nameof(String), exception));
                 }
                 catch (FormatException exception)
                 {
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException("String", exception));
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlExceptionHelper.CreateConversionException(nameof(String), exception));
                 }
             }
 

--- a/src/System.Private.Xml/src/Resources/Strings.resx
+++ b/src/System.Private.Xml/src/Resources/Strings.resx
@@ -3449,4 +3449,7 @@ Usage: dotnet {0} [--assembly &lt;assembly file path&gt;] [--type &lt;type name&
   <data name="event_XmlSerializerExpired" xml:space="preserve">
     <value>Pre-generated serializer '{0}' has expired. You need to re-generate serializer for '{1}'</value>
   </data>
+  <data name="CompilingScriptsNotSupported" xml:space="preserve">
+    <value>Compiling JScript/CSharp scripts is not supported</value>
+  </data>
 </root>

--- a/src/System.Private.Xml/src/System/Xml/Serialization/Compilation.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/Compilation.cs
@@ -80,7 +80,7 @@ namespace System.Xml.Serialization
 
             if (fallbackToCSharpAssemblyGeneration)
             {
-                throw new PlatformNotSupportedException("Compiling JScript/CSharp scripts is not supported");
+                throw new PlatformNotSupportedException(SR.CompilingScriptsNotSupported);
             }
 
 #if DEBUG

--- a/src/System.Private.Xml/src/System/Xml/Xsl/Xslt/XsltLoader.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/Xslt/XsltLoader.cs
@@ -1315,7 +1315,7 @@ namespace System.Xml.Xsl.Xslt
                 return;
             }
 
-            throw new PlatformNotSupportedException("Compiling JScript/CSharp scripts is not supported"); // Not adding any scripts as script compilation is not available
+            throw new PlatformNotSupportedException(SR.CompilingScriptsNotSupported); // Not adding any scripts as script compilation is not available
         }
 
         private readonly XsltAttribute[] _assemblyAttributes = {

--- a/src/System.Private.Xml/src/System/Xml/Xsl/XsltOld/Compiler.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/XsltOld/Compiler.cs
@@ -778,7 +778,7 @@ namespace System.Xml.Xsl.XsltOld
                 Hashtable typeDecls = _typeDeclsByLang[(int)langTmp];
                 if (lang == langTmp)
                 {
-                    throw new PlatformNotSupportedException("Compiling JScript/CSharp scripts is not supported");
+                    throw new PlatformNotSupportedException(SR.CompilingScriptsNotSupported);
                 }
                 else if (typeDecls.Contains(ns))
                 {

--- a/src/System.Reflection.Metadata/src/Resources/Strings.resx
+++ b/src/System.Reflection.Metadata/src/Resources/Strings.resx
@@ -399,4 +399,10 @@
   <data name="InvalidExceptionRegionBounds" xml:space="preserve">
     <value>Invalid exception region bounds: start offset ({0}) is greater than end offset ({1}).</value>
   </data>
+  <data name="UnexpectedValue" xml:space="preserve">
+    <value>Unexpected value '{0}' of type '{1}'</value>
+  </data>
+  <data name="UnreachableLocation" xml:space="preserve">
+    <value>This program location is thought to be unreachable.</value>
+  </data>
 </root>

--- a/src/System.Reflection.Metadata/src/Resources/Strings.resx
+++ b/src/System.Reflection.Metadata/src/Resources/Strings.resx
@@ -402,6 +402,9 @@
   <data name="UnexpectedValue" xml:space="preserve">
     <value>Unexpected value '{0}' of type '{1}'</value>
   </data>
+  <data name="UnexpectedValueUnknownType" xml:space="preserve">
+    <value>Unexpected value '{0}' of unknown type.</value>
+  </data>
   <data name="UnreachableLocation" xml:space="preserve">
     <value>This program location is thought to be unreachable.</value>
   </data>

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/ExceptionUtilities.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/ExceptionUtilities.cs
@@ -7,9 +7,9 @@ namespace System.Reflection.Internal
     internal static class ExceptionUtilities
     {
         internal static Exception UnexpectedValue(object value) =>
-            new InvalidOperationException($"Unexpected value '{value}' of type '{value?.GetType().FullName ?? "<unknown>"}'");
+            new InvalidOperationException(SR.Format(SR.UnexpectedValue, value, value?.GetType().FullName ?? "<unknown>"));
 
         internal static Exception Unreachable =>
-            new InvalidOperationException("This program location is thought to be unreachable.");
+            new InvalidOperationException(SR.UnreachableLocation);
     }
 }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/ExceptionUtilities.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/ExceptionUtilities.cs
@@ -6,8 +6,15 @@ namespace System.Reflection.Internal
 {
     internal static class ExceptionUtilities
     {
-        internal static Exception UnexpectedValue(object value) =>
-            new InvalidOperationException(SR.Format(SR.UnexpectedValue, value, value?.GetType().FullName ?? "<unknown>"));
+        internal static Exception UnexpectedValue(object value)
+        {
+            if (value?.GetType().FullName != null)
+            {
+                return new InvalidOperationException(SR.Format(SR.UnexpectedValue, value, value.GetType().FullName));
+            }
+
+            return new InvalidOperationException(SR.Format(SR.UnexpectedValueUnknownType, value));
+        }
 
         internal static Exception Unreachable =>
             new InvalidOperationException(SR.UnreachableLocation);

--- a/src/System.Runtime.WindowsRuntime/src/Resources/Strings.resx
+++ b/src/System.Runtime.WindowsRuntime/src/Resources/Strings.resx
@@ -338,4 +338,7 @@
   <data name="PlatformNotSupported_WindowsRuntime" xml:space="preserve">
     <value>Windows Runtime (WinRT) is not supported on this platform.</value>
   </data>
+  <data name="InvalidAction" xml:space="preserve">
+    <value>Invalid action value: {0}</value>
+  </data>
 </root>

--- a/src/System.Runtime.WindowsRuntime/src/Resources/Strings.resx
+++ b/src/System.Runtime.WindowsRuntime/src/Resources/Strings.resx
@@ -339,6 +339,6 @@
     <value>Windows Runtime (WinRT) is not supported on this platform.</value>
   </data>
   <data name="InvalidAction" xml:space="preserve">
-    <value>Invalid action value: {0}</value>
+    <value>Invalid action value: '{0}'.</value>
   </data>
 </root>

--- a/src/System.Runtime.WindowsRuntime/src/System/IO/StreamOperationAsyncResult.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/IO/StreamOperationAsyncResult.cs
@@ -40,7 +40,7 @@ namespace System.IO
                                                       bool processCompletedOperationInCallback)
         {
             if (asyncStreamOperation == null)
-                throw new ArgumentNullException("asyncReadOperation");
+                throw new ArgumentNullException(nameof(asyncStreamOperation));
 
             _userCompletionCallback = userCompletionCallback;
             _userAsyncStateInfo = userAsyncStateInfo;

--- a/src/System.Runtime.WindowsRuntime/src/System/IO/WinRtToNetFxStreamAdapter.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/IO/WinRtToNetFxStreamAdapter.cs
@@ -283,7 +283,7 @@ namespace System.IO
             set
             {
                 if (value < 0)
-                    throw new ArgumentOutOfRangeException("Position", SR.ArgumentOutOfRange_IO_CannotSeekToNegativePosition);
+                    throw new ArgumentOutOfRangeException(nameof(Position), SR.ArgumentOutOfRange_IO_CannotSeekToNegativePosition);
 
                 IRandomAccessStream wrtStr = EnsureNotDisposed<IRandomAccessStream>();
 

--- a/src/System.Runtime.WindowsRuntime/src/System/Runtime/InteropServices/WindowsRuntime/MarshalingHelpers.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Runtime/InteropServices/WindowsRuntime/MarshalingHelpers.cs
@@ -160,7 +160,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
                 NotifyCollectionChangedAction.Replace => new NotifyCollectionChangedEventArgs(action, newItems, oldItems, newStartingIndex),
                 NotifyCollectionChangedAction.Move => new NotifyCollectionChangedEventArgs(action, newItems, newStartingIndex, oldStartingIndex),
                 NotifyCollectionChangedAction.Reset => new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset),
-                _ => throw new ArgumentException("Invalid action value: " + action),
+                _ => throw new ArgumentException(SR.Format(SR.InvalidAction, action)),
             };
     }
 

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlDsigBase64Transform.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlDsigBase64Transform.cs
@@ -66,7 +66,7 @@ namespace System.Security.Cryptography.Xml
 
         private void LoadStreamInput(Stream inputStream)
         {
-            if (inputStream == null) throw new ArgumentException("obj");
+            if (inputStream == null) throw new ArgumentException(nameof(inputStream));
             MemoryStream ms = new MemoryStream();
             byte[] buffer = new byte[1024];
             int bytesRead;

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlDsigBase64Transform.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlDsigBase64Transform.cs
@@ -66,7 +66,7 @@ namespace System.Security.Cryptography.Xml
 
         private void LoadStreamInput(Stream inputStream)
         {
-            if (inputStream == null) throw new ArgumentException(nameof(inputStream));
+            if (inputStream == null) throw new ArgumentException("obj");
             MemoryStream ms = new MemoryStream();
             byte[] buffer = new byte[1024];
             int bytesRead;

--- a/src/System.Threading/src/System/Threading/Barrier.cs
+++ b/src/System.Threading/src/System/Threading/Barrier.cs
@@ -938,7 +938,7 @@ namespace System.Threading
         {
             if (_disposed)
             {
-                throw new ObjectDisposedException("Barrier", SR.Barrier_Dispose);
+                throw new ObjectDisposedException(nameof(Barrier), SR.Barrier_Dispose);
             }
         }
     }

--- a/src/System.Threading/src/System/Threading/CountdownEvent.cs
+++ b/src/System.Threading/src/System/Threading/CountdownEvent.cs
@@ -570,7 +570,7 @@ namespace System.Threading
         {
             if (_disposed)
             {
-                throw new ObjectDisposedException("CountdownEvent");
+                throw new ObjectDisposedException(nameof(CountdownEvent));
             }
         }
     }

--- a/src/System.Windows.Extensions/src/System/Media/SoundPlayer.cs
+++ b/src/System.Windows.Extensions/src/System/Media/SoundPlayer.cs
@@ -72,7 +72,7 @@ namespace System.Media
             {
                 if (value < 0)
                 {
-                    throw new ArgumentOutOfRangeException("LoadTimeout", value, SR.SoundAPILoadTimeout);
+                    throw new ArgumentOutOfRangeException(nameof(LoadTimeout), value, SR.SoundAPILoadTimeout);
                 }
 
                 _loadTimeout = value;


### PR DESCRIPTION
Related to #40074

I used this pattern `Exception\(".+?"` to find hardcoded exception messages.
The PR skips exceptions in tests include changes for:

- System.Composition.Hosting
- System.Diagnostics.DiagnosticSource
- System.DirectoryServices
- System.Drawing.Common
- System.IO.FileSystem
- System.IO.Packaging
- System.Numerics.Tensors
- System.Private.DataContractSerialization
- System.Private.Xml
- System.Reflection.Metadata
- System.Runtime.WindowsRuntime 
- System.Security.Cryptography.Xml

There need some changes in `src\Common\src`, but I don't actually know where I can find Strings.resx 
 for Comman. Could you please suggest?

In the next step, I think, I should extend regex to `Exception\(\$".+?"`

Please review,
Thank you in advance