### PR TITLE
Add .ionide folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ cross/android-rootfs/
 # Visual Studio
 .vs/
 
+# Ionide
+.ionide/
+
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*


### PR DESCRIPTION
Ionide is the F# plugin for VS Code. It will create `.ionide/` folders with cache data in dotnet project folders. Adding to `.gitignore`.