### PR TITLE
Raise JsonException when PolicyProperty is null

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
@@ -338,10 +338,10 @@ namespace System.Text.Json
         {
             Debug.Assert(ShouldDeserialize);
 
-            if (ElementClassInfo != null)
+            JsonPropertyInfo propertyInfo;
+            if (ElementClassInfo != null && (propertyInfo = ElementClassInfo.PolicyProperty) != null)
             {
                 // Forward the setter to the value-based JsonPropertyInfo.
-                JsonPropertyInfo propertyInfo = ElementClassInfo.PolicyProperty;
                 propertyInfo.ReadEnumerable(tokenType, ref state, ref reader);
             }
             else

--- a/src/System.Text.Json/tests/Serialization/PolymorphicTests.cs
+++ b/src/System.Text.Json/tests/Serialization/PolymorphicTests.cs
@@ -439,6 +439,18 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<MyClass>(@"{ ""Value"": ""A value"", ""Thing"": { ""Number"": 123 } }"));
         }
 
+        [Fact]
+        public static void GenericListOfInterface_WithInvalidJson_ThrowsJsonException()
+        {
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<MyThingCollection>("false"));
+        }
+
+        [Fact]
+        public static void GenericListOfInterface_WithValidJson_ThrowsNotSupportedException()
+        {
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<MyThingCollection>("{}"));
+        }
+
         class MyClass
         {
             public string Value { get; set; }
@@ -454,5 +466,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             public int Number { get; set; }
         }
+
+        class MyThingCollection : List<IThing> { }
     }
 }


### PR DESCRIPTION
Current approach of deserializer is that if the token being handled is
unexpected, `JsonException` is raised before typechecking/validating
the target type. Which means it is later when `NotSupportedException`
is issued due to the lack of interface support.

Therefore, this PR changes the flow leading to `NullReferenceException`
to `JsonException` to align it with other unexpected token cases.

This is different than what was proposed in #40449: throw
`NotSupportedException` now and when interface support is added, raise
`JsonException`. This approach is future proof and agnostic of
interface support.

Addresses #40449