### PR TITLE
Httpstress: Add more checksum validations & expose Kestrel Http2 limits configuration

### DIFF
--- a/src/System.Net.Http/tests/StressTests/HttpStress/ChecksumHelpers.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/ChecksumHelpers.cs
@@ -65,6 +65,7 @@ namespace HttpStress
         }
 
         public static ulong CalculateCRC(byte[] buf) => update_crc(InitialCrc, buf, buf.Length) ^ InitialCrc;
+        public static ulong CalculateCRC(string text, Encoding encoding = null) => update_crc(InitialCrc, text, encoding) ^ InitialCrc;
 
         public static ulong CalculateHeaderCrc<T>(IEnumerable<(string name, T)> headers, Encoding encoding = null) where T : IEnumerable<string>
         {

--- a/src/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
@@ -406,6 +406,7 @@ namespace HttpStress
                 async ctx =>
                 {
                     string content = ctx.GetRandomString(0, ctx.MaxContentLength);
+                    ulong checksum = CRC.CalculateCRC(content);
 
                     using var req = new HttpRequestMessage(HttpMethod.Post, "/") { Content = new StringContent(content) };
 
@@ -413,7 +414,8 @@ namespace HttpStress
                     using HttpResponseMessage m = await ctx.SendAsync(req, HttpCompletionOption.ResponseHeadersRead);
 
                     ValidateStatusCode(m);
-                    ValidateContent(content, await m.Content.ReadAsStringAsync());
+                    string checksumMessage = ValidateServerChecksum(m.Headers, checksum) ? "server checksum matches client checksum" : "server checksum mismatch";
+                    ValidateContent(content, await m.Content.ReadAsStringAsync(), checksumMessage);
                 }),
 
                 ("HEAD",

--- a/src/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
@@ -323,24 +323,28 @@ namespace HttpStress
                 async ctx =>
                 {
                     string content = ctx.GetRandomString(0, ctx.MaxContentLength);
+                    ulong checksum = CRC.CalculateCRC(content);
 
                     using var req = new HttpRequestMessage(HttpMethod.Post, "/") { Content = new StringDuplexContent(content) };
                     using HttpResponseMessage m = await ctx.SendAsync(req);
 
                     ValidateStatusCode(m);
-                    ValidateContent(content, await m.Content.ReadAsStringAsync());
+                    string checksumMessage = ValidateServerChecksum(m.Headers, checksum) ? "server checksum matches client checksum" : "server checksum mismatch";
+                    ValidateContent(content, await m.Content.ReadAsStringAsync(), checksumMessage);
                 }),
 
                 ("POST Multipart Data",
                 async ctx =>
                 {
                     (string expected, MultipartContent formDataContent) formData = GetMultipartContent(ctx, ctx.MaxRequestParameters);
+                    ulong checksum = CRC.CalculateCRC(formData.expected);
 
                     using var req = new HttpRequestMessage(HttpMethod.Post, "/") { Content = formData.formDataContent };
                     using HttpResponseMessage m = await ctx.SendAsync(req);
 
                     ValidateStatusCode(m);
-                    ValidateContent($"{formData.expected}", await m.Content.ReadAsStringAsync());
+                    string checksumMessage = ValidateServerChecksum(m.Headers, checksum) ? "server checksum matches client checksum" : "server checksum mismatch";
+                    ValidateContent(formData.expected, await m.Content.ReadAsStringAsync(), checksumMessage);
                 }),
 
                 ("POST Duplex",
@@ -348,11 +352,16 @@ namespace HttpStress
                 {
                     string content = ctx.GetRandomString(0, ctx.MaxContentLength);
 
+                    ulong checksum = CRC.CalculateCRC(content);
+
                     using var req = new HttpRequestMessage(HttpMethod.Post, "/duplex") { Content = new StringDuplexContent(content) };
                     using HttpResponseMessage m = await ctx.SendAsync(req, HttpCompletionOption.ResponseHeadersRead);
 
                     ValidateStatusCode(m);
-                    ValidateContent(content, await m.Content.ReadAsStringAsync());
+                    string response = await m.Content.ReadAsStringAsync();
+
+                    string checksumMessage = ValidateServerChecksum(m.TrailingHeaders, checksum, required: false) ? "server checksum matches client checksum" : "server checksum mismatch";
+                    ValidateContent(content, await m.Content.ReadAsStringAsync(), checksumMessage);
                 }),
 
                 ("POST Duplex Slow",

--- a/src/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
@@ -351,7 +351,6 @@ namespace HttpStress
                 async ctx =>
                 {
                     string content = ctx.GetRandomString(0, ctx.MaxContentLength);
-
                     ulong checksum = CRC.CalculateCRC(content);
 
                     using var req = new HttpRequestMessage(HttpMethod.Post, "/duplex") { Content = new StringDuplexContent(content) };

--- a/src/System.Net.Http/tests/StressTests/HttpStress/Configuration.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/Configuration.cs
@@ -45,6 +45,10 @@ namespace HttpStress
         public bool UseHttpSys { get; set; }
         public string LogPath { get; set; }
         public bool LogAspNet { get; set; }
+        public int? ServerMaxConcurrentStreams { get; set; }
+        public int? ServerMaxFrameSize { get; set; }
+        public int? ServerInitialConnectionWindowSize { get; set; }
+        public int? ServerMaxRequestHeaderFieldSize { get; set; }
     }
 
 }

--- a/src/System.Net.Http/tests/StressTests/HttpStress/Program.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/Program.cs
@@ -52,6 +52,10 @@ public static class Program
         cmd.AddOption(new Option("-winHttp", "Use WinHttpHandler for the stress client.") { Argument = new Argument<bool>("enable", false) });
         cmd.AddOption(new Option("-displayInterval", "Client stats display interval in seconds. Defaults to 5 seconds.") { Argument = new Argument<int>("seconds", 5) });
         cmd.AddOption(new Option("-clientTimeout", "Default HttpClient timeout in seconds. Defaults to 10 seconds.") { Argument = new Argument<int>("seconds", 10) });
+        cmd.AddOption(new Option("-serverMaxConcurrentStreams", "Overrides kestrel max concurrent streams per connection.") { Argument = new Argument<int?>("streams", null) });
+        cmd.AddOption(new Option("-serverMaxFrameSize", "Overrides kestrel max frame size setting.") { Argument = new Argument<int?>("bytes", null) });
+        cmd.AddOption(new Option("-serverInitialConnectionWindowSize", "Overrides kestrel initial connection window size setting.") { Argument = new Argument<int?>("bytes", null) });
+        cmd.AddOption(new Option("-serverMaxRequestHeaderFieldSize", "Overrides kestrel max request header field size.") { Argument = new Argument<int?>("bytes", null) });
 
         ParseResult cmdline = cmd.Parse(args);
         if (cmdline.Errors.Count > 0)
@@ -90,7 +94,11 @@ public static class Program
 
             UseHttpSys = cmdline.ValueForOption<bool>("-httpSys"),
             LogAspNet = cmdline.ValueForOption<bool>("-aspnetlog"),
-            LogPath = cmdline.HasOption("-trace") ? cmdline.ValueForOption<string>("-trace") : null
+            LogPath = cmdline.HasOption("-trace") ? cmdline.ValueForOption<string>("-trace") : null,
+            ServerMaxConcurrentStreams = cmdline.ValueForOption<int?>("-serverMaxConcurrentStreams"),
+            ServerMaxFrameSize = cmdline.ValueForOption<int?>("-serverMaxFrameSize"),
+            ServerInitialConnectionWindowSize = cmdline.ValueForOption<int?>("-serverInitialConnectionWindowSize"),
+            ServerMaxRequestHeaderFieldSize = cmdline.ValueForOption<int?>("-serverMaxRequestHeaderFieldSize"),
         };
 
         return true;


### PR DESCRIPTION
Makes the following changes to the stress suite:

* Adds more checksum validations to stress operations.
* Exposes parts of kestrel http2 limits configuration, for easier repro of bugs like #40663.