### PR TITLE
Refactor DdlImports - System.Reflection.Metadata

### DIFF
--- a/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
+++ b/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
@@ -8,6 +8,12 @@
     <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release;netstandard1.1-Debug;netstandard1.1-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+      <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\Kernel32\Interop.ReadFile_SafeHandle_IntPtr.cs">
+      <Link>Common\CoreLib\Interop\Windows\kernel32\Interop.ReadFile_SafeHandle_IntPtr.cs</Link>
+    </Compile>
     <Compile Include="System\Reflection\Internal\Utilities\PinnedObject.cs" />
     <Compile Include="System\Reflection\Internal\Utilities\CriticalDisposableObject.cs" Condition="'$(TargetFramework)' != 'netstandard1.1'" />
     <Compile Include="System\Reflection\Internal\Utilities\CriticalDisposableObject.netstandard1.1.cs" Condition="'$(TargetFramework)' == 'netstandard1.1'" />

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.cs
@@ -53,12 +53,12 @@ namespace System.Reflection.Internal
                 return false;
             }
 
-            bool result = false;
-            int bytesRead = 0;
+            int result;
+            int bytesRead;
 
             try
             {
-                result = ReadFile(handle, buffer, size, out bytesRead, IntPtr.Zero);
+                result = Interop.Kernel32.ReadFile(handle, buffer, size, out bytesRead, IntPtr.Zero);
             }
             catch
             {
@@ -66,7 +66,7 @@ namespace System.Reflection.Internal
                 return false;
             }
 
-            if (!result || bytesRead != size)
+            if (result == 0 || bytesRead != size)
             {
                 // We used to throw here, but this is where we land if the FileStream was
                 // opened with useAsync: true, which is currently the default on .NET Core.
@@ -78,15 +78,5 @@ namespace System.Reflection.Internal
 
             return true;
         }
-
-        [DllImport(@"kernel32.dll", EntryPoint = "ReadFile", ExactSpelling = true, SetLastError = true)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern unsafe bool ReadFile(
-             SafeHandle fileHandle,
-             byte* buffer,
-             int byteCount,
-             out int bytesRead,
-             IntPtr overlapped
-        );
     }
 }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.netstandard1.1.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/FileStreamReadLightUp.netstandard1.1.cs
@@ -100,12 +100,12 @@ namespace System.Reflection.Internal
                 return false;
             }
 
-            bool result = false;
-            int bytesRead = 0;
+            int result;
+            int bytesRead;
 
             try
             {
-                result = ReadFile(handle, buffer, size, out bytesRead, IntPtr.Zero);
+                result = Interop.Kernel32.ReadFile(handle, buffer, size, out bytesRead, IntPtr.Zero);
             }
             catch
             {
@@ -113,7 +113,7 @@ namespace System.Reflection.Internal
                 return false;
             }
 
-            if (!result || bytesRead != size)
+            if (result == 0 || bytesRead != size)
             {
                 // We used to throw here, but this is where we land if the FileStream was
                 // opened with useAsync: true, which is currently the default on .NET Core.
@@ -125,15 +125,5 @@ namespace System.Reflection.Internal
 
             return true;
         }
-
-        [DllImport(@"kernel32.dll", EntryPoint = "ReadFile", ExactSpelling = true, SetLastError = true)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern unsafe bool ReadFile(
-             SafeHandle fileHandle,
-             byte* buffer,
-             int byteCount,
-             out int bytesRead,
-             IntPtr overlapped
-        );
     }
 }

--- a/src/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
+++ b/src/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ExternallyShipping>false</ExternallyShipping>
+    <NoWarn>436</NoWarn> <!-- Type conflicts on "Interop" due to InternalsVisibleTo access -->
     <Configurations>netcoreapp-Debug;netcoreapp-Release;netfx-Debug;netfx-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Contributes to #33774

Note that since test project has DllImports as well, CS0436 warnings (type (Interop) conflicts with imported type) were disabled.

cc: @stephentoub