### PR TITLE
Net.Http Use span.SequenceEqual rather than custom EqualsOrdinal

### DIFF
--- a/src/Common/src/System/CharArrayHelpers.cs
+++ b/src/Common/src/System/CharArrayHelpers.cs
@@ -8,27 +8,6 @@ namespace System
 {
     internal static class CharArrayHelpers
     {
-        internal static bool EqualsOrdinal(string left, char[] right, int rightStartIndex, int rightLength)
-        {
-            Debug.Assert(left != null, "Expected non-null string");
-            DebugAssertArrayInputs(right, rightStartIndex, rightLength);
-
-            if (left.Length != rightLength)
-            {
-                return false;
-            }
-
-            for (int i = 0; i < left.Length; i++)
-            {
-                if (left[i] != right[rightStartIndex + i])
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
         internal static bool EqualsOrdinalAsciiIgnoreCase(string left, char[] right, int rightStartIndex, int rightLength)
         {
             Debug.Assert(left != null, "Expected non-null string");

--- a/src/Common/src/System/Net/HttpKnownHeaderNames.TryGetHeaderName.cs
+++ b/src/Common/src/System/Net/HttpKnownHeaderNames.TryGetHeaderName.cs
@@ -22,7 +22,7 @@ namespace System.Net
             return TryGetHeaderName(
                 array, startIndex, length,
                 (arr, index) => arr[index],
-                (known, arr, start, len) => CharArrayHelpers.EqualsOrdinal(known, arr, start, len),
+                (known, arr, start, len) => known.AsSpan().SequenceEqual(arr.AsSpan(start, len)),
                 out name);
         }
 

--- a/src/Common/tests/Tests/System/CharArrayHelpersTests.cs
+++ b/src/Common/tests/Tests/System/CharArrayHelpersTests.cs
@@ -12,31 +12,6 @@ namespace Tests.System
     {
         [Theory]
         [InlineData("Foo", "Foo", true)]
-        [InlineData("FOO", "FOO", true)]
-        [InlineData("fOO", "fOO", true)]
-        [InlineData("HTTP/", "HTTP/", true)]
-        [InlineData("http/", "http/", true)]
-        [InlineData("GZIP", "GZIP", true)]
-        [InlineData("gzip", "gzip", true)]
-        [InlineData("DEFLATE", "DEFLATE", true)]
-        [InlineData("deflate", "deflate", true)]
-        [InlineData("Content-Length", "Content-Length", true)]
-        [InlineData("content-length", "content-length", true)]
-        [InlineData("DEFLATE", "deflate", false)]
-        [InlineData("foo", "bar", false)]
-        [InlineData("GZIP", "DEFLATE", false)]
-        [InlineData("Content-Length", "content-length", false)]
-        public void EqualsOrdinal_ComparingVariousInputsBothWays_ReturnsExpected(string leftString, string rightString, bool expected)
-        {
-            char[] left = leftString.ToCharArray();
-            char[] right = rightString.ToCharArray();
-
-            Assert.Equal(expected, CharArrayHelpers.EqualsOrdinal(leftString, right, 0, right.Length));
-            Assert.Equal(expected, CharArrayHelpers.EqualsOrdinal(rightString, left, 0, left.Length));
-        }
-
-        [Theory]
-        [InlineData("Foo", "Foo", true)]
         [InlineData("Foo", "FOO", true)]
         [InlineData("Foo", "fOO", true)]
         [InlineData("HTTP/", "http/", true)]

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
@@ -282,7 +282,7 @@ namespace System.Net.Http
 
             string knownReasonPhrase = HttpStatusDescription.Get(statusCode);
 
-            return (knownReasonPhrase != null && CharArrayHelpers.EqualsOrdinal(knownReasonPhrase, buffer, 0, bufferLength)) ?
+            return (knownReasonPhrase != null && knownReasonPhrase.AsSpan().SequenceEqual(buffer.AsSpan(0, bufferLength))) ?
                 knownReasonPhrase :
                 new string(buffer, 0, bufferLength);
         }


### PR DESCRIPTION
Code deduplication and vectorized method

Wasn't sure about changing EqualsOrdinalAsciiIgnoreCase to Span as its only used with the 4 very short strings `Gzip`, `HTTP/1.1`, `HTTP/1.0` and `Deflate`; so leaving it char by char might be advantageous? However it is also only used infrequently, and would save code duplication - happy for someone else to make the call on this /cc @stephentoub 