### PR TITLE
Change some internal async Task methods to be async ValueTask

### DIFF
--- a/src/System.IO.Compression.Brotli/src/System/IO/Compression/enc/BrotliStream.Compress.cs
+++ b/src/System.IO.Compression.Brotli/src/System/IO/Compression/enc/BrotliStream.Compress.cs
@@ -76,12 +76,12 @@ namespace System.IO.Compression
             EnsureNoActiveAsyncOperation();
             EnsureNotDisposed();
 
-            return new ValueTask(cancellationToken.IsCancellationRequested ?
-                Task.FromCanceled<int>(cancellationToken) :
-                WriteAsyncMemoryCore(buffer, cancellationToken));
+            return cancellationToken.IsCancellationRequested ?
+                new ValueTask(Task.FromCanceled<int>(cancellationToken)) :
+                WriteAsyncMemoryCore(buffer, cancellationToken);
         }
 
-        private async Task WriteAsyncMemoryCore(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken, bool isFinalBlock = false)
+        private async ValueTask WriteAsyncMemoryCore(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken, bool isFinalBlock = false)
         {
             AsyncOperationStarting();
             try

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
@@ -631,7 +631,7 @@ namespace System.IO.Compression
             }
         }
 
-        private async Task PurgeBuffersAsync()
+        private async ValueTask PurgeBuffersAsync()
         {
             // Same logic as PurgeBuffers, except with async counterparts.
 
@@ -809,12 +809,12 @@ namespace System.IO.Compression
             EnsureNoActiveAsyncOperation();
             EnsureNotDisposed();
 
-            return new ValueTask(cancellationToken.IsCancellationRequested ?
-                Task.FromCanceled<int>(cancellationToken) :
-                WriteAsyncMemoryCore(buffer, cancellationToken));
+            return cancellationToken.IsCancellationRequested ?
+                new ValueTask(Task.FromCanceled<int>(cancellationToken)) :
+                WriteAsyncMemoryCore(buffer, cancellationToken);
         }
 
-        private async Task WriteAsyncMemoryCore(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
+        private async ValueTask WriteAsyncMemoryCore(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
         {
             AsyncOperationStarting();
             try
@@ -838,7 +838,7 @@ namespace System.IO.Compression
         /// <summary>
         /// Writes the bytes that have already been deflated
         /// </summary>
-        private async Task WriteDeflaterOutputAsync(CancellationToken cancellationToken)
+        private async ValueTask WriteDeflaterOutputAsync(CancellationToken cancellationToken)
         {
             Debug.Assert(_deflater != null && _buffer != null);
             while (!_deflater.NeedsInput())

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.cs
@@ -184,7 +184,7 @@ namespace System.Net.Http
             SetRequestAuthenticationHeaderValue(request, new AuthenticationHeaderValue(BasicScheme, base64AuthString), isProxyAuth);
         }
 
-        private static async Task<bool> TrySetDigestAuthToken(HttpRequestMessage request, NetworkCredential credential, DigestResponse digestResponse, bool isProxyAuth)
+        private static async ValueTask<bool> TrySetDigestAuthToken(HttpRequestMessage request, NetworkCredential credential, DigestResponse digestResponse, bool isProxyAuth)
         {
             string parameter = await GetDigestTokenForCredential(credential, request, digestResponse).ConfigureAwait(false);
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
@@ -429,7 +429,7 @@ namespace System.Net.Http
 
             public override bool NeedsDrain => (_connection != null);
 
-            public override async Task<bool> DrainAsync(int maxDrainBytes)
+            public override async ValueTask<bool> DrainAsync(int maxDrainBytes)
             {
                 Debug.Assert(_connection != null);
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingWriteStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingWriteStream.cs
@@ -31,11 +31,11 @@ namespace System.Net.Http
                     // Don't write if nothing was given, especially since we don't want to accidentally send a 0 chunk,
                     // which would indicate end of body.  Instead, just ensure no content is stuck in the buffer.
                     connection.FlushAsync() :
-                    new ValueTask(WriteChunkAsync(connection, buffer));
+                    WriteChunkAsync(connection, buffer);
 
                 return task;
 
-                static async Task WriteChunkAsync(HttpConnection connection, ReadOnlyMemory<byte> buffer)
+                static async ValueTask WriteChunkAsync(HttpConnection connection, ReadOnlyMemory<byte> buffer)
                 {
                     // Write chunk length in hex followed by \r\n
                     await connection.WriteHexInt32Async(buffer.Length).ConfigureAwait(false);
@@ -47,7 +47,7 @@ namespace System.Net.Http
                 }
             }
 
-            public override async Task FinishAsync()
+            public override async ValueTask FinishAsync()
             {
                 // Send 0 byte chunk to indicate end, then final CrLf
                 HttpConnection connection = GetConnectionOrThrow();

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthReadStream.cs
@@ -191,7 +191,7 @@ namespace System.Net.Http
 
             public override bool NeedsDrain => (_connection != null);
 
-            public override async Task<bool> DrainAsync(int maxDrainBytes)
+            public override async ValueTask<bool> DrainAsync(int maxDrainBytes)
             {
                 Debug.Assert(_connection != null);
                 Debug.Assert(_contentBytesRemaining > 0);

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthWriteStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthWriteStream.cs
@@ -23,13 +23,13 @@ namespace System.Net.Http
                 // that are still buffered.
                 HttpConnection connection = GetConnectionOrThrow();
                 Debug.Assert(connection._currentRequest != null);
-                return new ValueTask(connection.WriteAsync(buffer));
+                return connection.WriteAsync(buffer);
             }
 
-            public override Task FinishAsync()
+            public override ValueTask FinishAsync()
             {
                 _connection = null;
-                return Task.CompletedTask;
+                return default;
             }
         }
     }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/CreditManager.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/CreditManager.cs
@@ -64,9 +64,9 @@ namespace System.Net.Http
                 var waiter = new Waiter { Amount = amount };
                 (_waiters ??= new Queue<Waiter>()).Enqueue(waiter);
 
-                return new ValueTask<int>(cancellationToken.CanBeCanceled ?
-                                          waiter.WaitWithCancellationAsync(cancellationToken) :
-                                          waiter.Task);
+                return cancellationToken.CanBeCanceled ?
+                    waiter.WaitWithCancellationAsync(cancellationToken) :
+                    new ValueTask<int>(waiter.Task);
             }
         }
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -127,7 +127,7 @@ namespace System.Net.Http
 
         private object SyncObject => _httpStreams;
 
-        public async Task SetupAsync()
+        public async ValueTask SetupAsync()
         {
             _outgoingBuffer.EnsureAvailableSpace(s_http2ConnectionPreface.Length +
                 FrameHeader.Size + (FrameHeader.SettingLength * 2) +
@@ -165,7 +165,7 @@ namespace System.Net.Http
             _ = ProcessIncomingFramesAsync();
         }
 
-        private async Task EnsureIncomingBytesAsync(int minReadBytes)
+        private async ValueTask EnsureIncomingBytesAsync(int minReadBytes)
         {
             if (NetEventSource.IsEnabled) Trace($"{nameof(minReadBytes)}={minReadBytes}");
             if (_incomingBuffer.ActiveLength >= minReadBytes)
@@ -321,7 +321,7 @@ namespace System.Net.Http
             }
         }
 
-        private async Task ProcessHeadersFrame(FrameHeader frameHeader)
+        private async ValueTask ProcessHeadersFrame(FrameHeader frameHeader)
         {
             if (NetEventSource.IsEnabled) Trace($"{frameHeader}");
             Debug.Assert(frameHeader.Type == FrameType.Headers);
@@ -783,7 +783,7 @@ namespace System.Net.Http
             }
         }
 
-        private async Task AcquireWriteLockAsync(CancellationToken cancellationToken)
+        private async ValueTask AcquireWriteLockAsync(CancellationToken cancellationToken)
         {
             Task acquireLockTask = _writerLock.WaitAsync(cancellationToken);
             if (!acquireLockTask.IsCompletedSuccessfully)

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -269,7 +269,7 @@ namespace System.Net.Http
             // We can either get 100 response from server and send body
             // or we may exceed timeout and send request body anyway.
             // If we get response status >= 300, we will not send the request body.
-            public async Task<bool> WaitFor100ContinueAsync(CancellationToken cancellationToken)
+            public async ValueTask<bool> WaitFor100ContinueAsync(CancellationToken cancellationToken)
             {
                 Debug.Assert(_request.Content != null);
                 if (NetEventSource.IsEnabled) Trace($"Waiting to send request body content for 100-Continue.");
@@ -969,7 +969,7 @@ namespace System.Net.Http
                 }
             }
 
-            private async Task SendDataAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
+            private async ValueTask SendDataAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
             {
                 ReadOnlyMemory<byte> remaining = buffer;
 
@@ -1047,11 +1047,11 @@ namespace System.Net.Http
                 // if it is cancelable, then register for the cancellation callback, allocate a task for the asynchronously
                 // completing case, etc.
                 return cancellationToken.CanBeCanceled ?
-                    new ValueTask(GetCancelableWaiterTask(cancellationToken)) :
+                    GetCancelableWaiterTask(cancellationToken) :
                     new ValueTask(this, _waitSource.Version);
             }
 
-            private async Task GetCancelableWaiterTask(CancellationToken cancellationToken)
+            private async ValueTask GetCancelableWaiterTask(CancellationToken cancellationToken)
             {
                 using (cancellationToken.UnsafeRegister(s =>
                 {
@@ -1213,7 +1213,7 @@ namespace System.Net.Http
                         return new ValueTask(Task.FromException(new ObjectDisposedException(nameof(Http2WriteStream))));
                     }
 
-                    return new ValueTask(http2Stream.SendDataAsync(buffer, cancellationToken));
+                    return http2Stream.SendDataAsync(buffer, cancellationToken);
                 }
 
                 public override Task FlushAsync(CancellationToken cancellationToken)

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -217,7 +217,7 @@ namespace System.Net.Http
             _readOffset += bytesToConsume;
         }
 
-        private async Task WriteHeadersAsync(HttpHeaders headers, string cookiesFromContainer)
+        private async ValueTask WriteHeadersAsync(HttpHeaders headers, string cookiesFromContainer)
         {
             if (headers.HeaderStore != null)
             {
@@ -278,7 +278,7 @@ namespace System.Net.Http
             }
         }
 
-        private async Task WriteHostHeaderAsync(Uri uri)
+        private async ValueTask WriteHostHeaderAsync(Uri uri)
         {
             await WriteBytesAsync(KnownHeaders.Host.AsciiBytesWithColonSpace).ConfigureAwait(false);
 
@@ -773,7 +773,7 @@ namespace System.Net.Http
 
         private static bool IsLineEmpty(ArraySegment<byte> line) => line.Count == 0;
 
-        private async Task SendRequestContentAsync(HttpRequestMessage request, HttpContentWriteStream stream, CancellationToken cancellationToken)
+        private async ValueTask SendRequestContentAsync(HttpRequestMessage request, HttpContentWriteStream stream, CancellationToken cancellationToken)
         {
             // Now that we're sending content, prohibit retries on this connection.
             _canRetry = false;
@@ -986,7 +986,7 @@ namespace System.Net.Http
             _writeOffset += source.Length;
         }
 
-        private async Task WriteAsync(ReadOnlyMemory<byte> source)
+        private async ValueTask WriteAsync(ReadOnlyMemory<byte> source)
         {
             int remaining = _writeBuffer.Length - _writeOffset;
 
@@ -1063,10 +1063,10 @@ namespace System.Net.Http
 
             // There's data in the write buffer and the data we're writing doesn't fit after it.
             // Do two writes, one to flush the buffer and then another to write the supplied content.
-            return new ValueTask(FlushThenWriteWithoutBufferingAsync(source));
+            return FlushThenWriteWithoutBufferingAsync(source);
         }
 
-        private async Task FlushThenWriteWithoutBufferingAsync(ReadOnlyMemory<byte> source)
+        private async ValueTask FlushThenWriteWithoutBufferingAsync(ReadOnlyMemory<byte> source)
         {
             await FlushAsync().ConfigureAwait(false);
             await WriteToStreamAsync(source).ConfigureAwait(false);
@@ -1405,7 +1405,7 @@ namespace System.Net.Http
         }
 
         // Throws IOException on EOF.  This is only called when we expect more data.
-        private async Task FillAsync()
+        private async ValueTask FillAsync()
         {
             Debug.Assert(_readAheadTask == null);
 
@@ -1598,7 +1598,7 @@ namespace System.Net.Http
             return bytesToCopy;
         }
 
-        private async Task CopyFromBufferAsync(Stream destination, int count, CancellationToken cancellationToken)
+        private async ValueTask CopyFromBufferAsync(Stream destination, int count, CancellationToken cancellationToken)
         {
             Debug.Assert(count <= _readLength - _readOffset);
 
@@ -1768,7 +1768,7 @@ namespace System.Net.Http
             }
         }
 
-        public async Task DrainResponseAsync(HttpResponseMessage response)
+        public async ValueTask DrainResponseAsync(HttpResponseMessage response)
         {
             Debug.Assert(_inUse);
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -311,7 +311,7 @@ namespace System.Net.Http
 
             // We are at the connection limit. Wait for an available connection or connection count (indicated by null).
             if (NetEventSource.IsEnabled) Trace("Connection limit reached, waiting for available connection.");
-            return new ValueTask<HttpConnection>(waiter.WaitWithCancellationAsync(cancellationToken));
+            return waiter.WaitWithCancellationAsync(cancellationToken);
         }
 
         private async ValueTask<(HttpConnectionBase connection, bool isNewConnection, HttpResponseMessage failureResponse)>

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentReadStream.cs
@@ -29,10 +29,10 @@ namespace System.Net.Http
 
             protected bool IsDisposed => _disposed == 1;
 
-            public virtual Task<bool> DrainAsync(int maxDrainBytes)
+            public virtual ValueTask<bool> DrainAsync(int maxDrainBytes)
             {
                 Debug.Fail($"DrainAsync should not be called for this response stream: {GetType()}");
-                return Task.FromResult(false);
+                return new ValueTask<bool>(false);
             }
 
             protected override void Dispose(bool disposing)

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentWriteStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentWriteStream.cs
@@ -36,7 +36,7 @@ namespace System.Net.Http
 
             public sealed override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken) => throw new NotSupportedException();
 
-            public abstract Task FinishAsync();
+            public abstract ValueTask FinishAsync();
         }
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/TaskCompletionSourceWithCancellation.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/TaskCompletionSourceWithCancellation.cs
@@ -20,7 +20,7 @@ namespace System.Net.Http
             TrySetCanceled(_cancellationToken);
         }
 
-        public async Task<T> WaitWithCancellationAsync(CancellationToken cancellationToken)
+        public async ValueTask<T> WaitWithCancellationAsync(CancellationToken cancellationToken)
         {
             _cancellationToken = cancellationToken;
             using (cancellationToken.UnsafeRegister(s => ((TaskCompletionSourceWithCancellation<T>)s).OnCancellation(), this))

--- a/src/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -765,7 +765,7 @@ namespace System.Net.Security
             ValidateParameters(buffer, offset, count);
 
             SslWriteSync writeAdapter = new SslWriteSync(this);
-            WriteAsyncInternal(writeAdapter, new ReadOnlyMemory<byte>(buffer, offset, count)).GetAwaiter().GetResult();
+            WriteAsyncInternal(writeAdapter, new ReadOnlyMemory<byte>(buffer, offset, count)).AsTask().GetAwaiter().GetResult();
         }
 
         public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback asyncCallback, object asyncState)
@@ -803,7 +803,7 @@ namespace System.Net.Security
         {
             ThrowIfExceptionalOrNotAuthenticated();
             SslWriteAsync writeAdapter = new SslWriteAsync(this, cancellationToken);
-            return new ValueTask(WriteAsyncInternal(writeAdapter, buffer));
+            return WriteAsyncInternal(writeAdapter, buffer);
         }
 
         public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)

--- a/src/System.Net.Security/tests/UnitTests/Fakes/FakeSslStream.Implementation.cs
+++ b/src/System.Net.Security/tests/UnitTests/Fakes/FakeSslStream.Implementation.cs
@@ -37,7 +37,7 @@ namespace System.Net.Security
         {
         }
 
-        private Task WriteAsyncInternal<TWriteAdapter>(TWriteAdapter writeAdapter, ReadOnlyMemory<byte> buffer)
+        private ValueTask WriteAsyncInternal<TWriteAdapter>(TWriteAdapter writeAdapter, ReadOnlyMemory<byte> buffer)
             where TWriteAdapter : struct, ISslWriteAdapter => default;
 
         private ValueTask<int> ReadAsyncInternal<TReadAdapter>(TReadAdapter adapter, Memory<byte> buffer) => default;

--- a/src/System.Net.WebSockets/src/System/Net/WebSockets/WebSocket.cs
+++ b/src/System.Net.WebSockets/src/System/Net/WebSockets/WebSocket.cs
@@ -55,11 +55,11 @@ namespace System.Net.WebSockets
         }
 
         public virtual ValueTask SendAsync(ReadOnlyMemory<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken) =>
-            new ValueTask(MemoryMarshal.TryGetArray(buffer, out ArraySegment<byte> arraySegment) ?
-                SendAsync(arraySegment, messageType, endOfMessage, cancellationToken) :
-                SendWithArrayPoolAsync(buffer, messageType, endOfMessage, cancellationToken));
+            MemoryMarshal.TryGetArray(buffer, out ArraySegment<byte> arraySegment) ?
+                new ValueTask(SendAsync(arraySegment, messageType, endOfMessage, cancellationToken)) :
+                SendWithArrayPoolAsync(buffer, messageType, endOfMessage, cancellationToken);
 
-        private async Task SendWithArrayPoolAsync(
+        private async ValueTask SendWithArrayPoolAsync(
             ReadOnlyMemory<byte> buffer,
             WebSocketMessageType messageType,
             bool endOfMessage,

--- a/src/System.Runtime.Extensions/src/System/IO/BufferedStream.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/BufferedStream.cs
@@ -431,7 +431,7 @@ namespace System.IO
             _stream.Flush();
         }
 
-        private async Task FlushWriteAsync(CancellationToken cancellationToken)
+        private async ValueTask FlushWriteAsync(CancellationToken cancellationToken)
         {
             Debug.Assert(_stream != null);
             Debug.Assert(_readPos == 0 && _readLen == 0,
@@ -1117,7 +1117,7 @@ namespace System.IO
             }
 
             // Delegate to the async implementation.
-            return new ValueTask(WriteToUnderlyingStreamAsync(buffer, cancellationToken, semaphoreLockTask));
+            return WriteToUnderlyingStreamAsync(buffer, cancellationToken, semaphoreLockTask);
         }
 
         /// <summary>BufferedStream should be as thin a wrapper as possible. We want WriteAsync to delegate to
@@ -1125,7 +1125,7 @@ namespace System.IO
         /// in terms of the other. This allows BufferedStream to affect the semantics of the stream it wraps as
         /// little as possible.
         /// </summary>
-        private async Task WriteToUnderlyingStreamAsync(
+        private async ValueTask WriteToUnderlyingStreamAsync(
             ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken, Task semaphoreLockTask)
         {
             Debug.Assert(_stream != null);

--- a/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/CryptoStream.cs
+++ b/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/CryptoStream.cs
@@ -101,9 +101,9 @@ namespace System.Security.Cryptography
         // byte[] ciphertext = ms.ToArray();
         // cs.Close();
         public void FlushFinalBlock() =>
-            FlushFinalBlockAsync(useAsync: false).GetAwaiter().GetResult();
+            FlushFinalBlockAsync(useAsync: false).AsTask().GetAwaiter().GetResult();
 
-        private async Task FlushFinalBlockAsync(bool useAsync)
+        private async ValueTask FlushFinalBlockAsync(bool useAsync)
         {
             if (_finalBlockTransformed)
                 throw new NotSupportedException(SR.Cryptography_CryptoStream_FlushFinalBlockTwice);
@@ -496,7 +496,7 @@ namespace System.Security.Cryptography
         public override void Write(byte[] buffer, int offset, int count)
         {
             CheckWriteArguments(buffer, offset, count);
-            WriteAsyncCore(buffer, offset, count, default(CancellationToken), useAsync: false).GetAwaiter().GetResult();
+            WriteAsyncCore(buffer, offset, count, default(CancellationToken), useAsync: false).AsTask().GetAwaiter().GetResult();
         }
 
         private void CheckWriteArguments(byte[] buffer, int offset, int count)
@@ -511,7 +511,7 @@ namespace System.Security.Cryptography
                 throw new ArgumentException(SR.Argument_InvalidOffLen);
         }
 
-        private async Task WriteAsyncCore(byte[] buffer, int offset, int count, CancellationToken cancellationToken, bool useAsync)
+        private async ValueTask WriteAsyncCore(byte[] buffer, int offset, int count, CancellationToken cancellationToken, bool useAsync)
         {
             // write <= count bytes to the output stream, transforming as we go.
             // Basic idea: using bytes in the _InputBuffer first, make whole blocks,

--- a/src/System.Threading.Channels/src/System/Threading/Channels/ChannelWriter.cs
+++ b/src/System.Threading.Channels/src/System/Threading/Channels/ChannelWriter.cs
@@ -44,7 +44,7 @@ namespace System.Threading.Channels
                 return
                     cancellationToken.IsCancellationRequested ? new ValueTask(Task.FromCanceled<T>(cancellationToken)) :
                     TryWrite(item) ? default :
-                    new ValueTask(WriteAsyncCore(item, cancellationToken));
+                    WriteAsyncCore(item, cancellationToken);
             }
             catch (Exception e)
             {
@@ -52,7 +52,7 @@ namespace System.Threading.Channels
             }
         }
 
-        private async Task WriteAsyncCore(T innerItem, CancellationToken ct)
+        private async ValueTask WriteAsyncCore(T innerItem, CancellationToken ct)
         {
             while (await WaitToWriteAsync(ct).ConfigureAwait(false))
             {


### PR DESCRIPTION
Requires https://github.com/dotnet/coreclr/pull/26310.

We have some internal and private `async Task` methods that are only ever `await`ed (or returned out to callers via public API).  Today there's no benefit and a small downside to making them `async ValueTask` methods, so we've kept them as `async Task`.  However, if we end up changing the implementation of `async ValueTask` to pool underlying objects, there becomes a potential benefit to using `async ValueTask` for these instead of `async Task`.  This PR changes those in a variety of libraries where we care more about performance and allocations.  There are likely a few more methods we'd want to convert based on profiling, but I believe this represents the bulk of them.

This should only be merged if https://github.com/dotnet/coreclr/pull/26310 is merged and profiling determines that these changes are worthwhile.

cc: @benaadams