### PR TITLE
[release/3.0] Honor IsReadOnly when deserializing collections

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoCommon.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoCommon.cs
@@ -125,7 +125,7 @@ namespace System.Text.Json
         {
             object instance = collectionPropertyInfo.DeclaredTypeClassInfo.CreateObject();
 
-            if (instance is IList instanceOfIList)
+            if (instance is IList instanceOfIList && !instanceOfIList.IsReadOnly)
             {
                 foreach (object item in sourceList)
                 {
@@ -133,7 +133,7 @@ namespace System.Text.Json
                 }
                 return instanceOfIList;
             }
-            else if (instance is ICollection<TRuntimeProperty> instanceOfICollection)
+            else if (instance is ICollection<TRuntimeProperty> instanceOfICollection && !instanceOfICollection.IsReadOnly)
             {
                 foreach (TRuntimeProperty item in sourceList)
                 {
@@ -160,15 +160,17 @@ namespace System.Text.Json
 
             // TODO: Use reflection to support types implementing Stack or Queue.
 
-            ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(collectionPropertyInfo.DeclaredPropertyType, jsonPath);
-            return null;
+            throw ThrowHelper.GetNotSupportedException_SerializationNotSupportedCollection(
+                collectionPropertyInfo.DeclaredPropertyType,
+                collectionPropertyInfo.ParentClassType,
+                collectionPropertyInfo.PropertyInfo);
         }
 
         public override object CreateDerivedDictionaryInstance(JsonPropertyInfo collectionPropertyInfo, IDictionary sourceDictionary, string jsonPath, JsonSerializerOptions options)
         {
             object instance = collectionPropertyInfo.DeclaredTypeClassInfo.CreateObject();
 
-            if (instance is IDictionary instanceOfIDictionary)
+            if (instance is IDictionary instanceOfIDictionary && !instanceOfIDictionary.IsReadOnly)
             {
                 foreach (DictionaryEntry entry in sourceDictionary)
                 {
@@ -176,7 +178,7 @@ namespace System.Text.Json
                 }
                 return instanceOfIDictionary;
             }
-            else if (instance is IDictionary<string, TRuntimeProperty> instanceOfGenericIDictionary)
+            else if (instance is IDictionary<string, TRuntimeProperty> instanceOfGenericIDictionary && !instanceOfGenericIDictionary.IsReadOnly)
             {
                 foreach (DictionaryEntry entry in sourceDictionary)
                 {
@@ -188,8 +190,10 @@ namespace System.Text.Json
             // TODO: Use reflection to support types implementing SortedList and maybe immutable dictionaries.
 
             // Types implementing SortedList and immutable dictionaries will fail here.
-            ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(collectionPropertyInfo.DeclaredPropertyType, jsonPath);
-            return null;
+            throw ThrowHelper.GetNotSupportedException_SerializationNotSupportedCollection(
+                collectionPropertyInfo.DeclaredPropertyType,
+                collectionPropertyInfo.ParentClassType,
+                collectionPropertyInfo.PropertyInfo);
         }
 
         public override IEnumerable CreateIEnumerableInstance(Type parentType, IList sourceList, string jsonPath, JsonSerializerOptions options)

--- a/src/System.Text.Json/tests/Serialization/CustomConverterTests.DerivedTypes.cs
+++ b/src/System.Text.Json/tests/Serialization/CustomConverterTests.DerivedTypes.cs
@@ -106,7 +106,7 @@ namespace System.Text.Json.Serialization.Tests
             };
 
             // Without converter, we throw on deserialize.
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<UnsupportedDerivedTypesWrapper_IEnumerable>(json));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<UnsupportedDerivedTypesWrapper_IEnumerable>(json));
             // Without converter, we serialize as is.
             Assert.Equal(@"{""IEnumerableWrapper"":[""1"",""2"",""3""]}", JsonSerializer.Serialize(wrapper));
 

--- a/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
+++ b/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
@@ -193,7 +193,7 @@ namespace System.Text.Json.Serialization.Tests
             }
 
             {
-                Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<StringToStringIReadOnlyDictionaryWrapper>(JsonString));
+                Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<StringToStringIReadOnlyDictionaryWrapper>(JsonString));
 
                 StringToStringIReadOnlyDictionaryWrapper obj = new StringToStringIReadOnlyDictionaryWrapper(new Dictionary<string, string>()
                 {
@@ -208,7 +208,7 @@ namespace System.Text.Json.Serialization.Tests
             }
 
             {
-                Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<StringToStringIImmutableDictionaryWrapper>(JsonString));
+                Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<StringToStringIImmutableDictionaryWrapper>(JsonString));
 
                 StringToStringIImmutableDictionaryWrapper obj = new StringToStringIImmutableDictionaryWrapper(new Dictionary<string, string>()
                 {

--- a/src/System.Text.Json/tests/Serialization/TestClasses.GenericCollections.cs
+++ b/src/System.Text.Json/tests/Serialization/TestClasses.GenericCollections.cs
@@ -199,7 +199,7 @@ namespace System.Text.Json.Serialization.Tests
 
         public int Count => _list.Count;
 
-        public bool IsReadOnly => ((ICollection<string>)_list).IsReadOnly;
+        public virtual bool IsReadOnly => ((ICollection<string>)_list).IsReadOnly;
 
         public void Add(string item)
         {
@@ -237,6 +237,11 @@ namespace System.Text.Json.Serialization.Tests
         }
     }
 
+    public class ReadOnlyStringICollectionWrapper : StringICollectionWrapper
+    {
+        public override bool IsReadOnly => true;
+    }
+
     public class StringIListWrapper : IList<string>
     {
         private readonly List<string> _list = new List<string>();
@@ -245,7 +250,7 @@ namespace System.Text.Json.Serialization.Tests
 
         public int Count => _list.Count;
 
-        public bool IsReadOnly => ((IList<string>)_list).IsReadOnly;
+        public virtual bool IsReadOnly => ((IList<string>)_list).IsReadOnly;
 
         public void Add(string item)
         {
@@ -296,6 +301,11 @@ namespace System.Text.Json.Serialization.Tests
         {
             return ((IList<string>)_list).GetEnumerator();
         }
+    }
+
+    public class ReadOnlyStringIListWrapper : StringIListWrapper
+    {
+        public override bool IsReadOnly => true;
     }
 
     public class GenericIListWrapper<T> : IList<T>
@@ -714,7 +724,7 @@ namespace System.Text.Json.Serialization.Tests
 
         public int Count => ((IDictionary<string, string>)_dictionary).Count;
 
-        public bool IsReadOnly => ((IDictionary<string, string>)_dictionary).IsReadOnly;
+        public virtual bool IsReadOnly => ((IDictionary<string, string>)_dictionary).IsReadOnly;
 
         public void Add(string key, string value)
         {
@@ -770,6 +780,11 @@ namespace System.Text.Json.Serialization.Tests
         {
             return ((IDictionary<string, string>)_dictionary).GetEnumerator();
         }
+    }
+
+    public class ReadOnlyStringToStringIDictionaryWrapper : StringToStringIDictionaryWrapper
+    {
+        public override bool IsReadOnly => true;
     }
 
     public class StringToObjectIDictionaryWrapper : IDictionary<string, object>

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
+using System;
 using Xunit;
 
 namespace System.Text.Json.Serialization.Tests
@@ -97,7 +98,7 @@ namespace System.Text.Json.Serialization.Tests
             }
 
             // No way to populate this collection.
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<GenericIEnumerableWrapper<StringIEnumerableWrapper>>(@"[[""1"",""2""],[""3"",""4""]]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericIEnumerableWrapper<StringIEnumerableWrapper>>(@"[[""1"",""2""],[""3"",""4""]]"));
         }
 
         [Fact]
@@ -115,7 +116,7 @@ namespace System.Text.Json.Serialization.Tests
             }
 
             // No way to populate this collection.
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<GenericIEnumerableWrapper<int[]>>(@"[[1,2],[3, 4]]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericIEnumerableWrapper<int[]>>(@"[[1,2],[3, 4]]"));
         }
 
         [Fact]
@@ -133,7 +134,7 @@ namespace System.Text.Json.Serialization.Tests
             }
 
             // No way to populate this collection.
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<StringIEnumerableWrapper[]>(@"[[""1"",""2""],[""3"",""4""]]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<StringIEnumerableWrapper[]>(@"[[""1"",""2""],[""3"",""4""]]"));
         }
 
         [Fact]
@@ -151,8 +152,8 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(0, result.Count());
 
             // There is no way to populate this collection.
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<StringIEnumerableWrapper>(@"[""1"",""2""]"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<StringIEnumerableWrapper>(@"[]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<StringIEnumerableWrapper>(@"[""1"",""2""]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<StringIEnumerableWrapper>(@"[]"));
         }
 
         [Fact]
@@ -367,7 +368,7 @@ namespace System.Text.Json.Serialization.Tests
             }
 
             // There's no way to populate this collection.
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<GenericIReadOnlyCollectionWrapper<StringIReadOnlyCollectionWrapper>>(@"[[""1"",""2""],[""3"",""4""]]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericIReadOnlyCollectionWrapper<StringIReadOnlyCollectionWrapper>>(@"[[""1"",""2""],[""3"",""4""]]"));
         }
 
         [Fact]
@@ -384,7 +385,7 @@ namespace System.Text.Json.Serialization.Tests
                 }
             }
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<GenericIReadOnlyCollectionWrapper<int[]>>(@"[[1,2],[3,4]]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericIReadOnlyCollectionWrapper<int[]>>(@"[[1,2],[3,4]]"));
         }
 
         [Fact]
@@ -402,7 +403,7 @@ namespace System.Text.Json.Serialization.Tests
             }
 
             // No way to populate this collection.
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<StringIReadOnlyCollectionWrapper[]>(@"[[""1"",""2""],[""3"",""4""]]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<StringIReadOnlyCollectionWrapper[]>(@"[[""1"",""2""],[""3"",""4""]]"));
         }
 
         [Fact]
@@ -420,7 +421,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(0, result.Count());
 
             // No way to populate this collection.
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<StringIReadOnlyCollectionWrapper>(@"[""1"",""2""]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<StringIReadOnlyCollectionWrapper>(@"[""1"",""2""]"));
         }
 
         [Fact]
@@ -437,7 +438,7 @@ namespace System.Text.Json.Serialization.Tests
                 }
             }
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<GenericIReadOnlyListWrapper<StringIReadOnlyListWrapper>>(@"[[""1"",""2""],[""3"",""4""]]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericIReadOnlyListWrapper<StringIReadOnlyListWrapper>>(@"[[""1"",""2""],[""3"",""4""]]"));
         }
 
         [Fact]
@@ -455,7 +456,7 @@ namespace System.Text.Json.Serialization.Tests
             }
 
             // No way to populate this collection.
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<GenericIReadOnlyListWrapper<string[]>>(@"[[""1"",""2""],[""3"",""4""]]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericIReadOnlyListWrapper<string[]>>(@"[[""1"",""2""],[""3"",""4""]]"));
         }
 
         [Fact]
@@ -473,7 +474,7 @@ namespace System.Text.Json.Serialization.Tests
             }
 
             // No way to populate this collection.
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<StringIReadOnlyListWrapper[]>(@"[[""1"",""2""],[""3"",""4""]]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<StringIReadOnlyListWrapper[]>(@"[[""1"",""2""],[""3"",""4""]]"));
         }
 
         [Fact]
@@ -491,7 +492,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(0, result.Count());
 
             // No way to populate this collection.
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<StringIReadOnlyListWrapper>(@"[""1"",""2""]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<StringIReadOnlyListWrapper>(@"[""1"",""2""]"));
         }
 
         [Fact]
@@ -1134,16 +1135,24 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadSimpleTestClass_GenericWrappers_NoAddMethod_Throws()
         {
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<SimpleTestClassWithStringIEnumerableWrapper>(SimpleTestClassWithStringIEnumerableWrapper.s_json));
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<SimpleTestClassWithStringIReadOnlyCollectionWrapper>(SimpleTestClassWithStringIReadOnlyCollectionWrapper.s_json));
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<SimpleTestClassWithStringIReadOnlyListWrapper>(SimpleTestClassWithStringIReadOnlyListWrapper.s_json));
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<SimpleTestClassWithStringToStringIReadOnlyDictionaryWrapper>(SimpleTestClassWithStringToStringIReadOnlyDictionaryWrapper.s_json));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<SimpleTestClassWithStringIEnumerableWrapper>(SimpleTestClassWithStringIEnumerableWrapper.s_json));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<SimpleTestClassWithStringIReadOnlyCollectionWrapper>(SimpleTestClassWithStringIReadOnlyCollectionWrapper.s_json));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<SimpleTestClassWithStringIReadOnlyListWrapper>(SimpleTestClassWithStringIReadOnlyListWrapper.s_json));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<SimpleTestClassWithStringToStringIReadOnlyDictionaryWrapper>(SimpleTestClassWithStringToStringIReadOnlyDictionaryWrapper.s_json));
         }
 
         [Fact]
         public static void ReadPrimitiveStringCollection_Throws()
         {
             Assert.Throws<InvalidCastException>(() => JsonSerializer.Deserialize<StringCollection>(@"[""1"", ""2""]"));
+        }
+
+        [Fact]
+        public static void ReadReadOnlyCollections_Throws()
+        {
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ReadOnlyStringIListWrapper>(@"[""1"", ""2""]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ReadOnlyStringICollectionWrapper>(@"[""1"", ""2""]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ReadOnlyStringToStringIDictionaryWrapper>(@"{""Key"":""key"",""Value"":""value""}"));
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.ImmutableCollections.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.ImmutableCollections.cs
@@ -138,8 +138,8 @@ namespace System.Text.Json.Serialization.Tests
             result = JsonSerializer.Deserialize<IImmutableList<int>>(Encoding.UTF8.GetBytes(@"[]"));
             Assert.Equal(0, result.Count());
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<StringIImmutableListWrapper>(@"[""1"",""2""]"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<StringIImmutableListWrapper>(@"[]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<StringIImmutableListWrapper>(@"[""1"",""2""]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<StringIImmutableListWrapper>(@"[]"));
         }
 
         [Fact]
@@ -205,8 +205,8 @@ namespace System.Text.Json.Serialization.Tests
             result = JsonSerializer.Deserialize<IImmutableStack<int>>(Encoding.UTF8.GetBytes(@"[]"));
             Assert.Equal(0, result.Count());
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<StringIImmutableStackWrapper>(@"[""1"",""2""]"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<StringIImmutableStackWrapper>(@"[]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<StringIImmutableStackWrapper>(@"[""1"",""2""]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<StringIImmutableStackWrapper>(@"[]"));
         }
 
         [Fact]
@@ -268,8 +268,8 @@ namespace System.Text.Json.Serialization.Tests
             result = JsonSerializer.Deserialize<IImmutableQueue<int>>(Encoding.UTF8.GetBytes(@"[]"));
             Assert.Equal(0, result.Count());
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<StringIImmutableQueueWrapper>(@"[""1"",""2""]"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<StringIImmutableQueueWrapper>(@"[]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<StringIImmutableQueueWrapper>(@"[""1"",""2""]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<StringIImmutableQueueWrapper>(@"[]"));
         }
 
         [Fact]
@@ -339,8 +339,8 @@ namespace System.Text.Json.Serialization.Tests
             result = JsonSerializer.Deserialize<IImmutableSet<int>>(Encoding.UTF8.GetBytes(@"[]"));
             Assert.Equal(0, result.Count());
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<StringIImmutableSetWrapper>(@"[""1"",""2""]"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<StringIImmutableSetWrapper>(@"[]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<StringIImmutableSetWrapper>(@"[""1"",""2""]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<StringIImmutableSetWrapper>(@"[]"));
         }
 
         [Fact]
@@ -628,11 +628,11 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadSimpleTestClass_ImmutableCollectionWrappers_Throws()
         {
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<SimpleTestClassWithIImmutableDictionaryWrapper>(SimpleTestClassWithIImmutableDictionaryWrapper.s_json));
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<SimpleTestClassWithImmutableListWrapper>(SimpleTestClassWithImmutableListWrapper.s_json));
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<SimpleTestClassWithImmutableStackWrapper>(SimpleTestClassWithImmutableStackWrapper.s_json));
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<SimpleTestClassWithImmutableQueueWrapper>(SimpleTestClassWithImmutableQueueWrapper.s_json));
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<SimpleTestClassWithImmutableSetWrapper>(SimpleTestClassWithImmutableSetWrapper.s_json));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<SimpleTestClassWithIImmutableDictionaryWrapper>(SimpleTestClassWithIImmutableDictionaryWrapper.s_json));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<SimpleTestClassWithImmutableListWrapper>(SimpleTestClassWithImmutableListWrapper.s_json));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<SimpleTestClassWithImmutableStackWrapper>(SimpleTestClassWithImmutableStackWrapper.s_json));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<SimpleTestClassWithImmutableQueueWrapper>(SimpleTestClassWithImmutableQueueWrapper.s_json));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<SimpleTestClassWithImmutableSetWrapper>(SimpleTestClassWithImmutableSetWrapper.s_json));
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.NonGenericCollections.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.NonGenericCollections.cs
@@ -25,7 +25,7 @@ namespace System.Text.Json.Serialization.Tests
             }
 
             // No way to populate this collection.
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<GenericIEnumerableWrapper<WrapperForIEnumerable>>(@"[[1,2],[3,4]]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericIEnumerableWrapper<WrapperForIEnumerable>>(@"[[1,2],[3,4]]"));
         }
 
         [Fact]
@@ -181,7 +181,7 @@ namespace System.Text.Json.Serialization.Tests
             }
 
             // No way to populate this collection.
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<GenericICollectionWrapper<WrapperForICollection>>(@"[[1,2],[3,4]]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<GenericICollectionWrapper<WrapperForICollection>>(@"[[1,2],[3,4]]"));
         }
 
         [Fact]
@@ -305,7 +305,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(0, count);
 
             // TODO: use reflection to support types deriving from Stack.
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<StackWrapper>(@"[1,2]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<StackWrapper>(@"[1,2]"));
         }
 
         [Fact]
@@ -375,7 +375,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(0, count);
 
             // TODO: use reflection to support types deriving from Queue.
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<QueueWrapper>(@"[1,2]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<QueueWrapper>(@"[1,2]"));
         }
 
         [Fact]
@@ -451,10 +451,10 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadSimpleTestClass_NonGenericWrappers_NoAddMethod_Throws()
         {
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<SimpleTestClassWithIEnumerableWrapper>(SimpleTestClassWithIEnumerableWrapper.s_json));
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<SimpleTestClassWithICollectionWrapper>(SimpleTestClassWithICollectionWrapper.s_json));
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<SimpleTestClassWithStackWrapper>(SimpleTestClassWithStackWrapper.s_json));
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<SimpleTestClassWithQueueWrapper>(SimpleTestClassWithQueueWrapper.s_json));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<SimpleTestClassWithIEnumerableWrapper>(SimpleTestClassWithIEnumerableWrapper.s_json));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<SimpleTestClassWithICollectionWrapper>(SimpleTestClassWithICollectionWrapper.s_json));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<SimpleTestClassWithStackWrapper>(SimpleTestClassWithStackWrapper.s_json));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<SimpleTestClassWithQueueWrapper>(SimpleTestClassWithQueueWrapper.s_json));
         }
     }
 }


### PR DESCRIPTION
Ports https://github.com/dotnet/corefx/pull/40366 to 3.0.
Closes https://github.com/dotnet/corefx/issues/40237

// @layomia @steveharter @ahsonkhan 

## Description

Previously, the System.Text.Json serializer would try to call `Add` on any collection, even if it has an `IsReadOnly` property that returns `true`. This would lead to a `NotSupportedException`. It also used to throw a `JsonException` if a collection was unsupported.

After this PR, the serializer will no longer attempt to call `Add` if the collection has `IsReadOnly == true` and will always throw a `NotSupportedException` with a descriptive message for unsupported collections.

## Customer Impact

Customers will now have to catch/handle/deal with `NotSupportedException` in addition to `JsonException` when deserializing. Read-only collections will have a better exception message telling the customer that the collection is unsupported.

## Regression?

No.

## Risk

Low. Most collections that returns `true` for `IsReadOnly` will throw `NotSupportedException` when trying to call `Add` anyway. This will just give them a better exception message.