### PR TITLE
[Release/3.0] Deserialize extension data properly for child objects (#40662)

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleDictionary.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleDictionary.cs
@@ -104,8 +104,18 @@ namespace System.Text.Json
 
             if (state.Current.IsDictionaryProperty)
             {
-                // We added the items to the dictionary already.
-                state.Current.EndProperty();
+                // Handle special case of DataExtensionProperty where we just added a dictionary element to the extension property.
+                // Since the JSON value is not a dictionary element (it's a normal property in JSON) a JsonTokenType.EndObject
+                // encountered here is from the outer object so forward to HandleEndObject().
+                if (state.Current.JsonClassInfo.DataExtensionProperty == state.Current.JsonPropertyInfo)
+                {
+                    HandleEndObject(ref reader, ref state);
+                }
+                else
+                {
+                    // We added the items to the dictionary already.
+                    state.Current.EndProperty();
+                }
             }
             else if (state.Current.IsIDictionaryConstructibleProperty)
             {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleObject.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleObject.cs
@@ -9,7 +9,7 @@ namespace System.Text.Json
 {
     public static partial class JsonSerializer
     {
-        private static void HandleStartObject(JsonSerializerOptions options, ref Utf8JsonReader reader, ref ReadStack state)
+        private static void HandleStartObject(JsonSerializerOptions options, ref ReadStack state)
         {
             Debug.Assert(!state.Current.IsProcessingDictionary && !state.Current.IsProcessingIDictionaryConstructible);
 
@@ -52,9 +52,12 @@ namespace System.Text.Json
             }
         }
 
-        private static void HandleEndObject(JsonSerializerOptions options, ref Utf8JsonReader reader, ref ReadStack state)
+        private static void HandleEndObject(ref Utf8JsonReader reader, ref ReadStack state)
         {
-            Debug.Assert(!state.Current.IsProcessingDictionary && !state.Current.IsProcessingIDictionaryConstructible);
+            // Only allow dictionaries to be processed here if this is the DataExtensionProperty.
+            Debug.Assert(
+                (!state.Current.IsProcessingDictionary || state.Current.JsonClassInfo.DataExtensionProperty == state.Current.JsonPropertyInfo) &&
+                !state.Current.IsProcessingIDictionaryConstructible);
 
             // Check if we are trying to build the sorted cache.
             if (state.Current.PropertyRefCache != null)

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.cs
@@ -74,7 +74,7 @@ namespace System.Text.Json
                         }
                         else
                         {
-                            HandleStartObject(options, ref reader, ref readStack);
+                            HandleStartObject(options, ref readStack);
                         }
                     }
                     else if (tokenType == JsonTokenType.EndObject)
@@ -93,7 +93,7 @@ namespace System.Text.Json
                         }
                         else
                         {
-                            HandleEndObject(options, ref reader, ref readStack);
+                            HandleEndObject(ref reader, ref readStack);
                         }
                     }
                     else if (tokenType == JsonTokenType.StartArray)


### PR DESCRIPTION
Port PR #40662 to 3.0
(cherry picked from commit 2678218)

Fixes https://github.com/dotnet/corefx/issues/40618

### Description
Summary: extension data on child objects (which is stored on a property that contains the [JsonExtensionData] attribute may result in an exception (NullReferenceException or InvalidCastException) when deserializing.

Extension data is necessary for “partial deserialization” scenarios where the JSON includes property names that don’t exist on the object being deserialized. This may be because the “missing” properties are not necessary on the system doing the deserialization but must be added back when serializing so that other systems that require those properties can use them. This may also be used for version-resilient scenarios to preserve “overflow” data.

It works by stashing JSON that doesn’t match to any properties on the object being deserialized into a Dictionary property on the object that contains a [JsonExtensionData] attribute (the attribute is used to let the serializer know what property to use). Then during serialization, this extension data property is serialized and includes the “missing” properties.

### Customer Impact:
Extension data support is broken for cases where extension data needs to be maintained on child objects. It only works reliably on the root object. This was reported by the community.

### Regression?
Not in 3.0 since the code is new.

However, this is a regression in Preview 8. Extension data worked in Preview 7 although the semantics were different: the extension data in Preview 7 serialized with the extension property containing them (e.g. `"ExtensionData":{"MyMissingProperty":1}`. Based on feedback, the semantics were changed in Preview 8 and that introduced a regression. The Preview 8 semantics serialize the extension data to appear as if the “missing” properties existed  (e.g. `"MyMissingProperty":1`)

### Risk: Low.
The fix is very small and specific to deserialization of dictionaries and the extension data property. Tests were added to cover the community scenario, and existing tests modified to also cover the scenario.