### PR TITLE
[release/3.0] Update Utf8JsonWriter.WriteNumber{Value}(double/float) to support infinity correctly for all cases

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Double.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Double.cs
@@ -239,7 +239,7 @@ namespace System.Text.Json
             output[BytesPending++] = JsonConstants.Quote;
             output[BytesPending++] = JsonConstants.KeyValueSeperator;
 
-            bool result = Utf8Formatter.TryFormat(value, output.Slice(BytesPending), out int bytesWritten);
+            bool result = TryFormatDouble(value, output.Slice(BytesPending), out int bytesWritten);
             Debug.Assert(result);
             BytesPending += bytesWritten;
         }
@@ -270,7 +270,7 @@ namespace System.Text.Json
             output[BytesPending++] = JsonConstants.Quote;
             output[BytesPending++] = JsonConstants.KeyValueSeperator;
 
-            bool result = Utf8Formatter.TryFormat(value, output.Slice(BytesPending), out int bytesWritten);
+            bool result = TryFormatDouble(value, output.Slice(BytesPending), out int bytesWritten);
             Debug.Assert(result);
             BytesPending += bytesWritten;
         }
@@ -316,7 +316,7 @@ namespace System.Text.Json
             output[BytesPending++] = JsonConstants.KeyValueSeperator;
             output[BytesPending++] = JsonConstants.Space;
 
-            bool result = Utf8Formatter.TryFormat(value, output.Slice(BytesPending), out int bytesWritten);
+            bool result = TryFormatDouble(value, output.Slice(BytesPending), out int bytesWritten);
             Debug.Assert(result);
             BytesPending += bytesWritten;
         }
@@ -362,7 +362,7 @@ namespace System.Text.Json
             output[BytesPending++] = JsonConstants.KeyValueSeperator;
             output[BytesPending++] = JsonConstants.Space;
 
-            bool result = Utf8Formatter.TryFormat(value, output.Slice(BytesPending), out int bytesWritten);
+            bool result = TryFormatDouble(value, output.Slice(BytesPending), out int bytesWritten);
             Debug.Assert(result);
             BytesPending += bytesWritten;
         }

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Float.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Float.cs
@@ -239,7 +239,7 @@ namespace System.Text.Json
             output[BytesPending++] = JsonConstants.Quote;
             output[BytesPending++] = JsonConstants.KeyValueSeperator;
 
-            bool result = Utf8Formatter.TryFormat(value, output.Slice(BytesPending), out int bytesWritten);
+            bool result = TryFormatSingle(value, output.Slice(BytesPending), out int bytesWritten);
             Debug.Assert(result);
             BytesPending += bytesWritten;
         }
@@ -270,7 +270,7 @@ namespace System.Text.Json
             output[BytesPending++] = JsonConstants.Quote;
             output[BytesPending++] = JsonConstants.KeyValueSeperator;
 
-            bool result = Utf8Formatter.TryFormat(value, output.Slice(BytesPending), out int bytesWritten);
+            bool result = TryFormatSingle(value, output.Slice(BytesPending), out int bytesWritten);
             Debug.Assert(result);
             BytesPending += bytesWritten;
         }
@@ -316,7 +316,7 @@ namespace System.Text.Json
             output[BytesPending++] = JsonConstants.KeyValueSeperator;
             output[BytesPending++] = JsonConstants.Space;
 
-            bool result = Utf8Formatter.TryFormat(value, output.Slice(BytesPending), out int bytesWritten);
+            bool result = TryFormatSingle(value, output.Slice(BytesPending), out int bytesWritten);
             Debug.Assert(result);
             BytesPending += bytesWritten;
         }
@@ -362,7 +362,7 @@ namespace System.Text.Json
             output[BytesPending++] = JsonConstants.KeyValueSeperator;
             output[BytesPending++] = JsonConstants.Space;
 
-            bool result = Utf8Formatter.TryFormat(value, output.Slice(BytesPending), out int bytesWritten);
+            bool result = TryFormatSingle(value, output.Slice(BytesPending), out int bytesWritten);
             Debug.Assert(result);
             BytesPending += bytesWritten;
         }

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Double.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Double.cs
@@ -56,7 +56,7 @@ namespace System.Text.Json
                 output[BytesPending++] = JsonConstants.ListSeparator;
             }
 
-            bool result = Utf8Formatter.TryFormat(value, output.Slice(BytesPending), out int bytesWritten);
+            bool result = TryFormatDouble(value, output.Slice(BytesPending), out int bytesWritten);
             Debug.Assert(result);
             BytesPending += bytesWritten;
         }

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Float.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Float.cs
@@ -56,7 +56,7 @@ namespace System.Text.Json
                 output[BytesPending++] = JsonConstants.ListSeparator;
             }
 
-            bool result = Utf8Formatter.TryFormat(value, output.Slice(BytesPending), out int bytesWritten);
+            bool result = TryFormatSingle(value, output.Slice(BytesPending), out int bytesWritten);
             Debug.Assert(result);
             BytesPending += bytesWritten;
         }

--- a/src/System.Text.Json/tests/Serialization/OptionsTests.cs
+++ b/src/System.Text.Json/tests/Serialization/OptionsTests.cs
@@ -382,13 +382,13 @@ namespace System.Text.Json.Serialization.Tests
             GenericConverterTestHelper<bool>("JsonConverterBoolean", true, "true", options);
             GenericConverterTestHelper<byte>("JsonConverterByte", (byte)128, "128", options);
             GenericConverterTestHelper<char>("JsonConverterChar", 'A', "\"A\"", options);
-            GenericConverterTestHelper<double>("JsonConverterDouble", 3.14d, "3.14", options);
+            GenericConverterTestHelper<double>("JsonConverterDouble", 15.1d, "15.1", options);
             GenericConverterTestHelper<SampleEnum>("JsonConverterEnum`1", SampleEnum.Two, "2", options);
             GenericConverterTestHelper<short>("JsonConverterInt16", (short)5, "5", options);
             GenericConverterTestHelper<int>("JsonConverterInt32", -100, "-100", options);
             GenericConverterTestHelper<long>("JsonConverterInt64", (long)11111, "11111", options);
             GenericConverterTestHelper<sbyte>("JsonConverterSByte", (sbyte)-121, "-121", options);
-            GenericConverterTestHelper<float>("JsonConverterSingle", 3.14f, "3.14", options);
+            GenericConverterTestHelper<float>("JsonConverterSingle", 14.5f, "14.5", options);
             GenericConverterTestHelper<string>("JsonConverterString", "Hello", "\"Hello\"", options);
             GenericConverterTestHelper<ushort>("JsonConverterUInt16", (ushort)1206, "1206", options);
             GenericConverterTestHelper<uint>("JsonConverterUInt32", (uint)3333, "3333", options);

--- a/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
@@ -4331,7 +4331,99 @@ namespace System.Text.Json.Tests
         [InlineData(false, false, 12345)]
         public void WriteIntegerValue(bool formatted, bool skipValidation, int value)
         {
-            string expectedStr = GetIntegerExpectedString(prettyPrint: formatted, value);
+            string expectedStr = GetPropertyExpectedString(prettyPrint: formatted, value);
+
+            var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
+
+            for (int i = 0; i < 4; i++)
+            {
+                var output = new ArrayBufferWriter<byte>(1024);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
+
+                jsonUtf8.WriteStartObject();
+
+                switch (i)
+                {
+                    case 0:
+                        jsonUtf8.WriteNumber("message", value);
+                        break;
+                    case 1:
+                        jsonUtf8.WriteNumber("message".AsSpan(), value);
+                        break;
+                    case 2:
+                        jsonUtf8.WriteNumber(Encoding.UTF8.GetBytes("message"), value);
+                        break;
+                    case 3:
+                        jsonUtf8.WritePropertyName("message");
+                        jsonUtf8.WriteNumberValue(value);
+                        break;
+                }
+
+                jsonUtf8.WriteEndObject();
+                jsonUtf8.Flush();
+
+                JsonTestHelper.AssertContents(expectedStr, output);
+            }
+        }
+
+        [Theory]
+        [InlineData(true, true, float.MinValue)]
+        [InlineData(true, false, float.MinValue)]
+        [InlineData(false, true, float.MinValue)]
+        [InlineData(false, false, float.MinValue)]
+        [InlineData(true, true, float.MaxValue)]
+        [InlineData(true, false, float.MaxValue)]
+        [InlineData(false, true, float.MaxValue)]
+        [InlineData(false, false, float.MaxValue)]
+        public void WriteFloatValue(bool formatted, bool skipValidation, float value)
+        {
+            string expectedStr = GetPropertyExpectedString(prettyPrint: formatted, value);
+
+            var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
+
+            for (int i = 0; i < 4; i++)
+            {
+                var output = new ArrayBufferWriter<byte>(1024);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
+
+                jsonUtf8.WriteStartObject();
+
+                switch (i)
+                {
+                    case 0:
+                        jsonUtf8.WriteNumber("message", value);
+                        break;
+                    case 1:
+                        jsonUtf8.WriteNumber("message".AsSpan(), value);
+                        break;
+                    case 2:
+                        jsonUtf8.WriteNumber(Encoding.UTF8.GetBytes("message"), value);
+                        break;
+                    case 3:
+                        jsonUtf8.WritePropertyName("message");
+                        jsonUtf8.WriteNumberValue(value);
+                        break;
+                }
+
+                jsonUtf8.WriteEndObject();
+                jsonUtf8.Flush();
+
+                JsonTestHelper.AssertContents(expectedStr, output);
+            }
+        }
+
+        [Theory]
+        [InlineData(true, true, double.MinValue)]
+        [InlineData(true, false, double.MinValue)]
+        [InlineData(false, true, double.MinValue)]
+        [InlineData(false, false, double.MinValue)]
+        [InlineData(true, true, double.MaxValue)]
+        [InlineData(true, false, double.MaxValue)]
+        [InlineData(false, true, double.MaxValue)]
+        [InlineData(false, false, double.MaxValue)]
+        public void WriteDoubleValue(bool formatted, bool skipValidation, double value)
+        {
+            string expectedStr = GetPropertyExpectedString(prettyPrint: formatted, value);
 
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
 
@@ -4608,16 +4700,17 @@ namespace System.Text.Json.Tests
             int numberOfElements = 0;
             jsonUtf8.WriteStartArray();
             int currentCapactiy = output.Capacity;
+            int value = 1234567;
             while (currentCapactiy == output.Capacity)
             {
-                jsonUtf8.WriteNumberValue(1234567);
+                jsonUtf8.WriteNumberValue(value);
                 numberOfElements++;
             }
             Assert.Equal(currentCapactiy + 4096, output.Capacity);
             jsonUtf8.WriteEndArray();
             jsonUtf8.Flush();
 
-            string expectedStr = GetNumbersExpectedString(formatted, numberOfElements);
+            string expectedStr = GetNumbersExpectedString(formatted, numberOfElements, value);
             JsonTestHelper.AssertContents(expectedStr, output);
         }
 
@@ -4636,16 +4729,17 @@ namespace System.Text.Json.Tests
             int numberOfElements = 0;
             jsonUtf8.WriteStartArray();
             int currentCapactiy = output.Capacity;
+            long value = 1234567;
             while (currentCapactiy == output.Capacity)
             {
-                jsonUtf8.WriteNumberValue((long)1234567);
+                jsonUtf8.WriteNumberValue(value);
                 numberOfElements++;
             }
             Assert.Equal(currentCapactiy + 4096, output.Capacity);
             jsonUtf8.WriteEndArray();
             jsonUtf8.Flush();
 
-            string expectedStr = GetNumbersExpectedString(formatted, numberOfElements);
+            string expectedStr = GetNumbersExpectedString(formatted, numberOfElements, value);
             JsonTestHelper.AssertContents(expectedStr, output);
         }
 
@@ -4664,16 +4758,17 @@ namespace System.Text.Json.Tests
             int numberOfElements = 0;
             jsonUtf8.WriteStartArray();
             int currentCapactiy = output.Capacity;
+            uint value = 1234567;
             while (currentCapactiy == output.Capacity)
             {
-                jsonUtf8.WriteNumberValue((uint)1234567);
+                jsonUtf8.WriteNumberValue(value);
                 numberOfElements++;
             }
             Assert.Equal(currentCapactiy + 4096, output.Capacity);
             jsonUtf8.WriteEndArray();
             jsonUtf8.Flush();
 
-            string expectedStr = GetNumbersExpectedString(formatted, numberOfElements);
+            string expectedStr = GetNumbersExpectedString(formatted, numberOfElements, value);
             JsonTestHelper.AssertContents(expectedStr, output);
         }
 
@@ -4692,25 +4787,30 @@ namespace System.Text.Json.Tests
             int numberOfElements = 0;
             jsonUtf8.WriteStartArray();
             int currentCapactiy = output.Capacity;
+            ulong value = 1234567;
             while (currentCapactiy == output.Capacity)
             {
-                jsonUtf8.WriteNumberValue((ulong)1234567);
+                jsonUtf8.WriteNumberValue(value);
                 numberOfElements++;
             }
             Assert.Equal(currentCapactiy + 4096, output.Capacity);
             jsonUtf8.WriteEndArray();
             jsonUtf8.Flush();
 
-            string expectedStr = GetNumbersExpectedString(formatted, numberOfElements);
+            string expectedStr = GetNumbersExpectedString(formatted, numberOfElements, value);
             JsonTestHelper.AssertContents(expectedStr, output);
         }
 
         [Theory]
-        [InlineData(true, true)]
-        [InlineData(true, false)]
-        [InlineData(false, true)]
-        [InlineData(false, false)]
-        public void WriteNumberValueSingle(bool formatted, bool skipValidation)
+        [InlineData(true, true, float.MinValue)]
+        [InlineData(true, false, float.MinValue)]
+        [InlineData(false, true, float.MinValue)]
+        [InlineData(false, false, float.MinValue)]
+        [InlineData(true, true, float.MaxValue)]
+        [InlineData(true, false, float.MaxValue)]
+        [InlineData(false, true, float.MaxValue)]
+        [InlineData(false, false, float.MaxValue)]
+        public void WriteNumberValueSingle(bool formatted, bool skipValidation, float value)
         {
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
 
@@ -4722,23 +4822,27 @@ namespace System.Text.Json.Tests
             int currentCapactiy = output.Capacity;
             while (currentCapactiy == output.Capacity)
             {
-                jsonUtf8.WriteNumberValue((float)1234567);
+                jsonUtf8.WriteNumberValue(value);
                 numberOfElements++;
             }
             Assert.Equal(currentCapactiy + 4096, output.Capacity);
             jsonUtf8.WriteEndArray();
             jsonUtf8.Flush();
 
-            string expectedStr = GetNumbersExpectedString(formatted, numberOfElements);
+            string expectedStr = GetNumbersExpectedString(formatted, numberOfElements, value);
             JsonTestHelper.AssertContents(expectedStr, output);
         }
 
         [Theory]
-        [InlineData(true, true)]
-        [InlineData(true, false)]
-        [InlineData(false, true)]
-        [InlineData(false, false)]
-        public void WriteNumberValueDouble(bool formatted, bool skipValidation)
+        [InlineData(true, true, double.MinValue)]
+        [InlineData(true, false, double.MinValue)]
+        [InlineData(false, true, double.MinValue)]
+        [InlineData(false, false, double.MinValue)]
+        [InlineData(true, true, double.MaxValue)]
+        [InlineData(true, false, double.MaxValue)]
+        [InlineData(false, true, double.MaxValue)]
+        [InlineData(false, false, double.MaxValue)]
+        public void WriteNumberValueDouble(bool formatted, bool skipValidation, double value)
         {
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
 
@@ -4750,14 +4854,14 @@ namespace System.Text.Json.Tests
             int currentCapactiy = output.Capacity;
             while (currentCapactiy == output.Capacity)
             {
-                jsonUtf8.WriteNumberValue((double)1234567);
+                jsonUtf8.WriteNumberValue(value);
                 numberOfElements++;
             }
             Assert.Equal(currentCapactiy + 4096, output.Capacity);
             jsonUtf8.WriteEndArray();
             jsonUtf8.Flush();
 
-            string expectedStr = GetNumbersExpectedString(formatted, numberOfElements);
+            string expectedStr = GetNumbersExpectedString(formatted, numberOfElements, value);
             JsonTestHelper.AssertContents(expectedStr, output);
         }
 
@@ -4776,16 +4880,17 @@ namespace System.Text.Json.Tests
             int numberOfElements = 0;
             jsonUtf8.WriteStartArray();
             int currentCapactiy = output.Capacity;
+            decimal value = 1234567.0M;
             while (currentCapactiy == output.Capacity)
             {
-                jsonUtf8.WriteNumberValue((decimal)1234567);
+                jsonUtf8.WriteNumberValue(value);
                 numberOfElements++;
             }
             Assert.Equal(currentCapactiy + 4096, output.Capacity);
             jsonUtf8.WriteEndArray();
             jsonUtf8.Flush();
 
-            string expectedStr = GetNumbersExpectedString(formatted, numberOfElements);
+            string expectedStr = GetNumbersExpectedString(formatted, numberOfElements, value);
             JsonTestHelper.AssertContents(expectedStr, output);
         }
 
@@ -6419,12 +6524,12 @@ namespace System.Text.Json.Tests
             return Encoding.UTF8.GetString(ms.ToArray());
         }
 
-        private static string GetIntegerExpectedString(bool prettyPrint, int value)
+        private static string GetPropertyExpectedString<T>(bool prettyPrint, T value)
         {
-            var ms = new MemoryStream();
-            TextWriter streamWriter = new StreamWriter(ms, new UTF8Encoding(false), 1024, true);
+            var sb = new StringBuilder();
+            StringWriter stringWriter = new StringWriter(sb);
 
-            var json = new JsonTextWriter(streamWriter)
+            var json = new JsonTextWriter(stringWriter)
             {
                 Formatting = prettyPrint ? Formatting.Indented : Formatting.None
             };
@@ -6436,7 +6541,7 @@ namespace System.Text.Json.Tests
 
             json.Flush();
 
-            return Encoding.UTF8.GetString(ms.ToArray());
+            return sb.ToString();
         }
 
         private static string GetNumbersExpectedString(bool prettyPrint, string keyString, int[] ints, uint[] uints, long[] longs, ulong[] ulongs, float[] floats, double[] doubles, decimal[] decimals, bool escape = false)
@@ -6565,12 +6670,12 @@ namespace System.Text.Json.Tests
             return Encoding.UTF8.GetString(ms.ToArray());
         }
 
-        private static string GetNumbersExpectedString(bool prettyPrint, int numberOfElements)
+        private static string GetNumbersExpectedString<T>(bool prettyPrint, int numberOfElements, T value)
         {
-            var ms = new MemoryStream();
-            TextWriter streamWriter = new StreamWriter(ms, new UTF8Encoding(false), 1024, true);
+            var sb = new StringBuilder();
+            StringWriter stringWriter = new StringWriter(sb);
 
-            var json = new JsonTextWriter(streamWriter)
+            var json = new JsonTextWriter(stringWriter)
             {
                 Formatting = prettyPrint ? Formatting.Indented : Formatting.None,
             };
@@ -6578,13 +6683,13 @@ namespace System.Text.Json.Tests
             json.WriteStartArray();
             for (int i = 0; i < numberOfElements; i++)
             {
-                json.WriteValue(1234567);
+                json.WriteValue(value);
             }
             json.WriteEnd();
 
             json.Flush();
 
-            return Encoding.UTF8.GetString(ms.ToArray());
+            return sb.ToString();
         }
 
         private static string GetDatesExpectedString(bool prettyPrint, string keyString, DateTime[] dates, bool escape = false)


### PR DESCRIPTION
Ports https://github.com/dotnet/corefx/pull/40197 and https://github.com/dotnet/corefx/pull/40408 to 3.0

Fixes https://github.com/dotnet/corefx/issues/40133

cc @steveharter, @ericstj, @danmosemsft, @ahsonkhan @eerhardt, @Anipik, @wtgodbe, @WinCPP, @tannergooding  

## Description
For down-level platforms (specifically netfx), apply the best effort formatting of doubles and float so they are more likely to round-trip. This fix was added in https://github.com/dotnet/corefx/pull/38322 but not applied consistently for all the overloads that write double and floats as JSON via the writer.

Updating some tests that don't round-trip well on netfx since, in @tannergooding's words, the parsing algorithm for .net framework is incorrect and will fail to correctly parse some values, even at G17. .NET Framework doesn't provide a way to return more than 17 digits and so there is no workaround.

## Customer Impact

We now correctly handle writing double and floats based on the underlying framework. This change makes sure that the writer logic is consistent for netfx for all APIs so that is easy to reason about and maintain.

## Regression?

No.

## Risk

Low. Relevant test cases were added and it only impacts netfx. The only concern is that certain numbers that previously were round-tripping (like 3.14), by chance when using default ToString(), no longer do so when using G17. This is the expected behavior of double/float formatting on netfx.