### PR TITLE
Add harvest validation logic to the all configurations tests

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -66,9 +66,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>e5aaea7fcfc46449b035d5b220032bfb933e98a4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Packaging" Version="1.0.0-beta.19429.16">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Packaging" Version="1.0.0-beta.19430.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>e5aaea7fcfc46449b035d5b220032bfb933e98a4</Sha>
+      <Sha>316c80d0c373be63f991cc4d586db85273c1c553</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="1.0.0-beta.19429.16">
       <Uri>https://github.com/dotnet/arcade</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -34,7 +34,7 @@
     <MicrosoftDotNetGenFacadesPackageVersion>1.0.0-beta.19429.16</MicrosoftDotNetGenFacadesPackageVersion>
     <MicrosoftDotNetXUnitExtensionsPackageVersion>2.4.1-beta.19429.16</MicrosoftDotNetXUnitExtensionsPackageVersion>
     <MicrosoftDotNetXUnitConsoleRunnerPackageVersion>2.5.1-beta.19429.16</MicrosoftDotNetXUnitConsoleRunnerPackageVersion>
-    <MicrosoftDotNetBuildTasksPackagingPackageVersion>1.0.0-beta.19429.16</MicrosoftDotNetBuildTasksPackagingPackageVersion>
+    <MicrosoftDotNetBuildTasksPackagingPackageVersion>1.0.0-beta.19430.3</MicrosoftDotNetBuildTasksPackagingPackageVersion>
     <MicrosoftDotNetRemoteExecutorPackageVersion>1.0.0-beta.19429.16</MicrosoftDotNetRemoteExecutorPackageVersion>
     <MicrosoftDotNetBuildTasksFeedVersion>2.2.0-beta.19429.16</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftDotNetVersionToolsTasksPackageVersion>1.0.0-beta.19429.16</MicrosoftDotNetVersionToolsTasksPackageVersion>

--- a/pkg/test/testPackages.proj
+++ b/pkg/test/testPackages.proj
@@ -208,7 +208,16 @@
     <Exec Command="$(TestBuildCommand) &quot;$(TestProject)&quot;" EnvironmentVariables="@(CliEnvironment)" StandardOutputImportance="High" />
   </Target>
 
-  <Target Name="Build" DependsOnTargets="BuildProjects;ArchiveHelixItems" />
+  <UsingTask TaskName="ValidateHarvestVersionIsLatestForRelease" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <Target Name="HarvestVersionValidation">
+    <!-- This target will validate that all packages that are harvesting assets will be doing it from the right package version.
+         If an error is detected, the task will print out the command needed in order to fix the problem. This test requires
+         network access, as what it does is ensure that the harvest version we are using is the latest stable available for that
+         specific package release. -->
+    <ValidateHarvestVersionIsLatestForRelease PackageReports="@(PackageReports)" />
+  </Target>
+
+  <Target Name="Build" DependsOnTargets="BuildProjects;HarvestVersionValidation;ArchiveHelixItems" />
 
   <!-- define test to do nothing, for this project Build does all the testing -->
   <Target Name="Test" />


### PR DESCRIPTION
Fixes #39537 in master branch. After this is merged then we will need to port this to release/3.0 branch as well.

This will add harvesting validation that will make sure that once we enter into servicing mode, in the case we want to service a specific package which contains an asset being harvested from a different branch, we will ensure that we are harvesting the latest asset. We have recently found several bugs because of this lack of validation, so adding this will ensure that this won't happen again.