### PR TITLE
[release/3.0] Change 'type' to 'inputType' on serialize methods (#40372)

### DIFF
--- a/src/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/System.Text.Json/ref/System.Text.Json.cs
@@ -191,11 +191,11 @@ namespace System.Text.Json
         public static TValue Deserialize<TValue>(System.ReadOnlySpan<byte> utf8Json, System.Text.Json.JsonSerializerOptions options = null) { throw null; }
         public static TValue Deserialize<TValue>(string json, System.Text.Json.JsonSerializerOptions options = null) { throw null; }
         public static TValue Deserialize<TValue>(ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.JsonSerializerOptions options = null) { throw null; }
-        public static string Serialize(object value, System.Type type, System.Text.Json.JsonSerializerOptions options = null) { throw null; }
-        public static void Serialize(System.Text.Json.Utf8JsonWriter writer, object value, System.Type type, System.Text.Json.JsonSerializerOptions options = null) { }
-        public static System.Threading.Tasks.Task SerializeAsync(System.IO.Stream utf8Json, object value, System.Type type, System.Text.Json.JsonSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public static string Serialize(object value, System.Type inputType, System.Text.Json.JsonSerializerOptions options = null) { throw null; }
+        public static void Serialize(System.Text.Json.Utf8JsonWriter writer, object value, System.Type inputType, System.Text.Json.JsonSerializerOptions options = null) { }
+        public static System.Threading.Tasks.Task SerializeAsync(System.IO.Stream utf8Json, object value, System.Type inputType, System.Text.Json.JsonSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public static System.Threading.Tasks.Task SerializeAsync<TValue>(System.IO.Stream utf8Json, TValue value, System.Text.Json.JsonSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public static byte[] SerializeToUtf8Bytes(object value, System.Type type, System.Text.Json.JsonSerializerOptions options = null) { throw null; }
+        public static byte[] SerializeToUtf8Bytes(object value, System.Type inputType, System.Text.Json.JsonSerializerOptions options = null) { throw null; }
         public static byte[] SerializeToUtf8Bytes<TValue>(TValue value, System.Text.Json.JsonSerializerOptions options = null) { throw null; }
         public static void Serialize<TValue>(System.Text.Json.Utf8JsonWriter writer, TValue value, System.Text.Json.JsonSerializerOptions options = null) { }
         public static string Serialize<TValue>(TValue value, System.Text.Json.JsonSerializerOptions options = null) { throw null; }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.ByteArray.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.ByteArray.cs
@@ -22,12 +22,12 @@ namespace System.Text.Json
         /// </summary>
         /// <returns>A UTF-8 representation of the value.</returns>
         /// <param name="value">The value to convert.</param>
-        /// <param name="type">The type of the <paramref name="value"/> to convert.</param>
+        /// <param name="inputType">The type of the <paramref name="value"/> to convert.</param>
         /// <param name="options">Options to control the conversion behavior.</param>
-        public static byte[] SerializeToUtf8Bytes(object value, Type type, JsonSerializerOptions options = null)
+        public static byte[] SerializeToUtf8Bytes(object value, Type inputType, JsonSerializerOptions options = null)
         {
-            VerifyValueAndType(value, type);
-            return WriteCoreBytes(value, type, options);
+            VerifyValueAndType(value, inputType);
+            return WriteCoreBytes(value, inputType, options);
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
@@ -29,20 +29,20 @@ namespace System.Text.Json
         /// <returns>A task that represents the asynchronous write operation.</returns>
         /// <param name="utf8Json">The UTF-8 <see cref="System.IO.Stream"/> to write to.</param>
         /// <param name="value">The value to convert.</param>
-        /// <param name="type">The type of the <paramref name="value"/> to convert.</param>
+        /// <param name="inputType">The type of the <paramref name="value"/> to convert.</param>
         /// <param name="options">Options to control the conversion behavior.</param>
         /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> which may be used to cancel the write operation.</param>
-        public static Task SerializeAsync(Stream utf8Json, object value, Type type, JsonSerializerOptions options = null, CancellationToken cancellationToken = default)
+        public static Task SerializeAsync(Stream utf8Json, object value, Type inputType, JsonSerializerOptions options = null, CancellationToken cancellationToken = default)
         {
             if (utf8Json == null)
                 throw new ArgumentNullException(nameof(utf8Json));
 
-            VerifyValueAndType(value, type);
+            VerifyValueAndType(value, inputType);
 
-            return WriteAsyncCore(utf8Json, value, type, options, cancellationToken);
+            return WriteAsyncCore(utf8Json, value, inputType, options, cancellationToken);
         }
 
-        private static async Task WriteAsyncCore(Stream utf8Json, object value, Type type, JsonSerializerOptions options, CancellationToken cancellationToken)
+        private static async Task WriteAsyncCore(Stream utf8Json, object value, Type inputType, JsonSerializerOptions options, CancellationToken cancellationToken)
         {
             if (options == null)
             {
@@ -64,13 +64,13 @@ namespace System.Text.Json
                     return;
                 }
 
-                if (type == null)
+                if (inputType == null)
                 {
-                    type = value.GetType();
+                    inputType = value.GetType();
                 }
 
                 WriteStack state = default;
-                state.Current.Initialize(type, options);
+                state.Current.Initialize(inputType, options);
                 state.Current.CurrentValue = value;
 
                 bool isFinalBlock;

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.String.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.String.cs
@@ -26,22 +26,22 @@ namespace System.Text.Json
         /// </summary>
         /// <returns>A <see cref="System.String"/> representation of the value.</returns>
         /// <param name="value">The value to convert.</param>
-        /// <param name="type">The type of the <paramref name="value"/> to convert.</param>
+        /// <param name="inputType">The type of the <paramref name="value"/> to convert.</param>
         /// <param name="options">Options to control the conversion behavior.</param>
         /// <remarks>Using a <see cref="System.String"/> is not as efficient as using UTF-8
         /// encoding since the implementation internally uses UTF-8. See also <see cref="SerializeToUtf8Bytes"/>
         /// and <see cref="SerializeAsync"/>.
         /// </remarks>
-        public static string Serialize(object value, Type type, JsonSerializerOptions options = null)
+        public static string Serialize(object value, Type inputType, JsonSerializerOptions options = null)
         {
-            VerifyValueAndType(value, type);
+            VerifyValueAndType(value, inputType);
 
-            return ToStringInternal(value, type, options);
+            return ToStringInternal(value, inputType, options);
         }
 
-        private static string ToStringInternal(object value, Type type, JsonSerializerOptions options)
+        private static string ToStringInternal(object value, Type inputType, JsonSerializerOptions options)
         {
-            return WriteCoreString(value, type, options);
+            return WriteCoreString(value, inputType, options);
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Utf8JsonWriter.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Utf8JsonWriter.cs
@@ -22,12 +22,12 @@ namespace System.Text.Json
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="value">The value to convert and write.</param>
-        /// <param name="type">The type of the <paramref name="value"/> to convert.</param>
+        /// <param name="inputType">The type of the <paramref name="value"/> to convert.</param>
         /// <param name="options">Options to control the behavior.</param>
-        public static void Serialize(Utf8JsonWriter writer, object value, Type type, JsonSerializerOptions options = null)
+        public static void Serialize(Utf8JsonWriter writer, object value, Type inputType, JsonSerializerOptions options = null)
         {
-            VerifyValueAndType(value, type);
-            WriteValueCore(writer, value, type, options);
+            VerifyValueAndType(value, inputType);
+            WriteValueCore(writer, value, inputType, options);
         }
     }
 }


### PR DESCRIPTION
Port https://github.com/dotnet/corefx/pull/40372 to 3.0

cc: @eerhardt

## Description

During the mass API changes of the serializer #38933 for Preview 7, the parameter name changes from "type" to "inputType" on Serialize methods were only made to the ref.cs file, not the source, so a subsequent re-gen after Preview 7 of the ref.cs for an unrelated issue #39524 reverted that.

This PR adds backs the change from "type" to "inputType" to both the source and the ref.

## Regression?

The code is new in 3.0. However this is a "build-time" break from Preview 7 due to the renamed parameters, but this only applies if named parameters were used in the code, which is unlikely.

## Risk

Low. Only the argument names changed along with  the corresponding xml doc and very minor consuming code of those parameters.

