### PR TITLE
Remove direct reference from System.Runtime.WindowsRuntime to System.Private.CoreLib

### DIFF
--- a/src/System.Runtime.InteropServices.WindowsRuntime/ref/System.Runtime.InteropServices.WindowsRuntime.cs
+++ b/src/System.Runtime.InteropServices.WindowsRuntime/ref/System.Runtime.InteropServices.WindowsRuntime.cs
@@ -28,6 +28,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         public System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken AddEventHandler(T? handler) { throw null; }
         public static System.Runtime.InteropServices.WindowsRuntime.EventRegistrationTokenTable<T> GetOrCreateEventRegistrationTokenTable(ref System.Runtime.InteropServices.WindowsRuntime.EventRegistrationTokenTable<T>? refEventTable) { throw null; }
         public void RemoveEventHandler(System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken token) { }
+        public bool RemoveEventHandler(System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken token, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out T? handler) { throw null; }
         public void RemoveEventHandler(T? handler) { }
     }
     public partial interface IActivationFactory
@@ -58,11 +59,13 @@ namespace System.Runtime.InteropServices.WindowsRuntime
     public static partial class WindowsRuntimeMarshal
     {
         public static void AddEventHandler<T>(System.Func<T, System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken> addMethod, System.Action<System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken> removeMethod, T handler) { }
+        public static object GetUniqueObjectForIUnknownWithoutUnboxing(IntPtr iUnknown) { throw null; }
         public static void FreeHString(System.IntPtr ptr) { }
         public static System.Runtime.InteropServices.WindowsRuntime.IActivationFactory GetActivationFactory(System.Type type) { throw null; }
         public static string PtrToStringHString(System.IntPtr ptr) { throw null; }
         public static void RemoveAllEventHandlers(System.Action<System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken> removeMethod) { }
         public static void RemoveEventHandler<T>(System.Action<System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken> removeMethod, T handler) { }
+        public static bool ReportUnhandledError(System.Exception? e) { throw null; }
         public static System.IntPtr StringToHString(string s) { throw null; }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Parameter, Inherited=false, AllowMultiple=false)]

--- a/src/System.Runtime.InteropServices.WindowsRuntime/src/MatchingRefApiCompatBaseline.txt
+++ b/src/System.Runtime.InteropServices.WindowsRuntime/src/MatchingRefApiCompatBaseline.txt
@@ -3,6 +3,4 @@ CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.InteropServices.WindowsRu
 MembersMustExist : Member 'System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken..ctor(System.UInt64)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken.Equals(System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken.Value.get()' does not exist in the reference but it does exist in the implementation.
-MembersMustExist : Member 'System.Runtime.InteropServices.WindowsRuntime.EventRegistrationTokenTable<T>.RemoveEventHandler(System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken, T)' does not exist in the reference but it does exist in the implementation.
-MembersMustExist : Member 'System.Runtime.InteropServices.WindowsRuntime.WindowsRuntimeMarshal.GetUniqueObjectForIUnknownWithoutUnboxing(System.IntPtr)' does not exist in the reference but it does exist in the implementation.
 Total Issues: 6

--- a/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.csproj
+++ b/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.csproj
@@ -19,18 +19,24 @@
     <AssemblyVersion Condition="'$(TargetGroup)' == 'netstandard1.2'">4.0.11.0</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetsNetCoreApp)' == 'true' or '$(TargetsUap)' == 'true'">
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
     <Reference Include="mscorlib" />
     <Reference Include="Windows" />
+    <Reference Include="System.Collections" />
+    <Reference Include="System.Runtime" />
     <!-- Needed for the compiler to resolve IObservableMap.MapChanged. -->
-    <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj" />
-    <ProjectReference Include="..\..\System.Runtime.Extensions\src\System.Runtime.Extensions.csproj">
-      <Aliases>System_Runtime_Extensions</Aliases>
-    </ProjectReference>
-    <ProjectReference Include="..\..\System.Diagnostics.Debug\src\System.Diagnostics.Debug.csproj" />
-    <ProjectReference Include="..\..\System.Diagnostics.Tools\src\System.Diagnostics.Tools.csproj" />
-    <ProjectReference Include="..\..\System.Runtime.InteropServices.WindowsRuntime\src\System.Runtime.InteropServices.WindowsRuntime.csproj" />
-    <ProjectReference Include="..\..\System.ObjectModel\src\System.ObjectModel.csproj" />
+    <Reference Include="System.Runtime.Extensions" />
+    <Reference Include="System.Resources.ResourceManager" />
+    <Reference Include="System.Diagnostics.Contracts" />
+    <Reference Include="System.Diagnostics.Debug" />
+    <Reference Include="System.Diagnostics.Tools" />
+    <Reference Include="System.Threading" />
+    <Reference Include="System.Threading.Tasks" />
+    <Reference Include="System.Runtime.InteropServices" />
+    <Reference Include="System.Runtime.InteropServices.WindowsRuntime" />
+    <Reference Include="System.ObjectModel" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe" />
+    <Reference Include="System.Threading.Thread" />
+    <Reference Include="System.Threading.ThreadPool" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsNetCoreApp)' == 'true' or '$(TargetsUap)' == 'true'">
     <Compile Include="System\InternalHelpers.cs" />
@@ -59,6 +65,7 @@
     <Compile Include="System\Runtime\InteropServices\IAgileObject.cs" />
     <Compile Include="System\Runtime\InteropServices\IMarshal.cs" />
     <Compile Include="System\Runtime\InteropServices\WindowsRuntime\AsyncInfo.cs" />
+    <Compile Include="System\Runtime\InteropServices\WindowsRuntime\ExceptionSupport.cs" />
     <Compile Include="System\Runtime\InteropServices\WindowsRuntime\IBufferByteAccess.cs" />
     <Compile Include="System\Runtime\InteropServices\WindowsRuntime\WindowsRuntimeBuffer.cs" />
     <Compile Include="System\Runtime\InteropServices\WindowsRuntime\WindowsRuntimeBufferExtensions.cs" />
@@ -75,6 +82,9 @@
     <Compile Include="$(CommonPath)\Interop\Windows\Mincore\Interop.RoGetActivationFactory.cs">
       <Link>Common\Interop\Windows\Mincore\Interop.RoGetActivationFactory.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Runtime\InteropServices\WindowsRuntime\IRestrictedErrorInfo.cs">
+      <Link>Common\System\Runtime\InteropServices\WindowsRuntime\IRestrictedErrorIfno.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Runtime\InteropServices\WindowsRuntime\WindowsRuntimeImportAttribute.cs">
       <Link>Common\System\Runtime\InteropServices\WindowsRuntime\WindowsRuntimeImportAttribute.cs</Link>
     </Compile>
@@ -86,6 +96,9 @@
     </Compile>
     <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\Kernel32\Interop.FormatMessage.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.FormatMessage.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\Mincore\Interop.GetRestrictedErrorInfo.cs">
+      <Link>Common\Interop\Windows\Mincore\Interop.GetRestrictedErrorInfo.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Mincore\Interop.RoGetBufferMarshaler.cs">
       <Link>Common\Interop\Windows\Mincore\Interop.RoGetBufferMarshaler.cs</Link>

--- a/src/System.Runtime.WindowsRuntime/src/System/IO/StreamOperationAsyncResult.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/IO/StreamOperationAsyncResult.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Internal.Runtime.InteropServices.WindowsRuntime;
 using System.Diagnostics;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices.WindowsRuntime;

--- a/src/System.Runtime.WindowsRuntime/src/System/IO/WindowsRuntimeStreamExtensions.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/IO/WindowsRuntimeStreamExtensions.cs
@@ -2,16 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-extern alias System_Runtime_Extensions;
-
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading.Tasks;
 using Windows.Foundation;
 using Windows.Storage.Streams;
-using BufferedStream = System_Runtime_Extensions::System.IO.BufferedStream;
+using BufferedStream = System.IO.BufferedStream;
 
 namespace System.IO
 {

--- a/src/System.Runtime.WindowsRuntime/src/System/InternalHelpers.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/InternalHelpers.cs
@@ -2,7 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 
 namespace System
 {
@@ -12,5 +15,83 @@ namespace System
         {
             ex.HResult = code;
         }
+    }
+}
+
+namespace Internal.Threading.Tasks
+{
+
+    //
+    // An internal contract that exposes just enough async debugger support needed by the AsTask() extension methods in the WindowsRuntimeSystemExtensions class.
+    //
+    internal static class AsyncCausalitySupport
+    {
+        private static Action<Task> _addToActiveTasks;
+        private static Action<Task> _removeFromActiveTasks;
+        private static Func<bool> _loggingOn;
+        private static Action<Task, string> _traceOperationCreation;
+        private static Action<Task> _traceOperationCompletedSuccess;
+        private static Action<Task> _traceOperationCompletedError;
+
+// Initialize all static fields in 'AsyncCausalitySupport' when those fields are declared and remove the explicit static constructor
+#pragma warning disable CA1810
+        static AsyncCausalitySupport()
+        {
+            Type privateType = typeof(object).Assembly.GetType("Internal.Threading.Tasks.AsyncCausalitySupport");
+            _addToActiveTasks = (Action<Task>)privateType.GetMethod(nameof(AddToActiveTasks), BindingFlags.Static | BindingFlags.Public).CreateDelegate(typeof(Action<Task>));
+            _removeFromActiveTasks = (Action<Task>)privateType.GetMethod(nameof(RemoveFromActiveTasks), BindingFlags.Static | BindingFlags.Public).CreateDelegate(typeof(Action<Task>));
+            _loggingOn = (Func<bool>)privateType.GetProperty(nameof(LoggingOn), BindingFlags.Static | BindingFlags.Public).GetMethod.CreateDelegate(typeof(Func<bool>));
+            _traceOperationCreation = (Action<Task, string>)privateType.GetMethod(nameof(TraceOperationCreation), BindingFlags.Static | BindingFlags.Public).CreateDelegate(typeof(Action<Task, string>));
+            _traceOperationCompletedSuccess = (Action<Task>)privateType.GetMethod(nameof(TraceOperationCompletedSuccess), BindingFlags.Static | BindingFlags.Public).CreateDelegate(typeof(Action<Task>));
+            _traceOperationCompletedError = (Action<Task>)privateType.GetMethod(nameof(TraceOperationCompletedError), BindingFlags.Static | BindingFlags.Public).CreateDelegate(typeof(Action<Task>));
+        }
+#pragma warning restore CA1810
+
+        public static void AddToActiveTasks(Task task)
+        {
+            _addToActiveTasks(task);
+        }
+
+        public static void RemoveFromActiveTasks(Task task)
+        {
+            _removeFromActiveTasks(task);
+        }
+
+        public static bool LoggingOn => _loggingOn();
+
+        public static void TraceOperationCreation(Task task, string operationName)
+        {
+            _traceOperationCreation(task, operationName);
+        }
+
+        public static void TraceOperationCompletedSuccess(Task task)
+        {
+            _traceOperationCompletedSuccess(task);
+        }
+
+        public static void TraceOperationCompletedError(Task task)
+        {
+            _traceOperationCompletedError(task);
+        }
+    }
+}
+
+#nullable enable
+
+// TODO: Remove once the shared partition is also updated and use the definition in the shared partition.
+namespace Internal.Resources
+{
+    internal interface IWindowsRuntimeResourceManager
+    {
+        bool Initialize(string libpath, string reswFilename, out string? packageSimpleName, out string? encodedResWFilename);
+
+        string GetString(string stringName, string? startingCulture, string? neutralResourcesCulture);
+
+        System.Globalization.CultureInfo? GlobalResourceContextBestFitCultureInfo
+        {
+            get;
+        }
+
+        bool SetGlobalResourceContextDefaultCulture(System.Globalization.CultureInfo ci);
     }
 }

--- a/src/System.Runtime.WindowsRuntime/src/System/Runtime/InteropServices/WindowsRuntime/ExceptionSupport.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Runtime/InteropServices/WindowsRuntime/ExceptionSupport.cs
@@ -1,0 +1,119 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+
+namespace System.Runtime.InteropServices.WindowsRuntime
+{
+    internal static class ExceptionSupport
+    {
+        public static System.Exception AttachRestrictedErrorInfo(System.Exception e)
+        {
+            // If there is no exception, then the restricted error info doesn't apply to it
+            if (e != null)
+            {
+                try
+                {
+                    // Get the restricted error info for this thread and see if it may correlate to the current
+                    // exception object.  Note that in general the thread's IRestrictedErrorInfo is not meant for
+                    // exceptions that are marshaled Windows.Foundation.HResults and instead are intended for
+                    // HRESULT ABI return values.   However, in many cases async APIs will set the thread's restricted
+                    // error info as a convention in order to provide extended debugging information for the ErrorCode
+                    // property.
+                    IRestrictedErrorInfo restrictedErrorInfo = Interop.mincore.GetRestrictedErrorInfo();
+                    if (restrictedErrorInfo != null)
+                    {
+                        string description;
+                        string restrictedDescription;
+                        string capabilitySid;
+                        int restrictedErrorInfoHResult;
+                        restrictedErrorInfo.GetErrorDetails(out description,
+                                                            out restrictedErrorInfoHResult,
+                                                            out restrictedDescription,
+                                                            out capabilitySid);
+
+                        // Since this is a special case where by convention there may be a correlation, there is not a
+                        // guarantee that the restricted error info does belong to the async error code.  In order to
+                        // reduce the risk that we associate incorrect information with the exception object, we need
+                        // to apply a heuristic where we attempt to match the current exception's HRESULT with the
+                        // HRESULT the IRestrictedErrorInfo belongs to.  If it is a match we will assume association
+                        // for the IAsyncInfo case.
+                        if (e.HResult == restrictedErrorInfoHResult)
+                        {
+                            string errorReference;
+                            restrictedErrorInfo.GetReference(out errorReference);
+
+                            e.AddExceptionDataForRestrictedErrorInfo(restrictedDescription,
+                                                                     errorReference,
+                                                                     capabilitySid,
+                                                                     restrictedErrorInfo);
+                        }
+                    }
+                }
+                catch
+                {
+                    // If we can't get the restricted error info, then proceed as if it isn't associated with this
+                    // error.
+                }
+            }
+
+            return e;
+        }
+
+        internal static void AddExceptionDataForRestrictedErrorInfo(
+            this System.Exception ex,
+            string restrictedError,
+            string restrictedErrorReference,
+            string restrictedCapabilitySid,
+            object restrictedErrorObject,
+            bool hasrestrictedLanguageErrorObject = false)
+        {
+            IDictionary dict = ex.Data;
+            if (dict != null)
+            {
+                dict.Add("RestrictedDescription", restrictedError);
+                dict.Add("RestrictedErrorReference", restrictedErrorReference);
+                dict.Add("RestrictedCapabilitySid", restrictedCapabilitySid);
+
+                // Keep the error object alive so that user could retrieve error information
+                // using Data["RestrictedErrorReference"]
+                dict.Add("__RestrictedErrorObject", (restrictedErrorObject == null ? null : new __RestrictedErrorObject(restrictedErrorObject)));
+                dict.Add("__HasRestrictedLanguageErrorObject", hasrestrictedLanguageErrorObject);
+            }
+        }
+
+        public static bool ReportUnhandledError(System.Exception ex)
+        {
+            return System.Runtime.InteropServices.WindowsRuntime.WindowsRuntimeMarshal.ReportUnhandledError(ex);
+        }
+
+        //
+        // Exception requires anything to be added into Data dictionary is serializable
+        // This wrapper is made serializable to satisfy this requirement but does NOT serialize
+        // the object and simply ignores it during serialization, because we only need
+        // the exception instance in the app to hold the error object alive.
+        // Once the exception is serialized to debugger, debugger only needs the error reference string
+        //
+        [Serializable]
+        internal class __RestrictedErrorObject
+        {
+            // Hold the error object instance but don't serialize/deserialize it
+            [NonSerialized]
+            private readonly object _realErrorObject;
+
+            internal __RestrictedErrorObject(object errorObject)
+            {
+                _realErrorObject = errorObject;
+            }
+
+            public object RealErrorObject
+            {
+                get
+                {
+                    return _realErrorObject;
+                }
+            }
+        }
+    }
+}

--- a/src/System.Runtime.WindowsRuntime/src/System/Runtime/InteropServices/WindowsRuntime/ExceptionSupport.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Runtime/InteropServices/WindowsRuntime/ExceptionSupport.cs
@@ -3,12 +3,13 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections;
+using System.Runtime.InteropServices.WindowsRuntime;
 
 namespace System.Runtime.InteropServices.WindowsRuntime
 {
     internal static class ExceptionSupport
     {
-        public static System.Exception AttachRestrictedErrorInfo(System.Exception e)
+        public static Exception AttachRestrictedErrorInfo(Exception e)
         {
             // If there is no exception, then the restricted error info doesn't apply to it
             if (e != null)
@@ -62,7 +63,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         }
 
         internal static void AddExceptionDataForRestrictedErrorInfo(
-            this System.Exception ex,
+            this Exception ex,
             string restrictedError,
             string restrictedErrorReference,
             string restrictedCapabilitySid,
@@ -83,9 +84,9 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             }
         }
 
-        public static bool ReportUnhandledError(System.Exception ex)
+        public static bool ReportUnhandledError(Exception ex)
         {
-            return System.Runtime.InteropServices.WindowsRuntime.WindowsRuntimeMarshal.ReportUnhandledError(ex);
+            return WindowsRuntimeMarshal.ReportUnhandledError(ex);
         }
 
         //

--- a/src/System.Runtime.WindowsRuntime/src/System/Runtime/InteropServices/WindowsRuntime/MarshalingHelpers.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Runtime/InteropServices/WindowsRuntime/MarshalingHelpers.cs
@@ -11,8 +11,6 @@ using System.Runtime.CompilerServices;
 using System.Security;
 using System.Windows.Input;
 
-using Internal.Runtime.CompilerServices;
-
 namespace System.Runtime.InteropServices.WindowsRuntime
 {
     // Local definition of Windows.UI.Xaml.Interop.INotifyCollectionChangedEventArgs

--- a/src/System.Runtime.WindowsRuntime/src/System/Threading/Tasks/AsyncInfoToTaskBridge.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Threading/Tasks/AsyncInfoToTaskBridge.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Internal.Runtime.InteropServices.WindowsRuntime;
 using Internal.Threading.Tasks;
 using System.ComponentModel;
 using System.Diagnostics;

--- a/src/System.Runtime.WindowsRuntime/src/System/Threading/WindowsRuntimeSynchronizationContext.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Threading/WindowsRuntimeSynchronizationContext.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Internal.Runtime.InteropServices.WindowsRuntime;
 using System;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;

--- a/src/System.Runtime.WindowsRuntime/src/System/WindowsRuntimeSystemExtensions.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/WindowsRuntimeSystemExtensions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Internal.Runtime.InteropServices.WindowsRuntime;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;


### PR DESCRIPTION
Update System.Runtime.WindowsRuntime to not directly reference System.Private.CoreLib.

- Move `Internal.Runtime.InteropServices.WindowsRuntime.ExceptionSupport` in S.P.CL to `System.Runtime.InteropServices.WindowsRuntime.ExceptionSupport` in S.R.WR
- Expose `System.Runtime.InteropServices.WindowsRuntime.WindowsRuntimeMarshal.GetUniqueObjectForIUnknownWithoutUnboxing(System.IntPtr)` and `System.Runtime.InteropServices.WindowsRuntime.EventRegistrationTokenTable<T>.RemoveEventHandler(System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken, T)` from System.Runtime.InteropServices.WindowsRuntime facade assembly.
- Expose `System.Runtime.InteropServices.WindowsRuntime.WindowsRuntimeMarshal.ReportUnhandledError` from System.Runtime.InteropServices.WindowsRuntime facade assembly.
- Redesign `System.Resources.WindowsRuntimeResourceManager` to be called from System.Private.CoreLib exclusively through reflection (see coreclr PR for more information)
- Add local implementation of `Internal.Threading.Tasks.AsyncCausalitySupport` that calls the implementation in System.Private.CoreLib via reflection.
- Expose `System.Runtime.InteropServices.WindowsRuntime.WindowsRuntimeMarshal.ReportUnhandledError`.

cc: @terrajobst for API review of the newly exposed APIs.

Depends on dotnet/coreclr#26443