### PR TITLE
Add custom enum converter test for having flags as array

### DIFF
--- a/src/System.Text.Json/tests/Serialization/CustomConverterTests.Enum.cs
+++ b/src/System.Text.Json/tests/Serialization/CustomConverterTests.Enum.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using System.Reflection;
 using Xunit;
 
 namespace System.Text.Json.Serialization.Tests
@@ -111,6 +113,145 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal(MyBoolEnum.Unknown, value);
                 Assert.Equal(@"""?""", JsonSerializer.Serialize(value, options));
             }
+        }
+
+        // A custom enum converter that uses an array for containing bit flags.
+        private sealed class JsonStringEnumArrayConverter : JsonConverterFactory
+        {
+            public JsonStringEnumArrayConverter() { }
+
+            public override bool CanConvert(Type typeToConvert)
+            {
+                return typeToConvert.IsEnum;
+            }
+
+            public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+            {
+                JsonConverter converter = (JsonConverter)Activator.CreateInstance(
+                    typeof(JsonConverterEnumArray<>).MakeGenericType(typeToConvert),
+                    BindingFlags.Instance | BindingFlags.Public,
+                    binder: null,
+                    args: null,
+                    culture: null);
+
+                return converter;
+            }
+        }
+
+        internal class JsonConverterEnumArray<T> : JsonConverter<T>
+            where T : struct, Enum
+        {
+            public override bool CanConvert(Type type)
+            {
+                return type.IsEnum;
+            }
+
+            public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                if (reader.TokenType != JsonTokenType.StartArray)
+                {
+                    throw new JsonException();
+                }
+
+                string enumString = default;
+
+                bool first = true;
+                while (true)
+                {
+                    reader.Read();
+
+                    if (reader.TokenType == JsonTokenType.EndArray)
+                    {
+                        break;
+                    }
+
+                    if (reader.TokenType != JsonTokenType.String)
+                    {
+                        throw new JsonException();
+                    }
+
+                    string enumValue = reader.GetString();
+                    if (first)
+                    {
+                        first = false;
+                    }
+                    else
+                    {
+                        enumString += ",";
+                    }
+
+                    enumString += enumValue.ToString();
+                }
+
+                if (!Enum.TryParse(enumString, out T value))
+                {
+                    throw new JsonException();
+                }
+
+                return value;
+            }
+
+            public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+            {
+                string[] enumString = value.ToString().Split(",");
+
+                writer.WriteStartArray();
+
+                foreach (string enumValue in enumString)
+                {
+                    writer.WriteStringValue(enumValue);
+                }
+
+                writer.WriteEndArray();
+            }
+        }
+
+        [Flags]
+        [JsonConverter(typeof(JsonStringEnumArrayConverter))]
+        public enum eDevice : uint
+        {
+            Unknown = 0x0,
+            Phone = 0x1,
+            PC = 0x2,
+            Laptop = 0x4,
+            Tablet = 0x8,
+            IoT = 0x10,
+            Watch = 0x20,
+            TV = 0x40,
+            Hub = 0x80,
+            Studio = 0x100,
+            Book = 0x200,
+            MediaCenter = 0x400,
+        }
+
+        [Theory]
+        [InlineData(@"[""PC"",""Tablet""]")]
+        [InlineData(@"[""Tablet"",""PC""]")]
+        public static void EnumValue(string json)
+        {
+            eDevice obj = JsonSerializer.Deserialize<eDevice>(json);
+            Assert.Equal(eDevice.PC | eDevice.Tablet, obj);
+        }
+
+        private class ConnectionList
+        {
+            public List<ConnectionFile> Connections { get; set; }
+        }
+
+        private class ConnectionFile
+        {
+            public eDevice Device { get; set; }
+        }
+
+        [Theory]
+        [InlineData(@"{""Connections"": [{""Device"":[""PC"",""Tablet""]},{""Device"":[""PC"",""Laptop""]}]}")]
+        [InlineData(@"{""Connections"": [{""Device"":[""Tablet"",""PC""]},{""Device"":[""Laptop"",""PC""]}]}")]
+        public static void EnumArray(string json)
+        {
+            ConnectionList obj = JsonSerializer.Deserialize<ConnectionList>(json);
+            Assert.Equal(2, obj.Connections.Count);
+            Assert.Equal(eDevice.PC | eDevice.Tablet, obj.Connections[0].Device);
+            Assert.Equal(eDevice.PC | eDevice.Laptop, obj.Connections[1].Device);
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/CustomConverterTests.Enum.cs
+++ b/src/System.Text.Json/tests/Serialization/CustomConverterTests.Enum.cs
@@ -199,7 +199,7 @@ namespace System.Text.Json.Serialization.Tests
 
                 foreach (string enumValue in enumString)
                 {
-                    writer.WriteStringValue(enumValue);
+                    writer.WriteStringValue(enumValue.TrimStart());
                 }
 
                 writer.WriteEndArray();
@@ -229,8 +229,20 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData(@"[""Tablet"",""PC""]")]
         public static void EnumValue(string json)
         {
-            eDevice obj = JsonSerializer.Deserialize<eDevice>(json);
-            Assert.Equal(eDevice.PC | eDevice.Tablet, obj);
+            eDevice obj;
+
+            void Verify()
+            {
+                Assert.Equal(eDevice.PC | eDevice.Tablet, obj);
+            }
+
+            obj = JsonSerializer.Deserialize<eDevice>(json);
+            Verify();
+
+            // Round-trip and verify.
+            json = JsonSerializer.Serialize(obj);
+            obj = JsonSerializer.Deserialize<eDevice>(json);
+            Verify();
         }
 
         private class ConnectionList
@@ -244,14 +256,26 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Theory]
-        [InlineData(@"{""Connections"": [{""Device"":[""PC"",""Tablet""]},{""Device"":[""PC"",""Laptop""]}]}")]
-        [InlineData(@"{""Connections"": [{""Device"":[""Tablet"",""PC""]},{""Device"":[""Laptop"",""PC""]}]}")]
+        [InlineData(@"{""Connections"":[{""Device"":[""PC"",""Tablet""]},{""Device"":[""PC"",""Laptop""]}]}")]
+        [InlineData(@"{""Connections"":[{""Device"":[""Tablet"",""PC""]},{""Device"":[""Laptop"",""PC""]}]}")]
         public static void EnumArray(string json)
         {
-            ConnectionList obj = JsonSerializer.Deserialize<ConnectionList>(json);
-            Assert.Equal(2, obj.Connections.Count);
-            Assert.Equal(eDevice.PC | eDevice.Tablet, obj.Connections[0].Device);
-            Assert.Equal(eDevice.PC | eDevice.Laptop, obj.Connections[1].Device);
+            ConnectionList obj;
+
+            void Verify()
+            {
+                Assert.Equal(2, obj.Connections.Count);
+                Assert.Equal(eDevice.PC | eDevice.Tablet, obj.Connections[0].Device);
+                Assert.Equal(eDevice.PC | eDevice.Laptop, obj.Connections[1].Device);
+            }
+
+            obj = JsonSerializer.Deserialize<ConnectionList>(json);
+            Verify();
+
+            // Round-trip and verify.
+            json = JsonSerializer.Serialize(obj);
+            obj = JsonSerializer.Deserialize<ConnectionList>(json);
+            Verify();
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/CustomConverterTests.Enum.cs
+++ b/src/System.Text.Json/tests/Serialization/CustomConverterTests.Enum.cs
@@ -193,7 +193,7 @@ namespace System.Text.Json.Serialization.Tests
 
             public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
             {
-                string[] enumString = value.ToString().Split(",");
+                string[] enumString = value.ToString().Split(',');
 
                 writer.WriteStartArray();
 


### PR DESCRIPTION
Based on question https://github.com/dotnet/corefx/issues/40499, I created a custom converter that uses an array of strings to contain the bit flags.

This is an interesting example because it shows that a primitive (an Enum) can be represented by an array.
