### PR TITLE
[release/3.0] Fix issue where dictionary properties that immediately follow a skipped dictionary property were skipped.

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleDictionary.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleDictionary.cs
@@ -98,6 +98,7 @@ namespace System.Text.Json
         {
             if (state.Current.SkipProperty)
             {
+                // Todo: determine if this is reachable.
                 return;
             }
 

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleNull.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleNull.cs
@@ -12,6 +12,10 @@ namespace System.Text.Json
         {
             if (state.Current.SkipProperty)
             {
+                // Clear the current property in case it is a dictionary, since dictionaries must have EndProperty() called when completed.
+                // A non-dictionary property can also have EndProperty() called when completed, although it is redundant.
+                state.Current.EndProperty();
+
                 return false;
             }
 

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.cs
@@ -82,6 +82,10 @@ namespace System.Text.Json
                         if (readStack.Current.Drain)
                         {
                             readStack.Pop();
+
+                            // Clear the current property in case it is a dictionary, since dictionaries must have EndProperty() called when completed.
+                            // A non-dictionary property can also have EndProperty() called when completed, although it is redundant.
+                            readStack.Current.EndProperty();
                         }
                         else if (readStack.Current.IsProcessingDictionary || readStack.Current.IsProcessingIDictionaryConstructible)
                         {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
@@ -126,6 +126,7 @@ namespace System.Text.Json
             PropertyIndex = 0;
             EndProperty();
         }
+
         public void EndProperty()
         {
             CollectionPropertyInitialized = false;

--- a/src/System.Text.Json/tests/Serialization/Array.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Array.ReadTests.cs
@@ -450,11 +450,8 @@ namespace System.Text.Json.Serialization.Tests
             public IEnumerable<int> ParsedChild3 { get; set; }
         }
 
-        [Fact]
-        public static void ClassWithMixedSettersIsParsed()
-        {
-            // Tests that the parser picks back up after skipping/draining ignored elements.
-            string json = @"{
+        [Theory]
+        [InlineData(@"{
                 ""SkippedChild1"": {},
                 ""ParsedChild1"": [1],
                 ""UnmatchedProp"": null,
@@ -462,9 +459,18 @@ namespace System.Text.Json.Serialization.Tests
                 ""SkippedChild2"": {},
                 ""ParsedChild2"": [2,2],
                 ""SkippedChild3"": {},
-                ""ParsedChild3"": [3,3]
-            }";
-
+                ""ParsedChild3"": [3,3]}")]
+        [InlineData(@"{
+                ""SkippedChild1"": null,
+                ""ParsedChild1"": [1],
+                ""UnmatchedProp"": null,
+                ""SkippedChild2"": [],
+                ""SkippedChild2"": null,
+                ""ParsedChild2"": [2,2],
+                ""SkippedChild3"": null,
+                ""ParsedChild3"": [3,3]}")]
+        public static void ClassWithMixedSettersIsParsed(string json)
+        {
             ClassWithMixedSetters parsedObject = JsonSerializer.Deserialize<ClassWithMixedSetters>(json);
 
             Assert.Null(parsedObject.SkippedChild1);

--- a/src/System.Text.Json/tests/Serialization/Array.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Array.ReadTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace System.Text.Json.Serialization.Tests
@@ -427,7 +428,7 @@ namespace System.Text.Json.Serialization.Tests
 
         public class ClassWithPopulatedListAndSetter
         {
-            public List<int> MyList { get; set;  } = new List<int>() { 1 };
+            public List<int> MyList { get; set; } = new List<int>() { 1 };
         }
 
         [Fact]
@@ -437,6 +438,48 @@ namespace System.Text.Json.Serialization.Tests
             string json = @"{""MyList"":[2,3]}";
             ClassWithPopulatedListAndSetter obj = JsonSerializer.Deserialize<ClassWithPopulatedListAndSetter>(json);
             Assert.Equal(2, obj.MyList.Count);
+        }
+
+        public class ClassWithMixedSetters
+        {
+            public List<int> SkippedChild1 { get; }
+            public List<int> ParsedChild1 { get; set; }
+            public IEnumerable<int> SkippedChild2 { get; }
+            public IEnumerable<int> ParsedChild2 { get; set; }
+            [JsonIgnore] public IEnumerable<int> SkippedChild3 { get; set; } // Note this has a setter.
+            public IEnumerable<int> ParsedChild3 { get; set; }
+        }
+
+        [Fact]
+        public static void ClassWithMixedSettersIsParsed()
+        {
+            // Tests that the parser picks back up after skipping/draining ignored elements.
+            string json = @"{
+                ""SkippedChild1"": {},
+                ""ParsedChild1"": [1],
+                ""UnmatchedProp"": null,
+                ""SkippedChild2"": [{""DrainProp1"":{}, ""DrainProp2"":{""SubProp"":0}}],
+                ""SkippedChild2"": {},
+                ""ParsedChild2"": [2,2],
+                ""SkippedChild3"": {},
+                ""ParsedChild3"": [3,3]
+            }";
+
+            ClassWithMixedSetters parsedObject = JsonSerializer.Deserialize<ClassWithMixedSetters>(json);
+
+            Assert.Null(parsedObject.SkippedChild1);
+
+            Assert.NotNull(parsedObject.ParsedChild1);
+            Assert.Equal(1, parsedObject.ParsedChild1.Count);
+            Assert.Equal(1, parsedObject.ParsedChild1[0]);
+
+            Assert.Null(parsedObject.SkippedChild2);
+
+            Assert.NotNull(parsedObject.ParsedChild2);
+            Assert.True(parsedObject.ParsedChild2.SequenceEqual(new int[] { 2, 2 }));
+
+            Assert.NotNull(parsedObject.ParsedChild3);
+            Assert.True(parsedObject.ParsedChild3.SequenceEqual(new int[] { 3, 3 }));
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
+++ b/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
@@ -922,7 +922,7 @@ namespace System.Text.Json.Serialization.Tests
         public static void ClassWithNoSetterAndDictionary()
         {
             // We don't attempt to deserialize into dictionaries without a setter.
-            string json = @"{""MyDictionary"":{""Key1"":""Value1"", ""Key2"":""Value2""}}";
+            string json = @"{""MyDictionary"":{""Key1"":""Value1"", ""Key2"":""Value2""},""MyDictionaryWithSetter"":{""Key1"":""Value1""}}";
             ClassWithPopulatedDictionaryAndNoSetter obj = JsonSerializer.Deserialize<ClassWithPopulatedDictionaryAndNoSetter>(json);
             Assert.Equal(1, obj.MyDictionary.Count);
         }
@@ -934,6 +934,178 @@ namespace System.Text.Json.Serialization.Tests
             string json = @"{""MyImmutableDictionary"":{""Key1"":""Value1"", ""Key2"":""Value2""}}";
             ClassWithPopulatedDictionaryAndNoSetter obj = JsonSerializer.Deserialize<ClassWithPopulatedDictionaryAndNoSetter>(json);
             Assert.Equal(1, obj.MyImmutableDictionary.Count);
+        }
+
+        public class ClassWithIgnoredDictionary1
+        {
+            public Dictionary<string, int> Parsed1 { get; set; }
+            public Dictionary<string, int> Parsed2 { get; set; }
+            public Dictionary<string, int> Skipped3 { get; }
+        }
+
+        public class ClassWithIgnoredDictionary2
+        {
+            public IDictionary<string, int> Parsed1 { get; set; }
+            public IDictionary<string, int> Skipped2 { get; }
+            public IDictionary<string, int> Parsed3 { get; set; }
+        }
+
+        public class ClassWithIgnoredDictionary3
+        {
+            public Dictionary<string, int> Parsed1 { get; set; }
+            public Dictionary<string, int> Skipped2 { get; }
+            public Dictionary<string, int> Skipped3 { get; }
+        }
+
+        public class ClassWithIgnoredDictionary4
+        {
+            public Dictionary<string, int> Skipped1 { get; }
+            public Dictionary<string, int> Parsed2 { get; set; }
+            public Dictionary<string, int> Parsed3 { get; set; }
+        }
+
+        public class ClassWithIgnoredDictionary5
+        {
+            public Dictionary<string, int> Skipped1 { get; }
+            public Dictionary<string, int> Parsed2 { get; set; }
+            public Dictionary<string, int> Skipped3 { get; }
+        }
+
+        public class ClassWithIgnoredDictionary6
+        {
+            public Dictionary<string, int> Skipped1 { get; }
+            public Dictionary<string, int> Skipped2 { get; }
+            public Dictionary<string, int> Parsed3 { get; set; }
+        }
+
+        public class ClassWithIgnoredDictionary7
+        {
+            public Dictionary<string, int> Skipped1 { get; }
+            public Dictionary<string, int> Skipped2 { get; }
+            public Dictionary<string, int> Skipped3 { get; }
+        }
+
+        public class ClassWithIgnoredIDictionary
+        {
+            public IDictionary<string, int> Parsed1 { get; set; }
+            public IDictionary<string, int> Skipped2 { get; }
+            public IDictionary<string, int> Parsed3 { get; set; }
+        }
+
+        public class ClassWithIgnoreAttributeDictionary
+        {
+            public Dictionary<string, int> Parsed1 { get; set; }
+            [JsonIgnore] public Dictionary<string, int> Skipped2 { get; set; } // Note this has a setter.
+            public Dictionary<string, int> Parsed3 { get; set; }
+        }
+
+        public class ClassWithIgnoredImmutableDictionary
+        {
+            public ImmutableDictionary<string, int> Parsed1 { get; set; }
+            public ImmutableDictionary<string, int> Skipped2 { get; }
+            public ImmutableDictionary<string, int> Parsed3 { get; set; }
+        }
+
+        [Fact]
+        public static void IgnoredMembers()
+        {
+            // Verify all combinations of 3 properties with at least one ignore.
+            VerifyIgnore<ClassWithIgnoredDictionary1>(false, false, true);
+            VerifyIgnore<ClassWithIgnoredDictionary2>(false, true, false);
+            VerifyIgnore<ClassWithIgnoredDictionary3>(false, true, true);
+            VerifyIgnore<ClassWithIgnoredDictionary4>(true, false, false);
+            VerifyIgnore<ClassWithIgnoredDictionary5>(true, false, true);
+            VerifyIgnore<ClassWithIgnoredDictionary6>(true, true, false);
+            VerifyIgnore<ClassWithIgnoredDictionary7>(true, true, true);
+
+            // Verify single case for IDictionary, [Ignore] and ImmutableDictionary.
+            VerifyIgnore<ClassWithIgnoredIDictionary>(false, true, false, true);
+            VerifyIgnore<ClassWithIgnoreAttributeDictionary>(false, true, false, true);
+            VerifyIgnore<ClassWithIgnoredImmutableDictionary>(false, true, false, true);
+        }
+
+        private static void VerifyIgnore<T>(bool skip1, bool skip2, bool skip3, bool addMissing = false)
+        {
+            // Tests that the parser picks back up after skipping/draining ignored elements.
+            StringBuilder json = new StringBuilder(@"{");
+
+            if (addMissing)
+            {
+                json.Append(@"""MissingProp1"": {},");
+            }
+
+            if (skip1)
+            {
+                json.Append(@"""Skipped1"":{},");
+            }
+            else
+            {
+                json.Append(@"""Parsed1"":{""Key"":1},");
+            }
+
+            if (addMissing)
+            {
+                json.Append(@"""MissingProp2"": null,");
+            }
+
+            if (skip2)
+            {
+                json.Append(@"""Skipped2"":{},");
+            }
+            else
+            {
+                json.Append(@"""Parsed2"":{""Key"":2},");
+            }
+
+            if (addMissing)
+            {
+                json.Append(@"""MissingProp3"": {""ABC"":{}},");
+            }
+
+            if (skip3)
+            {
+                json.Append(@"""Skipped3"":{}}");
+            }
+            else
+            {
+                json.Append(@"""Parsed3"":{""Key"":3}}");
+            }
+
+            // Deserialize and verify.
+
+            T obj = JsonSerializer.Deserialize<T>(json.ToString());
+
+            IDictionary<string, int> GetProperty(string propertyName)
+            {
+                return (IDictionary<string, int>)obj.GetType().GetProperty(propertyName).GetValue(obj);
+            }
+
+            if (skip1)
+            {
+                Assert.Null(GetProperty("Skipped1"));
+            }
+            else
+            {
+                Assert.Equal(1, GetProperty("Parsed1")["Key"]);
+            }
+
+            if (skip2)
+            {
+                Assert.Null(GetProperty("Skipped2"));
+            }
+            else
+            {
+                Assert.Equal(2, GetProperty("Parsed2")["Key"]);
+            }
+
+            if (skip3)
+            {
+                Assert.Null(GetProperty("Skipped3"));
+            }
+            else
+            {
+                Assert.Equal(3, GetProperty("Parsed3")["Key"]);
+            }
         }
 
         public class ClassWithPopulatedDictionaryAndSetter

--- a/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
@@ -365,19 +365,23 @@ namespace System.Text.Json.Serialization.Tests
             public SimpleTestClass AnotherParsedChild { get; set; }
         }
 
-        [Fact]
-        public static void ClassWithNoSetterAndValidProperty()
-        {
-            // Tests that the parser picks back up after skipping/draining ignored elements.
-            string json = @"{
+        [Theory]
+        [InlineData(@"{
                 ""SkippedChild"": {},
                 ""ParsedChild"": {""MyInt16"":18},
                 ""UnmatchedProp"": null,
                 ""AnotherSkippedChild"": {""DrainProp1"":{}, ""DrainProp2"":{""SubProp"":0}},
                 ""AnotherSkippedChild"": {},
-                ""AnotherParsedChild"": {""MyInt16"":20}
-            }";
-
+                ""AnotherParsedChild"": {""MyInt16"":20}}")]
+        [InlineData(@"{
+                ""SkippedChild"": null,
+                ""ParsedChild"": {""MyInt16"":18},
+                ""UnmatchedProp"": null,
+                ""AnotherSkippedChild"": {""DrainProp1"":{}, ""DrainProp2"":{""SubProp"":0}},
+                ""AnotherSkippedChild"": null,
+                ""AnotherParsedChild"": {""MyInt16"":20}}")]
+        public static void ClassWithNoSetterAndValidProperty(string json)
+        {
             ClassWithNoSetter parsedObject = JsonSerializer.Deserialize<ClassWithNoSetter>(json);
 
             Assert.Null(parsedObject.SkippedChild);

--- a/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
@@ -356,5 +356,114 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(1, parsedObject.MySimpleTestClass.MyInt32Array[0]);
             Assert.Equal(2, parsedObject.MyInt32Array[0]);
         }
+
+        public class ClassWithNoSetter
+        {
+            public SimpleTestClass SkippedChild { get; }
+            public SimpleTestClass ParsedChild { get; set; }
+            public SimpleTestClass AnotherSkippedChild { get; }
+            public SimpleTestClass AnotherParsedChild { get; set; }
+        }
+
+        [Fact]
+        public static void ClassWithNoSetterAndValidProperty()
+        {
+            // Tests that the parser picks back up after skipping/draining ignored elements.
+            string json = @"{
+                ""SkippedChild"": {},
+                ""ParsedChild"": {""MyInt16"":18},
+                ""UnmatchedProp"": null,
+                ""AnotherSkippedChild"": {""DrainProp1"":{}, ""DrainProp2"":{""SubProp"":0}},
+                ""AnotherSkippedChild"": {},
+                ""AnotherParsedChild"": {""MyInt16"":20}
+            }";
+
+            ClassWithNoSetter parsedObject = JsonSerializer.Deserialize<ClassWithNoSetter>(json);
+
+            Assert.Null(parsedObject.SkippedChild);
+
+            Assert.NotNull(parsedObject.ParsedChild);
+            Assert.Equal(18, parsedObject.ParsedChild.MyInt16);
+
+            Assert.Null(parsedObject.AnotherSkippedChild);
+
+            Assert.NotNull(parsedObject.AnotherParsedChild);
+            Assert.Equal(20, parsedObject.AnotherParsedChild.MyInt16);
+        }
+
+        public class ClassMixingSkippedTypes
+        {
+            public IDictionary<string, string> SkippedDictionary { get; }
+
+            public SimpleTestClass ParsedClass { get; set; }
+
+            public IList<int> SkippedList { get; }
+            public IDictionary<string, string> AnotherSkippedDictionary { get; }
+            public SimpleTestClass SkippedClass { get; }
+
+            public Dictionary<string, int> ParsedDictionary { get; set; }
+
+            public IList<int> AnotherSkippedList { get; }
+            public IDictionary<string, string> AnotherSkippedDictionary2 { get; }           
+            public IDictionary<string, string> SkippedDictionaryNotInJson { get; }
+            public SimpleTestClass AnotherSkippedClass { get; }
+
+            public int[] ParsedList { get; set; }
+
+            public ClassMixingSkippedTypes ParsedSubMixedTypeParsedClass { get; set; }
+        }
+
+        [Fact]
+        public static void ClassWithMixingSkippedTypes()
+        {
+            // Tests that the parser picks back up after skipping/draining ignored elements. Complex version.
+            string json = @"{
+                ""SkippedDictionary"": {},
+                ""ParsedClass"": {""MyInt16"":18},
+                ""SkippedList"": [18,20],
+                ""UnmatchedList"": [{},{}],
+                ""AnotherSkippedDictionary"": {""Key"":""Value""},
+                ""SkippedClass"": {""MyInt16"":99},
+                ""ParsedDictionary"": {""Key1"":18},
+                ""UnmatchedProp"": null,
+                ""AnotherSkippedList"": null,
+                ""AnotherSkippedDictionary2"": {""Key"":""Value""},
+                ""AnotherSkippedDictionary2"": {""Key"":""Dupe""},
+                ""AnotherSkippedClass"": {},
+                ""ParsedList"": [18,20],
+                ""ParsedSubMixedTypeParsedClass"": {""ParsedDictionary"": {""Key1"":18}},
+                ""UnmatchedDictionary"": {""DrainProp1"":{}, ""DrainProp2"":{""SubProp"":0}}                
+            }";
+
+            ClassMixingSkippedTypes parsedObject = JsonSerializer.Deserialize<ClassMixingSkippedTypes>(json);
+
+            Assert.Null(parsedObject.SkippedDictionary);
+
+            Assert.NotNull(parsedObject.ParsedClass);
+            Assert.Equal(18, parsedObject.ParsedClass.MyInt16);
+
+            Assert.Null(parsedObject.SkippedList);
+            Assert.Null(parsedObject.AnotherSkippedDictionary);
+            Assert.Null(parsedObject.SkippedClass);
+
+            Assert.NotNull(parsedObject.ParsedDictionary);
+            Assert.Equal(1, parsedObject.ParsedDictionary.Count);
+            Assert.Equal(18, parsedObject.ParsedDictionary["Key1"]);
+
+            Assert.Null(parsedObject.AnotherSkippedList);
+            Assert.Null(parsedObject.AnotherSkippedDictionary2);
+            Assert.Null(parsedObject.SkippedDictionaryNotInJson);
+            Assert.Null(parsedObject.AnotherSkippedClass);
+
+            Assert.NotNull(parsedObject.ParsedList);
+            Assert.Equal(2, parsedObject.ParsedList.Length);
+            Assert.Equal(18, parsedObject.ParsedList[0]);
+            Assert.Equal(20, parsedObject.ParsedList[1]);
+
+            Assert.NotNull(parsedObject.ParsedSubMixedTypeParsedClass);
+            Assert.NotNull(parsedObject.ParsedSubMixedTypeParsedClass.ParsedDictionary);
+            Assert.Equal(1, parsedObject.ParsedSubMixedTypeParsedClass.ParsedDictionary.Count);
+            Assert.Equal(18, parsedObject.ParsedSubMixedTypeParsedClass.ParsedDictionary["Key1"]);
+        }
     }
 }


### PR DESCRIPTION
Port https://github.com/dotnet/corefx/pull/40490, https://github.com/dotnet/corefx/pull/40598 and #40629.
(cherry-picked from commits fb30a2d, 7cc4a04 and 546fdc4) 

### Description
Summary: dictionary values in JSON may be skipped in certain cases when they shouldn't be.

Detail: when JSON that contains dictionary values is skipped as expected during deserialization (because the corresponding property on the object being deserialized doesn't have a setter, or `[JsonIgnore]` is used on that property), then other dictionaries also in the JSON (directly following the skipped property) that should **not** be skipped are instead skipped and not thus not deserialized.

We want to address this in 3.0 or 3.1.

### Customer Impact:
Data loss when the issue is encountered.

### Regression? 
No

### Risk: Low.

The fix consists of two cases where an "EndProperty()" method needed to be called (one line of code for each case), and in areas very specific to deserializing objects and dictionaries. Several test permutations were added to cover different combinations\ordering of skipped and non-skipped properties.