### PR TITLE
Console tests: remove tests that expect to observe ANSI sequences

### DIFF
--- a/src/System.Console/tests/Color.cs
+++ b/src/System.Console/tests/Color.cs
@@ -51,21 +51,4 @@ public class Color
             Assert.Equal("1234", Encoding.UTF8.GetString(data.ToArray()));
         });
     }
-
-    [Fact]
-    [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // the CI system redirects stdout, so we can't easily test non-redirected behavior
-    [PlatformSpecific(TestPlatforms.AnyUnix)]
-    public static void NonRedirectedOutputDoesUseAnsiSequences()
-    {
-        // Make sure that when writing out to a UnixConsoleStream, the ANSI escape sequences are properly
-        // written out.
-        Helpers.RunInNonRedirectedOutput((data) =>
-        {
-            Console.ForegroundColor = ConsoleColor.Blue;
-            Console.BackgroundColor = ConsoleColor.Red;
-            Console.ResetColor();
-            const char Esc = (char)0x1B;
-            Assert.Equal(3, Encoding.UTF8.GetString(data.ToArray()).ToCharArray().Count(c => c == Esc));
-        });
-    }
 }

--- a/src/System.Console/tests/WindowAndCursorProps.cs
+++ b/src/System.Console/tests/WindowAndCursorProps.cs
@@ -173,19 +173,6 @@ public class WindowAndCursorProps
 
     [Fact]
     [PlatformSpecific(TestPlatforms.AnyUnix)]  // Expected behavior specific to Unix
-    [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] //CI system makes it difficult to run things in a non-redirected environments.
-    public static void NonRedirectedCursorVisible()
-    {
-        if (!Console.IsOutputRedirected)
-        {
-            // Validate that Console.CursorVisible adds something to the stream when in a non-redirected environment.
-            Helpers.RunInNonRedirectedOutput((data) => { Console.CursorVisible = false; Assert.True(data.ToArray().Length > 0); });
-            Helpers.RunInNonRedirectedOutput((data) => { Console.CursorVisible = true; Assert.True(data.ToArray().Length > 0); });
-        }
-    }
-
-    [Fact]
-    [PlatformSpecific(TestPlatforms.AnyUnix)]  // Expected behavior specific to Unix
     public static void CursorVisible_GetUnix_ThrowsPlatformNotSupportedException()
     {
         Assert.Throws<PlatformNotSupportedException>(() => Console.CursorVisible);


### PR DESCRIPTION
These tests expect ANSI escape sequences to be written to the Console.SetOut stream,
which doesn't match with the implementation (since https://github.com/dotnet/corefx/commit/98552707c585bc0f0c138fdeed991c28f00a0ac5).

Fixes https://github.com/dotnet/corefx/issues/39760, https://github.com/dotnet/corefx/issues/39721

CC @stephentoub @ViktorHofer @wfurt @danmosemsft @adlich @Adam-Booth