### PR TITLE
Change exception message when reading numbers with leading zeros

### DIFF
--- a/src/System.Text.Json/src/Resources/Strings.resx
+++ b/src/System.Text.Json/src/Resources/Strings.resx
@@ -441,4 +441,7 @@
   <data name="InvalidDuplicatePropertyNameHandling" xml:space="preserve">
     <value>The DuplicatePropertyNameHandling enum must be set to one of the supported values.</value>
   </data>
+  <data name="InvalidLeadingZerosInNumber" xml:space="preserve">
+    <value>Invalid leading zeros in '{0}'. Expected '.', 'e', 'E' or a delimiter after the zero.</value>
+  </data>
 </root>

--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
@@ -1584,7 +1584,7 @@ namespace System.Text.Json
             if (nextByte != '.' && nextByte != 'E' && nextByte != 'e')
             {
                 _bytePositionInLine += i;
-                ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedEndOfDigitNotFound, nextByte);
+                ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.InvalidLeadingZerosInNumber, bytes: data.Slice(i - 1, 2));
             }
 
             return ConsumeNumberResult.OperationIncomplete;

--- a/src/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
+++ b/src/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
@@ -380,6 +380,9 @@ namespace System.Text.Json
                 case ExceptionResource.UnexpectedEndOfLineSeparator:
                     message = SR.Format(SR.UnexpectedEndOfLineSeparator);
                     break;
+                case ExceptionResource.InvalidLeadingZerosInNumber:
+                    message = SR.Format(SR.InvalidLeadingZerosInNumber, characters);
+                    break;
                 default:
                     Debug.Fail($"The ExceptionResource enum value: {resource} is not part of the switch. Add the appropriate case and exception message.");
                     break;
@@ -633,6 +636,7 @@ namespace System.Text.Json
         UnexpectedEndOfLineSeparator,
         ExpectedOneCompleteToken,
         NotEnoughData,
+        InvalidLeadingZerosInNumber,
     }
 
     internal enum NumericType


### PR DESCRIPTION
Fixes #37882

Some scenarios tested:
`"{ \"foo\": 01 }"`
System.Text.Json.JsonReaderException : Invalid leading zeros in '01'. Expected '.', 'e', 'E' or a delimiter after the zero. LineNumber: 0 | BytePositionInLine: 10.

`"{ \"foo\": -01 }"`
System.Text.Json.JsonReaderException : Invalid leading zeros in '01'. Expected '.', 'e', 'E' or a delimiter after the zero. LineNumber: 0 | BytePositionInLine: 11.

`"{ \"foo\": -00 }"`
System.Text.Json.JsonReaderException : Invalid leading zeros in '00'. Expected '.', 'e', 'E' or a delimiter after the zero. LineNumber: 0 | BytePositionInLine: 11.

