### PR TITLE
[release/3.0] Fix BytesConsumed and error messages when reading JSON payloads within a multi-segment ReadOnlySequence via Utf8JsonReader

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
@@ -781,6 +781,7 @@ namespace System.Text.Json
             {
                 if (IsLastSpan)
                 {
+                    _bytePositionInLine += localBuffer.Length + 1;  // Account for the start quote
                     ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.EndOfStringNotFound);
                 }
                 return ConsumeStringNextSegment();
@@ -789,27 +790,23 @@ namespace System.Text.Json
 
         private bool ConsumeStringNextSegment()
         {
-            SequencePosition startPosition = _currentPosition;
-            SequencePosition end = default;
-            int startConsumed = _consumed + 1;
+            PartialStateForRollback rollBackState = CaptureState();
+
+            SequencePosition end;
             HasValueSequence = true;
             int leftOver = _buffer.Length - _consumed;
-
-            long prevTotalConsumed = _totalConsumed;
-            long prevPosition = _bytePositionInLine;
 
             while (true)
             {
                 if (!GetNextSpan())
                 {
-                    _totalConsumed = prevTotalConsumed;
-                    _bytePositionInLine = prevPosition;
-                    _consumed = startConsumed - 1;
-                    _currentPosition = startPosition;
                     if (IsLastSpan)
                     {
+                        _bytePositionInLine += leftOver;
+                        RollBackState(rollBackState, isError: true);
                         ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.EndOfStringNotFound);
                     }
+                    RollBackState(rollBackState);
                     return false;
                 }
 
@@ -831,13 +828,10 @@ namespace System.Text.Json
                     }
                     else
                     {
-                        long prevLineNumber = _lineNumber;
-
-                        _bytePositionInLine += idx + 1; // Add 1 for the first quote
+                        _bytePositionInLine += leftOver + idx;
                         _stringHasEscaping = true;
 
                         bool nextCharEscaped = false;
-                        bool sawNewLine = false;
                         while (true)
                         {
                         StartOfLoop:
@@ -861,30 +855,16 @@ namespace System.Text.Json
                                     int index = JsonConstants.EscapableChars.IndexOf(currentByte);
                                     if (index == -1)
                                     {
-                                        _currentPosition = startPosition;
+                                        RollBackState(rollBackState, isError: true);
                                         ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.InvalidCharacterAfterEscapeWithinString, currentByte);
                                     }
 
-                                    if (currentByte == JsonConstants.Quote)
-                                    {
-                                        // Ignore an escaped quote.
-                                        // This is likely the most common case, so adding an explicit check
-                                        // to avoid doing the unnecessary checks below.
-                                    }
-                                    else if (currentByte == 'n')
-                                    {
-                                        // Escaped new line character
-                                        _bytePositionInLine = -1; // Should be 0, but we increment _bytePositionInLine below already
-                                        _lineNumber++;
-                                        sawNewLine = true;
-                                    }
-                                    else if (currentByte == 'u')
+                                    if (currentByte == 'u')
                                     {
                                         // Expecting 4 hex digits to follow the escaped 'u'
                                         _bytePositionInLine++;  // move past the 'u'
 
-                                        bool movedToNext = false;
-                                        int numberOfHexDigits = 3;
+                                        int numberOfHexDigits = 0;
                                         int j = idx + 1;
                                         while (true)
                                         {
@@ -893,53 +873,43 @@ namespace System.Text.Json
                                                 byte nextByte = localBuffer[j];
                                                 if (!JsonReaderHelper.IsHexDigit(nextByte))
                                                 {
-                                                    _currentPosition = startPosition;
+                                                    RollBackState(rollBackState, isError: true);
                                                     ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.InvalidHexCharacterWithinString, nextByte);
                                                 }
-                                                if (j - idx > numberOfHexDigits)
-                                                {
-                                                    if (movedToNext)
-                                                    {
-                                                        nextCharEscaped = false;
-                                                        goto StartOfLoop;
-                                                    }
-                                                    goto DoneWithHex;
-                                                }
+                                                numberOfHexDigits++;
                                                 _bytePositionInLine++;
+                                                if (numberOfHexDigits >= 4)
+                                                {
+                                                    nextCharEscaped = false;
+                                                    idx = j + 1; // Skip the 4 hex digits, the for loop accounts for idx incrementing past the 'u'
+                                                    goto StartOfLoop;
+                                                }
                                             }
 
                                             if (!GetNextSpan())
                                             {
-                                                _currentPosition = startPosition;
                                                 if (IsLastSpan)
                                                 {
+                                                    RollBackState(rollBackState, isError: true);
                                                     ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.EndOfStringNotFound);
                                                 }
 
                                                 // We found less than 4 hex digits.
-                                                _lineNumber = prevLineNumber;
-                                                _bytePositionInLine = prevPosition;
-                                                _totalConsumed = prevTotalConsumed;
+                                                RollBackState(rollBackState);
                                                 return false;
                                             }
 
                                             _totalConsumed += localBuffer.Length;
 
                                             localBuffer = _buffer;
-                                            numberOfHexDigits -= j - idx;
-                                            idx = 0;
                                             j = 0;
-                                            movedToNext = true;
                                         }
-
-                                    DoneWithHex:
-                                        idx += 4;   // Skip the 4 hex digits, the for loop accounts for idx incrementing past the 'u'
                                     }
                                     nextCharEscaped = false;
                                 }
                                 else if (currentByte < JsonConstants.Space)
                                 {
-                                    _currentPosition = startPosition;
+                                    RollBackState(rollBackState, isError: true);
                                     ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.InvalidCharacterWithinString, currentByte);
                                 }
 
@@ -948,14 +918,12 @@ namespace System.Text.Json
 
                             if (!GetNextSpan())
                             {
-                                _currentPosition = startPosition;
                                 if (IsLastSpan)
                                 {
+                                    RollBackState(rollBackState, isError: true);
                                     ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.EndOfStringNotFound);
                                 }
-                                _lineNumber = prevLineNumber;
-                                _bytePositionInLine = prevPosition;
-                                _totalConsumed = prevTotalConsumed;
+                                RollBackState(rollBackState);
                                 return false;
                             }
 
@@ -965,7 +933,7 @@ namespace System.Text.Json
                         }
 
                     Done:
-                        _bytePositionInLine += sawNewLine ? leftOver + idx : leftOver + idx + 1;  // Add 1 for the end quote of the string.
+                        _bytePositionInLine++;  // Add 1 for the end quote of the string.
                         _consumed = idx + 1;    // Add 1 for the end quote of the string.
                         _totalConsumed += leftOver;
                         end = new SequencePosition(_currentPosition.GetObject(), _currentPosition.GetInteger() + idx);
@@ -977,7 +945,7 @@ namespace System.Text.Json
                 _bytePositionInLine += localBuffer.Length;
             }
 
-            SequencePosition start = new SequencePosition(startPosition.GetObject(), startPosition.GetInteger() + startConsumed);
+            SequencePosition start = rollBackState.GetStartPosition(offset: 1); // Offset for the starting quote
             ValueSequence = _sequence.Slice(start, end);
             _tokenType = JsonTokenType.String;
             return true;
@@ -992,16 +960,11 @@ namespace System.Text.Json
             Debug.Assert(data[idx] != JsonConstants.Quote);
             Debug.Assert(data[idx] == JsonConstants.BackSlash || data[idx] < JsonConstants.Space);
 
-            SequencePosition startPosition = _currentPosition;
-            SequencePosition end = default;
-            int startConsumed = _consumed + 1;
-            HasValueSequence = false;
-            int leftOver = _buffer.Length - idx;
-            int leftOverFromConsumed = _buffer.Length - _consumed;
+            PartialStateForRollback rollBackState = CaptureState();
 
-            long prevTotalConsumed = _totalConsumed;
-            long prevLineBytePosition = _bytePositionInLine;
-            long prevLineNumber = _lineNumber;
+            SequencePosition end;
+            HasValueSequence = false;
+            int leftOverFromConsumed = _buffer.Length - _consumed;
 
             _bytePositionInLine += idx + 1; // Add 1 for the first quote
 
@@ -1029,29 +992,16 @@ namespace System.Text.Json
                         int index = JsonConstants.EscapableChars.IndexOf(currentByte);
                         if (index == -1)
                         {
-                            _currentPosition = startPosition;
+                            RollBackState(rollBackState, isError: true);
                             ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.InvalidCharacterAfterEscapeWithinString, currentByte);
                         }
 
-                        if (currentByte == JsonConstants.Quote)
-                        {
-                            // Ignore an escaped quote.
-                            // This is likely the most common case, so adding an explicit check
-                            // to avoid doing the unnecessary checks below.
-                        }
-                        else if (currentByte == 'n')
-                        {
-                            // Escaped new line character
-                            _bytePositionInLine = -1; // Should be 0, but we increment _bytePositionInLine below already
-                            _lineNumber++;
-                        }
-                        else if (currentByte == 'u')
+                        if (currentByte == 'u')
                         {
                             // Expecting 4 hex digits to follow the escaped 'u'
                             _bytePositionInLine++;  // move past the 'u'
 
-                            bool movedToNext = false;
-                            int numberOfHexDigits = 3;
+                            int numberOfHexDigits = 0;
                             int j = idx + 1;
                             while (true)
                             {
@@ -1060,32 +1010,29 @@ namespace System.Text.Json
                                     byte nextByte = data[j];
                                     if (!JsonReaderHelper.IsHexDigit(nextByte))
                                     {
-                                        _currentPosition = startPosition;
+                                        RollBackState(rollBackState, isError: true);
                                         ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.InvalidHexCharacterWithinString, nextByte);
                                     }
-                                    if (j - idx > numberOfHexDigits)
-                                    {
-                                        if (movedToNext)
-                                        {
-                                            nextCharEscaped = false;
-                                            goto StartOfLoop;
-                                        }
-                                        goto DoneWithHex;
-                                    }
+                                    numberOfHexDigits++;
                                     _bytePositionInLine++;
+                                    if (numberOfHexDigits >= 4)
+                                    {
+                                        nextCharEscaped = false;
+                                        idx = j + 1; // Skip the 4 hex digits, the for loop accounts for idx incrementing past the 'u'
+                                        goto StartOfLoop;
+                                    }
                                 }
 
                                 if (!GetNextSpan())
                                 {
-                                    _currentPosition = startPosition;
                                     if (IsLastSpan)
                                     {
+                                        RollBackState(rollBackState, isError: true);
                                         ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.EndOfStringNotFound);
                                     }
 
                                     // We found less than 4 hex digits.
-                                    _lineNumber = prevLineNumber;
-                                    _bytePositionInLine = prevLineBytePosition;
+                                    RollBackState(rollBackState);
                                     return false;
                                 }
 
@@ -1096,21 +1043,15 @@ namespace System.Text.Json
                                 }
 
                                 data = _buffer;
-                                numberOfHexDigits -= j - idx;
-                                idx = 0;
                                 j = 0;
                                 HasValueSequence = true;
-                                movedToNext = true;
                             }
-
-                        DoneWithHex:
-                            idx += 4;   // Skip the 4 hex digits, the for loop accounts for idx incrementing past the 'u'
                         }
                         nextCharEscaped = false;
                     }
                     else if (currentByte < JsonConstants.Space)
                     {
-                        _currentPosition = startPosition;
+                        RollBackState(rollBackState, isError: true);
                         ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.InvalidCharacterWithinString, currentByte);
                     }
 
@@ -1119,13 +1060,12 @@ namespace System.Text.Json
 
                 if (!GetNextSpan())
                 {
-                    _currentPosition = startPosition;
                     if (IsLastSpan)
                     {
+                        RollBackState(rollBackState, isError: true);
                         ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.EndOfStringNotFound);
                     }
-                    _lineNumber = prevLineNumber;
-                    _bytePositionInLine = prevLineBytePosition;
+                    RollBackState(rollBackState);
                     return false;
                 }
 
@@ -1143,11 +1083,11 @@ namespace System.Text.Json
         Done:
             if (HasValueSequence)
             {
-                _bytePositionInLine += leftOver + idx + 1;  // Add 1 for the end quote of the string.
+                _bytePositionInLine++;  // Add 1 for the end quote of the string.
                 _consumed = idx + 1;    // Add 1 for the end quote of the string.
                 _totalConsumed += leftOverFromConsumed;
                 end = new SequencePosition(_currentPosition.GetObject(), _currentPosition.GetInteger() + idx);
-                SequencePosition start = new SequencePosition(startPosition.GetObject(), startPosition.GetInteger() + startConsumed);
+                SequencePosition start = rollBackState.GetStartPosition(offset: 1); // Offset for the starting quote
                 ValueSequence = _sequence.Slice(start, end);
             }
             else
@@ -1162,6 +1102,21 @@ namespace System.Text.Json
             return true;
         }
 
+        private void RollBackState(in PartialStateForRollback state, bool isError = false)
+        {
+            _totalConsumed = state._prevTotalConsumed;
+
+            // Don't roll back byte position in line for invalid JSON since that is provided
+            // to the user within the exception.
+            if (!isError)
+            {
+                _bytePositionInLine = state._prevBytePositionInLine;
+            }
+
+            _consumed = state._prevConsumed;
+            _currentPosition = state._prevCurrentPosition;
+        }
+
         // https://tools.ietf.org/html/rfc7159#section-6
         private bool TryGetNumberMultiSegment(ReadOnlySpan<byte> data, out int consumed)
         {
@@ -1169,20 +1124,16 @@ namespace System.Text.Json
             Debug.Assert(data.Length > 0);
 
             _numberFormat = default;
-            SequencePosition startPosition = _currentPosition;
-            int startConsumed = _consumed;
+
+            PartialStateForRollback rollBackState = CaptureState();
+
             consumed = 0;
-            long prevTotalConsumed = _totalConsumed;
-            long prevPosition = _bytePositionInLine;
             int i = 0;
 
-            ConsumeNumberResult signResult = ConsumeNegativeSignMultiSegment(ref data, ref i);
+            ConsumeNumberResult signResult = ConsumeNegativeSignMultiSegment(ref data, ref i, rollBackState);
             if (signResult == ConsumeNumberResult.NeedMoreData)
             {
-                _totalConsumed = prevTotalConsumed;
-                _bytePositionInLine = prevPosition;
-                _consumed = startConsumed;
-                _currentPosition = startPosition;
+                RollBackState(rollBackState);
                 return false;
             }
 
@@ -1193,13 +1144,10 @@ namespace System.Text.Json
 
             if (nextByte == '0')
             {
-                ConsumeNumberResult result = ConsumeZeroMultiSegment(ref data, ref i);
+                ConsumeNumberResult result = ConsumeZeroMultiSegment(ref data, ref i, rollBackState);
                 if (result == ConsumeNumberResult.NeedMoreData)
                 {
-                    _totalConsumed = prevTotalConsumed;
-                    _bytePositionInLine = prevPosition;
-                    _consumed = startConsumed;
-                    _currentPosition = startPosition;
+                    RollBackState(rollBackState);
                     return false;
                 }
                 if (result == ConsumeNumberResult.Success)
@@ -1215,10 +1163,7 @@ namespace System.Text.Json
                 ConsumeNumberResult result = ConsumeIntegerDigitsMultiSegment(ref data, ref i);
                 if (result == ConsumeNumberResult.NeedMoreData)
                 {
-                    _totalConsumed = prevTotalConsumed;
-                    _bytePositionInLine = prevPosition;
-                    _consumed = startConsumed;
-                    _currentPosition = startPosition;
+                    RollBackState(rollBackState);
                     return false;
                 }
                 if (result == ConsumeNumberResult.Success)
@@ -1230,7 +1175,7 @@ namespace System.Text.Json
                 nextByte = data[i];
                 if (nextByte != '.' && nextByte != 'E' && nextByte != 'e')
                 {
-                    _currentPosition = startPosition;
+                    RollBackState(rollBackState, isError: true);
                     ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedEndOfDigitNotFound, nextByte);
                 }
             }
@@ -1241,13 +1186,10 @@ namespace System.Text.Json
             {
                 i++;
                 _bytePositionInLine++;
-                ConsumeNumberResult result = ConsumeDecimalDigitsMultiSegment(ref data, ref i);
+                ConsumeNumberResult result = ConsumeDecimalDigitsMultiSegment(ref data, ref i, rollBackState);
                 if (result == ConsumeNumberResult.NeedMoreData)
                 {
-                    _totalConsumed = prevTotalConsumed;
-                    _bytePositionInLine = prevPosition;
-                    _consumed = startConsumed;
-                    _currentPosition = startPosition;
+                    RollBackState(rollBackState);
                     return false;
                 }
                 if (result == ConsumeNumberResult.Success)
@@ -1259,7 +1201,7 @@ namespace System.Text.Json
                 nextByte = data[i];
                 if (nextByte != 'E' && nextByte != 'e')
                 {
-                    _currentPosition = startPosition;
+                    RollBackState(rollBackState, isError: true);
                     ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedNextDigitEValueNotFound, nextByte);
                 }
             }
@@ -1269,13 +1211,10 @@ namespace System.Text.Json
             _numberFormat = JsonConstants.ScientificNotationFormat;
             _bytePositionInLine++;
 
-            signResult = ConsumeSignMultiSegment(ref data, ref i);
+            signResult = ConsumeSignMultiSegment(ref data, ref i, rollBackState);
             if (signResult == ConsumeNumberResult.NeedMoreData)
             {
-                _totalConsumed = prevTotalConsumed;
-                _bytePositionInLine = prevPosition;
-                _consumed = startConsumed;
-                _currentPosition = startPosition;
+                RollBackState(rollBackState);
                 return false;
             }
 
@@ -1286,10 +1225,7 @@ namespace System.Text.Json
             ConsumeNumberResult resultExponent = ConsumeIntegerDigitsMultiSegment(ref data, ref i);
             if (resultExponent == ConsumeNumberResult.NeedMoreData)
             {
-                _totalConsumed = prevTotalConsumed;
-                _bytePositionInLine = prevPosition;
-                _consumed = startConsumed;
-                _currentPosition = startPosition;
+                RollBackState(rollBackState);
                 return false;
             }
             if (resultExponent == ConsumeNumberResult.Success)
@@ -1299,13 +1235,13 @@ namespace System.Text.Json
 
             Debug.Assert(resultExponent == ConsumeNumberResult.OperationIncomplete);
 
-            _currentPosition = startPosition;
+            RollBackState(rollBackState, isError: true);
             ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedEndOfDigitNotFound, data[i]);
 
         Done:
             if (HasValueSequence)
             {
-                SequencePosition start = new SequencePosition(startPosition.GetObject(), startPosition.GetInteger() + startConsumed);
+                SequencePosition start = rollBackState.GetStartPosition();
                 SequencePosition end = new SequencePosition(_currentPosition.GetObject(), _currentPosition.GetInteger() + i);
                 ValueSequence = _sequence.Slice(start, end);
                 consumed = i;
@@ -1318,7 +1254,7 @@ namespace System.Text.Json
             return true;
         }
 
-        private ConsumeNumberResult ConsumeNegativeSignMultiSegment(ref ReadOnlySpan<byte> data, ref int i)
+        private ConsumeNumberResult ConsumeNegativeSignMultiSegment(ref ReadOnlySpan<byte> data, ref int i, in PartialStateForRollback rollBackState)
         {
             Debug.Assert(i == 0);
             byte nextByte = data[i];
@@ -1331,12 +1267,14 @@ namespace System.Text.Json
                 {
                     if (IsLastSpan)
                     {
+                        RollBackState(rollBackState, isError: true);
                         ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.RequiredDigitNotFoundEndOfData);
                     }
                     if (!GetNextSpan())
                     {
                         if (IsLastSpan)
                         {
+                            RollBackState(rollBackState, isError: true);
                             ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.RequiredDigitNotFoundEndOfData);
                         }
                         return ConsumeNumberResult.NeedMoreData;
@@ -1351,13 +1289,14 @@ namespace System.Text.Json
                 nextByte = data[i];
                 if (!JsonHelpers.IsDigit(nextByte))
                 {
+                    RollBackState(rollBackState, isError: true);
                     ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.RequiredDigitNotFoundAfterSign, nextByte);
                 }
             }
             return ConsumeNumberResult.OperationIncomplete;
         }
 
-        private ConsumeNumberResult ConsumeZeroMultiSegment(ref ReadOnlySpan<byte> data, ref int i)
+        private ConsumeNumberResult ConsumeZeroMultiSegment(ref ReadOnlySpan<byte> data, ref int i, in PartialStateForRollback rollBackState)
         {
             Debug.Assert(data[i] == (byte)'0');
             Debug.Assert(i == 0 || i == 1);
@@ -1404,6 +1343,7 @@ namespace System.Text.Json
             nextByte = data[i];
             if (nextByte != '.' && nextByte != 'E' && nextByte != 'e')
             {
+                RollBackState(rollBackState, isError: true);
                 ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedEndOfDigitNotFound, nextByte);
             }
 
@@ -1488,18 +1428,20 @@ namespace System.Text.Json
             return ConsumeNumberResult.OperationIncomplete;
         }
 
-        private ConsumeNumberResult ConsumeDecimalDigitsMultiSegment(ref ReadOnlySpan<byte> data, ref int i)
+        private ConsumeNumberResult ConsumeDecimalDigitsMultiSegment(ref ReadOnlySpan<byte> data, ref int i, in PartialStateForRollback rollBackState)
         {
             if (i >= data.Length)
             {
                 if (IsLastSpan)
                 {
+                    RollBackState(rollBackState, isError: true);
                     ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.RequiredDigitNotFoundEndOfData);
                 }
                 if (!GetNextSpan())
                 {
                     if (IsLastSpan)
                     {
+                        RollBackState(rollBackState, isError: true);
                         ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.RequiredDigitNotFoundEndOfData);
                     }
                     return ConsumeNumberResult.NeedMoreData;
@@ -1512,6 +1454,7 @@ namespace System.Text.Json
             byte nextByte = data[i];
             if (!JsonHelpers.IsDigit(nextByte))
             {
+                RollBackState(rollBackState, isError: true);
                 ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.RequiredDigitNotFoundAfterDecimal, nextByte);
             }
             i++;
@@ -1519,12 +1462,13 @@ namespace System.Text.Json
             return ConsumeIntegerDigitsMultiSegment(ref data, ref i);
         }
 
-        private ConsumeNumberResult ConsumeSignMultiSegment(ref ReadOnlySpan<byte> data, ref int i)
+        private ConsumeNumberResult ConsumeSignMultiSegment(ref ReadOnlySpan<byte> data, ref int i, in PartialStateForRollback rollBackState)
         {
             if (i >= data.Length)
             {
                 if (IsLastSpan)
                 {
+                    RollBackState(rollBackState, isError: true);
                     ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.RequiredDigitNotFoundEndOfData);
                 }
 
@@ -1532,6 +1476,7 @@ namespace System.Text.Json
                 {
                     if (IsLastSpan)
                     {
+                        RollBackState(rollBackState, isError: true);
                         ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.RequiredDigitNotFoundEndOfData);
                     }
                     return ConsumeNumberResult.NeedMoreData;
@@ -1551,6 +1496,7 @@ namespace System.Text.Json
                 {
                     if (IsLastSpan)
                     {
+                        RollBackState(rollBackState, isError: true);
                         ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.RequiredDigitNotFoundEndOfData);
                     }
 
@@ -1558,6 +1504,7 @@ namespace System.Text.Json
                     {
                         if (IsLastSpan)
                         {
+                            RollBackState(rollBackState, isError: true);
                             ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.RequiredDigitNotFoundEndOfData);
                         }
                         return ConsumeNumberResult.NeedMoreData;
@@ -1572,6 +1519,7 @@ namespace System.Text.Json
 
             if (!JsonHelpers.IsDigit(nextByte))
             {
+                RollBackState(rollBackState, isError: true);
                 ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.RequiredDigitNotFoundAfterSign, nextByte);
             }
 
@@ -2617,6 +2565,32 @@ namespace System.Text.Json
                     localBuffer = _buffer;
                     Debug.Assert(!localBuffer.IsEmpty);
                 }
+            }
+        }
+
+        private PartialStateForRollback CaptureState()
+        {
+            return new PartialStateForRollback(_totalConsumed, _bytePositionInLine, _consumed, _currentPosition);
+        }
+
+        private readonly struct PartialStateForRollback
+        {
+            public readonly long _prevTotalConsumed;
+            public readonly long _prevBytePositionInLine;
+            public readonly int _prevConsumed;
+            public readonly SequencePosition _prevCurrentPosition;
+
+            public PartialStateForRollback(long totalConsumed, long bytePositionInLine, int consumed, SequencePosition currentPosition)
+            {
+                _prevTotalConsumed = totalConsumed;
+                _prevBytePositionInLine = bytePositionInLine;
+                _prevConsumed = consumed;
+                _prevCurrentPosition = currentPosition;
+            }
+
+            public SequencePosition GetStartPosition(int offset = 0)
+            {
+                return new SequencePosition(_prevCurrentPosition.GetObject(), _prevCurrentPosition.GetInteger() + _prevConsumed + offset);
             }
         }
     }

--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
@@ -66,7 +66,9 @@ namespace System.Text.Json
             {
                 _currentPosition = jsonData.Start;
                 _nextPosition = _currentPosition;
-                if (_buffer.Length == 0)
+
+                bool firstSegmentIsEmpty = _buffer.Length == 0;
+                if (firstSegmentIsEmpty)
                 {
                     // Once we find a non-empty segment, we need to set current position to it.
                     // Therefore, track the next position in a copy before it gets advanced to the next segment.
@@ -84,7 +86,15 @@ namespace System.Text.Json
                     }
                 }
 
-                _isLastSegment = !jsonData.TryGet(ref _nextPosition, out _, advance: true) && isFinalBlock; // Don't re-order to avoid short-circuiting
+                // If firstSegmentIsEmpty is true,
+                //    only check if we have reached the last segment but do not advance _nextPosition. The while loop above already advanced it.
+                //    Otherwise, we would end up skipping a segment (i.e. advance = false).
+                // If firstSegmentIsEmpty is false,
+                //    make sure to advance _nextPosition so that it is no longer the same as _currentPosition (i.e. advance = true).
+                _isLastSegment = !jsonData.TryGet(ref _nextPosition, out _, advance: !firstSegmentIsEmpty) && isFinalBlock; // Don't re-order to avoid short-circuiting
+
+                Debug.Assert(!_nextPosition.Equals(_currentPosition));
+
                 _isMultiSegment = true;
             }
         }
@@ -1310,6 +1320,7 @@ namespace System.Text.Json
 
         private ConsumeNumberResult ConsumeNegativeSignMultiSegment(ref ReadOnlySpan<byte> data, ref int i)
         {
+            Debug.Assert(i == 0);
             byte nextByte = data[i];
 
             if (nextByte == '-')
@@ -1330,7 +1341,8 @@ namespace System.Text.Json
                         }
                         return ConsumeNumberResult.NeedMoreData;
                     }
-                    _totalConsumed++;
+                    Debug.Assert(i == 1);
+                    _totalConsumed += i;
                     HasValueSequence = true;
                     i = 0;
                     data = _buffer;
@@ -1348,9 +1360,10 @@ namespace System.Text.Json
         private ConsumeNumberResult ConsumeZeroMultiSegment(ref ReadOnlySpan<byte> data, ref int i)
         {
             Debug.Assert(data[i] == (byte)'0');
+            Debug.Assert(i == 0 || i == 1);
             i++;
             _bytePositionInLine++;
-            byte nextByte = default;
+            byte nextByte;
             if (i < data.Length)
             {
                 nextByte = data[i];
@@ -1378,7 +1391,7 @@ namespace System.Text.Json
                     return ConsumeNumberResult.NeedMoreData;
                 }
 
-                _totalConsumed++;
+                _totalConsumed += i;
                 HasValueSequence = true;
                 i = 0;
                 data = _buffer;
@@ -1523,6 +1536,7 @@ namespace System.Text.Json
                     }
                     return ConsumeNumberResult.NeedMoreData;
                 }
+                _totalConsumed += i;
                 HasValueSequence = true;
                 i = 0;
                 data = _buffer;
@@ -1548,7 +1562,7 @@ namespace System.Text.Json
                         }
                         return ConsumeNumberResult.NeedMoreData;
                     }
-                    _totalConsumed++;
+                    _totalConsumed += i;
                     HasValueSequence = true;
                     i = 0;
                     data = _buffer;

--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
@@ -1300,6 +1300,7 @@ namespace System.Text.Json
             {
                 if (IsLastSpan)
                 {
+                    _bytePositionInLine += localBuffer.Length + 1;  // Account for the start quote
                     ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.EndOfStringNotFound);
                 }
                 return false;
@@ -1344,19 +1345,7 @@ namespace System.Text.Json
                         ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.InvalidCharacterAfterEscapeWithinString, currentByte);
                     }
 
-                    if (currentByte == JsonConstants.Quote)
-                    {
-                        // Ignore an escaped quote.
-                        // This is likely the most common case, so adding an explicit check
-                        // to avoid doing the unnecessary checks below.
-                    }
-                    else if (currentByte == 'n')
-                    {
-                        // Escaped new line character
-                        _bytePositionInLine = -1; // Should be 0, but we increment _bytePositionInLine below already
-                        _lineNumber++;
-                    }
-                    else if (currentByte == 'u')
+                    if (currentByte == 'u')
                     {
                         // Expecting 4 hex digits to follow the escaped 'u'
                         _bytePositionInLine++;  // move past the 'u'
@@ -1529,7 +1518,7 @@ namespace System.Text.Json
             Debug.Assert(resultExponent == ConsumeNumberResult.OperationIncomplete);
 
             _bytePositionInLine += i;
-            ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedEndOfDigitNotFound, nextByte);
+            ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedEndOfDigitNotFound, data[i]);
 
         Done:
             ValueSpan = data.Slice(0, i);

--- a/src/System.Text.Json/tests/JsonTestHelper.cs
+++ b/src/System.Text.Json/tests/JsonTestHelper.cs
@@ -4,6 +4,7 @@
 
 using System.Buffers;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Text.Json.Tests;
@@ -151,20 +152,49 @@ namespace System.Text.Json
             return new ReadOnlySequence<byte>(firstSegment, 0, secondSegment, secondMem.Length);
         }
 
-        public static ReadOnlySequence<byte> GetSequence(byte[] _dataUtf8, int segmentSize)
+        public static ReadOnlySequence<byte> CreateSegments(byte[] data, int splitLocation)
         {
-            int numberOfSegments = _dataUtf8.Length / segmentSize + 1;
+            Debug.Assert(splitLocation <= data.Length);
+
+            ReadOnlyMemory<byte> dataMemory = data;
+
+            var firstSegment = new BufferSegment<byte>(dataMemory.Slice(0, splitLocation));
+            ReadOnlyMemory<byte> secondMem = dataMemory.Slice(splitLocation);
+            BufferSegment<byte> secondSegment = firstSegment.Append(secondMem);
+
+            return new ReadOnlySequence<byte>(firstSegment, 0, secondSegment, secondMem.Length);
+        }
+
+        public static ReadOnlySequence<byte> CreateSegments(byte[] data, int firstSplit, int secondSplit)
+        {
+            Debug.Assert(firstSplit <= data.Length && secondSplit <= data.Length && firstSplit <= secondSplit);
+
+            ReadOnlyMemory<byte> dataMemory = data;
+
+            var firstSegment = new BufferSegment<byte>(dataMemory.Slice(0, firstSplit));
+            ReadOnlyMemory<byte> secondMem = dataMemory.Slice(firstSplit, secondSplit - firstSplit);
+            BufferSegment<byte> secondSegment = firstSegment.Append(secondMem);
+
+            ReadOnlyMemory<byte> thirdMem = dataMemory.Slice(secondSplit);
+            BufferSegment<byte> thirdSegment = secondSegment.Append(thirdMem);
+
+            return new ReadOnlySequence<byte>(firstSegment, 0, thirdSegment, thirdMem.Length);
+        }
+
+        public static ReadOnlySequence<byte> GetSequence(byte[] dataUtf8, int segmentSize)
+        {
+            int numberOfSegments = dataUtf8.Length / segmentSize + 1;
             byte[][] buffers = new byte[numberOfSegments][];
 
             for (int j = 0; j < numberOfSegments - 1; j++)
             {
                 buffers[j] = new byte[segmentSize];
-                Array.Copy(_dataUtf8, j * segmentSize, buffers[j], 0, segmentSize);
+                Array.Copy(dataUtf8, j * segmentSize, buffers[j], 0, segmentSize);
             }
 
-            int remaining = _dataUtf8.Length % segmentSize;
+            int remaining = dataUtf8.Length % segmentSize;
             buffers[numberOfSegments - 1] = new byte[remaining];
-            Array.Copy(_dataUtf8, _dataUtf8.Length - remaining, buffers[numberOfSegments - 1], 0, remaining);
+            Array.Copy(dataUtf8, dataUtf8.Length - remaining, buffers[numberOfSegments - 1], 0, remaining);
 
             return BufferFactory.Create(buffers);
         }

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
@@ -142,6 +142,255 @@ namespace System.Text.Json.Tests
             Assert.Equal(expectedBytesConsumed, jsonReader.BytesConsumed);
         }
 
+        [Theory]
+        [InlineData("0{", 1, false, 0, '{')]
+        [InlineData("0e+1b", 4, false, 0, 'b')]
+        [InlineData("1e+0}", 4, true, 4, '}')]
+        [InlineData("12345.1. ", 7, false, 0, '.')]
+        [InlineData("- ", 1, false, 0, ' ')]
+        [InlineData("-f ", 1, false, 0, 'f')]
+        [InlineData("-} ", 1, false, 0, '}')]
+        [InlineData("1.f ", 2, false, 0, 'f')]
+        [InlineData("1.} ", 2, false, 0, '}')]
+        [InlineData("0. ", 2, false, 0, ' ')]
+        [InlineData("0.1f ", 3, false, 0, 'f')]
+        [InlineData("0.1} ", 3, true, 3, '}')]
+        [InlineData("0.1e1f ", 5, false, 0, 'f')]
+        [InlineData("+0 ", 0, false, 0, '+')]
+        [InlineData("+1 ", 0, false, 0, '+')]
+        [InlineData("0e ", 2, false, 0, ' ')]
+        [InlineData("0.1e ", 4, false, 0, ' ')]
+        [InlineData("01 ", 1, false, 0, '1')]
+        [InlineData("1a ", 1, false, 0, 'a')]
+        [InlineData("-01 ", 2, false, 0, '1')]
+        [InlineData("10.5e ", 5, false, 0, ' ')]
+        [InlineData("10.5e- ", 6, false, 0, ' ')]
+        [InlineData("10.5e+ ", 6, false, 0, ' ')]
+        [InlineData("10.5e-0.2 ", 7, false, 0, '.')]
+        public static void InvalidJsonNumberVariousSegmentSizes(string input, int expectedBytePositionInLine, bool firstReadSuccessful, int expectedConsumed, char invalidChar)
+        {
+            byte[] utf8 = Encoding.UTF8.GetBytes(input);
+
+            var jsonReader = new Utf8JsonReader(utf8);
+            InvalidReadNumberHelper(ref jsonReader, expectedBytePositionInLine, firstReadSuccessful, expectedConsumed, invalidChar);
+
+            ReadOnlySequence<byte> sequence = JsonTestHelper.GetSequence(utf8, 1);
+            jsonReader = new Utf8JsonReader(sequence);
+            InvalidReadNumberHelper(ref jsonReader, expectedBytePositionInLine, firstReadSuccessful, expectedConsumed, invalidChar);
+
+            for (int splitLocation = 0; splitLocation < utf8.Length; splitLocation++)
+            {
+                sequence = JsonTestHelper.CreateSegments(utf8, splitLocation);
+                jsonReader = new Utf8JsonReader(sequence);
+                InvalidReadNumberHelper(ref jsonReader, expectedBytePositionInLine, firstReadSuccessful, expectedConsumed, invalidChar);
+            }
+
+            for (int firstSplit = 0; firstSplit < utf8.Length; firstSplit++)
+            {
+                for (int secondSplit = firstSplit; secondSplit < utf8.Length; secondSplit++)
+                {
+                    sequence = JsonTestHelper.CreateSegments(utf8, firstSplit, secondSplit);
+                    jsonReader = new Utf8JsonReader(sequence);
+                    InvalidReadNumberHelper(ref jsonReader, expectedBytePositionInLine, firstReadSuccessful, expectedConsumed, invalidChar);
+                }
+            }
+        }
+
+        private static void InvalidReadNumberHelper(ref Utf8JsonReader jsonReader, int expectedBytePositionInLine, bool firstReadSuccessful, int expectedConsumed, char invalidChar)
+        {
+            if (firstReadSuccessful)
+            {
+                Assert.True(jsonReader.Read());
+
+                long tokenLength = jsonReader.HasValueSequence ? jsonReader.ValueSequence.Length : jsonReader.ValueSpan.Length;
+                Assert.Equal(expectedConsumed, tokenLength);
+                Assert.Equal(0, jsonReader.TokenStartIndex);
+                Assert.Equal(expectedConsumed, jsonReader.BytesConsumed - jsonReader.TokenStartIndex);
+            }
+
+            try
+            {
+                jsonReader.Read();
+                Assert.True(false, "Expected JsonException was not thrown for incomplete/invalid JSON payload reading.");
+            }
+            catch (JsonException ex)
+            {
+                Assert.Equal(0, ex.LineNumber);
+                Assert.Equal(expectedBytePositionInLine, ex.BytePositionInLine);
+                Assert.Equal(expectedConsumed, jsonReader.BytesConsumed);
+                Assert.Contains($"'{invalidChar}'", ex.Message);
+            }
+        }
+
+        [Theory]
+        [InlineData("\"\\\"\"}", 4, 4, "\"", 2)]
+        [InlineData("\"\\\"\"5", 4, 4, "\"", 2)]
+        [InlineData("\"\\\"\":", 4, 4, "\"", 2)]
+        [InlineData("\"\\\"\",", 4, 4, "\"", 2)]
+        [InlineData("\"abc\\t\"}", 7, 7, "abc\t", 5)]
+        [InlineData("\"abc\\u0061\"}", 11, 11, "abca", 9)]
+        [InlineData("\"abc\\u0061abc\"}", 14, 14, "abcaabc", 12)]
+        [InlineData("\"abc\\t\\\"\"}", 9, 9, "abc\t\"", 7)]
+        [InlineData("\"abc\\n\"}", 7, 7, "abc\n", 5)]
+        [InlineData("\"abc\\na\"}", 8, 8, "abc\na", 6)]
+        [InlineData("\"abc\\u0061X\"}", 12, 12, "abcaX", 10)]
+        [InlineData("\"\\u0061\"}", 8, 8, "a", 6)]
+        public static void ValidStringWithinInvalidJsonVariousSegmentSizes(string input, int expectedBytePositionInLine, int expectedConsumed, string expectedStr, int expectedTokenLength)
+        {
+            byte[] utf8 = Encoding.UTF8.GetBytes(input);
+
+            var jsonReader = new Utf8JsonReader(utf8);
+            ValidReadStringHelper(ref jsonReader, expectedBytePositionInLine, expectedConsumed, expectedStr, expectedTokenLength);
+
+            ReadOnlySequence<byte> sequence = JsonTestHelper.GetSequence(utf8, 1);
+            jsonReader = new Utf8JsonReader(sequence);
+            ValidReadStringHelper(ref jsonReader, expectedBytePositionInLine, expectedConsumed, expectedStr, expectedTokenLength);
+
+            for (int splitLocation = 0; splitLocation < utf8.Length; splitLocation++)
+            {
+                sequence = JsonTestHelper.CreateSegments(utf8, splitLocation);
+                jsonReader = new Utf8JsonReader(sequence);
+                ValidReadStringHelper(ref jsonReader, expectedBytePositionInLine, expectedConsumed, expectedStr, expectedTokenLength);
+            }
+
+            for (int firstSplit = 0; firstSplit < utf8.Length; firstSplit++)
+            {
+                for (int secondSplit = firstSplit; secondSplit < utf8.Length; secondSplit++)
+                {
+                    sequence = JsonTestHelper.CreateSegments(utf8, firstSplit, secondSplit);
+                    jsonReader = new Utf8JsonReader(sequence);
+                    ValidReadStringHelper(ref jsonReader, expectedBytePositionInLine, expectedConsumed, expectedStr, expectedTokenLength);
+                }
+            }
+        }
+
+        private static void ValidReadStringHelper(ref Utf8JsonReader jsonReader, int expectedBytePositionInLine, int expectedConsumed, string expectedStr, int expectedTokenLength)
+        {
+            Assert.True(jsonReader.Read());
+
+            Assert.Equal(JsonTokenType.String, jsonReader.TokenType);
+            long tokenLength = jsonReader.HasValueSequence ? jsonReader.ValueSequence.Length : jsonReader.ValueSpan.Length;
+            Assert.Equal(expectedTokenLength, tokenLength);
+            Assert.Equal(expectedTokenLength + 2, jsonReader.BytesConsumed - jsonReader.TokenStartIndex);
+            Assert.Equal(expectedStr, jsonReader.GetString());
+
+            try
+            {
+                jsonReader.Read();
+                Assert.True(false, "Expected JsonException was not thrown for incomplete/invalid JSON payload reading.");
+            }
+            catch (JsonException ex)
+            {
+                Assert.Equal(0, ex.LineNumber);
+                Assert.Equal(expectedBytePositionInLine, ex.BytePositionInLine);
+                Assert.Equal(expectedConsumed, jsonReader.BytesConsumed);
+            }
+        }
+
+        [Theory]
+        [InlineData("\"abc\\t", 6)]
+        [InlineData("\"abc\\t\\\"", 8)]
+        [InlineData("\"abc\\n", 6)]
+        [InlineData("\"abc\\nabc", 9)]
+        [InlineData("\"abc\\n\\\"", 8)]
+        [InlineData("\"hi\\n\\n\\n\\q\"", 10)]
+        [InlineData("\"abc\u0010\"", 4)]
+        [InlineData("\"abc\u0010abc\"", 4)]
+        [InlineData("\"abc\\p\"", 5)]
+        [InlineData("\"abc\\p", 5)]
+        [InlineData("\"abc\\u\"", 6)]
+        [InlineData("\"abc\\uX\"", 6)]
+        [InlineData("\"abc\\u", 6)]
+        [InlineData("\"abc\\u1\"", 7)]
+        [InlineData("\"abc\\u1X\"", 7)]
+        [InlineData("\"abc\\u1", 7)]
+        [InlineData("\"abc\\u12\"", 8)]
+        [InlineData("\"abc\\u12X\"", 8)]
+        [InlineData("\"abc\\u12", 8)]
+        [InlineData("\"abc\\u123\"", 9)]
+        [InlineData("\"abc\\u123X\"", 9)]
+        [InlineData("\"abc\\u123", 9)]
+        [InlineData("\"abc\\u1234\\\"", 12)]
+        [InlineData("\"abc\\u1234X\\\"", 13)]
+        [InlineData("\"abc\\u1234", 10)]
+        [InlineData("\"abcdefg", 8)]
+        [InlineData("\"\\u1234", 7)]
+        [InlineData("{\"name\": \"abc\\t", 6 + 9, 2, 9)]
+        [InlineData("{\"name\": \"abc\\t\\\"", 8 + 9, 2, 9)]
+        [InlineData("{\"name\": \"abc\\n", 6 + 9, 2, 9)]
+        [InlineData("{\"name\": \"abc\\nabc", 9 + 9, 2, 9)]
+        [InlineData("{\"name\": \"abc\\n\\\"", 8 + 9, 2, 9)]
+        [InlineData("{\"name\": \"hi\\n\\n\\n\\q\"", 10 + 9, 2, 9)]
+        [InlineData("{\"name\": \"abc\u0010\"", 4 + 9, 2, 9)]
+        [InlineData("{\"name\": \"abc\u0010abc\"", 4 + 9, 2, 9)]
+        [InlineData("{\"name\": \"abc\\p\"", 5 + 9, 2, 9)]
+        [InlineData("{\"name\": \"abc\\p", 5 + 9, 2, 9)]
+        [InlineData("{\"name\": \"abc\\u\"", 6 + 9, 2, 9)]
+        [InlineData("{\"name\": \"abc\\uX\"", 6 + 9, 2, 9)]
+        [InlineData("{\"name\": \"abc\\u", 6 + 9, 2, 9)]
+        [InlineData("{\"name\": \"abc\\u1\"", 7 + 9, 2, 9)]
+        [InlineData("{\"name\": \"abc\\u1X\"", 7 + 9, 2, 9)]
+        [InlineData("{\"name\": \"abc\\u1", 7 + 9, 2, 9)]
+        [InlineData("{\"name\": \"abc\\u12\"", 8 + 9, 2, 9)]
+        [InlineData("{\"name\": \"abc\\u12X\"", 8 + 9, 2, 9)]
+        [InlineData("{\"name\": \"abc\\u12", 8 + 9, 2, 9)]
+        [InlineData("{\"name\": \"abc\\u123\"", 9 + 9, 2, 9)]
+        [InlineData("{\"name\": \"abc\\u123X\"", 9 + 9, 2, 9)]
+        [InlineData("{\"name\": \"abc\\u123", 9 + 9, 2, 9)]
+        [InlineData("{\"name\": \"abc\\u1234\\\"", 12 + 9, 2, 9)]
+        [InlineData("{\"name\": \"abc\\u1234X\\\"", 13 + 9, 2, 9)]
+        [InlineData("{\"name\": \"abc\\u1234", 10 + 9, 2, 9)]
+        [InlineData("{\"name\": \"abcdefg", 8 + 9, 2, 9)]
+        [InlineData("{\"name\": \"\\u1234", 7 + 9, 2, 9)]
+        public static void InvalidJsonStringVariousSegmentSizes(string input, int expectedBytePositionInLine, int numberOfSuccessfulReads = 0, int expectedConsumed = 0)
+        {
+            byte[] utf8 = Encoding.UTF8.GetBytes(input);
+
+            var jsonReader = new Utf8JsonReader(utf8);
+            InvalidReadStringHelper(ref jsonReader, expectedBytePositionInLine, numberOfSuccessfulReads, expectedConsumed);
+
+            ReadOnlySequence<byte> sequence = JsonTestHelper.GetSequence(utf8, 1);
+            jsonReader = new Utf8JsonReader(sequence);
+            InvalidReadStringHelper(ref jsonReader, expectedBytePositionInLine, numberOfSuccessfulReads, expectedConsumed);
+
+            for (int splitLocation = 0; splitLocation < utf8.Length; splitLocation++)
+            {
+                sequence = JsonTestHelper.CreateSegments(utf8, splitLocation);
+                jsonReader = new Utf8JsonReader(sequence);
+                InvalidReadStringHelper(ref jsonReader, expectedBytePositionInLine, numberOfSuccessfulReads, expectedConsumed);
+            }
+
+            for (int firstSplit = 0; firstSplit < utf8.Length; firstSplit++)
+            {
+                for (int secondSplit = firstSplit; secondSplit < utf8.Length; secondSplit++)
+                {
+                    sequence = JsonTestHelper.CreateSegments(utf8, firstSplit, secondSplit);
+                    jsonReader = new Utf8JsonReader(sequence);
+                    InvalidReadStringHelper(ref jsonReader, expectedBytePositionInLine, numberOfSuccessfulReads, expectedConsumed);
+                }
+            }
+        }
+
+        private static void InvalidReadStringHelper(ref Utf8JsonReader jsonReader, int expectedBytePositionInLine, int numberOfSuccessfulReads, int expectedConsumed)
+        {
+            for (int i = 0; i < numberOfSuccessfulReads; i++)
+            {
+                Assert.True(jsonReader.Read());
+            }
+
+            try
+            {
+                jsonReader.Read();
+                Assert.True(false, "Expected JsonException was not thrown for incomplete/invalid JSON payload reading.");
+            }
+            catch (JsonException ex)
+            {
+                Assert.Equal(0, ex.LineNumber);
+                Assert.Equal(expectedBytePositionInLine, ex.BytePositionInLine);
+                Assert.Equal(expectedConsumed, jsonReader.BytesConsumed);
+            }
+        }
+
         [Fact]
         public static void InitialStateSimpleCtorMultiSegment()
         {
@@ -568,15 +817,24 @@ namespace System.Text.Json.Tests
         }
 
         [Theory]
-        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF, (byte)'1' }, true)]
-        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF, (byte)'1' }, false)]
-        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF }, true)]
-        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF }, false)]
-        public static void TestBOMWithSingleJsonValue(byte[] utf8BomAndValue, bool isFinalBlock)
+        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF, (byte)'1' }, true, 1)]
+        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF, (byte)'1' }, true, 2)]
+        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF, (byte)'1' }, true, 3)]
+        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF, (byte)'1' }, false, 1)]
+        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF, (byte)'1' }, false, 2)]
+        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF, (byte)'1' }, false, 3)]
+        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF }, true, 1)]
+        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF }, true, 2)]
+        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF }, true, 3)]
+        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF }, false, 1)]
+        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF }, false, 2)]
+        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF }, false, 3)]
+        public static void TestBOMWithSingleJsonValueMultiSegment(byte[] utf8BomAndValue, bool isFinalBlock, int segmentSize)
         {
             Assert.ThrowsAny<JsonException>(() =>
             {
-                var json = new Utf8JsonReader(utf8BomAndValue, isFinalBlock: isFinalBlock, state: default);
+                ReadOnlySequence<byte> sequence = JsonTestHelper.GetSequence(utf8BomAndValue, segmentSize);
+                var json = new Utf8JsonReader(sequence, isFinalBlock: isFinalBlock, state: default);
                 json.Read();
             });
         }

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.cs
@@ -2,11 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Buffers;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using Newtonsoft.Json;
 using Xunit;
 
@@ -1982,19 +1980,19 @@ namespace System.Text.Json.Tests
                         ;
                     Assert.True(false, "Expected JsonException was not thrown.");
                 }
-                catch (JsonException) {}
+                catch (JsonException) { }
             }
         }
 
         [Theory]
-        [InlineData("{\r\n\"is\\r\\nAct\u6F22\u5B57ive\": false \"in\u6F22\u5B57valid\"\r\n}", 30, 30, 2, 21)]
-        [InlineData("{\r\n\"is\\r\\nAct\u6F22\u5B57ive\": false \"in\u6F22\u5B57valid\"\r\n}", 31, 31, 2, 21)]
-        [InlineData("{\r\n\"is\\r\\nAct\u6F22\u5B57ive\": false, \"in\u6F22\u5B57valid\"\r\n}", 30, 30, 3, 0)]
-        [InlineData("{\r\n\"is\\r\\nAct\u6F22\u5B57ive\": false, \"in\u6F22\u5B57valid\"\r\n}", 31, 30, 3, 0)]
-        [InlineData("{\r\n\"is\\r\\nAct\u6F22\u5B57ive\": false, \"in\u6F22\u5B57valid\"\r\n}", 32, 30, 3, 0)]
-        [InlineData("{\r\n\"is\\r\\nAct\u6F22\u5B57ive\": false, 5\r\n}", 30, 30, 2, 22)]
-        [InlineData("{\r\n\"is\\r\\nAct\u6F22\u5B57ive\": false, 5\r\n}", 31, 30, 2, 22)]
-        [InlineData("{\r\n\"is\\r\\nAct\u6F22\u5B57ive\": false, 5\r\n}", 32, 30, 2, 22)]
+        [InlineData("{\r\n\"is\\r\\nAct\u6F22\u5B57ive\": false \"in\u6F22\u5B57valid\"\r\n}", 30, 30, 1, 28)]
+        [InlineData("{\r\n\"is\\r\\nAct\u6F22\u5B57ive\": false \"in\u6F22\u5B57valid\"\r\n}", 31, 31, 1, 28)]
+        [InlineData("{\r\n\"is\\r\\nAct\u6F22\u5B57ive\": false, \"in\u6F22\u5B57valid\"\r\n}", 30, 30, 2, 0)]
+        [InlineData("{\r\n\"is\\r\\nAct\u6F22\u5B57ive\": false, \"in\u6F22\u5B57valid\"\r\n}", 31, 30, 2, 0)]
+        [InlineData("{\r\n\"is\\r\\nAct\u6F22\u5B57ive\": false, \"in\u6F22\u5B57valid\"\r\n}", 32, 30, 2, 0)]
+        [InlineData("{\r\n\"is\\r\\nAct\u6F22\u5B57ive\": false, 5\r\n}", 30, 30, 1, 29)]
+        [InlineData("{\r\n\"is\\r\\nAct\u6F22\u5B57ive\": false, 5\r\n}", 31, 30, 1, 29)]
+        [InlineData("{\r\n\"is\\r\\nAct\u6F22\u5B57ive\": false, 5\r\n}", 32, 30, 1, 29)]
         public static void InvalidJsonSplitRemainsInvalid(string jsonString, int splitLocation, int consumed, int expectedlineNumber, int expectedBytePosition)
         {
             foreach (JsonCommentHandling commentHandling in Enum.GetValues(typeof(JsonCommentHandling)))
@@ -2047,7 +2045,7 @@ namespace System.Text.Json.Tests
         [InlineData("[[[[{\r\n\"t\u6F22\u5B57emp1\":[[[[{\"temp2\":[}]]]]}]]]]", 1, 28, 64)]
         [InlineData("[[[[{\r\n\"t\u6F22\u5B57emp1\":[[[[{\"temp2\":[]},[}]]]]}]]]]", 1, 32, 64)]
         [InlineData("{\r\n\t\"isActive\": false,\r\n\t\"array\": [\r\n\t\t[{\r\n\t\t\t\"id\": 1\r\n\t\t}]\r\n\t]\r\n}", 3, 3, 3)]
-        [InlineData("{\"Here is a \u6F22\u5B57string: \\\"\\\"\":\"Here is \u6F22\u5B57a\",\"Here is a back slash\\\\\":[\"Multiline\\r\\n String\\r\\n\",\"\\tMul\\r\\ntiline String\",\"\\\"somequote\\\"\\tMu\\\"\\\"l\\r\\ntiline\\\"another\\\" String\\\\\"],\"str:\"\\\"\\\"\"}", 4, 35, 64)]
+        [InlineData("{\"Here is a \u6F22\u5B57string: \\\"\\\"\":\"Here is \u6F22\u5B57a\",\"Here is a back slash\\\\\":[\"Multiline\\r\\n String\\r\\n\",\"\\tMul\\r\\ntiline String\",\"\\\"somequote\\\"\\tMu\\\"\\\"l\\r\\ntiline\\\"another\\\" String\\\\\"],\"str:\"\\\"\\\"\"}", 0, 190, 64)]
         public static void InvalidJsonWhenPartial(string jsonString, int expectedlineNumber, int expectedBytePosition, int maxDepth)
         {
             byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
@@ -2090,7 +2088,7 @@ namespace System.Text.Json.Tests
 
         [Theory]
         [InlineData("{\"text\": \"\u0E4F\u0020\u0E2A\u0E27\u0E31\u0E2A\u0E14\u0E35\\uABCZ \u0E42\u0E25\u0E01\"}", 0, 37)]   // * Hello\\uABCZ World in thai
-        [InlineData("{\"text\": \"\u0E4F\u0020\u0E2A\u0E39\u0E07\\n\u0E15\u0E48\u0E33\\uABCZ \u0E42\u0E25\u0E01\"}", 1, 14)]    // * High\\nlow\\uABCZ World in thai
+        [InlineData("{\"text\": \"\u0E4F\u0020\u0E2A\u0E39\u0E07\\n\u0E15\u0E48\u0E33\\uABCZ \u0E42\u0E25\u0E01\"}", 0, 39)]    // * High\\nlow\\uABCZ World in thai
         public static void PositionInCodeUnits(string jsonString, int expectedlineNumber, int expectedBytePosition)
         {
             byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
@@ -3740,6 +3738,20 @@ namespace System.Text.Json.Tests
             }
         }
 
+        [Theory]
+        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF, (byte)'1' }, true)]
+        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF, (byte)'1' }, false)]
+        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF }, true)]
+        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF }, false)]
+        public static void TestBOMWithSingleJsonValue(byte[] utf8BomAndValue, bool isFinalBlock)
+        {
+            Assert.ThrowsAny<JsonException>(() =>
+            {
+                var json = new Utf8JsonReader(utf8BomAndValue, isFinalBlock: isFinalBlock, state: default);
+                json.Read();
+            });
+        }
+
         public static IEnumerable<object[]> TestCases
         {
             get
@@ -4025,29 +4037,6 @@ namespace System.Text.Json.Tests
                     new object[] {"[1,/*comment*/]"},
                 };
             }
-        }
-
-        [Theory]
-        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF, (byte)'1' }, true, 1)]
-        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF, (byte)'1' }, true, 2)]
-        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF, (byte)'1' }, true, 3)]
-        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF, (byte)'1' }, false, 1)]
-        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF, (byte)'1' }, false, 2)]
-        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF, (byte)'1' }, false, 3)]
-        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF }, true, 1)]
-        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF }, true, 2)]
-        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF }, true, 3)]
-        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF }, false, 1)]
-        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF }, false, 2)]
-        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF }, false, 3)]
-        public static void TestBOMWithSingleJsonValueMultiSegment(byte[] utf8BomAndValue, bool isFinalBlock, int segmentSize)
-        {
-            Assert.ThrowsAny<JsonException>(() =>
-            {
-                ReadOnlySequence<byte> sequence = JsonTestHelper.GetSequence(utf8BomAndValue, segmentSize);
-                var json = new Utf8JsonReader(sequence, isFinalBlock: isFinalBlock, state: default);
-                json.Read();
-            });
         }
 
         public static IEnumerable<object[]> JsonWithInvalidTrailingCommas
@@ -4351,7 +4340,7 @@ namespace System.Text.Json.Tests
             {
                 return new List<object[]>
                 {
-                    new object[] {"\"", 0, 0},
+                    new object[] {"\"", 0, 1},
                     new object[] {"{]", 0, 1},
                     new object[] {"[}", 0, 1},
                     new object[] {"nul", 0, 3},
@@ -4359,7 +4348,8 @@ namespace System.Text.Json.Tests
                     new object[] {"fals", 0, 4},
                     new object[] {"\"a\u6F22\u5B57ge\":", 0, 11},
                     new object[] {"{\"a\u6F22\u5B57ge\":", 0, 13},
-                    new object[] {"{\"name\":\"A\u6F22\u5B57hso", 0, 8},
+                    new object[] {"{\"name\":\"A\u6F22\u5B57hso", 0, 19},
+                    new object[] {"{\"name\":\"A\u6F22\u5B57h\\nso", 0, 21},
                     new object[] {"12345.1.", 0, 7},
                     new object[] {"-", 0, 1},
                     new object[] {"-f", 0, 1},
@@ -4401,13 +4391,13 @@ namespace System.Text.Json.Tests
                     new object[] {"{\"ints\":[1, 2, 3, 4, 5", 0, 22},
                     new object[] {"{\"s\u6F22\u5B57trings\":[\"a\u6F22\u5B57bc\", \"def\"", 0, 36},
                     new object[] {"{\"age\":30, \"ints\":[1, 2, 3, 4, 5}}", 0, 32},
-                    new object[] {"{\"age\":30, \"name\":\"test}", 0, 18},
+                    new object[] {"{\"age\":30, \"name\":\"test}", 0, 24},
                     new object[] {"{\r\n\"isActive\": false \"\r\n}", 1, 18},
                     new object[] {"[[[[{\r\n\"t\u6F22\u5B57emp1\":[[[[{\"temp2\":[}]]]]}]]]]", 1, 28},
-                    new object[] {"[[[[{\r\n\"t\u6F22\u5B57emp1\":[[[[{\"temp2:[]}]]]]}]]]]", 1, 19},
+                    new object[] {"[[[[{\r\n\"t\u6F22\u5B57emp1\":[[[[{\"temp2:[]}]]]]}]]]]", 1, 38},
                     new object[] {"[[[[{\r\n\"t\u6F22\u5B57emp1\":[[[[{\"temp2\":[]},[}]]]]}]]]]", 1, 32},
                     new object[] {"{\r\n\t\"isActive\": false,\r\n\t\"array\": [\r\n\t\t[{\r\n\t\t\t\"id\": 1\r\n\t\t}]\r\n\t]\r\n}", 3, 3, 3},
-                    new object[] {"{\"Here is a \u6F22\u5B57string: \\\"\\\"\":\"Here is \u6F22\u5B57a\",\"Here is a back slash\\\\\":[\"Multiline\\r\\n String\\r\\n\",\"\\tMul\\r\\ntiline String\",\"\\\"somequote\\\"\\tMu\\\"\\\"l\\r\\ntiline\\\"another\\\" String\\\\\"],\"str:\"\\\"\\\"\"}", 4, 35},
+                    new object[] {"{\"Here is a \u6F22\u5B57string: \\\"\\\"\":\"Here is \u6F22\u5B57a\",\"Here is a back slash\\\\\":[\"Multiline\\r\\n String\\r\\n\",\"\\tMul\\r\\ntiline String\",\"\\\"somequote\\\"\\tMu\\\"\\\"l\\r\\ntiline\\\"another\\\" String\\\\\"],\"str:\"\\\"\\\"\"}", 0, 190},
                     new object[] {"\"hel\rlo\"", 0, 4},
                     new object[] {"\"hel\nlo\"", 0, 4},
                     new object[] {"\"hel\\uABCXlo\"", 0, 9},
@@ -4416,14 +4406,14 @@ namespace System.Text.Json.Tests
                     new object[] {"\"hel\nlo\\\"\"", 0, 4},
                     new object[] {"\"hel\\uABCXlo\\\"\"", 0, 9},
                     new object[] {"\"hel\\\tlo\\\"\"", 0, 5},
-                    new object[] {"\"he\\nl\rlo\\\"\"", 1, 1},
-                    new object[] {"\"he\\nl\nlo\\\"\"", 1, 1},
-                    new object[] {"\"he\\nl\\uABCXlo\\\"\"", 1, 6},
-                    new object[] {"\"he\\nl\\\tlo\\\"\"", 1, 2},
-                    new object[] {"\"he\\nl\rlo", 1, 1},
-                    new object[] {"\"he\\nl\nlo", 1, 1},
-                    new object[] {"\"he\\nl\\uABCXlo", 1, 6},
-                    new object[] {"\"he\\nl\\\tlo", 1, 2},
+                    new object[] {"\"he\\nl\rlo\\\"\"", 0, 6},
+                    new object[] {"\"he\\nl\nlo\\\"\"", 0, 6},
+                    new object[] {"\"he\\nl\\uABCXlo\\\"\"", 0, 11},
+                    new object[] {"\"he\\nl\\\tlo\\\"\"", 0, 7},
+                    new object[] {"\"he\\nl\rlo", 0, 6},
+                    new object[] {"\"he\\nl\nlo", 0, 6},
+                    new object[] {"\"he\\nl\\uABCXlo", 0, 11},
+                    new object[] {"\"he\\nl\\\tlo", 0, 7},
                 };
             }
         }


### PR DESCRIPTION
Ports https://github.com/dotnet/corefx/pull/40303 and https://github.com/dotnet/corefx/pull/40349 to 3.0

Addresses https://github.com/dotnet/corefx/issues/39974 for valid JSON and invalid JSON (where exception message is consistent/accurate)

cc @steveharter, @ericstj, @danmosemsft, @ahsonkhan @eerhardt, @Anipik, @wtgodbe, @bartonjs, @stephentoub, @GSPP 

## Description

For processing valid JSON input:
We missed updating the bytes consumed in one instance when parsing numbers within JSON that is contained within a multi-segment `ReadOnlySequence<byte>`. Updating other instances of consumed to be updated correctly as well. Additionally, we are now consistently recovering the necessary reader state when the user passes in incomplete payload so they can continue with more data on subsequent reads.

Also fix setting up the initial positions during the ctor when the first segment happens to be empty.

For processing invalid JSON input:
There were a few places where the exception message and the values we returned as part of usability/diagnostics was inconsistent (or incorrect) when the user passed-in multi-segment data. Also, even though we don't provide guarantees on the reader state being recoverable after an error, certain properties like Line Number and Position In Line are still useful. This change also makes sure to avoid incorrectly increasing line number when seeing escaped new line characters within quoted strings.

## Customer Impact

The bug was customer-reported as part of testing various JSON payloads (both valid/invalid) and making sure the behavior is consistent.

When polling Utf8JsonReader.BytesConsumed, the user will now see a consistent result regardless of which input source contained their data (whether it was a span, or a multi-segment sequence where the number being parsed straddled a segment boundary). For example, after reading "2e2", that was split into three segments, we reported BytesConsumed as 2 instead of 3.

When the user observes the exception for invalid JSON (or programmatically polls the Line Number/Position properties), the message and values are accurate in many of the edge cases now. This helps with end-user-experience and diagnostics.

## Regression?

No.

## Risk

Low. Significant test cases were added and this only affects an edge use case on multi-segment buffers where the user is relying on the BytesConsumed property (low usage). The other changes involve the exception path for invalid JSON. The only risk is that we are updating code that was previously prone to off-by-one errors, but we have significant tests for all the various number inputs.