### PR TITLE
Fix mail message encoding for transport when delivery method is pickup

### DIFF
--- a/src/System.Net.Mail/src/System/Net/Mail/MailWriter.cs
+++ b/src/System.Net.Mail/src/System/Net/Mail/MailWriter.cs
@@ -15,8 +15,9 @@ namespace System.Net.Mail
         /// ctor.
         /// </summary>
         /// <param name="stream">Underlying stream</param>
-        internal MailWriter(Stream stream)
-            : base(stream, true)
+        /// <param name="encodeForTransport">Specifies whether the data should be encoded for transport over SMTP</param>
+        internal MailWriter(Stream stream, bool encodeForTransport)
+            : base(stream, encodeForTransport)
         // This is the only stream that should encoding leading dots on a line.
         // This way it is done message wide and only once.
         {

--- a/src/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
+++ b/src/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
@@ -404,7 +404,7 @@ namespace System.Net.Mail
             }
 
             FileStream fileStream = new FileStream(pathAndFilename, FileMode.CreateNew);
-            return new MailWriter(fileStream);
+            return new MailWriter(fileStream, encodeForTransport: false);
         }
 
         protected void OnSendCompleted(AsyncCompletedEventArgs e)

--- a/src/System.Net.Mail/src/System/Net/Mail/SmtpTransport.cs
+++ b/src/System.Net.Mail/src/System/Net/Mail/SmtpTransport.cs
@@ -277,7 +277,7 @@ namespace System.Net.Mail
             }
 
             DataCommand.Send(_connection);
-            return new MailWriter(_connection.GetClosableStream());
+            return new MailWriter(_connection.GetClosableStream(), encodeForTransport: true);
         }
     }
 
@@ -326,7 +326,7 @@ namespace System.Net.Mail
                 ExceptionDispatchInfo.Throw(e);
             }
 
-            return new MailWriter(thisPtr._stream);
+            return new MailWriter(thisPtr._stream, encodeForTransport: true);
         }
         private void SendMailFrom()
         {

--- a/src/System.Net.Mail/tests/Functional/MailMessageTest.cs
+++ b/src/System.Net.Mail/tests/Functional/MailMessageTest.cs
@@ -177,7 +177,7 @@ namespace System.Net.Mail.Tests
                                 type: mailWriterType,
                                 bindingAttr: BindingFlags.Instance | BindingFlags.NonPublic,
                                 binder: null,
-                                args: new object[] { stream },
+                                args: new object[] { stream, true },    // true to encode message for transport
                                 culture: null,
                                 activationAttributes: null);
 

--- a/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -235,7 +235,9 @@ namespace System.Net.Mail.Tests
 
         public static IEnumerable<object[]> MessageBodyData()
         {
-            for (int i = 0; i < 100; i++)
+            // Current max line length folds at i==65. Bracketing that value to ensure potential
+            // future minor changes to max legnth do not render test ineffective
+            for (int i = 60; i < 71; i++)
                 yield return new object[] { new string('a', i) + '.' };
         }
 


### PR DESCRIPTION
Fix #33304. Mail messages encode lines that begin with a single period by doubling the period as per SMTP RFC. However, messages that are to be picked up from a directory instead of transported should not do this. 