### PR TITLE
Pass a CancellationToken in a few more places

### DIFF
--- a/src/Common/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/Common/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -445,7 +445,7 @@ namespace System.Net.WebSockets
 
         private async Task SendFrameFallbackAsync(MessageOpcode opcode, bool endOfMessage, ReadOnlyMemory<byte> payloadBuffer, CancellationToken cancellationToken)
         {
-            await _sendFrameAsyncLock.WaitAsync().ConfigureAwait(false);
+            await _sendFrameAsyncLock.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
                 int sendBytes = WriteFrameToSendBuffer(opcode, endOfMessage, payloadBuffer.Span);
@@ -893,8 +893,10 @@ namespace System.Net.WebSockets
                 }
 
                 await SendFrameAsync(
-                    MessageOpcode.Pong, true,
-                    _receiveBuffer.Slice(_receiveBufferOffset, (int)header.PayloadLength), default).ConfigureAwait(false);
+                    MessageOpcode.Pong,
+                    endOfMessage: true,
+                    _receiveBuffer.Slice(_receiveBufferOffset, (int)header.PayloadLength),
+                    cancellationToken).ConfigureAwait(false);
             }
 
             // Regardless of whether it was a ping or pong, we no longer need the payload.

--- a/src/System.Net.Http/src/System/Net/Http/MessageProcessingHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/MessageProcessingHandler.cs
@@ -114,7 +114,7 @@ namespace System.Net.Http
             // is not related to our cancellation token.
             if (cancellationToken.IsCancellationRequested && (e.CancellationToken == cancellationToken))
             {
-                tcs.TrySetCanceled();
+                tcs.TrySetCanceled(cancellationToken);
             }
             else
             {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -1619,7 +1619,7 @@ namespace System.Net.Http
             await CopyFromBufferAsync(destination, remaining, cancellationToken).ConfigureAwait(false);
             _readLength = _readOffset = 0;
 
-            await _stream.CopyToAsync(destination, bufferSize).ConfigureAwait(false);
+            await _stream.CopyToAsync(destination, bufferSize, cancellationToken).ConfigureAwait(false);
         }
 
         // Copy *exactly* [length] bytes into destination; throws on end of stream.

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -387,7 +387,7 @@ namespace System.Net.Http
             TransportContext transportContext = null;
 
             // Serialize creation attempt
-            await _http2ConnectionCreateLock.WaitAsync().ConfigureAwait(false);
+            await _http2ConnectionCreateLock.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
                 if (_http2Connection != null)

--- a/src/System.Runtime.Extensions/src/System/IO/BufferedStream.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/BufferedStream.cs
@@ -331,7 +331,7 @@ namespace System.IO
             Debug.Assert(_stream != null);
 
             SemaphoreSlim sem = LazyEnsureAsyncActiveSemaphoreInitialized();
-            await sem.WaitAsync().ConfigureAwait(false);
+            await sem.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
                 if (_writePos > 0)
@@ -633,7 +633,7 @@ namespace System.IO
             // Async IO Task accesses the buffer concurrently. If we fail to acquire the lock without waiting, make this
             // an Async operation.
             SemaphoreSlim sem = LazyEnsureAsyncActiveSemaphoreInitialized();
-            Task semaphoreLockTask = sem.WaitAsync();
+            Task semaphoreLockTask = sem.WaitAsync(cancellationToken);
             if (semaphoreLockTask.IsCompletedSuccessfully)
             {
                 bool completeSynchronously = true;
@@ -684,7 +684,7 @@ namespace System.IO
 
             int bytesFromBuffer = 0;
             SemaphoreSlim sem = LazyEnsureAsyncActiveSemaphoreInitialized();
-            Task semaphoreLockTask = sem.WaitAsync();
+            Task semaphoreLockTask = sem.WaitAsync(cancellationToken);
             if (semaphoreLockTask.IsCompletedSuccessfully)
             {
                 bool completeSynchronously = true;
@@ -1087,7 +1087,7 @@ namespace System.IO
 
             // Try to satisfy the request from the buffer synchronously.
             SemaphoreSlim sem = LazyEnsureAsyncActiveSemaphoreInitialized();
-            Task semaphoreLockTask = sem.WaitAsync();
+            Task semaphoreLockTask = sem.WaitAsync(cancellationToken);
             if (semaphoreLockTask.IsCompletedSuccessfully)
             {
                 bool completeSynchronously = true;
@@ -1338,7 +1338,7 @@ namespace System.IO
             Debug.Assert(_stream != null);
 
             // Synchronize async operations as does Read/WriteAsync.
-            await LazyEnsureAsyncActiveSemaphoreInitialized().WaitAsync().ConfigureAwait(false);
+            await LazyEnsureAsyncActiveSemaphoreInitialized().WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
                 int readBytes = _readLen - _readPos;

--- a/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/CryptoStream.cs
+++ b/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/CryptoStream.cs
@@ -203,7 +203,7 @@ namespace System.Security.Cryptography
             // thread if it does a second IO request until the first one completes.
 
             SemaphoreSlim semaphore = AsyncActiveSemaphore;
-            await semaphore.WaitAsync().ForceAsync();
+            await semaphore.WaitAsync(cancellationToken).ForceAsync();
             try
             {
                 return await ReadAsyncCore(buffer, offset, count, cancellationToken, useAsync: true).ConfigureAwait(false);
@@ -482,7 +482,7 @@ namespace System.Security.Cryptography
             // thread if it does a second IO request until the first one completes.
 
             SemaphoreSlim semaphore = AsyncActiveSemaphore;
-            await semaphore.WaitAsync().ForceAsync();
+            await semaphore.WaitAsync(cancellationToken).ForceAsync();
             try
             {
                 await WriteAsyncCore(buffer, offset, count, cancellationToken, useAsync: true).ConfigureAwait(false);


### PR DESCRIPTION
Most of these to WaitAsync shouldn't actually matter, as the semaphores being used are there for corner cases or to protect erroneous usage, but if there's no contention, passing a token won't hurt, and if there is contention, passing the token makes it more robust.

cc: @marklio 