### PR TITLE
Re-enable source link validation

### DIFF
--- a/.azure-ci.yml
+++ b/.azure-ci.yml
@@ -96,7 +96,7 @@ stages:
         dependsOn:
           - PrePublish
         enableSymbolValidation: false # https://github.com/dotnet/arcade/issues/2871
-        enableSourceLinkValidation: false # https://github.com/dotnet/arcade/issues/3603
+        enableSourceLinkValidation: true
         SDLValidationParameters:
           enable: true
           params: ' -SourceToolsList @("policheck","credscan")


### PR DESCRIPTION
fa168dd690798a683ef0d1e65d60ce5d6918d987 in arcade should have a fix to prevent OOM exceptions.

Fixes https://github.com/dotnet/corefx/issues/40195