### PR TITLE
Reconfigure terminal for Console usage even if only one of stdin/stdout was used by the child

### DIFF
--- a/src/Native/Unix/System.Native/pal_console.c
+++ b/src/Native/Unix/System.Native/pal_console.c
@@ -192,7 +192,7 @@ static bool ConfigureTerminal(bool signalForBreak, bool forChild, uint8_t minCha
         if (g_currentTermios.c_lflag == termios.c_lflag &&
             g_currentTermios.c_iflag == termios.c_iflag &&
             g_currentTermios.c_cc[VMIN] == termios.c_cc[VMIN] &&
-            g_currentTermios.c_cc[VMIN] == termios.c_cc[VMIN])
+            g_currentTermios.c_cc[VTIME] == termios.c_cc[VTIME])
         {
             return true;
         }

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
@@ -398,7 +398,9 @@ namespace System.Diagnostics
             // Unix applications expect the terminal to be in an echoing state by default.
             // To support processes that interact with the terminal (e.g. 'vi'), we need to configure the
             // terminal to echo. We keep this configuration as long as there are children possibly using the terminal.
-            bool usesTerminal = !startInfo.RedirectStandardInput || !startInfo.RedirectStandardOutput;
+            bool usesTerminal = !(startInfo.RedirectStandardInput &&
+                                  startInfo.RedirectStandardOutput &&
+                                  startInfo.RedirectStandardError);
 
             if (startInfo.UseShellExecute)
             {

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
@@ -398,8 +398,7 @@ namespace System.Diagnostics
             // Unix applications expect the terminal to be in an echoing state by default.
             // To support processes that interact with the terminal (e.g. 'vi'), we need to configure the
             // terminal to echo. We keep this configuration as long as there are children possibly using the terminal.
-            // We consider the child to be interactively using the terminal when both stdin and stdout are connected.
-            bool usesTerminal = !startInfo.RedirectStandardInput && !startInfo.RedirectStandardOutput;
+            bool usesTerminal = !startInfo.RedirectStandardInput || !startInfo.RedirectStandardOutput;
 
             if (startInfo.UseShellExecute)
             {


### PR DESCRIPTION
Process: Unix: ensure we reconfigure the terminal for Console usage if only one of stdin/stdout was used by the child.
Console: Unix: Fix cache check for VTIME (read timeout).

Fixes https://github.com/dotnet/corefx/issues/40557