### PR TITLE
Directory move fix

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/Directory.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Directory.cs
@@ -285,6 +285,11 @@ namespace System.IO
             if (!FileSystem.DirectoryExists(fullsourceDirName) && !FileSystem.FileExists(fullsourceDirName))
                 throw new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, fullsourceDirName));
 
+            // As our Linux x86/x64 builds won't throw an exception for a directory already existing
+            // we do a case sensitive compare here to ensure.
+            if (Directory.Exists(fulldestDirName) && GetDirectories(fulldestDirName, Path.GetFileName(fulldestDirName)).Any())
+                throw new IOException((SR.Format(SR.IO_AlreadyExists_Name, fulldestDirName)));
+
             FileSystem.MoveDirectory(fullsourceDirName, fulldestDirName);
         }
 

--- a/src/System.IO.FileSystem/src/System/IO/Directory.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Directory.cs
@@ -280,7 +280,6 @@ namespace System.IO
                 && string.Equals(sourcePath, destPath, StringComparison.Ordinal))
                 throw new IOException(SR.IO_SourceDestMustBeDifferent);
 
-
             string sourceRoot = Path.GetPathRoot(sourcePath);
             string destinationRoot = Path.GetPathRoot(destPath);
             // Don't check the paths if we already determined the paths are identical.

--- a/src/System.IO.FileSystem/src/System/IO/Directory.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Directory.cs
@@ -285,9 +285,18 @@ namespace System.IO
             if (!FileSystem.DirectoryExists(fullsourceDirName) && !FileSystem.FileExists(fullsourceDirName))
                 throw new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, fullsourceDirName));
 
+
+            string destinationDirectoryName = Path.GetFileName(destDirName);
+            // Here we have a bool to check if they're equal, but with different casing
+            // We allowing moving foo to the same directory, but renaming with a different case.
+            bool sameDirectoryWithDifferentCasing =
+                string.Equals(sourcePath, destPath, StringComparison.OrdinalIgnoreCase);
+
             // As our Linux x86/x64 builds won't throw an exception for a directory already existing
             // we do a case sensitive compare here to ensure.
-            if (Directory.Exists(fulldestDirName) && GetDirectories(fulldestDirName, Path.GetFileName(fulldestDirName)).Any())
+            // this is so if we move /foo to bar/fOO it fails.
+            if (!sameDirectoryWithDifferentCasing && FileSystem.DirectoryExists(fulldestDirName)
+                && GetDirectories(Path.GetDirectoryName(fulldestDirName)).Any(dir => dir.Equals(fulldestDirName, StringComparison.OrdinalIgnoreCase)))
                 throw new IOException((SR.Format(SR.IO_AlreadyExists_Name, fulldestDirName)));
 
             FileSystem.MoveDirectory(fullsourceDirName, fulldestDirName);

--- a/src/System.IO.FileSystem/src/System/IO/Directory.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Directory.cs
@@ -264,16 +264,12 @@ namespace System.IO
 
             string fullsourceDirName = Path.GetFullPath(sourceDirName);
             string sourcePath = PathInternal.EnsureTrailingSeparator(fullsourceDirName);
-            string sourceDirectoryName = Path.GetFileName(fullsourceDirName);
 
             string fulldestDirName = Path.GetFullPath(destDirName);
             string destPath = PathInternal.EnsureTrailingSeparator(fulldestDirName);
-            string destDirectoryName = Path.GetFileName(fulldestDirName);
 
             bool sameDirectoryIgnoreCase =
-                string.Equals(sourcePath, destPath, StringComparison.OrdinalIgnoreCase);
-            bool sameDirectoryNameIgnoreCase
-                = !string.IsNullOrEmpty(sourceDirectoryName) && string.Equals(sourceDirectoryName, destDirectoryName, StringComparison.OrdinalIgnoreCase);
+                string.Equals(sourcePath, destPath, StringComparison.OrdinalIgnoreCase);;
 
             // If the paths are the exact same, fail.
             if (sameDirectoryIgnoreCase
@@ -296,33 +292,11 @@ namespace System.IO
                 && FileSystem.DirectoryExists(fulldestDirName))
                 throw new IOException(SR.Format(SR.IO_AlreadyExists_Name, fulldestDirName));
 
-            if (!sameDirectoryIgnoreCase
-                && sameDirectoryNameIgnoreCase
-                && ContainsDirectory(Path.GetDirectoryName(fulldestDirName), destDirectoryName))
+            // If the direcotires aren't the same and the OS says the directory exists already, fail.
+            if (!sameDirectoryIgnoreCase && Directory.Exists(fulldestDirName))
                 throw new IOException(SR.Format(SR.IO_AlreadyExists_Name, fulldestDirName));
 
             FileSystem.MoveDirectory(fullsourceDirName, fulldestDirName);
-        }
-
-        private static bool ContainsDirectory(string fullPath, string directoryName) => ContainsDirectory(fullPath, directoryName, StringComparison.OrdinalIgnoreCase);
-
-        private static bool ContainsDirectory(string fullPath, string directoryName, StringComparison stringComparison)
-        {
-            string[] directories = GetDirectories(fullPath);
-            if (directories.Length == 0)
-            {
-                return false;
-            }
-
-            foreach (string directory in directories)
-            {
-                if (Path.GetFileName(Path.GetFullPath(directory)).Equals(directoryName, stringComparison))
-                {
-                    return true;
-                }
-            }
-
-            return false;
         }
 
         public static void Delete(string path)

--- a/src/System.IO.FileSystem/src/System/IO/Directory.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Directory.cs
@@ -269,7 +269,7 @@ namespace System.IO
             string destPath = PathInternal.EnsureTrailingSeparator(fulldestDirName);
 
             bool sameDirectoryIgnoreCase =
-                string.Equals(sourcePath, destPath, StringComparison.OrdinalIgnoreCase);;
+                string.Equals(sourcePath, destPath, StringComparison.OrdinalIgnoreCase);
 
             // If the paths are the exact same, fail.
             if (sameDirectoryIgnoreCase

--- a/src/System.IO.FileSystem/src/System/IO/Directory.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Directory.cs
@@ -270,12 +270,13 @@ namespace System.IO
 
             // Here we have a bool to check if they're equal, but with different casing
             // We allowing moving foo to the same directory, but renaming with a different case.
-            bool sameDirectoryWithDifferentCasing =
+            bool sameDirectoryIgnoreCase =
                 string.Equals(sourcePath, destPath, StringComparison.OrdinalIgnoreCase);
 
-            StringComparison pathComparison = PathInternal.StringComparison;
+            StringComparison pathComparison = StringComparison.Ordinal;
 
-            if (!sameDirectoryWithDifferentCasing
+            // If the paths are the exact same, fail.
+            if (sameDirectoryIgnoreCase
                 && string.Equals(sourcePath, destPath, pathComparison))
             {
                 throw new IOException(SR.IO_SourceDestMustBeDifferent);
@@ -294,7 +295,7 @@ namespace System.IO
             if (!FileSystem.DirectoryExists(fullsourceDirName) && !FileSystem.FileExists(fullsourceDirName))
                 throw new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, fullsourceDirName));
 
-            if (!sameDirectoryWithDifferentCasing
+            if (!sameDirectoryIgnoreCase
                 && FileSystem.DirectoryExists(fulldestDirName))
             {
                 throw new IOException(SR.Format(SR.IO_AlreadyExists_Name, fulldestDirName));

--- a/src/System.IO.FileSystem/src/System/IO/Directory.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Directory.cs
@@ -280,7 +280,7 @@ namespace System.IO
 
             string sourceRoot = Path.GetPathRoot(sourcePath);
             string destinationRoot = Path.GetPathRoot(destPath);
-            if (!string.Equals(sourceRoot, destinationRoot, PathInternal.StringComparison))
+            if (!string.Equals(sourceRoot, destinationRoot, StringComparison.OrdinalIgnoreCase))
                 throw new IOException(SR.IO_SourceDestMustHaveSameRoot);
 
             // Windows will throw if the source file/directory doesn't exist, we preemptively check

--- a/src/System.IO.FileSystem/src/System/IO/Directory.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Directory.cs
@@ -300,7 +300,7 @@ namespace System.IO
             // If the directory names are the same ignoring case
             // See if the source dest folder contains any directory with that name.
             if (sameDirectoryNameIgnoreCase
-                && GetDirectories(Path.GetDirectoryName(destPath)).Any(dir => dir.Equals(destDirectoryName, StringComparison.OrdinalIgnoreCase)))
+                && GetDirectories(destPath).Any(dir => Path.GetFileName(dir).Equals(destDirectoryName, StringComparison.OrdinalIgnoreCase)))
                 throw new IOException(SR.Format(SR.IO_AlreadyExists_Name, fulldestDirName));
 
             FileSystem.MoveDirectory(fullsourceDirName, fulldestDirName);

--- a/src/System.IO.FileSystem/src/System/IO/Directory.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Directory.cs
@@ -273,7 +273,7 @@ namespace System.IO
             bool sameDirectoryIgnoreCase =
                 string.Equals(sourcePath, destPath, StringComparison.OrdinalIgnoreCase);
             bool sameDirectoryNameIgnoreCase
-                = string.Equals(sourceDirectoryName, destDirectoryName, StringComparison.OrdinalIgnoreCase);
+                = !string.IsNullOrEmpty(sourceDirectoryName) && string.Equals(sourceDirectoryName, destDirectoryName, StringComparison.OrdinalIgnoreCase);
 
             // If the paths are the exact same, fail.
             if (sameDirectoryIgnoreCase

--- a/src/System.IO.FileSystem/src/System/IO/Directory.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Directory.cs
@@ -264,7 +264,7 @@ namespace System.IO
 
             string fullsourceDirName = Path.GetFullPath(sourceDirName);
             string sourcePath = PathInternal.EnsureTrailingSeparator(fullsourceDirName);
-            string sourceDirectoryName = Path.GetFileName(sourcePath);
+            string sourceDirectoryName = Path.GetFileName(fullsourceDirName);
 
             string fulldestDirName = Path.GetFullPath(destDirName);
             string destPath = PathInternal.EnsureTrailingSeparator(fulldestDirName);

--- a/src/System.IO.FileSystem/src/System/IO/Directory.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Directory.cs
@@ -278,7 +278,8 @@ namespace System.IO
 
             string sourceRoot = Path.GetPathRoot(sourcePath);
             string destinationRoot = Path.GetPathRoot(destPath);
-            // Don't check the paths if we already determined the paths are identical.
+
+            // Compare paths for the same, skip this step if we already know the paths are identical.
             if (!sameDirectoryIgnoreCase &&
                 !string.Equals(sourceRoot, destinationRoot, StringComparison.OrdinalIgnoreCase))
                 throw new IOException(SR.IO_SourceDestMustHaveSameRoot);

--- a/src/System.IO.FileSystem/src/System/IO/Directory.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Directory.cs
@@ -317,7 +317,7 @@ namespace System.IO
 
             foreach (string directory in directories)
             {
-                if (Path.GetFileName(directory).Equals(directoryName, stringComparison))
+                if (Path.GetFileName(Path.GetFullPath(directory)).Equals(directoryName, stringComparison))
                 {
                     return true;
                 }

--- a/src/System.IO.FileSystem/src/System/IO/Directory.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Directory.cs
@@ -300,7 +300,7 @@ namespace System.IO
             // If the directory names are the same ignoring case
             // See if the source dest folder contains any directory with that name.
             if (sameDirectoryNameIgnoreCase
-                && GetDirectories(Path.GetDirectoryName(fulldestDirName)).Any(dir => dir.Equals(destDirectoryName, StringComparison.OrdinalIgnoreCase)))
+                && GetDirectories(Path.GetDirectoryName(destPath)).Any(dir => dir.Equals(destDirectoryName, StringComparison.OrdinalIgnoreCase)))
                 throw new IOException(SR.Format(SR.IO_AlreadyExists_Name, fulldestDirName));
 
             FileSystem.MoveDirectory(fullsourceDirName, fulldestDirName);

--- a/src/System.IO.FileSystem/src/System/IO/Directory.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Directory.cs
@@ -268,38 +268,29 @@ namespace System.IO
             string fulldestDirName = Path.GetFullPath(destDirName);
             string destPath = PathInternal.EnsureTrailingSeparator(fulldestDirName);
 
-            // Here we have a bool to check if they're equal, but with different casing
-            // We allowing moving foo to the same directory, but renaming with a different case.
             bool sameDirectoryIgnoreCase =
                 string.Equals(sourcePath, destPath, StringComparison.OrdinalIgnoreCase);
 
-            StringComparison pathComparison = StringComparison.Ordinal;
 
             // If the paths are the exact same, fail.
             if (sameDirectoryIgnoreCase
-                && string.Equals(sourcePath, destPath, pathComparison))
-            {
+                && string.Equals(sourcePath, destPath, StringComparison.Ordinal))
                 throw new IOException(SR.IO_SourceDestMustBeDifferent);
-            }
 
 
             string sourceRoot = Path.GetPathRoot(sourcePath);
             string destinationRoot = Path.GetPathRoot(destPath);
-            if (!string.Equals(sourceRoot, destinationRoot, pathComparison))
-            {
+            if (!string.Equals(sourceRoot, destinationRoot, PathInternal.StringComparison))
                 throw new IOException(SR.IO_SourceDestMustHaveSameRoot);
-            }
 
             // Windows will throw if the source file/directory doesn't exist, we preemptively check
             // to make sure our cross platform behavior matches NetFX behavior.
             if (!FileSystem.DirectoryExists(fullsourceDirName) && !FileSystem.FileExists(fullsourceDirName))
                 throw new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, fullsourceDirName));
 
-            if (!sameDirectoryIgnoreCase
+            if (!sameDirectoryIgnoreCase // This check is to allowing renaming of directories
                 && FileSystem.DirectoryExists(fulldestDirName))
-            {
                 throw new IOException(SR.Format(SR.IO_AlreadyExists_Name, fulldestDirName));
-            }
 
             FileSystem.MoveDirectory(fullsourceDirName, fulldestDirName);
         }

--- a/src/System.IO.FileSystem/src/System/IO/Directory.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Directory.cs
@@ -268,7 +268,9 @@ namespace System.IO
             string fulldestDirName = Path.GetFullPath(destDirName);
             string destPath = PathInternal.EnsureTrailingSeparator(fulldestDirName);
 
-            StringComparison pathComparison = PathInternal.StringComparison;
+            // As we're moving a directory, case sensitivty should be ordinal
+            // even on a case-sensitive/case-preserving file system moving foo to FOO should still work.
+            StringComparison pathComparison = StringComparison.Ordinal;
 
             if (string.Equals(sourcePath, destPath, pathComparison))
                 throw new IOException(SR.IO_SourceDestMustBeDifferent);
@@ -282,9 +284,6 @@ namespace System.IO
             // to make sure our cross platform behavior matches NetFX behavior.
             if (!FileSystem.DirectoryExists(fullsourceDirName) && !FileSystem.FileExists(fullsourceDirName))
                 throw new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, fullsourceDirName));
-
-            if (FileSystem.DirectoryExists(fulldestDirName))
-                throw new IOException(SR.Format(SR.IO_AlreadyExists_Name, fulldestDirName));
 
             FileSystem.MoveDirectory(fullsourceDirName, fulldestDirName);
         }

--- a/src/System.IO.FileSystem/src/System/IO/Directory.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Directory.cs
@@ -297,13 +297,33 @@ namespace System.IO
                 && FileSystem.DirectoryExists(fulldestDirName))
                 throw new IOException(SR.Format(SR.IO_AlreadyExists_Name, fulldestDirName));
 
-            // If the directory names are the same ignoring case
-            // See if the source dest folder contains any directory with that name.
-            if (sameDirectoryNameIgnoreCase
-                && GetDirectories(destPath).Any(dir => Path.GetFileName(dir).Equals(destDirectoryName, StringComparison.OrdinalIgnoreCase)))
+            if (!sameDirectoryIgnoreCase
+                && sameDirectoryNameIgnoreCase
+                && ContainsDirectory(Path.GetDirectoryName(fulldestDirName), destDirectoryName))
                 throw new IOException(SR.Format(SR.IO_AlreadyExists_Name, fulldestDirName));
 
             FileSystem.MoveDirectory(fullsourceDirName, fulldestDirName);
+        }
+
+        private static bool ContainsDirectory(string fullPath, string directoryName) => ContainsDirectory(fullPath, directoryName, StringComparison.OrdinalIgnoreCase);
+
+        private static bool ContainsDirectory(string fullPath, string directoryName, StringComparison stringComparison)
+        {
+            string[] directories = GetDirectories(fullPath);
+            if (directories.Length == 0)
+            {
+                return false;
+            }
+
+            foreach (string directory in directories)
+            {
+                if (Path.GetFileName(directory).Equals(directoryName, stringComparison))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         public static void Delete(string path)

--- a/src/System.IO.FileSystem/src/System/IO/Directory.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Directory.cs
@@ -277,7 +277,7 @@ namespace System.IO
             bool sameDirectoryDifferentCase = directoriesAreCaseVariants
                                                 && string.Equals(destDirNameFromFullPath, sourceDirNameFromFullPath, fileSystemSensitivity);
 
-            // If the destination directories are the exact same name,
+            // If the destination directories are the exact same name
             if (!sameDirectoryDifferentCase
                 && string.Equals(sourcePath, destPath, fileSystemSensitivity))
                 throw new IOException(SR.IO_SourceDestMustBeDifferent);

--- a/src/System.IO.FileSystem/src/System/IO/Directory.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Directory.cs
@@ -298,7 +298,7 @@ namespace System.IO
                 && FileSystem.DirectoryExists(fulldestDirName))
                 throw new IOException(SR.Format(SR.IO_AlreadyExists_Name, fulldestDirName));
 
-            // If the direcotires aren't the same and the OS says the directory exists already, fail.
+            // If the directories aren't the same and the OS says the directory exists already, fail.
             if (!sameDirectoryDifferentCase && Directory.Exists(fulldestDirName))
                 throw new IOException(SR.Format(SR.IO_AlreadyExists_Name, fulldestDirName));
 

--- a/src/System.IO.FileSystem/src/System/IO/FileSystem.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileSystem.Windows.cs
@@ -336,6 +336,9 @@ namespace System.IO
                 if (errorCode == Interop.Errors.ERROR_FILE_NOT_FOUND)
                     throw Win32Marshal.GetExceptionForWin32Error(Interop.Errors.ERROR_PATH_NOT_FOUND, sourceFullPath);
 
+                if (errorCode == Interop.Errors.ERROR_ALREADY_EXISTS)
+                    throw Win32Marshal.GetExceptionForWin32Error(Interop.Errors.ERROR_ALREADY_EXISTS, sourceFullPath);
+
                 // This check was originally put in for Win9x (unfortunately without special casing it to be for Win9x only). We can't change the NT codepath now for backcomp reasons.
                 if (errorCode == Interop.Errors.ERROR_ACCESS_DENIED) // WinNT throws IOException. This check is for Win9x. We can't change it for backcomp.
                     throw new IOException(SR.Format(SR.UnauthorizedAccess_IODenied_Path, sourceFullPath), Win32Marshal.MakeHRFromErrorCode(errorCode));

--- a/src/System.IO.FileSystem/src/System/IO/FileSystem.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileSystem.Windows.cs
@@ -337,7 +337,7 @@ namespace System.IO
                     throw Win32Marshal.GetExceptionForWin32Error(Interop.Errors.ERROR_PATH_NOT_FOUND, sourceFullPath);
 
                 if (errorCode == Interop.Errors.ERROR_ALREADY_EXISTS)
-                    throw Win32Marshal.GetExceptionForWin32Error(Interop.Errors.ERROR_ALREADY_EXISTS, sourceFullPath);
+                    throw Win32Marshal.GetExceptionForWin32Error(Interop.Errors.ERROR_ALREADY_EXISTS, destFullPath);
 
                 // This check was originally put in for Win9x (unfortunately without special casing it to be for Win9x only). We can't change the NT codepath now for backcomp reasons.
                 if (errorCode == Interop.Errors.ERROR_ACCESS_DENIED) // WinNT throws IOException. This check is for Win9x. We can't change it for backcomp.

--- a/src/System.IO.FileSystem/tests/Directory/Move.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Move.cs
@@ -303,7 +303,6 @@ namespace System.IO.Tests
             Directory.CreateDirectory($"{TestDirectory}/bar/FOO");
             Directory.CreateDirectory($"{TestDirectory}/foo");
             Assert.True(Directory.Exists($"{TestDirectory}/bar/foo"));
-            Assert.True(Directory.Exists($"{TestDirectory}/bar/FOO"));
         }
 
         [ConditionalFact(nameof(AreAllLongPathsAvailable))]

--- a/src/System.IO.FileSystem/tests/Directory/Move.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Move.cs
@@ -293,7 +293,8 @@ namespace System.IO.Tests
         {
             Directory.CreateDirectory($"{TestDirectory}/FOO");
             Directory.CreateDirectory($"{TestDirectory}/bar/foo");
-            Assert.True(Directory.Exists($"{TestDirectory}/bar/foo"));
+            Directory.Move(Path.Combine(TestDirectory, "FOO"), Path.Combine(TestDirectory, "bar", "foo"));
+            Assert.True(Directory.Exists($"{TestDirectory}/bar/FOO"));
         }
 
         [Fact]
@@ -302,6 +303,7 @@ namespace System.IO.Tests
         {
             Directory.CreateDirectory($"{TestDirectory}/bar/FOO");
             Directory.CreateDirectory($"{TestDirectory}/foo");
+            Directory.Move(Path.Combine(TestDirectory, "foo"), Path.Combine(TestDirectory, "bar", "foo"));
             Assert.True(Directory.Exists($"{TestDirectory}/bar/foo"));
         }
 

--- a/src/System.IO.FileSystem/tests/Directory/Move.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Move.cs
@@ -240,7 +240,7 @@ namespace System.IO.Tests
             var fooDirectoryPath = Path.Combine(Directory.GetCurrentDirectory(), "foo");
             File.WriteAllText(Path.Combine(fooDirectoryPath, "bar.txt"), string.Empty);
             Directory.Move("foo", "FOO");
-            var firstFile = Directory.GetFiles(fooDirectoryPath);
+            var firstFile = Directory.GetFiles(Path.Combine(Directory.GetCurrentDirectory(), "FOO"));
             Assert.Equal("bar.txt", Path.GetFileName(firstFile[0]));
         }
 
@@ -261,7 +261,7 @@ namespace System.IO.Tests
             var fooDirectoryPath = Path.Combine(Directory.GetCurrentDirectory(), "foo");
             Directory.CreateDirectory(Path.Combine(fooDirectoryPath, "bar"));
             Directory.Move("foo", "FOO");
-            var firstFile = Directory.GetDirectories(fooDirectoryPath);
+            var firstFile = Directory.GetDirectories(Path.Combine(Directory.GetCurrentDirectory(), "FOO"));
             Assert.Equal("bar", Path.GetFileName(firstFile[0]));
         }
 

--- a/src/System.IO.FileSystem/tests/Directory/Move.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Move.cs
@@ -243,22 +243,6 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public void MoveDirectory_FailToMoveDirectoryWithUpperCaseToOtherDirectoryWithLowerCase()
-        {
-            Directory.CreateDirectory($"{TestDirectory}/FOO");
-            Directory.CreateDirectory($"{TestDirectory}/bar/foo");
-            Assert.Throws<IOException>(() => Directory.Move($"{TestDirectory}/FOO", $"{TestDirectory}/bar/foo"));
-        }
-
-        [Fact]
-        public void MoveDirectory_FailToMoveLowerCaseDirectoryWhenUpperCaseDirectoryExists()
-        {
-            Directory.CreateDirectory($"{TestDirectory}/bar/FOO");
-            Directory.CreateDirectory($"{TestDirectory}/foo");
-            Assert.Throws<IOException>(() => Directory.Move($"{TestDirectory}/foo", $"{TestDirectory}/bar/foo"));
-        }
-
-        [Fact]
         public void MoveDirectory_WithDifferentRootCase()
         {
             Directory.CreateDirectory($"{TestDirectory}/bar");
@@ -284,6 +268,43 @@ namespace System.IO.Tests
         #endregion
 
         #region PlatformSpecific
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void MoveDirectory_FailToMoveDirectoryWithUpperCaseToOtherDirectoryWithLowerCase()
+        {
+            Directory.CreateDirectory($"{TestDirectory}/FOO");
+            Directory.CreateDirectory($"{TestDirectory}/bar/foo");
+            Assert.Throws<IOException>(() => Directory.Move($"{TestDirectory}/FOO", $"{TestDirectory}/bar/foo"));
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void MoveDirectory_FailToMoveLowerCaseDirectoryWhenUpperCaseDirectoryExists()
+        {
+            Directory.CreateDirectory($"{TestDirectory}/bar/FOO");
+            Directory.CreateDirectory($"{TestDirectory}/foo");
+            Assert.Throws<IOException>(() => Directory.Move($"{TestDirectory}/foo", $"{TestDirectory}/bar/foo"));
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        public void MoveDirectory_ToNewDirectoryWithLowerVariantPresent()
+        {
+            Directory.CreateDirectory($"{TestDirectory}/FOO");
+            Directory.CreateDirectory($"{TestDirectory}/bar/foo");
+            Assert.True(Directory.Exists($"{TestDirectory}/bar/foo"));
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        public void MoveDirectory_ToNewDirectoryWithUpperVariantPresent()
+        {
+            Directory.CreateDirectory($"{TestDirectory}/bar/FOO");
+            Directory.CreateDirectory($"{TestDirectory}/foo");
+            Assert.True(Directory.Exists($"{TestDirectory}/bar/foo"));
+            Assert.True(Directory.Exists($"{TestDirectory}/bar/FOO"));
+        }
 
         [ConditionalFact(nameof(AreAllLongPathsAvailable))]
         [PlatformSpecific(TestPlatforms.Windows)]  // Long path succeeds

--- a/src/System.IO.FileSystem/tests/Directory/Move.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Move.cs
@@ -264,13 +264,7 @@ namespace System.IO.Tests
             Assert.Equal("bar", Path.GetFileName(firstFile[0]));
         }
 
-
-        #endregion
-
-        #region PlatformSpecific
-
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)]
         public void MoveDirectory_FailToMoveDirectoryWithUpperCaseToOtherDirectoryWithLowerCase()
         {
             Directory.CreateDirectory($"{TestDirectory}/FOO");
@@ -279,7 +273,6 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)]
         public void MoveDirectory_FailToMoveLowerCaseDirectoryWhenUpperCaseDirectoryExists()
         {
             Directory.CreateDirectory($"{TestDirectory}/bar/FOO");
@@ -287,25 +280,10 @@ namespace System.IO.Tests
             Assert.Throws<IOException>(() => Directory.Move($"{TestDirectory}/foo", $"{TestDirectory}/bar/foo"));
         }
 
-        [Fact]
-        [PlatformSpecific(TestPlatforms.AnyUnix)]
-        public void MoveDirectory_ToNewDirectoryWithLowerVariantPresent()
-        {
-            Directory.CreateDirectory($"{TestDirectory}/FOO");
-            Directory.CreateDirectory($"{TestDirectory}/bar/foo");
-            Directory.Move(Path.Combine(TestDirectory, "FOO"), Path.Combine(TestDirectory, "bar", "foo"));
-            Assert.True(Directory.Exists($"{TestDirectory}/bar/FOO"));
-        }
 
-        [Fact]
-        [PlatformSpecific(TestPlatforms.AnyUnix)]
-        public void MoveDirectory_ToNewDirectoryWithUpperVariantPresent()
-        {
-            Directory.CreateDirectory($"{TestDirectory}/bar/FOO");
-            Directory.CreateDirectory($"{TestDirectory}/foo");
-            Directory.Move(Path.Combine(TestDirectory, "foo"), Path.Combine(TestDirectory, "bar", "foo"));
-            Assert.True(Directory.Exists($"{TestDirectory}/bar/foo"));
-        }
+        #endregion
+
+        #region PlatformSpecific
 
         [ConditionalFact(nameof(AreAllLongPathsAvailable))]
         [PlatformSpecific(TestPlatforms.Windows)]  // Long path succeeds

--- a/src/System.IO.FileSystem/tests/Directory/Move.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Move.cs
@@ -213,13 +213,44 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public void Directory_MoveToNewDirectoryWithSameNameWithDifferentCasing()
+        public void MoveToNewDirectoryWithSameNameWithDifferentCasing()
         {
             Environment.CurrentDirectory = TestDirectory;
             Directory.CreateDirectory("foo");
             Directory.Move("foo", "FOO");
             var directoriesInCurrentDirectory = Directory.GetDirectories(Directory.GetCurrentDirectory());
             Assert.True(directoriesInCurrentDirectory[0].Contains("FOO", StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public void ThrowIOExceptionWhenDirectoryExists()
+        {
+            Environment.CurrentDirectory = TestDirectory;
+            Directory.CreateDirectory("foo");
+            Assert.Throws<IOException>(() => Directory.Move("foo", "foo"));
+        }
+
+        [Fact]
+        public void MoveDirectoryToNewDirectoryButWithDifferentCasing()
+        {
+            Environment.CurrentDirectory = TestDirectory;
+            Directory.CreateDirectory("foo");
+            var otherDirectoryName = "bar";
+            Directory.CreateDirectory(otherDirectoryName);
+            Directory.Move("foo", Path.Combine(otherDirectoryName, "FOO"));
+            Assert.True(Directory.Exists(Path.Combine(otherDirectoryName, "FOO")));
+            Assert.False(Directory.Exists("foo"));
+        }
+
+        [Fact]
+        public void MoveDirectoryToNewDirectoryWithExistingDirectoryOfTheSameNameWithDifferentCasing()
+        {
+            Environment.CurrentDirectory = TestDirectory;
+            Directory.CreateDirectory("foo");
+            var otherDirectoryName = "bar";
+            Directory.CreateDirectory(otherDirectoryName);
+            Directory.CreateDirectory(Path.Combine(otherDirectoryName, "FoO"));
+            Assert.Throws<IOException>(() => Directory.Move("foo", Path.Combine(otherDirectoryName, "foo"));
         }
 
         #endregion

--- a/src/System.IO.FileSystem/tests/Directory/Move.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Move.cs
@@ -212,6 +212,16 @@ namespace System.IO.Tests
             });
         }
 
+        [Fact]
+        public void Directory_MoveToNewDirectoryWithSameNameWithDifferentCasing()
+        {
+            Environment.CurrentDirectory = TestDirectory;
+            Directory.CreateDirectory("foo");
+            Directory.Move("foo", "FOO");
+            var directoriesInCurrentDirectory = Directory.GetDirectories(Directory.GetCurrentDirectory());
+            Assert.True(directoriesInCurrentDirectory[0].Contains("FOO", StringComparison.Ordinal));
+        }
+
         #endregion
 
         #region PlatformSpecific

--- a/src/System.IO.FileSystem/tests/Directory/Move.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Move.cs
@@ -215,53 +215,50 @@ namespace System.IO.Tests
         [Fact]
         public void ThrowIOExceptionWhenDirectoryExists()
         {
-            Environment.CurrentDirectory = TestDirectory;
-            Directory.CreateDirectory("foo");
-            Assert.Throws<IOException>(() => Directory.Move("foo", "foo"));
+            Directory.CreateDirectory($"{TestDirectory}/foo");
+            Assert.Throws<IOException>(() => Directory.Move($"{TestDirectory}/foo", $"{TestDirectory}/foo"));
         }
 
         [Fact]
         public void MoveDirectoryToNewDirectoryButWithDifferentCasing()
         {
-            Environment.CurrentDirectory = TestDirectory;
-            Directory.CreateDirectory("foo");
-            var otherDirectoryName = "bar";
-            Directory.CreateDirectory(otherDirectoryName);
-            Directory.Move("foo", Path.Combine(otherDirectoryName, "FOO"));
-            Assert.True(Directory.Exists(Path.Combine(otherDirectoryName, "FOO")));
-            Assert.False(Directory.Exists("foo"));
+            Directory.CreateDirectory(Path.Combine(TestDirectory, "foo"));
+            var otherDirectory = Path.Combine(TestDirectory, "bar");
+            Directory.CreateDirectory(Path.Combine(otherDirectory));
+            Directory.Move(Path.Combine(TestDirectory, "foo"), Path.Combine(otherDirectory, "FOO"));
+            Assert.True(Directory.Exists(Path.Combine(otherDirectory, "FOO")));
+            Assert.False(Directory.Exists(Path.Combine(TestDirectory, "foo")));
         }
 
         [Fact]
         public void MoveDirectory_SameDirectoryWithDifferentCasing_WithFileContent()
         {
-            Environment.CurrentDirectory = TestDirectory;
-            Directory.CreateDirectory("foo");
-            var fooDirectoryPath = Path.Combine(Directory.GetCurrentDirectory(), "foo");
-            File.WriteAllText(Path.Combine(fooDirectoryPath, "bar.txt"), string.Empty);
-            Directory.Move("foo", "FOO");
-            var firstFile = Directory.GetFiles(Path.Combine(Directory.GetCurrentDirectory(), "FOO"));
+            var fooDirectory = Path.Combine(TestDirectory, "foo");
+            var fooDirectoryUppercase = Path.Combine(TestDirectory, "FOO");
+            Directory.CreateDirectory(fooDirectory);
+            File.WriteAllText(Path.Combine(fooDirectory, "bar.txt"), string.Empty);
+            Directory.Move(fooDirectory, fooDirectoryUppercase);
+            var firstFile = Directory.GetFiles(fooDirectoryUppercase);
             Assert.Equal("bar.txt", Path.GetFileName(firstFile[0]));
         }
 
         [Fact]
         public void MoveDirectory_FailToMoveDirectoryWithUpperCaseToOtherDirectoryWithLowerCase()
         {
-            Environment.CurrentDirectory = TestDirectory;
-            Directory.CreateDirectory("FOO");
-            Directory.CreateDirectory("bar/foo");
-            Assert.Throws<IOException>(() => Directory.Move("FOO", "bar/foo"));
+            Directory.CreateDirectory($"{TestDirectory}/FOO");
+            Directory.CreateDirectory($"{TestDirectory}/bar/foo");
+            Assert.Throws<IOException>(() => Directory.Move($"{TestDirectory}/FOO", $"{TestDirectory}/bar/foo"));
         }
 
         [Fact]
         public void MoveDirectory_SameDirectoryWithDifferentCasing_WithDirectoryContent()
         {
-            Environment.CurrentDirectory = TestDirectory;
-            Directory.CreateDirectory("foo");
-            var fooDirectoryPath = Path.Combine(Directory.GetCurrentDirectory(), "foo");
+            var fooDirectoryPath = Path.Combine(TestDirectory, "foo");
+            var fooDirectoryPathUpperCase = Path.Combine(TestDirectory, "FOO");
+            Directory.CreateDirectory(fooDirectoryPath);
             Directory.CreateDirectory(Path.Combine(fooDirectoryPath, "bar"));
-            Directory.Move("foo", "FOO");
-            var firstFile = Directory.GetDirectories(Path.Combine(Directory.GetCurrentDirectory(), "FOO"));
+            Directory.Move(fooDirectoryPath, fooDirectoryPathUpperCase);
+            var firstFile = Directory.GetDirectories(fooDirectoryPathUpperCase);
             Assert.Equal("bar", Path.GetFileName(firstFile[0]));
         }
 

--- a/src/System.IO.FileSystem/tests/Directory/Move.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Move.cs
@@ -180,7 +180,7 @@ namespace System.IO.Tests
             string testDirDest = Path.Combine(TestDirectory, GetTestFileName());
 
             Directory.CreateDirectory(testDirSource);
-            Move(testDirSource + Path.DirectorySeparatorChar, testDirDest + Path.DirectorySeparatorChar);
+            Directory.Move(testDirSource + Path.DirectorySeparatorChar, testDirDest + Path.DirectorySeparatorChar);
             Assert.True(Directory.Exists(testDirDest));
         }
 

--- a/src/System.IO.FileSystem/tests/Directory/Move.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Move.cs
@@ -213,16 +213,6 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public void MoveToNewDirectoryWithSameNameWithDifferentCasing()
-        {
-            Environment.CurrentDirectory = TestDirectory;
-            Directory.CreateDirectory("foo");
-            Directory.Move("foo", "FOO");
-            var directoriesInCurrentDirectory = Directory.GetDirectories(Directory.GetCurrentDirectory());
-            Assert.True(directoriesInCurrentDirectory[0].Contains("FOO", StringComparison.Ordinal));
-        }
-
-        [Fact]
         public void ThrowIOExceptionWhenDirectoryExists()
         {
             Environment.CurrentDirectory = TestDirectory;
@@ -243,15 +233,38 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public void MoveDirectoryToNewDirectoryWithExistingDirectoryOfTheSameNameWithDifferentCasing()
+        public void MoveDirectory_SameDirectoryWithDifferentCasing_WithFileContent()
         {
             Environment.CurrentDirectory = TestDirectory;
             Directory.CreateDirectory("foo");
-            var otherDirectoryName = "bar";
-            Directory.CreateDirectory(otherDirectoryName);
-            Directory.CreateDirectory(Path.Combine(otherDirectoryName, "FoO"));
-            Assert.Throws<IOException>(() => Directory.Move("foo", Path.Combine(otherDirectoryName, "foo")));
+            var fooDirectoryPath = Path.Combine(Directory.GetCurrentDirectory(), "foo");
+            File.WriteAllText(Path.Combine(fooDirectoryPath, "bar.txt"), string.Empty);
+            Directory.Move("foo", "FOO");
+            var firstFile = Directory.GetFiles(fooDirectoryPath);
+            Assert.Equal("bar.txt", Path.GetFileName(firstFile[0]));
         }
+
+        [Fact]
+        public void MoveDirectory_FailToMoveDirectoryWithUpperCaseToOtherDirectoryWithLowerCase()
+        {
+            Environment.CurrentDirectory = TestDirectory;
+            Directory.CreateDirectory("FOO");
+            Directory.CreateDirectory("bar/foo");
+            Assert.Throws<IOException>(() => Directory.Move("FOO", "bar/foo"));
+        }
+
+        [Fact]
+        public void MoveDirectory_SameDirectoryWithDifferentCasing_WithDirectoryContent()
+        {
+            Environment.CurrentDirectory = TestDirectory;
+            Directory.CreateDirectory("foo");
+            var fooDirectoryPath = Path.Combine(Directory.GetCurrentDirectory(), "foo");
+            Directory.CreateDirectory(Path.Combine(fooDirectoryPath, "bar"));
+            Directory.Move("foo", "FOO");
+            var firstFile = Directory.GetDirectories(fooDirectoryPath);
+            Assert.Equal("bar", Path.GetFileName(firstFile[0]));
+        }
+
 
         #endregion
 

--- a/src/System.IO.FileSystem/tests/Directory/Move.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Move.cs
@@ -250,7 +250,7 @@ namespace System.IO.Tests
             var otherDirectoryName = "bar";
             Directory.CreateDirectory(otherDirectoryName);
             Directory.CreateDirectory(Path.Combine(otherDirectoryName, "FoO"));
-            Assert.Throws<IOException>(() => Directory.Move("foo", Path.Combine(otherDirectoryName, "foo"));
+            Assert.Throws<IOException>(() => Directory.Move("foo", Path.Combine(otherDirectoryName, "foo")));
         }
 
         #endregion

--- a/src/System.IO.FileSystem/tests/Directory/Move.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Move.cs
@@ -264,7 +264,13 @@ namespace System.IO.Tests
             Assert.Equal("bar", Path.GetFileName(firstFile[0]));
         }
 
+
+        #endregion
+
+        #region PlatformSpecific
+
         [Fact]
+        [PlatformSpecific(TestPlatforms.OSX)]
         public void MoveDirectory_FailToMoveDirectoryWithUpperCaseToOtherDirectoryWithLowerCase()
         {
             Directory.CreateDirectory($"{TestDirectory}/FOO");
@@ -273,17 +279,13 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.OSX)]
         public void MoveDirectory_FailToMoveLowerCaseDirectoryWhenUpperCaseDirectoryExists()
         {
             Directory.CreateDirectory($"{TestDirectory}/bar/FOO");
             Directory.CreateDirectory($"{TestDirectory}/foo");
             Assert.Throws<IOException>(() => Directory.Move($"{TestDirectory}/foo", $"{TestDirectory}/bar/foo"));
         }
-
-
-        #endregion
-
-        #region PlatformSpecific
 
         [ConditionalFact(nameof(AreAllLongPathsAvailable))]
         [PlatformSpecific(TestPlatforms.Windows)]  // Long path succeeds

--- a/src/System.IO.FileSystem/tests/Directory/Move.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Move.cs
@@ -213,14 +213,14 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public void ThrowIOExceptionWhenDirectoryExists()
+        public void MoveDirectory_ThrowIOExceptionWhenDirectoryExists()
         {
             Directory.CreateDirectory($"{TestDirectory}/foo");
             Assert.Throws<IOException>(() => Directory.Move($"{TestDirectory}/foo", $"{TestDirectory}/foo"));
         }
 
         [Fact]
-        public void MoveDirectoryToNewDirectoryButWithDifferentCasing()
+        public void MoveDirectory_ToNewDirectoryButWithDifferentCasing()
         {
             Directory.CreateDirectory(Path.Combine(TestDirectory, "foo"));
             var otherDirectory = Path.Combine(TestDirectory, "bar");
@@ -248,6 +248,23 @@ namespace System.IO.Tests
             Directory.CreateDirectory($"{TestDirectory}/FOO");
             Directory.CreateDirectory($"{TestDirectory}/bar/foo");
             Assert.Throws<IOException>(() => Directory.Move($"{TestDirectory}/FOO", $"{TestDirectory}/bar/foo"));
+        }
+
+        [Fact]
+        public void MoveDirectory_FailToMoveLowerCaseDirectoryWhenUpperCaseDirectoryExists()
+        {
+            Directory.CreateDirectory($"{TestDirectory}/bar/FOO");
+            Directory.CreateDirectory($"{TestDirectory}/foo");
+            Assert.Throws<IOException>(() => Directory.Move($"{TestDirectory}/foo", $"{TestDirectory}/bar/foo"));
+        }
+
+        [Fact]
+        public void MoveDirectory_WithDifferentRootCase()
+        {
+            Directory.CreateDirectory($"{TestDirectory}/bar");
+            Directory.Move($"{TestDirectory}/bar".ToLower(), $"{TestDirectory}/foo");
+            Assert.True(Directory.Exists($"{TestDirectory}/foo"));
+            Assert.False(Directory.Exists($"{TestDirectory}/bar"));
         }
 
         [Fact]

--- a/src/System.IO.FileSystem/tests/Directory/Move.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Move.cs
@@ -262,7 +262,8 @@ namespace System.IO.Tests
         public void MoveDirectory_WithDifferentRootCase()
         {
             Directory.CreateDirectory($"{TestDirectory}/bar");
-            Directory.Move($"{TestDirectory}/bar".ToLower(), $"{TestDirectory}/foo");
+            var root = Path.GetPathRoot(TestDirectory);
+            Directory.Move($"{TestDirectory}/bar".Replace(root, root.ToLower()), $"{TestDirectory}/foo");
             Assert.True(Directory.Exists($"{TestDirectory}/foo"));
             Assert.False(Directory.Exists($"{TestDirectory}/bar"));
         }

--- a/src/System.IO.FileSystem/tests/Directory/Move.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Move.cs
@@ -270,7 +270,7 @@ namespace System.IO.Tests
         #region PlatformSpecific
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.OSX)]
+        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX | TestPlatforms.FreeBSD | TestPlatforms.NetBSD)]
         public void MoveDirectory_FailToMoveDirectoryWithUpperCaseToOtherDirectoryWithLowerCase()
         {
             Directory.CreateDirectory($"{TestDirectory}/FOO");
@@ -279,7 +279,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.OSX)]
+        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX | TestPlatforms.FreeBSD | TestPlatforms.NetBSD)]
         public void MoveDirectory_FailToMoveLowerCaseDirectoryWhenUpperCaseDirectoryExists()
         {
             Directory.CreateDirectory($"{TestDirectory}/bar/FOO");

--- a/src/System.IO.FileSystem/tests/Directory/Move.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Move.cs
@@ -213,14 +213,22 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public void MoveDirectory_ThrowIOExceptionWhenDirectoryExists()
+        public void ThrowIOExceptionWhenMovingDirectoryToItself()
         {
-            Directory.CreateDirectory($"{TestDirectory}/foo");
-            Assert.Throws<IOException>(() => Directory.Move($"{TestDirectory}/foo", $"{TestDirectory}/foo"));
+            Directory.CreateDirectory(Path.Combine(TestDirectory, "foo"));
+            Assert.Throws<IOException>(() => Directory.Move(Path.Combine(TestDirectory, "foo"), Path.Combine(TestDirectory, "foo")));
         }
 
         [Fact]
-        public void MoveDirectory_ToNewDirectoryButWithDifferentCasing()
+        public void ThrowIOExceptionWhenMovingToExistingDirectoryWithSameCase()
+        {
+            Directory.CreateDirectory(Path.Combine(TestDirectory, "foo"));
+            Directory.CreateDirectory(Path.Combine(TestDirectory, "bar", "foo"));
+            Assert.Throws<IOException>(() => Directory.Move(Path.Combine(TestDirectory, "foo"), Path.Combine(TestDirectory, "bar", "foo")));
+        }
+
+        [Fact]
+        public void ToNewDirectoryButWithDifferentCasing()
         {
             Directory.CreateDirectory(Path.Combine(TestDirectory, "foo"));
             var otherDirectory = Path.Combine(TestDirectory, "bar");
@@ -231,7 +239,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public void MoveDirectory_SameDirectoryWithDifferentCasing_WithFileContent()
+        public void SameDirectoryWithDifferentCasing_WithFileContent()
         {
             var fooDirectory = Path.Combine(TestDirectory, "foo");
             var fooDirectoryUppercase = Path.Combine(TestDirectory, "FOO");
@@ -243,7 +251,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public void MoveDirectory_WithDifferentRootCase()
+        public void WithDifferentRootCase()
         {
             Directory.CreateDirectory($"{TestDirectory}/bar");
             var root = Path.GetPathRoot(TestDirectory);
@@ -253,7 +261,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public void MoveDirectory_SameDirectoryWithDifferentCasing_WithDirectoryContent()
+        public void SameDirectoryWithDifferentCasing_WithDirectoryContent()
         {
             var fooDirectoryPath = Path.Combine(TestDirectory, "foo");
             var fooDirectoryPathUpperCase = Path.Combine(TestDirectory, "FOO");
@@ -262,6 +270,23 @@ namespace System.IO.Tests
             Directory.Move(fooDirectoryPath, fooDirectoryPathUpperCase);
             var firstFile = Directory.GetDirectories(fooDirectoryPathUpperCase);
             Assert.Equal("bar", Path.GetFileName(firstFile[0]));
+        }
+
+        [Fact]
+        public void DirectoryWithDifferentCasingThanFileSystem_ToAnotherDirectory()
+        {
+            Directory.CreateDirectory(Path.Combine(TestDirectory, "FOO"));
+            Directory.CreateDirectory(Path.Combine(TestDirectory, "bar"));
+            Directory.Move(Path.Combine(TestDirectory, "foo"), Path.Combine(TestDirectory, "bar", "FOO"));
+        }
+
+        [Fact]
+        public void DirectoryWithDifferentCasingThanFileSystem_ToItself()
+        {
+            Directory.CreateDirectory(Path.Combine(TestDirectory, "FOO"));
+            Directory.Move(Path.Combine(TestDirectory, "foo"), Path.Combine(TestDirectory, "FOO"));
+            Assert.True(Directory.Exists(Path.Combine(TestDirectory, "FOO")));
+
         }
 
 
@@ -282,12 +307,22 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.FreeBSD | TestPlatforms.NetBSD )]
+        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.FreeBSD | TestPlatforms.NetBSD)]
         public void MoveDirectory_FailToMoveDirectoryWithUpperCaseToOtherDirectoryWithLowerCase()
         {
             Directory.CreateDirectory($"{TestDirectory}/FOO");
             Directory.CreateDirectory($"{TestDirectory}/bar/foo");
             Assert.Throws<IOException>(() => Directory.Move($"{TestDirectory}/FOO", $"{TestDirectory}/bar/foo"));
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.OSX)]
+        public void MoveDirectory_NoOpWhenMovingDirectoryWithUpperCaseToOtherDirectoryWithLowerCase()
+        {
+            Directory.CreateDirectory($"{TestDirectory}/FOO");
+            Directory.CreateDirectory($"{TestDirectory}/bar/foo");
+            Directory.Move($"{TestDirectory}/FOO", $"{TestDirectory}/bar/foo");
+            Assert.True(Directory.Exists(Path.Combine(TestDirectory, "bar", "foo")));
         }
 
         [Fact]

--- a/src/System.IO.FileSystem/tests/Directory/Move.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Move.cs
@@ -282,19 +282,6 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.AnyUnix)]
-        public void CaseVariantDirectoryNameWithCaseVariantPaths_CaseSystemFileSystem()
-        {
-            var directoryToBeMoved = Path.Combine(TestDirectory, "FOO", "bar");
-            var newPath = Path.Combine(TestDirectory, "foo", "bar");
-            Directory.CreateDirectory(Path.Combine(TestDirectory, "FOO", "bar"));
-            Directory.CreateDirectory(Path.Combine(TestDirectory, "foo"));
-
-            Directory.Move(directoryToBeMoved, Path.Combine(newPath, "bar"));
-            Assert.False(Directory.Exists(directoryToBeMoved));
-        }
-
-        [Fact]
         [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX | TestPlatforms.FreeBSD | TestPlatforms.NetBSD)]
         public void MoveDirectory_FailToMoveDirectoryWithUpperCaseToOtherDirectoryWithLowerCase()
         {

--- a/src/System.IO.FileSystem/tests/Directory/Move.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Move.cs
@@ -270,6 +270,31 @@ namespace System.IO.Tests
         #region PlatformSpecific
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void CaseVariantDirectoryNameWithCaseVariantPaths_CaseInsensitiveFileSystem()
+        {
+            var directoryToBeMoved = Path.Combine(TestDirectory, "FOO", "bar");
+            var newPath = Path.Combine(TestDirectory, "foo", "bar");
+            Directory.CreateDirectory(Path.Combine(TestDirectory, "FOO", "bar"));
+            Directory.CreateDirectory(Path.Combine(TestDirectory, "foo"));
+
+            Assert.Throws<IOException>(() => Directory.Move(directoryToBeMoved, Path.Combine(newPath, "bar")));
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        public void CaseVariantDirectoryNameWithCaseVariantPaths_CaseSystemFileSystem()
+        {
+            var directoryToBeMoved = Path.Combine(TestDirectory, "FOO", "bar");
+            var newPath = Path.Combine(TestDirectory, "foo", "bar");
+            Directory.CreateDirectory(Path.Combine(TestDirectory, "FOO", "bar"));
+            Directory.CreateDirectory(Path.Combine(TestDirectory, "foo"));
+
+            Directory.Move(directoryToBeMoved, Path.Combine(newPath, "bar"));
+            Assert.False(Directory.Exists(directoryToBeMoved));
+        }
+
+        [Fact]
         [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX | TestPlatforms.FreeBSD | TestPlatforms.NetBSD)]
         public void MoveDirectory_FailToMoveDirectoryWithUpperCaseToOtherDirectoryWithLowerCase()
         {

--- a/src/System.IO.FileSystem/tests/Directory/Move.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Move.cs
@@ -277,7 +277,7 @@ namespace System.IO.Tests
         #region PlatformSpecific
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)]
+        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX)]
         public void DirectoryWithDifferentCasingThanFileSystem_ToAnotherDirectory()
         {
             Directory.CreateDirectory(Path.Combine(TestDirectory, "FOO"));
@@ -286,7 +286,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)]
+        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX)]
         public void DirectoryWithDifferentCasingThanFileSystem_ToItself()
         {
             Directory.CreateDirectory(Path.Combine(TestDirectory, "FOO"));
@@ -295,7 +295,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        [PlatformSpecific(TestPlatforms.Linux)]
         public void DirectoryWithDifferentCasingThanFileSystem_ToAnotherDirectory_CaseSensitiveOS()
         {
             Directory.CreateDirectory(Path.Combine(TestDirectory, "FOO"));
@@ -304,7 +304,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        [PlatformSpecific(TestPlatforms.Linux)]
         public void DirectoryWithDifferentCasingThanFileSystem_ToItself_CaseSensitiveOS()
         {
             Directory.CreateDirectory(Path.Combine(TestDirectory, "FOO"));

--- a/src/System.IO.FileSystem/tests/Directory/Move.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Move.cs
@@ -272,7 +272,12 @@ namespace System.IO.Tests
             Assert.Equal("bar", Path.GetFileName(firstFile[0]));
         }
 
+        #endregion
+
+        #region PlatformSpecific
+
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
         public void DirectoryWithDifferentCasingThanFileSystem_ToAnotherDirectory()
         {
             Directory.CreateDirectory(Path.Combine(TestDirectory, "FOO"));
@@ -281,18 +286,30 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
         public void DirectoryWithDifferentCasingThanFileSystem_ToItself()
         {
             Directory.CreateDirectory(Path.Combine(TestDirectory, "FOO"));
             Directory.Move(Path.Combine(TestDirectory, "foo"), Path.Combine(TestDirectory, "FOO"));
             Assert.True(Directory.Exists(Path.Combine(TestDirectory, "FOO")));
-
         }
 
+        [Fact]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        public void DirectoryWithDifferentCasingThanFileSystem_ToAnotherDirectory_CaseSensitiveOS()
+        {
+            Directory.CreateDirectory(Path.Combine(TestDirectory, "FOO"));
+            Directory.CreateDirectory(Path.Combine(TestDirectory, "bar"));
+            Assert.Throws<DirectoryNotFoundException>(() => Directory.Move(Path.Combine(TestDirectory, "foo"), Path.Combine(TestDirectory, "bar", "FOO")));
+        }
 
-        #endregion
-
-        #region PlatformSpecific
+        [Fact]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        public void DirectoryWithDifferentCasingThanFileSystem_ToItself_CaseSensitiveOS()
+        {
+            Directory.CreateDirectory(Path.Combine(TestDirectory, "FOO"));
+            Assert.Throws<DirectoryNotFoundException>(() => Directory.Move(Path.Combine(TestDirectory, "foo"), Path.Combine(TestDirectory, "FOO")));
+        }
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]

--- a/src/System.IO.FileSystem/tests/Directory/Move.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Move.cs
@@ -282,7 +282,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX | TestPlatforms.FreeBSD | TestPlatforms.NetBSD)]
+        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.FreeBSD | TestPlatforms.NetBSD )]
         public void MoveDirectory_FailToMoveDirectoryWithUpperCaseToOtherDirectoryWithLowerCase()
         {
             Directory.CreateDirectory($"{TestDirectory}/FOO");


### PR DESCRIPTION
Fix for #40013 

Allowing the moving of directories with different casing.

Thus if in a case-sensitive file system renaming Directory .\foo to .\FOO should still be allowed.

But still preventing a directory having .\foo .\fOO .\FOO

As I am no expert on inter-opting with the OS I look forward to feedback

(And I went out on a bit of a limb with the design of this change)