### PR TITLE
Change EnsureBufferContainsAsync to ValueTask

### DIFF
--- a/src/Common/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/Common/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -1191,7 +1191,7 @@ namespace System.Net.WebSockets
             _receiveBufferOffset += count;
         }
 
-        private async Task EnsureBufferContainsAsync(int minimumRequiredBytes, CancellationToken cancellationToken, bool throwOnPrematureClosure = true)
+        private async ValueTask EnsureBufferContainsAsync(int minimumRequiredBytes, CancellationToken cancellationToken, bool throwOnPrematureClosure = true)
         {
             Debug.Assert(minimumRequiredBytes <= _receiveBuffer.Length, $"Requested number of bytes {minimumRequiredBytes} must not exceed {_receiveBuffer.Length}");
 


### PR DESCRIPTION
With https://github.com/dotnet/coreclr/pull/26310 this prevents it allocating Tasks in the common case

Pre
![image](https://user-images.githubusercontent.com/1142958/63550819-5d3c2880-c52b-11e9-81aa-1056dbec2c2d.png)



Post
![image](https://user-images.githubusercontent.com/1142958/63550427-8f00bf80-c52a-11e9-803e-d1abbffe875f.png)

/cc @stephentoub 