### PR TITLE
Enable macOS10.14 in PR builds

### DIFF
--- a/eng/pipelines/macos.yml
+++ b/eng/pipelines/macos.yml
@@ -56,8 +56,4 @@ stages:
         submitToHelix: true
 
         variables:
-          - ${{ if eq(parameters.fullMatrix, 'false') }}:
-            - macOSQueues: OSX.1013.Amd64.Open
-
-          - ${{ if eq(parameters.fullMatrix, 'true') }}:
             - macOSQueues: OSX.1013.Amd64.Open+OSX.1014.Amd64.Open


### PR DESCRIPTION
Spoke with @MattGal who told me that the pool is idle and waiting for some work. This should help to discover issues with macOS 10.14 more easily. I.e.: https://github.com/dotnet/corefx/issues/40262