### PR TITLE
invalidate state when directory is created

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
+++ b/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs
@@ -92,7 +92,11 @@ namespace System.IO
             throw new ArgumentException(SR.Format(SR.Argument_InvalidSubPath, path, FullPath), nameof(path));
         }
 
-        public void Create() => FileSystem.CreateDirectory(FullPath);
+        public void Create()
+        {
+            FileSystem.CreateDirectory(FullPath);
+            Invalidate();
+        }
 
         // Returns an array of Files in the DirectoryInfo specified by path
         public FileInfo[] GetFiles() => GetFiles("*", enumerationOptions: EnumerationOptions.Compatible);

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/Create.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/Create.cs
@@ -74,5 +74,14 @@ namespace System.IO.Tests
             DirectoryInfo testInfo = new DirectoryInfo(testDir + extension + trailing);
             Assert.Equal(trailing, testInfo.Extension);
         }
+
+        [Fact]
+        public void CreateDirectoryWithAttributes()
+        {
+            string testDir = Path.Combine(GetTestFilePath(), "CreateDirectoryWithAttributes");
+            DirectoryInfo testInfo = new DirectoryInfo(testDir);
+            testInfo.Create();
+            testInfo.Attributes = FileAttributes.Directory | FileAttributes.Normal;
+        }
     }
 }


### PR DESCRIPTION
The failure is caused by fact that we cache _exist = false so when code assigns to Attributes it fails without trying with  unexpected error. 

Since this works in Windows it seems reasonable to fix this for compatibility. 
I was also looking at other functions like Delete. But it seems like there is explicit test to verify that Exist property does not change after deletion so I left it unchanged. 

new test added. 


fixes https://github.com/dotnet/runtime/issues/30708