### PR TITLE
[release/3.0] Honor JsonIgnore attribute when applied to unsupported collections

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.AddProperty.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.AddProperty.cs
@@ -33,7 +33,7 @@ namespace System.Text.Json
 
             if (implementedType != propertyType)
             {
-                jsonInfo = CreateProperty(implementedType, implementedType, implementedType, null, typeof(object), options);
+                jsonInfo = CreateProperty(implementedType, implementedType, implementedType, propertyInfo, typeof(object), options);
             }
             else
             {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoCommon.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoCommon.cs
@@ -32,7 +32,11 @@ namespace System.Text.Json
         {
             base.Initialize(parentClassType, declaredPropertyType, runtimePropertyType, implementedPropertyType, propertyInfo, elementType, converter, options);
 
-            if (propertyInfo != null)
+            if (propertyInfo != null &&
+                // We only want to get the getter and setter if we are going to use them.
+                // If the declared type is not the property info type, then we are just
+                // getting metadata on how best to (de)serialize derived types.
+                declaredPropertyType == propertyInfo.PropertyType)
             {
                 if (propertyInfo.GetMethod?.IsPublic == true)
                 {

--- a/src/System.Text.Json/tests/Serialization/PropertyVisibilityTests.cs
+++ b/src/System.Text.Json/tests/Serialization/PropertyVisibilityTests.cs
@@ -156,21 +156,31 @@ namespace System.Text.Json.Serialization.Tests
 
             // Unsupported collections will throw by default.
             Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ClassWithUnsupportedDictionary>(json));
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Serialize(new ClassWithUnsupportedDictionary()));
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<WrapperForClassWithUnsupportedDictionary>(wrapperJson));
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Serialize(new WrapperForClassWithUnsupportedDictionary()));
+            // Using new options instance to prevent using previously cached metadata.
+            JsonSerializerOptions options = new JsonSerializerOptions();
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Serialize(new ClassWithUnsupportedDictionary(), options));
+            options = new JsonSerializerOptions();
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<WrapperForClassWithUnsupportedDictionary>(wrapperJson, options));
+            options = new JsonSerializerOptions();
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Serialize(new WrapperForClassWithUnsupportedDictionary(), options));
 
             // When ignored, we can serialize and deserialize without exceptions.
-            ClassWithIgnoredUnsupportedDictionary obj = JsonSerializer.Deserialize<ClassWithIgnoredUnsupportedDictionary>(json);
+            options = new JsonSerializerOptions();
+            ClassWithIgnoredUnsupportedDictionary obj = JsonSerializer.Deserialize<ClassWithIgnoredUnsupportedDictionary>(json, options);
             Assert.Null(obj.MyDict);
+
+            options = new JsonSerializerOptions();
             Assert.Equal("{}", JsonSerializer.Serialize(new ClassWithIgnoredUnsupportedDictionary()));
 
-            WrapperForClassWithIgnoredUnsupportedDictionary wrapperObj = JsonSerializer.Deserialize<WrapperForClassWithIgnoredUnsupportedDictionary>(wrapperJson);
+            options = new JsonSerializerOptions();
+            WrapperForClassWithIgnoredUnsupportedDictionary wrapperObj = JsonSerializer.Deserialize<WrapperForClassWithIgnoredUnsupportedDictionary>(wrapperJson, options);
             Assert.Null(wrapperObj.MyClass.MyDict);
+
+            options = new JsonSerializerOptions();
             Assert.Equal(@"{""MyClass"":{}}", JsonSerializer.Serialize(new WrapperForClassWithIgnoredUnsupportedDictionary()
             {
                 MyClass = new ClassWithIgnoredUnsupportedDictionary(),
-            })); ;
+            }, options)); ;
         }
 
         [Fact]
@@ -181,19 +191,27 @@ namespace System.Text.Json.Serialization.Tests
 
             // Unsupported types will throw by default.
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ClassWithUnsupportedBigInteger>(json));
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<WrapperForClassWithUnsupportedBigInteger>(wrapperJson));
+            // Using new options instance to prevent using previously cached metadata.
+            JsonSerializerOptions options = new JsonSerializerOptions();
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<WrapperForClassWithUnsupportedBigInteger>(wrapperJson, options));
 
             // When ignored, we can serialize and deserialize without exceptions.
-            ClassWithIgnoredUnsupportedBigInteger obj = JsonSerializer.Deserialize<ClassWithIgnoredUnsupportedBigInteger>(json);
+            options = new JsonSerializerOptions();
+            ClassWithIgnoredUnsupportedBigInteger obj = JsonSerializer.Deserialize<ClassWithIgnoredUnsupportedBigInteger>(json, options);
             Assert.Null(obj.MyBigInteger);
+
+            options = new JsonSerializerOptions();
             Assert.Equal("{}", JsonSerializer.Serialize(new ClassWithIgnoredUnsupportedBigInteger()));
 
-            WrapperForClassWithIgnoredUnsupportedBigInteger wrapperObj = JsonSerializer.Deserialize<WrapperForClassWithIgnoredUnsupportedBigInteger>(wrapperJson);
+            options = new JsonSerializerOptions();
+            WrapperForClassWithIgnoredUnsupportedBigInteger wrapperObj = JsonSerializer.Deserialize<WrapperForClassWithIgnoredUnsupportedBigInteger>(wrapperJson, options);
             Assert.Null(wrapperObj.MyClass.MyBigInteger);
+
+            options = new JsonSerializerOptions();
             Assert.Equal(@"{""MyClass"":{}}", JsonSerializer.Serialize(new WrapperForClassWithIgnoredUnsupportedBigInteger()
             {
                 MyClass = new ClassWithIgnoredUnsupportedBigInteger(),
-            })); ;
+            }, options));
         }
 
         public class ObjectDictWrapper : Dictionary<int, string> { }

--- a/src/System.Text.Json/tests/Serialization/PropertyVisibilityTests.cs
+++ b/src/System.Text.Json/tests/Serialization/PropertyVisibilityTests.cs
@@ -180,7 +180,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(@"{""MyClass"":{}}", JsonSerializer.Serialize(new WrapperForClassWithIgnoredUnsupportedDictionary()
             {
                 MyClass = new ClassWithIgnoredUnsupportedDictionary(),
-            }, options)); ;
+            }, options));
         }
 
         [Fact]


### PR DESCRIPTION
Ports https://github.com/dotnet/corefx/pull/40401 to 3.0

cc @steveharter, @ericstj, @danmosemsft, @ahsonkhan @eerhardt, @Anipik, @wtgodbe

## Description
Fixes bug where the JsonIgnore attribute was not being honored for unsupported collections.

This change allows us to (de)serialize without throwing NotSupported/JsonException when unsupported collections are ignored like in this scenario:

```csharp
class JsonIgnoreTest
{
    [JsonIgnore]
    public ConcurrentDictionary<object, object> MyDict { get; set; }
}
```

## Customer Impact
Provides expected behavior in scenario above.
Fixed #40305 in master.

## Regression?

No.

## Risk

Low. Relevant test cases were added.