### PR TITLE
Fixed a bug causing all subsequent properties to be skipped during json deserialization once a dictionary has been skipped.

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.cs
@@ -82,6 +82,7 @@ namespace System.Text.Json
                         if (readStack.Current.Drain)
                         {
                             readStack.Pop();
+                            readStack.Current.EndObject();
                         }
                         else if (readStack.Current.IsProcessingDictionary || readStack.Current.IsProcessingIDictionaryConstructible)
                         {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
@@ -126,6 +126,7 @@ namespace System.Text.Json
             PropertyIndex = 0;
             EndProperty();
         }
+
         public void EndProperty()
         {
             CollectionPropertyInitialized = false;

--- a/src/System.Text.Json/tests/Serialization/Array.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Array.ReadTests.cs
@@ -427,14 +427,16 @@ namespace System.Text.Json.Serialization.Tests
 
         public class ClassWithPopulatedListAndSetter
         {
-            public List<int> MyList { get; set;  } = new List<int>() { 1 };
+            public List<int> MySkippedList { get; }
+
+            public List<int> MyList { get; set; } = new List<int>() { 1 };
         }
 
         [Fact]
         public static void ClassWithPopulatedList()
         {
             // We replace the contents of this collection; we don't attempt to add items to the existing collection instance.
-            string json = @"{""MyList"":[2,3]}";
+            string json = @"{""MySkippedList"":[1,2],""MyList"":[2,3]}";
             ClassWithPopulatedListAndSetter obj = JsonSerializer.Deserialize<ClassWithPopulatedListAndSetter>(json);
             Assert.Equal(2, obj.MyList.Count);
         }

--- a/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
+++ b/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
@@ -916,15 +916,19 @@ namespace System.Text.Json.Serialization.Tests
 
             public Dictionary<string, string> MyDictionary { get; } = new Dictionary<string, string>() { { "Key", "Value" } };
             public ImmutableDictionary<string, string> MyImmutableDictionary { get; } = ImmutableDictionary.Create<string, string>();
+
+            public IDictionary<string, string> MyDictionaryWithSetter { get; set; }
         }
 
         [Fact]
         public static void ClassWithNoSetterAndDictionary()
         {
             // We don't attempt to deserialize into dictionaries without a setter.
-            string json = @"{""MyDictionary"":{""Key1"":""Value1"", ""Key2"":""Value2""}}";
+            string json = @"{""MyDictionary"":{""Key1"":""Value1"", ""Key2"":""Value2""},""MyDictionaryWithSetter"":{""Key1"":""Value1""}}";
             ClassWithPopulatedDictionaryAndNoSetter obj = JsonSerializer.Deserialize<ClassWithPopulatedDictionaryAndNoSetter>(json);
             Assert.Equal(1, obj.MyDictionary.Count);
+            Assert.NotNull(obj.MyDictionaryWithSetter);
+            Assert.Equal(1, obj.MyDictionaryWithSetter.Count);
         }
 
         [Fact]

--- a/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
@@ -356,5 +356,22 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(1, parsedObject.MySimpleTestClass.MyInt32Array[0]);
             Assert.Equal(2, parsedObject.MyInt32Array[0]);
         }
+
+        public class ClassWithNoSetter
+        {
+            public SimpleTestClass SkippedChild { get; }
+
+            public SimpleTestClass ParsedChild { get; set; }
+        }
+
+        [Fact]
+        public static void ClassWithNoSetterAndValidProperty()
+        {
+            string json = "{\"SkippedChild\":{\"MyInt16\":1},\"ParsedChild\":{\"MyInt16\":18}}";
+            ClassWithNoSetter parsedObject = JsonSerializer.Deserialize<ClassWithNoSetter>(json);
+
+            Assert.NotNull(parsedObject.ParsedChild);
+            Assert.Equal(18, parsedObject.ParsedChild.MyInt16);
+        }
     }
 }


### PR DESCRIPTION
Given a class set up like this...
```
        public class ClassWithPopulatedDictionaryAndNoSetter
        {
            public Dictionary<string, string> MyDictionary { get; } = new Dictionary<string, string>() { { "Key", "Value" } };

            public IDictionary<string, string> MyDictionaryWithSetter { get; set; }
        }
```
...and some json like this...
```
{"MyDictionary":{"Key1":"Value1", "Key2":"Value2"},"MyDictionaryWithSetter":{"Key1":"Value1"}}
```
...the JsonSerializer.Deserialize operation will correctly skip "MyDictionary" because it doesn't have a public setter, but won't parse "MyDictionaryWithSetter" because it gets stuck in an open dictionary state.