### PR TITLE
Fix reading past comments after an end object or end array token within Utf8JsonReader

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
@@ -1899,7 +1899,53 @@ namespace System.Text.Json
             }
             else
             {
-                goto RollBack;
+                Debug.Assert(_tokenType == JsonTokenType.EndArray || _tokenType == JsonTokenType.EndObject);
+                if (_inObject)
+                {
+                    if (first != JsonConstants.Quote)
+                    {
+                        if (first == JsonConstants.CloseBrace)
+                        {
+                            if (_readerOptions.AllowTrailingCommas)
+                            {
+                                EndObject();
+                                goto Done;
+                            }
+                            ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.TrailingCommaNotAllowedBeforeObjectEnd);
+                        }
+
+                        ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedStartOfPropertyNotFound, first);
+                    }
+                    if (ConsumePropertyNameMultiSegment())
+                    {
+                        goto Done;
+                    }
+                    else
+                    {
+                        goto RollBack;
+                    }
+                }
+                else
+                {
+                    if (first == JsonConstants.CloseBracket)
+                    {
+                        if (_readerOptions.AllowTrailingCommas)
+                        {
+                            EndArray();
+                            goto Done;
+                        }
+                        ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.TrailingCommaNotAllowedBeforeArrayEnd);
+                    }
+
+                    if (ConsumeValueMultiSegment(first))
+                    {
+                        goto Done;
+                    }
+                    else
+                    {
+                        goto RollBack;
+                    }
+                }
             }
 
         Done:

--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
@@ -1846,48 +1846,36 @@ namespace System.Text.Json
             }
             else if (_tokenType == JsonTokenType.StartObject)
             {
-                if (first == JsonConstants.CloseBrace)
+                Debug.Assert(first != JsonConstants.CloseBrace);
+                if (first != JsonConstants.Quote)
                 {
-                    EndObject();
+                    ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedStartOfPropertyNotFound, first);
                 }
-                else
-                {
-                    if (first != JsonConstants.Quote)
-                    {
-                        ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedStartOfPropertyNotFound, first);
-                    }
 
-                    long prevTotalConsumed = _totalConsumed;
-                    int prevConsumed = _consumed;
-                    long prevPosition = _bytePositionInLine;
-                    long prevLineNumber = _lineNumber;
-                    if (!ConsumePropertyNameMultiSegment())
-                    {
-                        // roll back potential changes
-                        _consumed = prevConsumed;
-                        _tokenType = JsonTokenType.StartObject;
-                        _bytePositionInLine = prevPosition;
-                        _lineNumber = prevLineNumber;
-                        _totalConsumed = prevTotalConsumed;
-                        goto RollBack;
-                    }
-                    goto Done;
+                long prevTotalConsumed = _totalConsumed;
+                int prevConsumed = _consumed;
+                long prevPosition = _bytePositionInLine;
+                long prevLineNumber = _lineNumber;
+                if (!ConsumePropertyNameMultiSegment())
+                {
+                    // roll back potential changes
+                    _consumed = prevConsumed;
+                    _tokenType = JsonTokenType.StartObject;
+                    _bytePositionInLine = prevPosition;
+                    _lineNumber = prevLineNumber;
+                    _totalConsumed = prevTotalConsumed;
+                    goto RollBack;
                 }
+                goto Done;
             }
             else if (_tokenType == JsonTokenType.StartArray)
             {
-                if (first == JsonConstants.CloseBracket)
+                Debug.Assert(first != JsonConstants.CloseBracket);
+                if (!ConsumeValueMultiSegment(first))
                 {
-                    EndArray();
+                    goto RollBack;
                 }
-                else
-                {
-                    if (!ConsumeValueMultiSegment(first))
-                    {
-                        goto RollBack;
-                    }
-                    goto Done;
-                }
+                goto Done;
             }
             else if (_tokenType == JsonTokenType.PropertyName)
             {
@@ -1902,20 +1890,12 @@ namespace System.Text.Json
                 Debug.Assert(_tokenType == JsonTokenType.EndArray || _tokenType == JsonTokenType.EndObject);
                 if (_inObject)
                 {
+                    Debug.Assert(first != JsonConstants.CloseBracket);
                     if (first != JsonConstants.Quote)
                     {
-                        if (first == JsonConstants.CloseBrace)
-                        {
-                            if (_readerOptions.AllowTrailingCommas)
-                            {
-                                EndObject();
-                                goto Done;
-                            }
-                            ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.TrailingCommaNotAllowedBeforeObjectEnd);
-                        }
-
                         ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedStartOfPropertyNotFound, first);
                     }
+
                     if (ConsumePropertyNameMultiSegment())
                     {
                         goto Done;
@@ -1927,15 +1907,7 @@ namespace System.Text.Json
                 }
                 else
                 {
-                    if (first == JsonConstants.CloseBracket)
-                    {
-                        if (_readerOptions.AllowTrailingCommas)
-                        {
-                            EndArray();
-                            goto Done;
-                        }
-                        ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.TrailingCommaNotAllowedBeforeArrayEnd);
-                    }
+                    Debug.Assert(first != JsonConstants.CloseBracket);
 
                     if (ConsumeValueMultiSegment(first))
                     {

--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
@@ -2031,7 +2031,53 @@ namespace System.Text.Json
             }
             else
             {
-                goto RollBack;
+                Debug.Assert(_tokenType == JsonTokenType.EndArray || _tokenType == JsonTokenType.EndObject);
+                if (_inObject)
+                {
+                    if (first != JsonConstants.Quote)
+                    {
+                        if (first == JsonConstants.CloseBrace)
+                        {
+                            if (_readerOptions.AllowTrailingCommas)
+                            {
+                                EndObject();
+                                goto Done;
+                            }
+                            ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.TrailingCommaNotAllowedBeforeObjectEnd);
+                        }
+
+                        ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedStartOfPropertyNotFound, first);
+                    }
+                    if (ConsumePropertyName())
+                    {
+                        goto Done;
+                    }
+                    else
+                    {
+                        goto RollBack;
+                    }
+                }
+                else
+                {
+                    if (first == JsonConstants.CloseBracket)
+                    {
+                        if (_readerOptions.AllowTrailingCommas)
+                        {
+                            EndArray();
+                            goto Done;
+                        }
+                        ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.TrailingCommaNotAllowedBeforeArrayEnd);
+                    }
+
+                    if (ConsumeValue(first))
+                    {
+                        goto Done;
+                    }
+                    else
+                    {
+                        goto RollBack;
+                    }
+                }
             }
 
         Done:

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
@@ -1728,6 +1728,189 @@ namespace System.Text.Json.Tests
             }
         }
 
+
+
+        [Theory]
+        [InlineData("{\"Property1\": [ 42], \"Property2\": 42}")]
+        [InlineData("{\"Property1\": [ 42], // comment\n\"Property2\": 42}")]
+        [InlineData("{\"Property1\": [ 42], // comment\r\"Property2\": 42}")]
+        [InlineData("{\"Property1\": [ 42], // comment\r\n\"Property2\": 42}")]
+        [InlineData("{\"Property1\": [ 42], /*comment*/\"Property2\": 42}")]
+        [InlineData("{\"Property1\": [ 42] // comment\n,\"Property2\": 42}")]
+        [InlineData("{\"Property1\": [ 42], // comment\n // comment\n\"Property2\": 42}")]
+        [InlineData("[[ 42], // comment\n 42]")]
+        [InlineData("[[ 42, // comment\n 43], // comment\n 42]")]
+        [InlineData("[[ \"42\", // comment\n 43], // comment\n 42]")]
+        [InlineData("[[ true, // comment\n 43], // comment\n 42]")]
+        [InlineData("[[ false, // comment\n 43], // comment\n 42]")]
+        [InlineData("[[ null, // comment\n 43], // comment\n 42]")]
+        [InlineData("{\"Property1\": {\"Property1.1\": 42}, \"Property2\": 42}")]
+        [InlineData("{\"Property1\": {\"Property1.1\": 42}, // comment\n\"Property2\": 42}")]
+        [InlineData("{\"Property1\": {\"Property1.1\": 42}, // comment\r\"Property2\": 42}")]
+        [InlineData("{\"Property1\": {\"Property1.1\": 42}, // comment\r\n\"Property2\": 42}")]
+        [InlineData("{\"Property1\": {\"Property1.1\": 42}, /*comment*/\"Property2\": 42}")]
+        [InlineData("{\"Property1\": {\"Property1.1\": 42} // comment\n,\"Property2\": 42}")]
+        [InlineData("{\"Property1\": {\"Property1.1\": 42}, // comment\n // comment\n\"Property2\": 42}")]
+        [InlineData("[{\"Property1\": 42}, // comment\n 42]")]
+        [InlineData("[{\"Property1\": 42, // comment\n \"prop\": 43 }, // comment\n 42]")]
+        [InlineData("[{\"Property1\": \"42\", // comment\n \"prop\": 43 }, // comment\n 42]")]
+        [InlineData("[{\"Property1\": true, // comment\n \"prop\": 43 }, // comment\n 42]")]
+        [InlineData("[{\"Property1\": false, // comment\n \"prop\": 43 }, // comment\n 42]")]
+        [InlineData("[{\"Property1\": null, // comment\n \"prop\": 43 }, // comment\n 42]")]
+        public static void ReadJsonStringsWithComments(string jsonString)
+        {
+            byte[] input = Encoding.UTF8.GetBytes(jsonString);
+
+            foreach (JsonCommentHandling commentHandling in Enum.GetValues(typeof(JsonCommentHandling)))
+            {
+                if (commentHandling == JsonCommentHandling.Disallow)
+                {
+                    continue;
+                }
+
+                var options = new JsonReaderOptions() { CommentHandling = commentHandling };
+                var optionsWithTrailing = new JsonReaderOptions() { CommentHandling = commentHandling, AllowTrailingCommas = true };
+
+                var reader = new Utf8JsonReader(input, options);
+                ReadWithCommentsHelper(ref reader, input.Length);
+
+                reader = new Utf8JsonReader(input, optionsWithTrailing);
+                ReadWithCommentsHelper(ref reader, input.Length);
+
+                ReadOnlySequence<byte> sequence = JsonTestHelper.GetSequence(input, 1);
+                reader = new Utf8JsonReader(sequence, options);
+                ReadWithCommentsHelper(ref reader, input.Length);
+
+                reader = new Utf8JsonReader(sequence, optionsWithTrailing);
+                ReadWithCommentsHelper(ref reader, input.Length);
+
+                for (int splitLocation = 0; splitLocation < input.Length; splitLocation++)
+                {
+                    sequence = JsonTestHelper.CreateSegments(input, splitLocation);
+                    reader = new Utf8JsonReader(sequence, options);
+                    ReadWithCommentsHelper(ref reader, input.Length);
+
+                    reader = new Utf8JsonReader(sequence, optionsWithTrailing);
+                    ReadWithCommentsHelper(ref reader, input.Length);
+                }
+
+                for (int firstSplit = 0; firstSplit < input.Length; firstSplit++)
+                {
+                    for (int secondSplit = firstSplit; secondSplit < input.Length; secondSplit++)
+                    {
+                        sequence = JsonTestHelper.CreateSegments(input, firstSplit, secondSplit);
+                        reader = new Utf8JsonReader(sequence, options);
+                        ReadWithCommentsHelper(ref reader, input.Length);
+
+                        reader = new Utf8JsonReader(sequence, optionsWithTrailing);
+                        ReadWithCommentsHelper(ref reader, input.Length);
+                    }
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData("{\"Property1\": [ 42], }")]
+        [InlineData("{\"Property1\": [ 42], // comment\n}")]
+        [InlineData("{\"Property1\": [ 42], // comment\r}")]
+        [InlineData("{\"Property1\": [ 42], // comment\r\n}")]
+        [InlineData("{\"Property1\": [ 42], /*comment*/}")]
+        [InlineData("{\"Property1\": [ 42] // comment\n,}")]
+        [InlineData("{\"Property1\": [ 42], // comment\n // comment\n}")]
+        [InlineData("[[ 42], // comment\n ]")]
+        [InlineData("[[ 42, // comment\n ], // comment\n ]")]
+        [InlineData("[[ \"42\", // comment\n ], // comment\n ]")]
+        [InlineData("[[ true, // comment\n ], // comment\n ]")]
+        [InlineData("[[ false, // comment\n ], // comment\n ]")]
+        [InlineData("[[ null, // comment\n ], // comment\n ]")]
+        [InlineData("{\"Property1\": {\"Property1.1\": 42}, }")]
+        [InlineData("{\"Property1\": {\"Property1.1\": 42}, // comment\n}")]
+        [InlineData("{\"Property1\": {\"Property1.1\": 42}, // comment\r}")]
+        [InlineData("{\"Property1\": {\"Property1.1\": 42}, // comment\r\n}")]
+        [InlineData("{\"Property1\": {\"Property1.1\": 42}, /*comment*/}")]
+        [InlineData("{\"Property1\": {\"Property1.1\": 42} // comment\n,}")]
+        [InlineData("{\"Property1\": {\"Property1.1\": 42}, // comment\n // comment\n}")]
+        [InlineData("[{\"Property1\": 42}, // comment\n ]")]
+        [InlineData("[{\"Property1\": 42, // comment\n }, // comment\n ]")]
+        [InlineData("[{\"Property1\": \"42\", // comment\n }, // comment\n ]")]
+        [InlineData("[{\"Property1\": true, // comment\n }, // comment\n ]")]
+        [InlineData("[{\"Property1\": false, // comment\n }, // comment\n ]")]
+        [InlineData("[{\"Property1\": null, // comment\n }, // comment\n ]")]
+        public static void ReadJsonStringsWithCommentsAndTrailingCommas(string jsonString)
+        {
+            byte[] input = Encoding.UTF8.GetBytes(jsonString);
+
+            foreach (JsonCommentHandling commentHandling in Enum.GetValues(typeof(JsonCommentHandling)))
+            {
+                if (commentHandling == JsonCommentHandling.Disallow)
+                {
+                    continue;
+                }
+
+                var options = new JsonReaderOptions() { CommentHandling = commentHandling };
+                var optionsWithTrailing = new JsonReaderOptions() { CommentHandling = commentHandling, AllowTrailingCommas = true };
+
+                var reader = new Utf8JsonReader(input, options);
+                ReadWithCommentsHelper(ref reader, -1, validateThrows: true);
+
+                reader = new Utf8JsonReader(input, optionsWithTrailing);
+                ReadWithCommentsHelper(ref reader, input.Length);
+
+                ReadOnlySequence<byte> sequence = JsonTestHelper.GetSequence(input, 1);
+                reader = new Utf8JsonReader(sequence, options);
+                ReadWithCommentsHelper(ref reader, -1, validateThrows: true);
+
+                reader = new Utf8JsonReader(sequence, optionsWithTrailing);
+                ReadWithCommentsHelper(ref reader, input.Length);
+
+                for (int splitLocation = 0; splitLocation < input.Length; splitLocation++)
+                {
+                    sequence = JsonTestHelper.CreateSegments(input, splitLocation);
+                    reader = new Utf8JsonReader(sequence, options);
+                    ReadWithCommentsHelper(ref reader, input.Length, validateThrows: true);
+
+                    reader = new Utf8JsonReader(sequence, optionsWithTrailing);
+                    ReadWithCommentsHelper(ref reader, input.Length);
+                }
+
+                for (int firstSplit = 0; firstSplit < input.Length; firstSplit++)
+                {
+                    for (int secondSplit = firstSplit; secondSplit < input.Length; secondSplit++)
+                    {
+                        sequence = JsonTestHelper.CreateSegments(input, firstSplit, secondSplit);
+                        reader = new Utf8JsonReader(sequence, options);
+                        ReadWithCommentsHelper(ref reader, input.Length, validateThrows: true);
+
+                        reader = new Utf8JsonReader(sequence, optionsWithTrailing);
+                        ReadWithCommentsHelper(ref reader, input.Length);
+                    }
+                }
+            }
+        }
+
+        private static void ReadWithCommentsHelper(ref Utf8JsonReader reader, int expectedConsumed, bool validateThrows = false)
+        {
+            if (validateThrows)
+            {
+                try
+                {
+                    while (reader.Read())
+                        ;
+                    Assert.True(false, "Expected JsonException was not thrown when reading JSON with trailing commas.");
+                }
+                catch (JsonException ex)
+                {
+                    Assert.Contains("trailing", ex.Message);
+                }
+            }
+            else
+            {
+                while (reader.Read())
+                    ;
+                Assert.Equal(expectedConsumed, reader.BytesConsumed);
+            }
+        }
+
         [Theory]
         [MemberData(nameof(SingleJsonTokenStartIndex))]
         public static void TestTokenStartIndexMultiSegment_SingleValue(string jsonString, int expectedIndex)


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/40385

This fix needs to be ported to 3.0

cc @IonKiwi, @am11, @bartonjs, @stephentoub, @steveharter, @ericstj  