### PR TITLE
Fix HashSet.SetCapacity() that increases capacity failing after a successful Remove().

### DIFF
--- a/src/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.cs
@@ -344,19 +344,5 @@ namespace System.Collections.Tests
             ISet<T> iset = (set as ISet<T>);
             Assert.NotNull(iset);
         }
-
-        [Theory]
-        [MemberData(nameof(ValidCollectionSizes))]
-        public void EnsureCapacity_AfterRemovingOne(int setLength)
-        {
-            if (setLength == 0)
-            {
-                return;
-            }
-
-            HashSet<T> set = (HashSet<T>)GenericISetFactory(setLength);
-            set.Remove(set.ElementAt(0));
-            set.EnsureCapacity(set.Count * 3); // * 3 to ensure we hit the next prime so that a resize happens.
-        }
     }
 }

--- a/src/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.netcoreapp.cs
+++ b/src/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.netcoreapp.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace System.Collections.Tests
@@ -270,6 +271,23 @@ namespace System.Collections.Tests
 
             set = new HashSet<T>();
             Assert.Equal(17, set.EnsureCapacity(13));
+        }
+
+        [Theory]
+        [InlineData(2)]
+        [InlineData(10)]
+        public void EnsureCapacity_Generic_GrowCapacityWithFreeList(int setLength)
+        {
+            HashSet<T> set = (HashSet<T>)GenericISetFactory(setLength);
+
+            // Remove the first element to ensure we have a free list.
+            Assert.True(set.Remove(set.ElementAt(0)));
+
+            int currentCapacity = set.EnsureCapacity(0);
+            Assert.True(currentCapacity > 0);
+
+            int newCapacity = set.EnsureCapacity(currentCapacity + 1);
+            Assert.True(newCapacity > currentCapacity);
         }
 
         #endregion


### PR DESCRIPTION
HashSet.SetCapacity does not take into account the freelist, and will bomb out due to a bad array index.

Resolves #40621