### PR TITLE
Ignore casing in servicename displayname test on nano server

### DIFF
--- a/src/System.ServiceProcess.ServiceController/tests/SafeServiceControllerTests.cs
+++ b/src/System.ServiceProcess.ServiceController/tests/SafeServiceControllerTests.cs
@@ -163,7 +163,9 @@ namespace System.ServiceProcess.Tests
 
             var controller = new ServiceController();
             controller.ServiceName = KeyIsoSvcName;
-            Assert.Equal(keyIsoDisplayName, controller.DisplayName);
+
+            // On Nano Server >=1809 the casing is sometimes changed during normalization: Expected: KEYISO, Actual: KeyIso
+            Assert.Equal(keyIsoDisplayName, controller.DisplayName, ignoreCase: PlatformDetection.IsWindowsNanoServer);
         }
 
         [Fact]


### PR DESCRIPTION
This seems to be caused by a win32 api change on Windows Nano Server >1809. What surprises me is that this doesn't happen consistently, only once in a while. Ignoring the case to fix the build meanwhile.

https://dnceng.visualstudio.com/public/_build/results?buildId=331032&view=ms.vss-test-web.build-test-results-tab&runId=9700648&resultId=169043&paneView=debug

```
Assert.Equal() Failure\r\n ↓ (pos 1)\r\nExpected: KEYISO\r\nActual: KeyIso\r\n ↑ (pos 1)

   at System.ServiceProcess.Tests.SafeServiceControllerTests.SetServiceName_GetDisplayName() in /_/src/System.ServiceProcess.ServiceController/tests/SafeServiceControllerTests.cs:line 167
```