### PR TITLE
Fix additional issue of dictionary properties being skipped

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleDictionary.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleDictionary.cs
@@ -98,6 +98,7 @@ namespace System.Text.Json
         {
             if (state.Current.SkipProperty)
             {
+                // Todo: determine if this is reachable.
                 return;
             }
 

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleNull.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleNull.cs
@@ -12,6 +12,10 @@ namespace System.Text.Json
         {
             if (state.Current.SkipProperty)
             {
+                // Clear the current property in case it is a dictionary, since dictionaries must have EndProperty() called when completed.
+                // A non-dictionary property can also have EndProperty() called when completed, although it is redundant.
+                state.Current.EndProperty();
+
                 return false;
             }
 

--- a/src/System.Text.Json/tests/Serialization/Array.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Array.ReadTests.cs
@@ -450,11 +450,8 @@ namespace System.Text.Json.Serialization.Tests
             public IEnumerable<int> ParsedChild3 { get; set; }
         }
 
-        [Fact]
-        public static void ClassWithMixedSettersIsParsed()
-        {
-            // Tests that the parser picks back up after skipping/draining ignored elements.
-            string json = @"{
+        [Theory]
+        [InlineData(@"{
                 ""SkippedChild1"": {},
                 ""ParsedChild1"": [1],
                 ""UnmatchedProp"": null,
@@ -462,9 +459,18 @@ namespace System.Text.Json.Serialization.Tests
                 ""SkippedChild2"": {},
                 ""ParsedChild2"": [2,2],
                 ""SkippedChild3"": {},
-                ""ParsedChild3"": [3,3]
-            }";
-
+                ""ParsedChild3"": [3,3]}")]
+        [InlineData(@"{
+                ""SkippedChild1"": null,
+                ""ParsedChild1"": [1],
+                ""UnmatchedProp"": null,
+                ""SkippedChild2"": [],
+                ""SkippedChild2"": null,
+                ""ParsedChild2"": [2,2],
+                ""SkippedChild3"": null,
+                ""ParsedChild3"": [3,3]}")]
+        public static void ClassWithMixedSettersIsParsed(string json)
+        {
             ClassWithMixedSetters parsedObject = JsonSerializer.Deserialize<ClassWithMixedSetters>(json);
 
             Assert.Null(parsedObject.SkippedChild1);

--- a/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
+++ b/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
@@ -922,7 +922,7 @@ namespace System.Text.Json.Serialization.Tests
         public static void ClassWithNoSetterAndDictionary()
         {
             // We don't attempt to deserialize into dictionaries without a setter.
-            string json = @"{""MyDictionary"":{""Key1"":""Value1"", ""Key2"":""Value2""},""MyDictionaryWithSetter"":{""Key1"":""Value1""}}";
+            string json = @"{""MyDictionary"":{""Key1"":""Value1"", ""Key2"":""Value2""}}";
             ClassWithPopulatedDictionaryAndNoSetter obj = JsonSerializer.Deserialize<ClassWithPopulatedDictionaryAndNoSetter>(json);
             Assert.Equal(1, obj.MyDictionary.Count);
         }
@@ -1006,8 +1006,37 @@ namespace System.Text.Json.Serialization.Tests
             public ImmutableDictionary<string, int> Parsed3 { get; set; }
         }
 
+        [Theory]
+        [InlineData(@"{""Parsed1"":{""Key"":1},""Parsed3"":{""Key"":2}}")] // No value for skipped property
+        [InlineData(@"{""Parsed1"":{""Key"":1},""Skipped2"":{}, ""Parsed3"":{""Key"":2}}")] // Empty object {} skipped
+        [InlineData(@"{""Parsed1"":{""Key"":1},""Skipped2"":null, ""Parsed3"":{""Key"":2}}")] // null object skipped
+        [InlineData(@"{""Parsed1"":{""Key"":1},""Skipped2"":{""Key"":9}, ""Parsed3"":{""Key"":2}}")] // Valid "int" values skipped
+        // Invalid "int" values:
+        [InlineData(@"{""Parsed1"":{""Key"":1},""Skipped2"":{""Key"":[1,2,3]}, ""Parsed3"":{""Key"":2}}")]
+        [InlineData(@"{""Parsed1"":{""Key"":1},""Skipped2"":{""Key"":{}}, ""Parsed3"":{""Key"":2}}")]
+        [InlineData(@"{""Parsed1"":{""Key"":1},""Skipped2"":{""Key"":null}, ""Parsed3"":{""Key"":2}}")]
+        public static void IgnoreDictionaryProperty(string json)
+        {
+            // Verify deserialization
+            ClassWithIgnoredDictionary2 obj = JsonSerializer.Deserialize<ClassWithIgnoredDictionary2>(json);
+            Assert.Equal(1, obj.Parsed1.Count);
+            Assert.Equal(1, obj.Parsed1["Key"]);
+            Assert.Null(obj.Skipped2);
+            Assert.Equal(1, obj.Parsed3.Count);
+            Assert.Equal(2, obj.Parsed3["Key"]);
+
+            // Round-trip and verify.
+            string jsonRoundTripped = JsonSerializer.Serialize(obj);
+            ClassWithIgnoredDictionary2 objRoundTripped = JsonSerializer.Deserialize<ClassWithIgnoredDictionary2>(jsonRoundTripped);
+            Assert.Equal(1, objRoundTripped.Parsed1.Count);
+            Assert.Equal(1, objRoundTripped.Parsed1["Key"]);
+            Assert.Null(objRoundTripped.Skipped2);
+            Assert.Equal(1, objRoundTripped.Parsed3.Count);
+            Assert.Equal(2, objRoundTripped.Parsed3["Key"]);
+        }
+
         [Fact]
-        public static void IgnoredMembers()
+        public static void IgnoreDictionaryPropertyWithDifferentOrdering()
         {
             // Verify all combinations of 3 properties with at least one ignore.
             VerifyIgnore<ClassWithIgnoredDictionary1>(false, false, true);
@@ -1019,9 +1048,10 @@ namespace System.Text.Json.Serialization.Tests
             VerifyIgnore<ClassWithIgnoredDictionary7>(true, true, true);
 
             // Verify single case for IDictionary, [Ignore] and ImmutableDictionary.
-            VerifyIgnore<ClassWithIgnoredIDictionary>(false, true, false, true);
-            VerifyIgnore<ClassWithIgnoreAttributeDictionary>(false, true, false, true);
-            VerifyIgnore<ClassWithIgnoredImmutableDictionary>(false, true, false, true);
+            // Also specify addMissing to add additional skipped JSON that does not have a corresponding property.
+            VerifyIgnore<ClassWithIgnoredIDictionary>(false, true, false, addMissing: true);
+            VerifyIgnore<ClassWithIgnoreAttributeDictionary>(false, true, false, addMissing: true);
+            VerifyIgnore<ClassWithIgnoredImmutableDictionary>(false, true, false, addMissing: true);
         }
 
         private static void VerifyIgnore<T>(bool skip1, bool skip2, bool skip3, bool addMissing = false)

--- a/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
@@ -365,19 +365,23 @@ namespace System.Text.Json.Serialization.Tests
             public SimpleTestClass AnotherParsedChild { get; set; }
         }
 
-        [Fact]
-        public static void ClassWithNoSetterAndValidProperty()
-        {
-            // Tests that the parser picks back up after skipping/draining ignored elements.
-            string json = @"{
+        [Theory]
+        [InlineData(@"{
                 ""SkippedChild"": {},
                 ""ParsedChild"": {""MyInt16"":18},
                 ""UnmatchedProp"": null,
                 ""AnotherSkippedChild"": {""DrainProp1"":{}, ""DrainProp2"":{""SubProp"":0}},
                 ""AnotherSkippedChild"": {},
-                ""AnotherParsedChild"": {""MyInt16"":20}
-            }";
-
+                ""AnotherParsedChild"": {""MyInt16"":20}}")]
+        [InlineData(@"{
+                ""SkippedChild"": null,
+                ""ParsedChild"": {""MyInt16"":18},
+                ""UnmatchedProp"": null,
+                ""AnotherSkippedChild"": {""DrainProp1"":{}, ""DrainProp2"":{""SubProp"":0}},
+                ""AnotherSkippedChild"": null,
+                ""AnotherParsedChild"": {""MyInt16"":20}}")]
+        public static void ClassWithNoSetterAndValidProperty(string json)
+        {
             ClassWithNoSetter parsedObject = JsonSerializer.Deserialize<ClassWithNoSetter>(json);
 
             Assert.Null(parsedObject.SkippedChild);


### PR DESCRIPTION
With extended testing, another issue with dictionary properties being skipped was found. This adds on top of #40490 and #40598.

Same as the original issue where dictionary properties can be skipped, but now with a "null" value instead of an object value ("{}").

Will also need to be applied to https://github.com/dotnet/corefx/pull/40624 (3.0).

cc @CodeBlanch