### PR TITLE
[release/3.0] Do not do hidden/unavoidable sync stream writes when using the Utf8JsonWriter (during grow).

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
@@ -1034,28 +1034,11 @@ namespace System.Text.Json
 
             Debug.Assert(BytesPending != 0);
 
-            _memory = default;
-
             if (_stream != null)
             {
                 Debug.Assert(_arrayBufferWriter != null);
 
-                _arrayBufferWriter.Advance(BytesPending);
-                BytesPending = 0;
-
-#if BUILDING_INBOX_LIBRARY
-                _stream.Write(_arrayBufferWriter.WrittenSpan);
-#else
-                Debug.Assert(_arrayBufferWriter.WrittenMemory.Length == _arrayBufferWriter.WrittenCount);
-                bool result = MemoryMarshal.TryGetArray(_arrayBufferWriter.WrittenMemory, out ArraySegment<byte> underlyingBuffer);
-                Debug.Assert(underlyingBuffer.Offset == 0);
-                Debug.Assert(_arrayBufferWriter.WrittenCount == underlyingBuffer.Count);
-                _stream.Write(underlyingBuffer.Array, underlyingBuffer.Offset, underlyingBuffer.Count);
-#endif
-                BytesCommitted += _arrayBufferWriter.WrittenCount;
-                _arrayBufferWriter.Clear();
-
-                _memory = _arrayBufferWriter.GetMemory(sizeHint);
+                _memory = _arrayBufferWriter.GetMemory(checked(BytesPending + sizeHint));
 
                 Debug.Assert(_memory.Length >= sizeHint);
             }

--- a/src/System.Text.Json/tests/JsonTestHelper.cs
+++ b/src/System.Text.Json/tests/JsonTestHelper.cs
@@ -687,6 +687,14 @@ namespace System.Text.Json
             Assert.Equal(expectedValue.NormalizeToJsonNetFormat(), value.NormalizeToJsonNetFormat());
         }
 
+        public static void AssertContents(string expectedValue, MemoryStream stream)
+        {
+            string value = Encoding.UTF8.GetString(stream.ToArray());
+
+            // Temporary hack until we can use the same escape algorithm on both sides and make sure we want uppercase hex.
+            Assert.Equal(expectedValue.NormalizeToJsonNetFormat(), value.NormalizeToJsonNetFormat());
+        }
+
         public static void AssertContentsNotEqual(string expectedValue, ArrayBufferWriter<byte> buffer)
         {
             string value = Encoding.UTF8.GetString(

--- a/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
@@ -55,6 +55,204 @@ namespace System.Text.Json.Tests
             Assert.Throws<ArgumentException>(() => new Utf8JsonWriter(stream, options));
         }
 
+        [Fact]
+        public void WriteJsonWritesToIBWOnDemand_Dispose()
+        {
+            var output = new ArrayBufferWriter<byte>();
+            var writer = new Utf8JsonWriter(output);
+            WriteLargeArrayOfStrings(writer, 1_000);
+            Assert.Equal(17347, writer.BytesCommitted);
+            Assert.Equal(5544, writer.BytesPending);
+            Assert.Equal(0, writer.CurrentDepth);
+            Assert.Equal(17347, output.WrittenCount);
+
+            writer.Dispose();
+
+            Assert.Equal(0, writer.BytesPending);
+            Assert.Equal(22891, output.WrittenCount);
+            JsonTestHelper.AssertContents(GetExpectedLargeArrayOfStrings(1_000), output);
+        }
+
+        [Fact]
+        public void WriteJsonOnlyWritesToStreamOnDemand_Dispose()
+        {
+            string expectedString = GetExpectedLargeArrayOfStrings(1_000);
+            Assert.Equal(22891, expectedString.Length);
+            using (var stream = new MemoryStream())
+            {
+                var writer = new Utf8JsonWriter(stream);
+                WriteLargeArrayOfStrings(writer, 1_000);
+                Assert.Equal(0, writer.BytesCommitted);
+                Assert.Equal(expectedString.Length, writer.BytesPending);
+                Assert.Equal(0, writer.CurrentDepth);
+                // Unless user disposes the writer or calls flush/flushasync explicitly, nothing gets written to the stream
+                Assert.Equal(0, stream.Position);
+
+                writer.Dispose();
+
+                Assert.Equal(0, writer.BytesPending);
+                Assert.Equal(expectedString.Length, stream.Position);
+                JsonTestHelper.AssertContents(expectedString, stream);
+            }
+        }
+
+        [Fact]
+        public async Task WriteJsonOnlyWritesToStreamOnDemand_DisposeAsync()
+        {
+            string expectedString = GetExpectedLargeArrayOfStrings(1_000);
+            Assert.Equal(22891, expectedString.Length);
+            using (var stream = new MemoryStream())
+            {
+                var writer = new Utf8JsonWriter(stream);
+                WriteLargeArrayOfStrings(writer, 1_000);
+                Assert.Equal(0, writer.BytesCommitted);
+                Assert.Equal(expectedString.Length, writer.BytesPending);
+                Assert.Equal(0, writer.CurrentDepth);
+                // Unless user disposes the writer or calls flush/flushasync explicitly, nothing gets written to the stream
+                Assert.Equal(0, stream.Position);
+
+                await writer.DisposeAsync();
+
+                Assert.Equal(0, writer.BytesPending);
+                Assert.Equal(expectedString.Length, stream.Position);
+                JsonTestHelper.AssertContents(expectedString, stream);
+            }
+        }
+
+        [Fact]
+        public void WriteJsonOnlyWritesToStreamOnDemand_Flush()
+        {
+            string expectedString = GetExpectedLargeArrayOfStrings(1_000);
+            Assert.Equal(22891, expectedString.Length);
+            using (var stream = new MemoryStream())
+            {
+                var writer = new Utf8JsonWriter(stream);
+                WriteLargeArrayOfStrings(writer, 1_000);
+                Assert.Equal(0, writer.BytesCommitted);
+                Assert.Equal(expectedString.Length, writer.BytesPending);
+                Assert.Equal(0, writer.CurrentDepth);
+                // Unless user disposes the writer or calls flush/flushasync explicitly, nothing gets written to the stream
+                Assert.Equal(0, stream.Position);
+
+                writer.Flush();
+
+                Assert.Equal(0, writer.BytesPending);
+                Assert.Equal(expectedString.Length, stream.Position);
+
+                writer.Dispose();
+
+                Assert.Equal(0, writer.BytesPending);
+                Assert.Equal(expectedString.Length, stream.Position);
+                JsonTestHelper.AssertContents(expectedString, stream);
+            }
+        }
+
+        [Fact]
+        public async Task WriteJsonOnlyWritesToStreamOnDemand_FlushAsync()
+        {
+            string expectedString = GetExpectedLargeArrayOfStrings(1_000);
+            Assert.Equal(22891, expectedString.Length);
+            using (var stream = new MemoryStream())
+            {
+                var writer = new Utf8JsonWriter(stream);
+                WriteLargeArrayOfStrings(writer, 1_000);
+                Assert.Equal(0, writer.BytesCommitted);
+                Assert.Equal(expectedString.Length, writer.BytesPending);
+                Assert.Equal(0, writer.CurrentDepth);
+                // Unless user disposes the writer or calls flush/flushasync explicitly, nothing gets written to the stream
+                Assert.Equal(0, stream.Position);
+
+                await writer.FlushAsync();
+
+                Assert.Equal(0, writer.BytesPending);
+                Assert.Equal(expectedString.Length, stream.Position);
+
+                await writer.DisposeAsync();
+
+                Assert.Equal(0, writer.BytesPending);
+                Assert.Equal(expectedString.Length, stream.Position);
+                JsonTestHelper.AssertContents(expectedString, stream);
+            }
+        }
+
+        private static void WriteLargeArrayOfStrings(Utf8JsonWriter writer, int length)
+        {
+            writer.WriteStartArray();
+            for (int i = 0; i < length; i++)
+            {
+                writer.WriteStringValue($"some array value {i}");
+            }
+            writer.WriteEndArray();
+        }
+
+        private static string GetExpectedLargeArrayOfStrings(int length)
+        {
+            var stringBuilder = new StringBuilder();
+            using (TextWriter stringWriter = new StringWriter(stringBuilder))
+            using (var json = new JsonTextWriter(stringWriter))
+            {
+                json.Formatting = Formatting.None;
+                json.WriteStartArray();
+                for (int i = 0; i < length; i++)
+                {
+                    json.WriteValue($"some array value {i}");
+                }
+                json.WriteEnd();
+            }
+            return stringBuilder.ToString();
+        }
+
+        // NOTE: WritingTooLargeProperty test is constrained to run on Windows and MacOSX because it causes
+        //       problems on Linux due to the way deferred memory allocation works. On Linux, the allocation can
+        //       succeed even if there is not enough memory but then the test may get killed by the OOM killer at the
+        //       time the memory is accessed which triggers the full memory allocation.
+        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX)]
+        [ConditionalFact(nameof(IsX64))]
+        [OuterLoop]
+        public void WriteLargeJsonToStreamWithoutFlushing()
+        {
+            var largeArray = new char[150_000_000];
+            largeArray.AsSpan().Fill('a');
+
+            // Text size chosen so that after several doublings of the underlying buffer we reach ~2 GB (but don't go over)
+            JsonEncodedText text1 = JsonEncodedText.Encode(largeArray.AsSpan(0, 7_500));
+            JsonEncodedText text2 = JsonEncodedText.Encode(largeArray.AsSpan(0, 5_000));
+            JsonEncodedText text3 = JsonEncodedText.Encode(largeArray.AsSpan(0, 150_000_000));
+
+            using (var output = new MemoryStream())
+            using (var writer = new Utf8JsonWriter(output))
+            {
+                writer.WriteStartArray();
+                writer.WriteStringValue(text1);
+                Assert.Equal(7_503, writer.BytesPending);
+
+                for (int i = 0; i < 30_000; i++)
+                {
+                    writer.WriteStringValue(text2);
+                }
+                Assert.Equal(150_097_503, writer.BytesPending);
+
+                for (int i = 0; i < 6; i++)
+                {
+                    writer.WriteStringValue(text3);
+                }
+                Assert.Equal(1_050_097_521, writer.BytesPending);
+
+                // Next write forces a grow beyond 2 GB
+                Assert.Throws<OverflowException>(() => writer.WriteStringValue(text3));
+
+                Assert.Equal(1_050_097_521, writer.BytesPending);
+
+                var text4 = JsonEncodedText.Encode(largeArray.AsSpan(0, 1));
+                for (int i = 0; i < 10_000_000; i++)
+                {
+                    writer.WriteStringValue(text4);
+                }
+
+                Assert.Equal(1_050_097_521 + (4 * 10_000_000), writer.BytesPending);
+            }
+        }
+
         [Theory]
         [InlineData(true, true)]
         [InlineData(true, false)]


### PR DESCRIPTION
Ports https://github.com/dotnet/corefx/pull/40047 to 3.0

Fixes https://github.com/dotnet/corefx/issues/39837

cc @steveharter, @ericstj, @danmosemsft, @ahsonkhan @eerhardt, @Anipik, @wtgodbe, @bartonjs, @stephentoub 

## Description
Avoid writing synchronously to the underlying stream when growing the buffer used to write JSON into. We rely on the user explicitly calling FlushAsync (or DisposeAsync) for flushing the buffer and writing to the stream.

## Customer Impact

The current implementation did a hidden synchronous write to the stream which goes against ASP.NET's no sync IO default policy. Without this, there is no way for the user to avoid the sync write and within an aspnet app and would be required to turn that policy off (by setting `options.AllowSynchronousIO` when configuring the services on Startup), which isn't ideal. Now, the user is able to create a `Utf8JsonWriter` around an ASP.NET Core `context.Response.Body` Stream, as a way of easily writing out a response JSON payload. This mismatch was previously causing unexpected failures. See https://github.com/dotnet/corefx/issues/39648 for an example.

## Regression?

No.

## Risk

Low. Verified within an aspnet test app that we are no longer doing sync-writes and violating the default policy. As a side-effect of this change, if the user writes more than 1 GB of JSON without flushing, we'd throw, but that is an extreme edge case which the user shouldn't get into.