### PR TITLE
Use UTC date in Json{Object,String}Tests

### DIFF
--- a/src/System.Text.Json/tests/JsonObjectTests.cs
+++ b/src/System.Text.Json/tests/JsonObjectTests.cs
@@ -142,7 +142,7 @@ namespace System.Text.Json.Tests
         [Fact]
         public static void TestDateTimeOffset()
         {
-            DateTimeOffset dateTimeOffset = new DateTime(DateTime.MinValue.Ticks);
+            DateTimeOffset dateTimeOffset = new DateTime(DateTime.MinValue.Ticks, DateTimeKind.Utc);
             var jsonObject = new JsonObject { { "dateTimeOffset", dateTimeOffset } };
             Assert.Equal(dateTimeOffset.ToString(), (JsonString)jsonObject["dateTimeOffset"]);
         }

--- a/src/System.Text.Json/tests/JsonStringTests.cs
+++ b/src/System.Text.Json/tests/JsonStringTests.cs
@@ -90,7 +90,7 @@ namespace System.Text.Json.Tests
         [Fact]
         public static void TestDateTimeOffset()
         {
-            DateTimeOffset dateTimeOffset = new DateTime(DateTime.MinValue.Ticks);
+            DateTimeOffset dateTimeOffset = new DateTime(DateTime.MinValue.Ticks, DateTimeKind.Utc);
             var jsonString = new JsonString(dateTimeOffset);
             Assert.Equal(dateTimeOffset.ToString(), jsonString);
         }


### PR DESCRIPTION
Two tests were failing as follows:

```sh
cd corefx/src/System.Text.Json/tests && dotnet msbuild /t:BuildAndTest

...snip...
      System.Text.Json.Tests.JsonObjectTests.TestDateTimeOffset [FAIL]
        System.ArgumentOutOfRangeException : The UTC time represented when the offset is applied must be between year 0 and 10,000. (Parameter 'offset')
        Stack Trace:
          /_/src/System.Private.CoreLib/shared/System/DateTimeOffset.cs(982,0): at System.DateTimeOffset.ValidateDate(DateTime dateTime, TimeSpan offset)
          /_/src/System.Private.CoreLib/shared/System/DateTimeOffset.cs(81,0): at System.DateTimeOffset..ctor(DateTime dateTime)
          /_/src/System.Private.CoreLib/shared/System/DateTimeOffset.cs(1013,0): at System.DateTimeOffset.op_Implicit(DateTime dateTime)
          /private/tmp/corefx/src/System.Text.Json/tests/JsonObjectTests.cs(145,0): at System.Text.Json.Tests.JsonObjectTests.TestDateTimeOffset()
      System.Text.Json.Tests.JsonStringTests.TestDateTimeOffset [FAIL]
        System.ArgumentOutOfRangeException : The UTC time represented when the offset is applied must be between year 0 and 10,000. (Parameter 'offset')
        Stack Trace:
          /_/src/System.Private.CoreLib/shared/System/DateTimeOffset.cs(982,0): at System.DateTimeOffset.ValidateDate(DateTime dateTime, TimeSpan offset)
          /_/src/System.Private.CoreLib/shared/System/DateTimeOffset.cs(81,0): at System.DateTimeOffset..ctor(DateTime dateTime)
          /_/src/System.Private.CoreLib/shared/System/DateTimeOffset.cs(1013,0): at System.DateTimeOffset.op_Implicit(DateTime dateTime)
          /private/tmp/corefx/src/System.Text.Json/tests/JsonStringTests.cs(93,0): at System.Text.Json.Tests.JsonStringTests.TestDateTimeOffset()
    Finished:    System.Text.Json.Tests
```