### PR TITLE
[release/3.0] Fix BitArray.CopyTo to byte[] regression - update offset for extra bits.

### DIFF
--- a/src/System.Collections/src/System/Collections/BitArray.cs
+++ b/src/System.Collections/src/System/Collections/BitArray.cs
@@ -657,7 +657,7 @@ namespace System.Collections
                     Debug.Assert(span.Length > 0);
                     Debug.Assert(m_array.Length > quotient);
                     // mask the final byte
-                    span[span.Length - 1] = (byte)((m_array[quotient] >> (remainder * 8)) & ((1 << (int)extraBits) - 1));
+                    span[remainder] = (byte)((m_array[quotient] >> (remainder * 8)) & ((1 << (int)extraBits) - 1));
                 }
 
                 switch (remainder)

--- a/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
@@ -313,6 +313,106 @@ namespace System.Collections.Tests
         }
 
         [Fact]
+        public static void CopyToByteArray()
+        {
+            for (int size = 4; size < 100; size++)
+            {
+                var bitArray = new BitArray(size);
+                bitArray[1] = true;
+                bitArray[3] = true;
+
+                for (int i = 0; i < 100; i++)
+                {
+                    byte[] expectedOutput = new byte[100 + (size / 8 + 1)];
+                    byte[] actualOutput = new byte[expectedOutput.Length];
+
+                    expectedOutput[i] = 10;
+                    bitArray.CopyTo(actualOutput, i);
+
+                    Assert.Equal(expectedOutput, actualOutput);
+                }
+            }
+        }
+
+        [Fact]
+        public static void CopyToBoolArray()
+        {
+            for (int size = 4; size < 100; size++)
+            {
+                var bitArray = new BitArray(size);
+                bitArray[1] = true;
+                bitArray[3] = true;
+
+                for (int i = 0; i < 100; i++)
+                {
+                    bool[] expectedOutput = new bool[100 + size];
+                    bool[] actualOutput = new bool[expectedOutput.Length];
+
+                    expectedOutput[i + 1] = true;
+                    expectedOutput[i + 3] = true;
+                    bitArray.CopyTo(actualOutput, i);
+
+                    Assert.Equal(expectedOutput, actualOutput);
+                }
+            }
+        }
+
+        [Fact]
+        public static void CopyToIntArray()
+        {
+            for (int size = 10; size < 100; size++)
+            {
+                var bitArray = new BitArray(size);
+                bitArray[1] = true;
+                bitArray[3] = true;
+                bitArray[9] = true;
+
+                for (int i = 0; i < 100; i++)
+                {
+                    int[] expectedOutput = new int[100 + (size / 32 + 1)];
+                    int[] actualOutput = new int[expectedOutput.Length];
+
+                    expectedOutput[i] = 522;
+                    bitArray.CopyTo(actualOutput, i);
+
+                    Assert.Equal(expectedOutput, actualOutput);
+                }
+            }
+        }
+
+        // https://github.com/dotnet/corefx/issues/39929
+        [Fact]
+        public static void CopyToByteArray_Regression39929()
+        {
+            bool[] directionBools = { true, true, true, true };
+            bool[] levelBools = { false, false, false, true };
+            byte[] byteHolder = new byte[2];
+            BitArray directionBits = new BitArray(directionBools);
+            BitArray levelBits = new BitArray(levelBools);
+
+            directionBits.CopyTo(byteHolder, 0);
+            levelBits.CopyTo(byteHolder, 1);
+
+            byte[] expectedOutput = { 0x0F, 0x08 };
+            Assert.Equal(expectedOutput, byteHolder);
+        }
+
+        // https://github.com/dotnet/core/issues/3194
+        [Fact]
+        public static void CopyToByteArray_Regression3194()
+        {
+            byte[] actualOutput = new byte[10];
+            BitArray bitArray = new BitArray(1);
+            bitArray[0] = true;
+
+            bitArray.CopyTo(actualOutput, 5);
+
+            byte[] expectedOutput = new byte[10];
+            expectedOutput[5] = 1;
+            Assert.Equal(expectedOutput, actualOutput);
+        }
+
+        [Fact]
         public static void CopyTo_Type_Invalid()
         {
             ICollection bitArray = new BitArray(10);


### PR DESCRIPTION
Ports https://github.com/dotnet/corefx/pull/40441 to 3.0

Fixes https://github.com/dotnet/corefx/issues/39929

cc @ericstj, @Anipik, @wtgodbe, @stephentoub, @jkotas  

## Description

Previously (i.e. in .NET Core 2.1 and earlier), we were writing one **byte** at a time, and then if the bit array contained extra **bits** to be copied over, we used the next index to write those bits. That was changed as part of https://github.com/dotnet/corefx/pull/33367. Now, we are writing **4 bytes** at a time, and if we have 1-3 bytes left to write, we have the switch on remainder below. Beyond that, any extra bits left to copy (i.e. < 1 byte) should go at offset `remainder`.

The index at which we wrote the extra bits was incorrect. I believe using `remainder` as the offset to write the last bits to is correct.

## Customer Impact

The bug was customer-reported as a regression of previous `BitArray.CopyTo(byte[], index)` behavior. When the user tried to copy at a certain index, previously copied data at other indices would get overwritten, resulting in data corruption.

## Regression?

Yes, between .NET Core 2.2 (and earlier) and .NET Core 3.0.

## Risk

Low. The reported issue is tested/fixed and the change is a single line to address the offset issue.