### PR TITLE
Fix failing System.Text.Json test

### DIFF
--- a/src/System.Text.Json/tests/Serialization/CustomConverterTests.DerivedTypes.cs
+++ b/src/System.Text.Json/tests/Serialization/CustomConverterTests.DerivedTypes.cs
@@ -106,7 +106,7 @@ namespace System.Text.Json.Serialization.Tests
             };
 
             // Without converter, we throw on deserialize.
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<UnsupportedDerivedTypesWrapper_IEnumerable>(json));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<UnsupportedDerivedTypesWrapper_IEnumerable>(json));
             // Without converter, we serialize as is.
             Assert.Equal(@"{""IEnumerableWrapper"":[""1"",""2"",""3""]}", JsonSerializer.Serialize(wrapper));
 


### PR DESCRIPTION
This fixes the following test (added in https://github.com/dotnet/corefx/pull/40411) that started failing after https://github.com/dotnet/corefx/pull/40366 was merged:

```
System.Text.Json.Serialization.Tests.CustomConverterTests.CustomUnsupportedIEnumerableConverter [FAIL]
      Assert.Throws() Failure
      Expected: typeof(System.Text.Json.JsonException)
      Actual:   typeof(System.NotSupportedException): The collection type 'System.Text.Json.Serialization.Tests.StringIEnumerableWrapper' on 'System.Text.Json.Serialization.Tests.UnsupportedDerivedTypesWrapper_IEnumerable.IEnumerableWrapper' is not supported.
      ---- System.NotSupportedException : The collection type 'System.Text.Json.Serialization.Tests.StringIEnumerableWrapper' on 'System.Text.Json.Serialization.Tests.UnsupportedDerivedTypesWrapper_IEnumerable.IEnumerableWrapper' is not supported.
      Stack Trace:
        /_/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoCommon.cs(158,0): at System.Text.Json.JsonPropertyInfoCommon`4.CreateDerivedEnumerableInstance(JsonPropertyInfo collectionPropertyInfo, IList sourceList, String jsonPath, JsonSerializerOptions options)
        /_/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/DefaultDerivedEnumerableConverter.cs(13,0): at System.Text.Json.Serialization.Converters.DefaultDerivedEnumerableConverter.CreateFromList(ReadStack& state, IList sourceList, JsonSerializerOptions options)
        /_/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs(110,0): at System.Text.Json.JsonSerializer.HandleEndArray(JsonSerializerOptions options, Utf8JsonReader& reader, ReadStack& state)
        /_/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.cs(109,0): at System.Text.Json.JsonSerializer.ReadCore(JsonSerializerOptions options, Utf8JsonReader& reader, ReadStack& readStack)
        /_/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Helpers.cs(24,0): at System.Text.Json.JsonSerializer.ReadCore(Type returnType, JsonSerializerOptions options, Utf8JsonReader& reader)
        /_/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs(65,0): at System.Text.Json.JsonSerializer.ParseCore(String json, Type returnType, JsonSerializerOptions options)
        /_/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs(31,0): at System.Text.Json.JsonSerializer.Deserialize[TValue](String json, JsonSerializerOptions options)
        ----- Inner Stack Trace -----
        /_/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoCommon.cs(158,0): at System.Text.Json.JsonPropertyInfoCommon`4.CreateDerivedEnumerableInstance(JsonPropertyInfo collectionPropertyInfo, IList sourceList, String jsonPath, JsonSerializerOptions options)
        /_/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/DefaultDerivedEnumerableConverter.cs(13,0): at System.Text.Json.Serialization.Converters.DefaultDerivedEnumerableConverter.CreateFromList(ReadStack& state, IList sourceList, JsonSerializerOptions options)
        /_/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs(110,0): at System.Text.Json.JsonSerializer.HandleEndArray(JsonSerializerOptions options, Utf8JsonReader& reader, ReadStack& state)
        /_/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.cs(109,0): at System.Text.Json.JsonSerializer.ReadCore(JsonSerializerOptions options, Utf8JsonReader& reader, ReadStack& readStack)
        /_/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Helpers.cs(24,0): at System.Text.Json.JsonSerializer.ReadCore(Type returnType, JsonSerializerOptions options, Utf8JsonReader& reader)
        /_/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs(65,0): at System.Text.Json.JsonSerializer.ParseCore(String json, Type returnType, JsonSerializerOptions options)
        /_/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs(31,0): at System.Text.Json.JsonSerializer.Deserialize[TValue](String json, JsonSerializerOptions options)
```