### PR TITLE
[release/3.0] Fix UAF when removing trusted certs on OSX

### DIFF
--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_keychain.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_keychain.c
@@ -291,7 +291,6 @@ static int32_t CheckTrustSettings(SecCertificateRef cert)
 
     if (status == noErr)
     {
-        CFRelease(cert);
         return kErrorUserTrust;
     }
 
@@ -305,7 +304,6 @@ static int32_t CheckTrustSettings(SecCertificateRef cert)
 
     if (status == noErr)
     {
-        CFRelease(cert);
         return kErrorAdminTrust;
     }
 
@@ -455,9 +453,11 @@ AppleCryptoNative_X509StoreRemoveCertificate(CFTypeRef certOrIdentity, SecKeycha
     {
         if (!IsCertInKeychain(cert, keychain))
         {
+            CFRelease(cert);
             return 1;
         }
 
+        CFRelease(cert);
         return ret;
     }
 


### PR DESCRIPTION
CheckTrustSettings called CFRelease on cert, which downref'd it to zero
before IsCertInKeychain ran.

Now CheckTrustSettings leaves cert alive, and it's the caller's responsibility to CFRelease.

Fixes #40491.