### PR TITLE
Fix PLINQ outerloop tests

### DIFF
--- a/src/System.Linq.Parallel/tests/Combinatorial/SourcesAndOperators.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/SourcesAndOperators.cs
@@ -244,34 +244,34 @@ namespace System.Linq.Parallel.Tests
             yield return new object[] { Labeled.Label<Func<ParallelQuery<int>, Action, ParallelQuery<int>>>("Where-Index", (source, cancel) => source.Where((x, index) => { cancel(); return true; })) };
         }
 
-        public static IEnumerable<object[]> BinaryOperations(Labeled<Operation> otherSource)
+        public static IEnumerable<Labeled<Operation>> BinaryOperations(Labeled<Operation> otherSource)
         {
             string label = otherSource.ToString();
             Operation other = otherSource.Item;
 
-            yield return new object[] { Label("Concat-Right:" + label, (start, count, source) => source(start, count / 2).Concat(other(start + count / 2, count / 2 + count % 2))) };
-            yield return new object[] { Label("Concat-Left:" + label, (start, count, source) => other(start, count / 2).Concat(source(start + count / 2, count / 2 + count % 2))) };
+            yield return Label("Concat-Right:" + label, (start, count, source) => source(start, count / 2).Concat(other(start + count / 2, count / 2 + count % 2)));
+            yield return Label("Concat-Left:" + label, (start, count, source) => other(start, count / 2).Concat(source(start + count / 2, count / 2 + count % 2)));
 
             // Comparator needs to cover _source_ size, as which of two "equal" items is returned is undefined for unordered collections.
-            yield return new object[] { Label("Except-Right:" + label, (start, count, source) => source(start, count + count / 2).Except(other(start + count, count), new ModularCongruenceComparer(count * 2))) };
-            yield return new object[] { Label("Except-Left:" + label, (start, count, source) => other(start, count + count / 2).Except(source(start + count, count), new ModularCongruenceComparer(count * 2))) };
+            yield return Label("Except-Right:" + label, (start, count, source) => source(start, count + count / 2).Except(other(start + count, count), new ModularCongruenceComparer(count * 2)));
+            yield return Label("Except-Left:" + label, (start, count, source) => other(start, count + count / 2).Except(source(start + count, count), new ModularCongruenceComparer(count * 2)));
 
-            yield return new object[] { Label("GroupJoin-Right:" + label, (start, count, source) => source(start, count).GroupJoin(other(start, count * CountFactor), x => x, y => y % count, (x, g) => g.Min(), new ModularCongruenceComparer(count))) };
-            yield return new object[] { Label("GroupJoin-Left:" + label, (start, count, source) => other(start, count).GroupJoin(source(start, count * CountFactor), x => x, y => y % count, (x, g) => g.Min(), new ModularCongruenceComparer(count))) };
+            yield return Label("GroupJoin-Right:" + label, (start, count, source) => source(start, count).GroupJoin(other(start, count * CountFactor), x => x, y => y % count, (x, g) => g.Min(), new ModularCongruenceComparer(count)));
+            yield return Label("GroupJoin-Left:" + label, (start, count, source) => other(start, count).GroupJoin(source(start, count * CountFactor), x => x, y => y % count, (x, g) => g.Min(), new ModularCongruenceComparer(count)));
 
             // Comparator needs to cover _source_ size, as which of two "equal" items is returned is undefined.
-            yield return new object[] { Label("Intersect-Right:" + label, (start, count, source) => source(start, count + count / 2).Intersect(other(start - count / 2, count + count / 2), new ModularCongruenceComparer(count * 2))) };
-            yield return new object[] { Label("Intersect-Left:" + label, (start, count, source) => other(start, count + count / 2).Intersect(source(start - count / 2, count + count / 2), new ModularCongruenceComparer(count * 2))) };
+            yield return Label("Intersect-Right:" + label, (start, count, source) => source(start, count + count / 2).Intersect(other(start - count / 2, count + count / 2), new ModularCongruenceComparer(count * 2)));
+            yield return Label("Intersect-Left:" + label, (start, count, source) => other(start, count + count / 2).Intersect(source(start - count / 2, count + count / 2), new ModularCongruenceComparer(count * 2)));
 
-            yield return new object[] { Label("Join-Right:" + label, (start, count, source) => source(0, count).Join(other(start, count), x => x, y => y - start, (x, y) => x + start, new ModularCongruenceComparer(count))) };
-            yield return new object[] { Label("Join-Left:" + label, (start, count, source) => other(0, count).Join(source(start, count), x => x, y => y - start, (x, y) => x + start, new ModularCongruenceComparer(count))) };
+            yield return Label("Join-Right:" + label, (start, count, source) => source(0, count).Join(other(start, count), x => x, y => y - start, (x, y) => x + start, new ModularCongruenceComparer(count)));
+            yield return Label("Join-Left:" + label, (start, count, source) => other(0, count).Join(source(start, count), x => x, y => y - start, (x, y) => x + start, new ModularCongruenceComparer(count)));
 
-            yield return new object[] { Label("Union-Right:" + label, (start, count, source) => source(start, count * 3 / 4).Union(other(start + count / 2, count / 2 + count % 2), new ModularCongruenceComparer(count))) };
-            yield return new object[] { Label("Union-Left:" + label, (start, count, source) => other(start, count * 3 / 4).Union(source(start + count / 2, count / 2 + count % 2), new ModularCongruenceComparer(count))) };
+            yield return Label("Union-Right:" + label, (start, count, source) => source(start, count * 3 / 4).Union(other(start + count / 2, count / 2 + count % 2), new ModularCongruenceComparer(count)));
+            yield return Label("Union-Left:" + label, (start, count, source) => other(start, count * 3 / 4).Union(source(start + count / 2, count / 2 + count % 2), new ModularCongruenceComparer(count)));
 
             // When both sources are unordered any element can be matched to any other, so a different check is required.
-            yield return new object[] { Label("Zip-Unordered-Right:" + label, (start, count, source) => source(0, count).Zip(other(start * 2, count), (x, y) => x + start)) };
-            yield return new object[] { Label("Zip-Unordered-Left:" + label, (start, count, source) => other(start * 2, count).Zip(source(0, count), (x, y) => y + start)) };
+            yield return Label("Zip-Unordered-Right:" + label, (start, count, source) => source(0, count).Zip(other(start * 2, count), (x, y) => x + start));
+            yield return Label("Zip-Unordered-Left:" + label, (start, count, source) => other(start * 2, count).Zip(source(0, count), (x, y) => y + start));
         }
 
         public static IEnumerable<object[]> BinaryOperations()
@@ -284,7 +284,7 @@ namespace System.Linq.Parallel.Tests
             foreach (Labeled<Operation> source in UnorderedRangeSources())
             {
                 // Operations having multiple paths to check.
-                foreach (Labeled<Operation> operation in BinaryOperations(LabeledDefaultSource).Select(i => i[0]))
+                foreach (Labeled<Operation> operation in BinaryOperations(LabeledDefaultSource))
                 {
                     yield return new object[] { source, operation };
                 }
@@ -298,7 +298,7 @@ namespace System.Linq.Parallel.Tests
                 // Each binary can work differently, depending on which of the two source queries (or both) is ordered.
 
                 // For most, only the ordering of the first query is important
-                foreach (Labeled<Operation> operation in BinaryOperations(LabeledDefaultSource).Select(i => i[0]).Where(op => !(op.ToString().StartsWith("Union") || op.ToString().StartsWith("Zip") || op.ToString().StartsWith("Concat")) && op.ToString().Contains("Right")))
+                foreach (Labeled<Operation> operation in BinaryOperations(LabeledDefaultSource).Where(op => !(op.ToString().StartsWith("Union") || op.ToString().StartsWith("Zip") || op.ToString().StartsWith("Concat")) && op.ToString().Contains("Right")))
                 {
                     yield return new object[] { source, operation };
                 }
@@ -333,7 +333,7 @@ namespace System.Linq.Parallel.Tests
         {
             Labeled<Operation> failing = Label("Failing", (start, count, s) => s(start, count).Select<int, int>(x => { throw new DeliberateTestException(); }));
 
-            foreach (Labeled<Operation> operation in BinaryOperations(LabeledDefaultSource).Select(i => i[0]))
+            foreach (Labeled<Operation> operation in BinaryOperations(LabeledDefaultSource))
             {
                 yield return new object[] { LabeledDefaultSource.Append(failing), operation };
                 yield return new object[] { Failing, operation };

--- a/src/System.Linq.Parallel/tests/Combinatorial/SourcesAndOperators.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/SourcesAndOperators.cs
@@ -42,14 +42,14 @@ namespace System.Linq.Parallel.Tests
             foreach (Labeled<Operation> source in UnorderedRangeSources())
             {
                 yield return source.AsOrdered();
-                foreach (Labeled<Operation> ordering in OrderOperators())
+                foreach (Labeled<Operation> ordering in OrderOperatorSources())
                 {
                     yield return source.Append(ordering);
                 }
             }
         }
 
-        public static IEnumerable<Labeled<Operation>> OrderOperators()
+        public static IEnumerable<Labeled<Operation>> OrderOperatorSources()
         {
             yield return Label("OrderBy", (start, count, source) => source(start, count).OrderBy(x => x));
             yield return Label("OrderByDescending", (start, count, source) => source(start, count).OrderByDescending(x => -x));
@@ -57,7 +57,7 @@ namespace System.Linq.Parallel.Tests
             yield return Label("ThenByDescending", (start, count, source) => source(start, count).OrderBy(x => 0).ThenByDescending(x => -x));
         }
 
-        public static IEnumerable<Labeled<Operation>> ReverseOrderOperators()
+        public static IEnumerable<Labeled<Operation>> ReverseOrderOperatorSources()
         {
             yield return Label("OrderBy-Reversed", (start, count, source) => source(start, count).OrderBy(x => x, ReverseComparer.Instance));
             yield return Label("OrderByDescending-Reversed", (start, count, source) => source(start, count).OrderByDescending(x => -x, ReverseComparer.Instance));
@@ -81,7 +81,7 @@ namespace System.Linq.Parallel.Tests
                 yield return new object[] { LabeledDefaultSource, operation };
             }
 
-            foreach (Labeled<Operation> operation in OrderOperators())
+            foreach (Labeled<Operation> operation in OrderOperatorSources())
             {
                 yield return new object[] { Failing, operation };
             }
@@ -136,7 +136,7 @@ namespace System.Linq.Parallel.Tests
             }
         }
 
-        public static IEnumerable<Labeled<Operation>> SkipTakeOperations()
+        public static IEnumerable<Labeled<Operation>> SkipTakeOperationSources()
         {
             // Take/Skip-based operations require ordered input, or will disobey
             // the [start, start + count) convention expected in tests.
@@ -152,7 +152,7 @@ namespace System.Linq.Parallel.Tests
         {
             foreach (Labeled<Operation> source in RangeSources())
             {
-                foreach (Labeled<Operation> operation in SkipTakeOperations())
+                foreach (Labeled<Operation> operation in SkipTakeOperationSources())
                 {
                     yield return new object[] { source, operation };
                 }
@@ -173,7 +173,7 @@ namespace System.Linq.Parallel.Tests
             Labeled<Operation> reverse = UnaryOperations().Select(i => (Labeled<Operation>)i[0]).Where(op => op.ToString().Contains("Reverse")).Single();
             foreach (Labeled<Operation> source in UnorderedRangeSources())
             {
-                foreach (Labeled<Operation> ordering in ReverseOrderOperators())
+                foreach (Labeled<Operation> ordering in ReverseOrderOperatorSources())
                 {
                     yield return new object[] { source.Append(ordering), reverse };
                 }
@@ -184,7 +184,7 @@ namespace System.Linq.Parallel.Tests
             {
                 foreach (Labeled<Operation> operation in UnaryOperations().Select(i => i[0]))
                 {
-                    foreach (Labeled<Operation> ordering in OrderOperators())
+                    foreach (Labeled<Operation> ordering in OrderOperatorSources())
                     {
                         yield return new object[] { source, operation.Append(ordering) };
                     }
@@ -222,7 +222,7 @@ namespace System.Linq.Parallel.Tests
                 yield return new object[] { LabeledDefaultSource, operation };
             }
 
-            foreach (Labeled<Operation> operation in UnaryOperations().Select(i => i[0]).Cast<Labeled<Operation>>().Concat(SkipTakeOperations()))
+            foreach (Labeled<Operation> operation in UnaryOperations().Select(i => i[0]).Cast<Labeled<Operation>>().Concat(SkipTakeOperationSources()))
             {
                 yield return new object[] { Failing, operation };
             }
@@ -244,7 +244,7 @@ namespace System.Linq.Parallel.Tests
             yield return new object[] { Labeled.Label<Func<ParallelQuery<int>, Action, ParallelQuery<int>>>("Where-Index", (source, cancel) => source.Where((x, index) => { cancel(); return true; })) };
         }
 
-        public static IEnumerable<Labeled<Operation>> BinaryOperations(Labeled<Operation> otherSource)
+        public static IEnumerable<Labeled<Operation>> BinaryOperatorSources(Labeled<Operation> otherSource)
         {
             string label = otherSource.ToString();
             Operation other = otherSource.Item;
@@ -276,7 +276,7 @@ namespace System.Linq.Parallel.Tests
 
         public static IEnumerable<object[]> BinaryOperations()
         {
-            return BinaryOperations(LabeledDefaultSource).Select(op => new object[] { op });
+            return BinaryOperatorSources(LabeledDefaultSource).Select(op => new object[] { op });
         }
 
         public static IEnumerable<object[]> BinaryUnorderedOperators()
@@ -284,7 +284,7 @@ namespace System.Linq.Parallel.Tests
             foreach (Labeled<Operation> source in UnorderedRangeSources())
             {
                 // Operations having multiple paths to check.
-                foreach (Labeled<Operation> operation in BinaryOperations(LabeledDefaultSource))
+                foreach (Labeled<Operation> operation in BinaryOperatorSources(LabeledDefaultSource))
                 {
                     yield return new object[] { source, operation };
                 }
@@ -298,13 +298,13 @@ namespace System.Linq.Parallel.Tests
                 // Each binary can work differently, depending on which of the two source queries (or both) is ordered.
 
                 // For most, only the ordering of the first query is important
-                foreach (Labeled<Operation> operation in BinaryOperations(LabeledDefaultSource).Where(op => !(op.ToString().StartsWith("Union") || op.ToString().StartsWith("Zip") || op.ToString().StartsWith("Concat")) && op.ToString().Contains("Right")))
+                foreach (Labeled<Operation> operation in BinaryOperatorSources(LabeledDefaultSource).Where(op => !(op.ToString().StartsWith("Union") || op.ToString().StartsWith("Zip") || op.ToString().StartsWith("Concat")) && op.ToString().Contains("Right")))
                 {
                     yield return new object[] { source, operation };
                 }
 
                 // For Concat and Union, both sources must be ordered
-                foreach (var operation in BinaryOperations(RangeSources().First()).Where(op => op.ToString().StartsWith("Concat") || op.ToString().StartsWith("Union")))
+                foreach (var operation in BinaryOperatorSources(RangeSources().First()).Where(op => op.ToString().StartsWith("Concat") || op.ToString().StartsWith("Union")))
                 {
                     yield return new object[] { source, operation };
                 }
@@ -322,7 +322,7 @@ namespace System.Linq.Parallel.Tests
             // Ordering the output should always be safe
             foreach (object[] parameters in BinaryUnorderedOperators())
             {
-                foreach (Labeled<Operation> ordering in OrderOperators())
+                foreach (Labeled<Operation> ordering in OrderOperatorSources())
                 {
                     yield return new[] { parameters[0], ((Labeled<Operation>)parameters[1]).Append(ordering) };
                 }
@@ -333,7 +333,7 @@ namespace System.Linq.Parallel.Tests
         {
             Labeled<Operation> failing = Label("Failing", (start, count, s) => s(start, count).Select<int, int>(x => { throw new DeliberateTestException(); }));
 
-            foreach (Labeled<Operation> operation in BinaryOperations(LabeledDefaultSource))
+            foreach (Labeled<Operation> operation in BinaryOperatorSources(LabeledDefaultSource))
             {
                 yield return new object[] { LabeledDefaultSource.Append(failing), operation };
                 yield return new object[] { Failing, operation };

--- a/src/System.Linq.Parallel/tests/Combinatorial/UnorderedParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/UnorderedParallelQueryCombinationTests.cs
@@ -587,7 +587,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [MemberData(nameof(UnaryOperations))]
-        [MemberData(nameof(BinaryOperations))]
+        //[MemberData(nameof(BinaryOperations))]
         public static void ToArray_Unordered(Labeled<Operation> operation)
         {
             IntegerRangeSet seen = new IntegerRangeSet(DefaultStart, DefaultSize);


### PR DESCRIPTION
https://github.com/dotnet/corefx/pull/40415 broke a bunch of PLINQ outerloop tests.  This reverts those changes to PLINQ and provides a simple renaming fix to the original problem it was trying to solve.

cc: @wfurt 