### PR TITLE
Deserialize extension data properly for child objects

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleDictionary.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleDictionary.cs
@@ -104,16 +104,17 @@ namespace System.Text.Json
             if (state.Current.IsDictionaryProperty)
             {
                 // Handle special case of DataExtensionProperty where we just added a dictionary element to the extension property.
-                // Since the JSON value is not a dictionary element (just a normal property value) a JsonTokenType.EndObject
+                // Since the JSON value is not a dictionary element (it's a normal property in JSON) a JsonTokenType.EndObject
                 // encountered here is from the outer object so forward to HandleEndObject().
                 if (state.Current.JsonClassInfo.DataExtensionProperty == state.Current.JsonPropertyInfo)
                 {
-                    HandleEndObject( ref reader, ref state);
-                    return;
+                    HandleEndObject(ref reader, ref state);
                 }
-
-                // We added the items to the dictionary already.
-                state.Current.EndProperty();
+                else
+                {
+                    // We added the items to the dictionary already.
+                    state.Current.EndProperty();
+                }
             }
             else if (state.Current.IsIDictionaryConstructibleProperty)
             {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleDictionary.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleDictionary.cs
@@ -103,6 +103,15 @@ namespace System.Text.Json
 
             if (state.Current.IsDictionaryProperty)
             {
+                // Handle special case of DataExtensionProperty where we just added a dictionary element to the extension property.
+                // Since the JSON value is not a dictionary element (just a normal property value) a JsonTokenType.EndObject
+                // encountered here is from the outer object so forward to HandleEndObject().
+                if (state.Current.JsonClassInfo.DataExtensionProperty == state.Current.JsonPropertyInfo)
+                {
+                    HandleEndObject( ref reader, ref state);
+                    return;
+                }
+
                 // We added the items to the dictionary already.
                 state.Current.EndProperty();
             }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleObject.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleObject.cs
@@ -9,7 +9,7 @@ namespace System.Text.Json
 {
     public static partial class JsonSerializer
     {
-        private static void HandleStartObject(JsonSerializerOptions options, ref Utf8JsonReader reader, ref ReadStack state)
+        private static void HandleStartObject(JsonSerializerOptions options, ref ReadStack state)
         {
             Debug.Assert(!state.Current.IsProcessingDictionary && !state.Current.IsProcessingIDictionaryConstructible);
 
@@ -52,9 +52,12 @@ namespace System.Text.Json
             }
         }
 
-        private static void HandleEndObject(JsonSerializerOptions options, ref Utf8JsonReader reader, ref ReadStack state)
+        private static void HandleEndObject(ref Utf8JsonReader reader, ref ReadStack state)
         {
-            Debug.Assert(!state.Current.IsProcessingDictionary && !state.Current.IsProcessingIDictionaryConstructible);
+            // Only allow dictionaries to be processed here if this is the DataExtensionProperty.
+            Debug.Assert(
+                (!state.Current.IsProcessingDictionary || state.Current.JsonClassInfo.DataExtensionProperty == state.Current.JsonPropertyInfo) &&
+                !state.Current.IsProcessingIDictionaryConstructible);
 
             // Check if we are trying to build the sorted cache.
             if (state.Current.PropertyRefCache != null)

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.cs
@@ -74,7 +74,7 @@ namespace System.Text.Json
                         }
                         else
                         {
-                            HandleStartObject(options, ref reader, ref readStack);
+                            HandleStartObject(options, ref readStack);
                         }
                     }
                     else if (tokenType == JsonTokenType.EndObject)
@@ -93,7 +93,7 @@ namespace System.Text.Json
                         }
                         else
                         {
-                            HandleEndObject(options, ref reader, ref readStack);
+                            HandleEndObject(ref reader, ref readStack);
                         }
                     }
                     else if (tokenType == JsonTokenType.StartArray)

--- a/src/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
+++ b/src/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
@@ -353,11 +353,12 @@ namespace System.Text.Json.Serialization.Tests
             public ClassWithExtensionProperty MyReference { get; set; }
         }
 
-        [Fact]
-        public static void ObjectTree()
+        [Theory]
+        [InlineData(@"{""MyIntMissing"":2,""MyReference"":{""MyIntMissingChild"":3}}")]
+        [InlineData(@"{""MyReference"":{""MyIntMissingChild"":3},""MyIntMissing"":2}")]
+        [InlineData(@"{""MyReference"":{""MyNestedClass"":null,""MyInt"":0,""MyIntMissingChild"":3},""MyIntMissing"":2}")]
+        public static void NestedClass(string json)
         {
-            string json = @"{""MyIntMissing"":2, ""MyReference"":{""MyIntMissingChild"":3}}";
-
             ClassWithReference obj = JsonSerializer.Deserialize<ClassWithReference>(json);
             Assert.IsType<JsonElement>(obj.MyOverflow["MyIntMissing"]);
             Assert.Equal(1, obj.MyOverflow.Count);
@@ -368,6 +369,110 @@ namespace System.Text.Json.Serialization.Tests
             Assert.IsType<JsonElement>(child.MyOverflow["MyIntMissingChild"]);
             Assert.Equal(1, child.MyOverflow.Count);
             Assert.Equal(3, child.MyOverflow["MyIntMissingChild"].GetInt32());
+
+            // Round-trip the json.
+            json = JsonSerializer.Serialize(obj);
+            obj = JsonSerializer.Deserialize<ClassWithReference>(json);
+            Assert.IsType<JsonElement>(obj.MyOverflow["MyIntMissing"]);
+            Assert.Equal(1, obj.MyOverflow.Count);
+            Assert.Equal(2, obj.MyOverflow["MyIntMissing"].GetInt32());
+
+            child = obj.MyReference;
+            Assert.IsType<JsonElement>(child.MyOverflow["MyIntMissingChild"]);
+            Assert.IsType<JsonElement>(child.MyOverflow["MyIntMissingChild"]);
+            Assert.Equal(1, child.MyOverflow.Count);
+            Assert.Equal(3, child.MyOverflow["MyIntMissingChild"].GetInt32());
+        }
+
+        private class ParentClassWithObject
+        {
+            public string Text { get; set; }
+            public ChildClassWithObject Child { get; set; }
+
+            [JsonExtensionData]
+            public Dictionary<string, object> ExtensionData { get; set; } = new Dictionary<string, object>();
+        }
+
+        private class ChildClassWithObject
+        {
+            public int Number { get; set; }
+
+            [JsonExtensionData]
+            public Dictionary<string, object> ExtensionData { get; set; } = new Dictionary<string, object>();
+        }
+
+        [Fact]
+        public static void NestedClassWithObjectExtensionDataProperty()
+        {
+            var child = new ChildClassWithObject { Number = 2 };
+            child.ExtensionData.Add("SpecialInformation", "I am child class");
+
+            var parent = new ParentClassWithObject { Text = "Hello World" };
+            parent.ExtensionData.Add("SpecialInformation", "I am parent class");
+            parent.Child = child;
+
+            Assert.Equal("Hello World", parent.Text);
+            Assert.IsType<string>(parent.ExtensionData["SpecialInformation"]);
+            Assert.Equal("I am parent class", (string)parent.ExtensionData["SpecialInformation"]);
+            Assert.Equal(2, parent.Child.Number);
+            Assert.IsType<string>(parent.Child.ExtensionData["SpecialInformation"]);
+            Assert.Equal("I am child class", (string)parent.Child.ExtensionData["SpecialInformation"]);
+
+            // Round-trip and verify.
+            string json = JsonSerializer.Serialize(parent);
+            parent = JsonSerializer.Deserialize<ParentClassWithObject>(json);
+
+            Assert.Equal("Hello World", parent.Text);
+            Assert.IsType<JsonElement>(parent.ExtensionData["SpecialInformation"]);
+            Assert.Equal("I am parent class", ((JsonElement)parent.ExtensionData["SpecialInformation"]).GetString());
+            Assert.Equal(2, parent.Child.Number);
+            Assert.IsType<JsonElement>(parent.Child.ExtensionData["SpecialInformation"]);
+            Assert.Equal("I am child class", ((JsonElement)parent.Child.ExtensionData["SpecialInformation"]).GetString());
+        }
+
+        private class ParentClassWithJsonElement
+        {
+            public string Text { get; set; }
+
+            public List<ChildClassWithJsonElement> Children { get; set; } = new List<ChildClassWithJsonElement>();
+
+            [JsonExtensionData]
+            public Dictionary<string, JsonElement> ExtensionData { get; set; } = new Dictionary<string, JsonElement>();
+        }
+
+        private class ChildClassWithJsonElement
+        {
+            public int Number { get; set; }
+
+            [JsonExtensionData]
+            public Dictionary<string, JsonElement> ExtensionData { get; set; } = new Dictionary<string, JsonElement>();
+        }
+
+        [Fact]
+        public static void NestedClassWithJsonElementExtensionDataProperty()
+        {
+            var child = new ChildClassWithJsonElement { Number = 4 };
+            child.ExtensionData.Add("SpecialInformation", JsonDocument.Parse(JsonSerializer.SerializeToUtf8Bytes("I am child class")).RootElement);
+
+            var parent = new ParentClassWithJsonElement { Text = "Hello World" };
+            parent.ExtensionData.Add("SpecialInformation", JsonDocument.Parse(JsonSerializer.SerializeToUtf8Bytes("I am parent class")).RootElement);
+            parent.Children.Add(child);
+
+            Verify();
+
+            // Round-trip and verify.
+            string json = JsonSerializer.Serialize(parent);
+            parent = JsonSerializer.Deserialize<ParentClassWithJsonElement>(json);
+            Verify();
+
+            void Verify()
+            {
+                Assert.Equal("Hello World", parent.Text);
+                Assert.Equal("I am parent class", parent.ExtensionData["SpecialInformation"].GetString());
+                Assert.Equal(1, parent.Children.Count);
+                Assert.Equal(4, parent.Children[0].Number);
+                Assert.Equal("I am child class", parent.Children[0].ExtensionData["SpecialInformation"].GetString());
+            }
         }
 
         [Fact]

--- a/src/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
+++ b/src/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
@@ -440,7 +440,8 @@ namespace System.Text.Json.Serialization.Tests
             public List<ChildClassWithJsonElement> Children { get; set; } = new List<ChildClassWithJsonElement>();
 
             [JsonExtensionData]
-            public Dictionary<string, JsonElement> ExtensionData { get; set; } = new Dictionary<string, JsonElement>();
+            // Use SortedDictionary as verification of supporting derived dictionaries.
+            public SortedDictionary<string, JsonElement> ExtensionData { get; set; } = new SortedDictionary<string, JsonElement>();
         }
 
         private class ChildClassWithJsonElement

--- a/src/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
+++ b/src/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.DirectoryServices.Protocols;
 using System.Linq;
 using Xunit;
 


### PR DESCRIPTION
Addresses https://github.com/dotnet/corefx/issues/40618 for master.

Under certain cases (a child object and whether the JSON for the extension data is at the end of the current object), the extension data was not deserialized properly resulting in exceptions.

This should be ported to 3.0.
