### PR TITLE
JsonSerializer will now ignore properties decorated with JsonExtensionDataAttribute if they are null when serializing.

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleDictionary.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleDictionary.cs
@@ -26,8 +26,9 @@ namespace System.Text.Json
                 if (enumerable == null)
                 {
                     // If applicable, we only want to ignore object properties.
-                    if (state.Current.JsonClassInfo.ClassType != ClassType.Object ||
-                        !state.Current.JsonPropertyInfo.IgnoreNullValues)
+                    if (state.Current.ExtensionDataStatus != ExtensionDataWriteStatus.Writing &&
+                        (state.Current.JsonClassInfo.ClassType != ClassType.Object ||
+                        !state.Current.JsonPropertyInfo.IgnoreNullValues))
                     {
                         // Write a null object or enumerable.
                         state.Current.WriteObjectOrArrayStart(ClassType.Dictionary, writer, writeNull: true);

--- a/src/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
+++ b/src/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
@@ -54,6 +54,14 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        public static void ExtensionPropertyIgnoredWhenNull()
+        {
+            string expected = @"{}";
+            string actual = JsonSerializer.Serialize(new ClassWithExtensionPropertyAsObject());
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
         public static void ExtensionPropertyAlreadyInstantiated()
         {
             Assert.NotNull(new ClassWithExtensionPropertyAlreadyInstantiated().MyOverflow);


### PR DESCRIPTION
Currently a class using [JsonExtensionData] like this...
```
        private class ClassWithExtensionPropertyAsObject
        {
            [JsonExtensionData]
            public Dictionary<string, object> MyOverflow { get; set; }
        }
```

Will serialize as...
```
{
        "MyOverflow": null
}
```

When "MyOverflow" Property is null.

This PR fixes that so it ends up as...
```
{
}
```

I think this better matches the intention of [JsonExtensionData] and Json.NET behavior so people aren't surprised when using the new lib.