### PR TITLE
HTTP2: fix header corruption issue

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackEncoder.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackEncoder.cs
@@ -291,6 +291,7 @@ namespace System.Net.Http.HPack
 
                 valueLength = checked((int)(valueLength + (values.Length - 1) * separator.Length));
 
+                destination[0] = 0;
                 if (IntegerEncoder.Encode(valueLength, 7, destination, out int integerLength))
                 {
                     Debug.Assert(integerLength >= 1);

--- a/src/System.Net.Http/tests/UnitTests/HPack/HPackRoundtripTests.cs
+++ b/src/System.Net.Http/tests/UnitTests/HPack/HPackRoundtripTests.cs
@@ -55,19 +55,13 @@ namespace System.Net.Http.Unit.Tests.HPack
         private static void CompareHttpHeaders(HttpHeaders expected, HttpHeaders actual)
         {
             Assert.Equal(expected.Count(), actual.Count());
-
-            expected
-                .Zip(actual)
-                .AssertForall(x => CompareHttpHeader(x.First, x.Second));
+            Assert.All(expected.Zip(actual), x => CompareHttpHeader(x.First, x.Second));
 
             void CompareHttpHeader(KeyValuePair<string, IEnumerable<string>> expected, KeyValuePair<string, IEnumerable<string>> actual)
             {
                 Assert.Equal(expected.Key, actual.Key);
                 Assert.Equal(expected.Value.Count(), actual.Value.Count());
-
-                expected.Value
-                    .Zip(actual.Value)
-                    .AssertForall(x => Assert.Equal(x.First, x.Second));
+                Assert.All(expected.Value.Zip(actual.Value), x => Assert.Equal(x.First, x.Second));
             }
         }
 
@@ -171,10 +165,5 @@ namespace System.Net.Http.Unit.Tests.HPack
                 header.TryAddWithoutValidation(descriptor, headerValue.Split(',').Select(x => x.Trim()));
             }
         }
-    }
-
-    public static class AssertExtensions
-    {
-        public static void AssertForall<T>(this IEnumerable<T> collection, Action<T> body) => Assert.All(collection, body);
     }
 }

--- a/src/System.Net.Http/tests/UnitTests/HPack/HPackRoundtripTests.cs
+++ b/src/System.Net.Http/tests/UnitTests/HPack/HPackRoundtripTests.cs
@@ -17,19 +17,18 @@ namespace System.Net.Http.Unit.Tests.HPack
     {
 
         public static IEnumerable<object[]> TestHeaders =>
-            new HttpHeaders[]
+            new (string, string[])[]
             {
-                BuildHttpHeaders(("header", new[] { "value" })),
+                ("header", new[] { "value" }),
 
-                BuildHttpHeaders(("header", new[] { "value1", "value2" })),
+                ("header", new[] { "value1", "value2" }),
 
-                BuildHttpHeaders(
-                    ("header-0", new[] { "value1", "value2" }),
-                    ("header-0", new[] { "value3" }),
-                    ("header-1", new[] { "value1" }),
-                    ("header-2", new[] { "value1", "value2" }))
+                (("header-0", new[] { "value1", "value2" }),
+                 ("header-0", new[] { "value3" }),
+                 ("header-1", new[] { "value1" }),
+                 ("header-2", new[] { "value1", "value2" }))
 
-            }.Select(h => new[] { h });
+            }.Select(h => new[] { BuildHttpHeaders(h) });
 
         [Theory, MemberData(nameof(TestHeaders))]
         public void HPack_Roundtrip_Headers(HttpHeaders headers)

--- a/src/System.Net.Http/tests/UnitTests/HPack/HPackRoundtripTests.cs
+++ b/src/System.Net.Http/tests/UnitTests/HPack/HPackRoundtripTests.cs
@@ -17,18 +17,19 @@ namespace System.Net.Http.Unit.Tests.HPack
     {
 
         public static IEnumerable<object[]> TestHeaders =>
-            new (string, string[])[]
+            new HttpHeaders[]
             {
-                ("header", new[] { "value" }),
+                BuildHttpHeaders(("header", new[] { "value" })),
 
-                ("header", new[] { "value1", "value2" }),
+                BuildHttpHeaders(("header", new[] { "value1", "value2" })),
 
-                (("header-0", new[] { "value1", "value2" }),
-                 ("header-0", new[] { "value3" }),
-                 ("header-1", new[] { "value1" }),
-                 ("header-2", new[] { "value1", "value2" }))
+                BuildHttpHeaders(
+                    ("header-0", new[] { "value1", "value2" }),
+                    ("header-0", new[] { "value3" }),
+                    ("header-1", new[] { "value1" }),
+                    ("header-2", new[] { "value1", "value2" }))
 
-            }.Select(h => new[] { BuildHttpHeaders(h) });
+            }.Select(h => new[] { h });
 
         [Theory, MemberData(nameof(TestHeaders))]
         public void HPack_Roundtrip_Headers(HttpHeaders headers)

--- a/src/System.Net.Http/tests/UnitTests/HPack/HPackRoundtripTests.cs
+++ b/src/System.Net.Http/tests/UnitTests/HPack/HPackRoundtripTests.cs
@@ -32,7 +32,7 @@ namespace System.Net.Http.Unit.Tests.HPack
             }.Select(h => new[] { h });
 
         [Theory, MemberData(nameof(TestHeaders))]
-        public void HPack_Roundtrip_Headers(HttpHeaders headers)
+        public void HPack_HeaderEncodeDecodeRoundtrip_ShouldMatchOriginalInput(HttpHeaders headers)
         {
             Memory<byte> encoding = HPackEncode(headers);
             HttpHeaders decodedHeaders = HPackDecode(encoding);

--- a/src/System.Net.Http/tests/UnitTests/HPack/HPackRoundtripTests.cs
+++ b/src/System.Net.Http/tests/UnitTests/HPack/HPackRoundtripTests.cs
@@ -1,0 +1,215 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.HPack;
+using System.Net.Http.Headers;
+using System.Text;
+using Xunit;
+
+namespace System.Net.Http.Unit.Tests.HPack
+{
+    public class HPackRoundtripTests
+    {
+
+        #region "tests"
+
+        // TODO: Extend to Property-Based Test using FsCheck 
+
+        [Fact]
+        public void HPack_Roundtrip_Single_Header_With_Single_Value()
+        {
+            HttpHeaders headers =
+                BuildHttpHeaders(
+                    new[] {
+                        ("header", new[] { "value" })
+                    }
+                );
+
+            Memory<byte> encoding = HPackEncode(headers);
+            HttpHeaders decodedHeaders = HPackDecode(encoding);
+
+            CompareHttpHeaders(headers, decodedHeaders);
+        }
+
+        [Fact]
+        public void HPack_Roundtrip_Single_Header_With_Two_Values()
+        {
+            HttpHeaders headers =
+                BuildHttpHeaders(
+                    new[] {
+                        ("header", new[] { "value1", "value2" })
+                    }
+                );
+
+            Memory<byte> encoding = HPackEncode(headers);
+            HttpHeaders decodedHeaders = HPackDecode(encoding);
+
+            CompareHttpHeaders(headers, decodedHeaders);
+        }
+
+        [Fact]
+        public void HPack_Roundtrip_Multiple_Headers()
+        {
+            HttpHeaders headers =
+                BuildHttpHeaders(
+                    new[] {
+                        ("header-0", new[] { "value1", "value2" }),
+                        ("header-0", new[] { "value3" }),
+                        ("header-1", new[] { "value1" }),
+                        ("header-2", new[] { "value1", "value2" })
+                    }
+                );
+
+            Memory<byte> encoding = HPackEncode(headers);
+            HttpHeaders decodedHeaders = HPackDecode(encoding);
+
+            CompareHttpHeaders(headers, decodedHeaders);
+        }
+
+        #endregion
+
+        #region "helpers"
+
+        private HttpHeaders BuildHttpHeaders((string key, string[] values)[] seedValues)
+        {
+            var headers = new HttpRequestHeaders();
+
+
+            foreach ((string key, string[] value) header in seedValues)
+            {
+                headers.Add(header.key, header.value);
+            }
+
+            return headers;
+        }
+
+        private void CompareHttpHeaders(HttpHeaders expected, HttpHeaders actual)
+        {
+            Assert.Equal(expected.Count(), actual.Count());
+
+            expected
+                .Zip(actual)
+                .ToList()
+                .ForEach(x => CompareHttpHeader(x.First, x.Second));
+
+            void CompareHttpHeader(KeyValuePair<string, IEnumerable<string>> expected, KeyValuePair<string, IEnumerable<string>> actual)
+            {
+                Assert.Equal(expected.Key, actual.Key);
+                Assert.Equal(expected.Value.Count(), actual.Value.Count());
+
+                expected.Value
+                    .Zip(actual.Value)
+                    .ToList()
+                    .ForEach(x => Assert.Equal(x.First, x.Second));
+            }
+        }
+
+        // adapted from Header serialization code in Http2Connection.cs
+        private static Memory<byte> HPackEncode(HttpHeaders headers)
+        {
+            var buffer = new ArrayBuffer(4);
+            FillAvailableSpaceWithOnes(buffer);
+
+            foreach (KeyValuePair<HeaderDescriptor, string[]> header in headers.GetHeaderDescriptorsAndValues())
+            {
+                KnownHeader knownHeader = header.Key.KnownHeader;
+                if (knownHeader != null)
+                {
+                    // For all other known headers, send them via their pre-encoded name and the associated value.
+                    WriteBytes(knownHeader.Http2EncodedName);
+                    string separator = null;
+                    if (header.Value.Length > 1)
+                    {
+                        HttpHeaderParser parser = header.Key.Parser;
+                        if (parser != null && parser.SupportsMultipleValues)
+                        {
+                            separator = parser.Separator;
+                        }
+                        else
+                        {
+                            separator = HttpHeaderParser.DefaultSeparator;
+                        }
+                    }
+
+                    WriteLiteralHeaderValues(header.Value, separator);
+                }
+                else
+                {
+                    // The header is not known: fall back to just encoding the header name and value(s).
+                    WriteLiteralHeader(header.Key.Name, header.Value);
+                }
+            }
+
+            return buffer.ActiveMemory;
+
+            void WriteBytes(ReadOnlySpan<byte> bytes)
+            {
+                if (bytes.Length > buffer.AvailableLength)
+                {
+                    buffer.EnsureAvailableSpace(bytes.Length);
+                    FillAvailableSpaceWithOnes(buffer);
+                }
+
+                bytes.CopyTo(buffer.AvailableSpan);
+                buffer.Commit(bytes.Length);
+            }
+
+            void WriteLiteralHeaderValues(string[] values, string separator)
+            {
+                int bytesWritten;
+                while (!HPackEncoder.EncodeStringLiterals(values, separator, buffer.AvailableSpan, out bytesWritten))
+                {
+                    buffer.EnsureAvailableSpace(buffer.AvailableLength + 1);
+                    FillAvailableSpaceWithOnes(buffer);
+                }
+
+                buffer.Commit(bytesWritten);
+            }
+
+            void WriteLiteralHeader(string name, string[] values)
+            {
+                int bytesWritten;
+                while (!HPackEncoder.EncodeLiteralHeaderFieldWithoutIndexingNewName(name, values, HttpHeaderParser.DefaultSeparator, buffer.AvailableSpan, out bytesWritten))
+                {
+                    buffer.EnsureAvailableSpace(buffer.AvailableLength + 1);
+                    FillAvailableSpaceWithOnes(buffer);
+                }
+
+                buffer.Commit(bytesWritten);
+            }
+
+            // force issues related to buffer not being zeroed out
+            void FillAvailableSpaceWithOnes(ArrayBuffer buffer) => buffer.AvailableSpan.Fill(0xff);
+        }
+
+        // adapted from header deserialization code in Http2Connection.cs
+        private static HttpHeaders HPackDecode(Memory<byte> memory)
+        {
+            var header = new HttpRequestHeaders();
+            var hpackDecoder = new HPackDecoder(maxDynamicTableSize: 0, maxResponseHeadersLength: HttpHandlerDefaults.DefaultMaxResponseHeadersLength * 1024);
+
+            hpackDecoder.Decode(memory.Span, true, ((_, name, value) => HeaderHandler(name, value)), null);
+
+            return header;
+
+            void HeaderHandler(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
+            {
+                if (!HeaderDescriptor.TryGet(name, out HeaderDescriptor descriptor))
+                {
+                    throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_header_name, Encoding.ASCII.GetString(name)));
+                }
+
+                string headerValue = descriptor.GetHeaderValue(value);
+
+                header.TryAddWithoutValidation(descriptor, headerValue.Split(',').Select(x => x.Trim()));
+            }
+        }
+    }
+
+    #endregion
+}

--- a/src/System.Net.Http/tests/UnitTests/HPack/HPackRoundtripTests.cs
+++ b/src/System.Net.Http/tests/UnitTests/HPack/HPackRoundtripTests.cs
@@ -79,7 +79,6 @@ namespace System.Net.Http.Unit.Tests.HPack
         {
             var headers = new HttpRequestHeaders();
 
-
             foreach ((string key, string[] value) header in seedValues)
             {
                 headers.Add(header.key, header.value);

--- a/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -303,6 +303,9 @@
     <Compile Include="..\..\src\System\Net\Http\CurlHandler\CurlResponseHeaderReader.cs">
       <Link>ProductionCode\System\Net\Http\CurlResponseHeaderReader.cs</Link>
     </Compile>
+    <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\ArrayBuffer.cs">
+      <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\ArrayBuffer.cs</Link>
+    </Compile>
     <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\HttpEnvironmentProxy.cs">
       <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\HttpEnvironmentProxy.cs</Link>
     </Compile>
@@ -416,6 +419,7 @@
     <Compile Include="HPack\DynamicTableTest.cs" />
     <Compile Include="HPack\HPackDecoderTest.cs" />
     <Compile Include="HPack\HPackIntegerTest.cs" />
+    <Compile Include="HPack\HPackRoundtripTests.cs" />
     <Compile Include="HPack\HuffmanDecodingTests.cs" />
     <Compile Include="HttpContentTest.cs" />
     <Compile Include="HttpRuleParserTest.cs" />


### PR DESCRIPTION
Fixes a bug in HPackEncoder which results in header data corruption in cases where the write buffer has not been zeroed out. Adds HPack roundtrip unit tests that reproduce the error.

Fixes #40459.