### PR TITLE
Correcting baseline numbers here as 5.0 should have higher numbers then 3.1

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -241,7 +241,7 @@
       }
     },
     "Microsoft.VisualBasic.Core": {
-      "BaselineVersion": "10.5.0",
+      "BaselineVersion": "10.6.0",
       "InboxOn": {
         "netcoreapp3.0": "10.0.4.0",
         "uap10.0.16300": "10.0.4.0"

--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -21,14 +21,14 @@
       }
     },
     "Microsoft.Bcl.AsyncInterfaces": {
-      "BaselineVersion": "1.1.0",
+      "BaselineVersion": "1.2.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "1.0.0.0": "1.0.0"
       }
     },
     "Microsoft.Bcl.HashCode": {
-      "BaselineVersion": "1.1.0",
+      "BaselineVersion": "1.2.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "1.0.0.0": "1.0.0"
@@ -117,11 +117,11 @@
       }
     },
     "Microsoft.Diagnostics.Tracing.EventSource.Redist": {
-      "BaselineVersion": "2.2.0",
       "StableVersions": [
         "2.0.0",
         "2.0.1"
       ],
+      "BaselineVersion": "2.3.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "2.0.0.0": "2.0.0",
@@ -155,6 +155,10 @@
         "2.1.4",
         "2.2.0"
       ],
+      "BaselineVersion": "5.0.0",
+      "InboxOn": {}
+    },
+    "Microsoft.NETCore.Platforms.Future": {
       "BaselineVersion": "5.0.0",
       "InboxOn": {}
     },
@@ -201,12 +205,19 @@
       }
     },
     "Microsoft.Private.CoreFx.NETCoreApp": {
+      "BaselineVersion": "5.0.0",
       "InboxOn": {}
     },
     "Microsoft.Private.CoreFx.OOB": {
+      "BaselineVersion": "5.0.0",
+      "InboxOn": {}
+    },
+    "Microsoft.Private.CoreFx.UAP": {
+      "BaselineVersion": "5.0.0",
       "InboxOn": {}
     },
     "Microsoft.Private.PackageBaseline": {
+      "BaselineVersion": "5.0.0",
       "InboxOn": {}
     },
     "Microsoft.VisualBasic": {
@@ -343,6 +354,7 @@
         "2.0.1",
         "2.1.0"
       ],
+      "BaselineVersion": "5.0.0",
       "InboxOn": {}
     },
     "Microsoft.Windows.Compatibility.Shims": {
@@ -357,7 +369,7 @@
         "1.0.0",
         "2.0.0"
       ],
-      "BaselineVersion": "2.2.0",
+      "BaselineVersion": "2.3.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "1.0.0.0": "1.0.0",
@@ -526,6 +538,10 @@
       "BaselineVersion": "5.0.0",
       "InboxOn": {}
     },
+    "runtime.win10-x64.Microsoft.Private.CoreFx.UAP": {
+      "BaselineVersion": "5.0.0",
+      "InboxOn": {}
+    },
     "runtime.win7-x64.runtime.native.System.Data.SqlClient.sni": {
       "StableVersions": [
         "4.0.1",
@@ -540,6 +556,10 @@
         "4.3.0"
       ],
       "BaselineVersion": "4.3.0",
+      "InboxOn": {}
+    },
+    "runtime.win-x64.Microsoft.Private.CoreFx.NETCoreApp": {
+      "BaselineVersion": "5.0.0",
       "InboxOn": {}
     },
     "SMDiagnostics": {
@@ -763,7 +783,7 @@
         "1.4.0",
         "1.5.0"
       ],
-      "BaselineVersion": "1.7.0",
+      "BaselineVersion": "1.8.0",
       "InboxOn": {
         "netcoreapp2.0": "1.2.2.0",
         "netcoreapp2.1": "1.2.3.0",
@@ -1055,7 +1075,7 @@
         "1.1.0",
         "1.2.0"
       ],
-      "BaselineVersion": "1.4.0",
+      "BaselineVersion": "1.5.0",
       "InboxOn": {}
     },
     "System.Composition.AttributedModel": {
@@ -1064,7 +1084,7 @@
         "1.1.0",
         "1.2.0"
       ],
-      "BaselineVersion": "1.4.0",
+      "BaselineVersion": "1.5.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "1.0.31.0": "1.0.31",
@@ -1079,7 +1099,7 @@
         "1.1.0",
         "1.2.0"
       ],
-      "BaselineVersion": "1.3.0",
+      "BaselineVersion": "1.5.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "1.0.31.0": "1.0.31",
@@ -1094,7 +1114,7 @@
         "1.1.0",
         "1.2.0"
       ],
-      "BaselineVersion": "1.4.0",
+      "BaselineVersion": "1.5.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "1.0.31.0": "1.0.31",
@@ -1109,7 +1129,7 @@
         "1.1.0",
         "1.2.0"
       ],
-      "BaselineVersion": "1.4.0",
+      "BaselineVersion": "1.5.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "1.0.31.0": "1.0.31",
@@ -1124,7 +1144,7 @@
         "1.1.0",
         "1.2.0"
       ],
-      "BaselineVersion": "1.4.0",
+      "BaselineVersion": "1.5.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "1.0.31.0": "1.0.31",
@@ -3173,7 +3193,7 @@
       "StableVersions": [
         "0.1.0"
       ],
-      "BaselineVersion": "0.3.0",
+      "BaselineVersion": "0.4.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "0.1.0.0": "0.1.0",
@@ -3436,7 +3456,7 @@
         "4.0.1",
         "4.3.0"
       ],
-      "BaselineVersion": "4.3.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "netcoreapp2.0": "4.0.3.0",
         "netcoreapp3.0": "4.1.0.0",
@@ -3463,7 +3483,7 @@
         "4.0.1",
         "4.3.0"
       ],
-      "BaselineVersion": "4.3.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "netcoreapp2.0": "4.0.3.0",
         "netcoreapp3.0": "4.1.0.0",
@@ -3534,7 +3554,7 @@
         "1.5.0",
         "1.6.0"
       ],
-      "BaselineVersion": "1.8.0",
+      "BaselineVersion": "1.9.0",
       "InboxOn": {
         "netcoreapp2.0": "1.4.2.0",
         "netcoreapp2.1": "1.4.3.0",
@@ -4954,9 +4974,9 @@
       ],
       "BaselineVersion": "5.0.0",
       "InboxOn": {
+        "netcoreapp3.0": "4.1.2.0",
         "monoandroid10": "Any",
         "monotouch10": "Any",
-        "netcoreapp3.0": "4.1.2.0",
         "uap10.0.16299": "4.1.1.0",
         "uap10.0.16300": "4.1.2.0",
         "xamarinios10": "Any",
@@ -5156,7 +5176,7 @@
       ],
       "BaselineVersion": "5.0.0",
         "InboxOn": {
-          "netcoreapp3.0":  "4.0.1.0"
+        "netcoreapp3.0": "4.0.1.0"
         },
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.5.0",

--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -158,10 +158,6 @@
       "BaselineVersion": "5.0.0",
       "InboxOn": {}
     },
-    "Microsoft.NETCore.Platforms.Future": {
-      "BaselineVersion": "5.0.0",
-      "InboxOn": {}
-    },
     "Microsoft.NETCore.Targets": {
       "StableVersions": [
         "1.0.0",
@@ -203,22 +199,6 @@
       "InboxOn": {
         "wp8": "8.0.0.0"
       }
-    },
-    "Microsoft.Private.CoreFx.NETCoreApp": {
-      "BaselineVersion": "5.0.0",
-      "InboxOn": {}
-    },
-    "Microsoft.Private.CoreFx.OOB": {
-      "BaselineVersion": "5.0.0",
-      "InboxOn": {}
-    },
-    "Microsoft.Private.CoreFx.UAP": {
-      "BaselineVersion": "5.0.0",
-      "InboxOn": {}
-    },
-    "Microsoft.Private.PackageBaseline": {
-      "BaselineVersion": "5.0.0",
-      "InboxOn": {}
     },
     "Microsoft.VisualBasic": {
       "StableVersions": [
@@ -347,15 +327,6 @@
         "4.0.0.0": "4.5.0",
         "4.0.1.0": "4.6.0"
       }
-    },
-    "Microsoft.Windows.Compatibility": {
-      "StableVersions": [
-        "2.0.0",
-        "2.0.1",
-        "2.1.0"
-      ],
-      "BaselineVersion": "5.0.0",
-      "InboxOn": {}
     },
     "Microsoft.Windows.Compatibility.Shims": {
       "StableVersions": [
@@ -535,30 +506,6 @@
       "InboxOn": {}
     },
     "runtime.native.System.IO.Ports": {
-      "BaselineVersion": "5.0.0",
-      "InboxOn": {}
-    },
-    "runtime.win10-x64.Microsoft.Private.CoreFx.UAP": {
-      "BaselineVersion": "5.0.0",
-      "InboxOn": {}
-    },
-    "runtime.win7-x64.runtime.native.System.Data.SqlClient.sni": {
-      "StableVersions": [
-        "4.0.1",
-        "4.3.0"
-      ],
-      "BaselineVersion": "4.3.0",
-      "InboxOn": {}
-    },
-    "runtime.win7-x86.runtime.native.System.Data.SqlClient.sni": {
-      "StableVersions": [
-        "4.0.1",
-        "4.3.0"
-      ],
-      "BaselineVersion": "4.3.0",
-      "InboxOn": {}
-    },
-    "runtime.win-x64.Microsoft.Private.CoreFx.NETCoreApp": {
       "BaselineVersion": "5.0.0",
       "InboxOn": {}
     },

--- a/src/Microsoft.Bcl.AsyncInterfaces/Directory.Build.props
+++ b/src/Microsoft.Bcl.AsyncInterfaces/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>1.1.0</PackageVersion>
+    <PackageVersion>1.2.0</PackageVersion>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <!-- This assembly should never be placed inbox as it is only for downlevel compatibility. -->

--- a/src/Microsoft.Bcl.HashCode/Directory.Build.props
+++ b/src/Microsoft.Bcl.HashCode/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>1.1.0</PackageVersion>
+    <PackageVersion>1.2.0</PackageVersion>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <!-- This assembly should never be placed inbox as it is only for downlevel compatibility. -->

--- a/src/Microsoft.Diagnostics.Tracing.EventSource.Redist/Directory.Build.props
+++ b/src/Microsoft.Diagnostics.Tracing.EventSource.Redist/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>2.2.0</PackageVersion>
+    <PackageVersion>2.3.0</PackageVersion>
     <AssemblyVersion>2.0.2.0</AssemblyVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/Microsoft.VisualBasic.Core/Directory.Build.props
+++ b/src/Microsoft.VisualBasic.Core/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>10.5.0</PackageVersion>
+    <PackageVersion>10.6.0</PackageVersion>
     <AssemblyVersion>10.0.4.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IsNETCoreApp>true</IsNETCoreApp>

--- a/src/Microsoft.XmlSerializer.Generator/Directory.Build.props
+++ b/src/Microsoft.XmlSerializer.Generator/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>2.2.0</PackageVersion>
+    <PackageVersion>2.3.0</PackageVersion>
     <SkipValidatePackage>true</SkipValidatePackage>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <AssemblyFileVersion>$(AssemblyVersion)</AssemblyFileVersion>

--- a/src/System.Collections.Immutable/Directory.Build.props
+++ b/src/System.Collections.Immutable/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>1.7.0</PackageVersion>
+    <PackageVersion>1.8.0</PackageVersion>
     <AssemblyVersion>1.2.4.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IsNETCoreApp>true</IsNETCoreApp>

--- a/src/System.Composition/Directory.Build.props
+++ b/src/System.Composition/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>1.4.0</PackageVersion>
+    <PackageVersion>1.5.0</PackageVersion>
     <AssemblyVersion>1.0.34.0</AssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/src/System.Numerics.Tensors/Directory.Build.props
+++ b/src/System.Numerics.Tensors/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>0.3.0</PackageVersion>
+    <PackageVersion>0.4.0</PackageVersion>
     <AssemblyVersion>0.2.0.0</AssemblyVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <!-- This is a preview package. Do not mark as stable. -->

--- a/src/System.Reflection.Metadata/Directory.Build.props
+++ b/src/System.Reflection.Metadata/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>1.8.0</PackageVersion>
+    <PackageVersion>1.9.0</PackageVersion>
     <AssemblyVersion>1.4.4.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IsNETCoreApp>true</IsNETCoreApp>


### PR DESCRIPTION
The package.Index file is generated by editing the updateRootPackageIndex target
- Get All the .nupkg package from shipping and non-shipping folder
- Get the packageId and Version of the .nupkg
- treat them as they are provided by user as baselinePackages itemgroup

```c#
foreach (var packageFolder in PackageFolders.NullAsEmpty().Select(f => f.GetMetadata("FullPath")))
{
    var nupkgs = Directory.EnumerateFiles(packageFolder, "*.nupkg", SearchOption.TopDirectoryOnly);

    if (nupkgs.Any())
    {
        foreach (var nupkg in nupkgs)
        {
            using (var reader = new PackageArchiveReader(nupkg))
            {
                var identity = reader.GetIdentity();
                Log.LogMessage($"Updating from {nupkg}.");
                var info = GetOrCreatePackageInfo(index, identity.Id);
                info.BaselineVersion = Version.Parse(identity.Version.Major.ToString() +"." + identity.Version.Minor.ToString()+ "."+ identity.Version.Revision.ToString());
            }
        }
    }
}
```

@ericstj  is it worth adding this functionality to updatePackage task ? currently the packageFolders just update the assembly version and the relationship between package version and assembly version.