### PR TITLE
Revert "Enable build on hosted arm64"

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -64,8 +64,10 @@
     <TargetGroup Condition="'$(TargetGroup)' == ''">netcoreapp</TargetGroup>
     <OSGroup Condition="'$(OSGroup)' == ''">$(DefaultOSGroup)</OSGroup>
     <ConfigurationGroup Condition="'$(ConfigurationGroup)' == ''">Debug</ConfigurationGroup>
-    <HostArch>$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</HostArch>
-    <ArchGroup Condition="'$(ArchGroup)' == ''">$(HostArch)</ArchGroup>
+    <HostArch>$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)</HostArch>
+    <ArchGroup Condition="'$(ArchGroup)' == '' AND '$(HostArch)' == 'Arm'">arm</ArchGroup>
+    <ArchGroup Condition="'$(ArchGroup)' == '' AND '$(HostArch)' == 'Arm64'">arm64</ArchGroup>
+    <ArchGroup Condition="'$(ArchGroup)' == ''">x64</ArchGroup>
 
     <!-- Initialize BuildConfiguration from the individual properties if it wasn't already explicitly set -->
     <BuildConfiguration Condition="'$(BuildConfiguration)' == ''">$(TargetGroup)-$(OSGroup)-$(ConfigurationGroup)-$(ArchGroup)</BuildConfiguration>
@@ -133,9 +135,9 @@
     <_runtimeOS Condition="'$(_runtimeOS)' == 'tizen.4.0.0'">linux</_runtimeOS>
     <_runtimeOS Condition="'$(_runtimeOS)' == 'tizen.5.0.0'">linux</_runtimeOS>
     <_runtimeOS Condition="'$(PortableBuild)' == 'true'">$(_portableOS)</_runtimeOS>
-    <ToolRuntimeRID>$(_runtimeOS)-$(HostArch)</ToolRuntimeRID>
+    <ToolRuntimeRID>$(_runtimeOS)-x64</ToolRuntimeRID>
     <!-- We build linux-musl-arm on a ubuntu container, so we can't use the toolset build for alpine runtime. We need to use portable linux RID for our toolset in order to be able to use it. -->
-    <ToolRuntimeRID Condition="'$(_runtimeOS)' == 'linux-musl' AND $(ArchGroup.StartsWith('arm')) AND !$(HostArch.StartsWith('arm'))">linux-x64</ToolRuntimeRID>
+    <ToolRuntimeRID Condition="'$(_runtimeOS)' == 'linux-musl' AND $(ArchGroup.StartsWith('arm')) AND !$(HostArch.StartsWith('Arm'))">linux-x64</ToolRuntimeRID>
 
     <!-- There are no WebAssembly tools, so treat them as Windows -->
     <ToolRuntimeRID Condition="'$(RuntimeOS)' == 'WebAssembly'">win-x64</ToolRuntimeRID>


### PR DESCRIPTION
Reverts dotnet/corefx#40311

FYI @ViktorHofer @wfurt @omajid @Jozkee 

I'm reverting this PR as it broke our VS scenario. Basically by default, we always built targeting x64, but because VS runs as an x86 process, we are now picking a different configuration when building inside VS. This is causing for all of our tests to break, as now you won't be able to build and run tests from VS. I'm not sure what was the main reasoning behind the original change, since I assumed that you could achieve the same thing by simply passing in ArchGroup when calling ./build.sh and that would allow you to control how to build in a hosted environment. Anyways, I'm revering this now in order to unblock devs broken trying to run tests in VS now, @omajid but feel free to submit a new PR taking this problem in consideration.