### PR TITLE
Fix Select.Count bug that iterates twice

### DIFF
--- a/src/System.Linq/src/System/Linq/Select.SpeedOpt.cs
+++ b/src/System.Linq/src/System/Linq/Select.SpeedOpt.cs
@@ -658,15 +658,20 @@ namespace System.Linq
 
             public int GetCount(bool onlyIfCheap)
             {
-                // In case someone uses Count() to force evaluation of
-                // the selector, run it provided `onlyIfCheap` is false.
-
                 if (!onlyIfCheap)
                 {
+                    // In case someone uses Count() to force evaluation of
+                    // the selector, run it provided `onlyIfCheap` is false.
+
+                    int count = 0;
+
                     foreach (TSource item in _source)
                     {
                         _selector(item);
+                        checked { count++; }
                     }
+
+                    return count;
                 }
 
                 return _source.GetCount(onlyIfCheap);

--- a/src/System.Linq/tests/EnumerableTests.cs
+++ b/src/System.Linq/tests/EnumerableTests.cs
@@ -345,25 +345,5 @@ namespace System.Linq.Tests
 
             void IDisposable.Dispose() => _dispose();
         }
-
-        protected sealed class DisposeTrackingEnumerable<T> : IEnumerable<T>
-        {
-            public bool EnumeratorDisposed { get; private set; }
-
-
-            public IEnumerator<T> GetEnumerator() => new Enumerator(this);
-            IEnumerator IEnumerable.GetEnumerator() => new Enumerator(this);
-
-            private sealed class Enumerator : IEnumerator<T>
-            {
-                private readonly DisposeTrackingEnumerable<T> _enumerable;
-                public Enumerator(DisposeTrackingEnumerable<T> enumerable) => _enumerable = enumerable;
-                public void Dispose() => _enumerable.EnumeratorDisposed = true;
-                public T Current => default;
-                object IEnumerator.Current => default;
-                public bool MoveNext() => false;
-                public void Reset() { }
-            }
-        }
     }
 }

--- a/src/System.Linq/tests/LifecycleTests.cs
+++ b/src/System.Linq/tests/LifecycleTests.cs
@@ -1,0 +1,283 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading;
+using Xunit;
+
+namespace System.Linq.Tests
+{
+    public class LifecycleTests : EnumerableTests
+    {
+        [Fact]
+        public void UnaryOperations_SourceEnumeratorDisposed()
+        {
+            // Using Assert.All instead of a Theory to avoid overloading the system with hundreds of thousands of distinct test cases.
+            IEnumerable<(Source source, Unary unary1, Unary unary2, Sink sink)> inputs =
+                from source in Sources()
+                from unary1 in UnaryOperations()
+                from unary2 in UnaryOperations()
+                from sink in Sinks()
+                select (source, unary1, unary2, sink);
+
+            Assert.All(inputs, input =>
+            {
+                var (source, unary1, unary2, sink) = input;
+                var e = new LifecycleTrackingEnumerable<int>(source.Work);
+
+                // source -> unary1 -> unary2 -> sink
+                bool argError = false;
+                try
+                {
+                    sink.Work(unary2.Work(unary1.Work(e)));
+                }
+                catch (Exception exc) when (exc is ArgumentException || exc is InvalidOperationException)
+                {
+                    argError = true;
+                }
+
+                // We expect the source's enumerator should have been constructed 0 or 1 times,
+                // once if there's no short-circuiting involved.  Then the enumerator's Dispose
+                // should have been invoked the same number of times.
+                bool shortCircuits = argError || ShortCircuits(source, unary1, unary2, sink);
+                Assert.InRange(e.EnumeratorCtorCalls, shortCircuits ? 0 : 1, 1);
+                Assert.Equal(e.EnumeratorCtorCalls, e.EnumeratorDisposeCalls);
+            });
+        }
+
+        [Fact]
+        public void BinaryOperations_SourceEnumeratorsDisposed()
+        {
+            // Using Assert.All instead of a Theory to avoid overloading the system with hundreds of thousands of distinct test cases.
+            IEnumerable<(Source source, Unary unary, Binary binary, Sink sink)> inputs =
+                from source in Sources()
+                from unary in UnaryOperations()
+                from binary in BinaryOperations()
+                from sink in Sinks()
+                select (source, unary, binary, sink);
+
+            Assert.All(inputs, input =>
+            {
+                var (source, unary, binary, sink) = input;
+                var es = new[] { new LifecycleTrackingEnumerable<int>(source.Work), new LifecycleTrackingEnumerable<int>(source.Work) };
+
+                // ((source -> unary), (source -> unary)) -> binary -> sink
+                bool argError = false;
+                try
+                {
+                    sink.Work(binary.Work(unary.Work(es[0]), unary.Work(es[1])));
+                }
+                catch (Exception exc) when (exc is ArgumentException || exc is InvalidOperationException)
+                {
+                    argError = true;
+                }
+
+                // We expect the source's enumerator should have been constructed 0 or 1 times,
+                // once if there's no short-circuiting involved.  Then the enumerator's Dispose
+                // should have been invoked the same number of times.
+                bool shortCircuits = argError || ShortCircuits(source, binary, unary, sink);
+                Assert.All(es, e =>
+                {
+                    Assert.InRange(e.EnumeratorCtorCalls, shortCircuits ? 0 : 1, 1);
+                    Assert.Equal(e.EnumeratorCtorCalls, e.EnumeratorDisposeCalls);
+                });
+            });
+        }
+
+        private static bool ShortCircuits(params Operation[] ops) => ops.Any(o => o.ShortCircuits);
+
+        private static IEnumerable<Source> Sources()
+        {
+            foreach (int size in new[] { 0, 1, 2 })
+            {
+                yield return new Source($"Enumerable{size}", NumberRangeGuaranteedNotCollectionType(0, size));
+                yield return new Source($"Collection{size}", new TestCollection<int>(new int[size]));
+                yield return new Source($"ReadOnlyCollection{size}", new TestReadOnlyCollection<int>(new int[size]));
+                yield return new Source($"NonGenericCollection{size}", new TestNonGenericCollection<int>(new int[size]));
+            }
+        }
+
+        private static int s_nextValue = 42;
+
+        private static IEnumerable<Unary> UnaryOperations()
+        {
+            yield return new Unary(nameof(Enumerable.Append), e => e.Append(Interlocked.Increment(ref s_nextValue)));
+            yield return new Unary(nameof(Enumerable.AsEnumerable), e => e.AsEnumerable());
+            yield return new Unary(nameof(Enumerable.Cast), e => e.Cast<int>());
+            yield return new Unary(nameof(Enumerable.Distinct), e => e.Distinct());
+            yield return new Unary(nameof(Enumerable.DefaultIfEmpty), e => e.DefaultIfEmpty());
+            yield return new Unary(nameof(Enumerable.GroupBy), e => e.GroupBy(i => i).Select(g => g.Key));
+            yield return new Unary(nameof(Enumerable.GroupBy), e => e.GroupBy(i => i, i => i).Select(g => g.Key));
+            yield return new Unary(nameof(Enumerable.OfType), e => e.OfType<int>());
+            yield return new Unary(nameof(Enumerable.OrderBy), e => e.OrderBy(i => i));
+            yield return new Unary(nameof(Enumerable.OrderByDescending), e => e.OrderByDescending(i => i));
+            yield return new Unary(nameof(Enumerable.Prepend), e => e.Prepend(Interlocked.Increment(ref s_nextValue)));
+            yield return new Unary(nameof(Enumerable.Reverse), e => e.Reverse());
+            yield return new Unary(nameof(Enumerable.Select), e => e.Select(i => i));
+            yield return new Unary(nameof(Enumerable.Select), e => e.Select((i, index) => i));
+            yield return new Unary(nameof(Enumerable.SelectMany), e => e.SelectMany(i => new[] { i }));
+            yield return new Unary(nameof(Enumerable.SelectMany), e => e.SelectMany((i, index) => new[] { i }));
+            yield return new Unary(nameof(Enumerable.Skip), e => e.Skip(1));
+            yield return new Unary(nameof(Enumerable.SkipWhile), e => e.SkipWhile(i => true));
+            yield return new Unary(nameof(Enumerable.SkipWhile), e => e.SkipWhile(i => false));
+            yield return new Unary(nameof(Enumerable.SkipLast), e => e.SkipLast(1));
+            yield return new Unary(nameof(Enumerable.Take), e => e.Take(int.MaxValue - 1));
+            yield return new Unary(nameof(Enumerable.TakeLast), e => e.TakeLast(int.MaxValue - 1));
+            yield return new Unary(nameof(Enumerable.TakeWhile), e => e.TakeWhile(i => true));
+            yield return new Unary(nameof(Enumerable.TakeWhile), e => e.TakeWhile(i => false), shortCircuits: true);
+            yield return new Unary(nameof(Enumerable.ThenBy), e => e.OrderBy(i => i).ThenBy(i => i));
+            yield return new Unary(nameof(Enumerable.ThenByDescending), e => e.OrderByDescending(i => i).ThenByDescending(i => i));
+            yield return new Unary(nameof(Enumerable.Where), e => e.Where(i => true));
+            yield return new Unary(nameof(Enumerable.Where), e => e.Where((i, index) => false));
+            yield return new Unary("identity", e => e);
+        }
+
+        private static IEnumerable<Binary> BinaryOperations()
+        {
+            yield return new Binary(nameof(Enumerable.Concat), (e1, e2) => e1.Concat(e2));
+            yield return new Binary(nameof(Enumerable.Except), (e1, e2) => e1.Except(e2));
+            yield return new Binary(nameof(Enumerable.GroupJoin), (e1, e2) => e1.GroupJoin(e2, i => i, i => i, (i, e3) => i), shortCircuits: true);
+            yield return new Binary(nameof(Enumerable.Intersect), (e1, e2) => e1.Intersect(e2));
+            yield return new Binary(nameof(Enumerable.Join), (e1, e2) => e1.Join(e2, i => i, i => i, (i1, i2) => i1), shortCircuits: true);
+            yield return new Binary(nameof(Enumerable.Union), (e1, e2) => e1.Union(e2));
+            yield return new Binary(nameof(Enumerable.Zip), (e1, e2) => e1.Zip(e2).Select(i => i.First), shortCircuits: true);
+            yield return new Binary(nameof(Enumerable.Zip), (e1, e2) => e1.Zip(e2, (i, j) => i), shortCircuits: true);
+        }
+
+        private static IEnumerable<Sink> Sinks()
+        {
+            yield return new Sink(nameof(Enumerable.All), e => e.All(i => true));
+            yield return new Sink(nameof(Enumerable.Aggregate), e => e.Aggregate(0, (i, j) => i + j));
+            yield return new Sink(nameof(Enumerable.Aggregate), e => e.Aggregate(0, (i, j) => i + j, i => i));
+            yield return new Sink(nameof(Enumerable.Aggregate), e => e.Aggregate((i, j) => i + j));
+            yield return new Sink(nameof(Enumerable.Average), e => e.Average());
+            yield return new Sink(nameof(Enumerable.Average), e => e.Average(i => i));
+            yield return new Sink(nameof(Enumerable.Any), e => e.Any(), shortCircuits: true);
+            yield return new Sink(nameof(Enumerable.Any), e => e.Any(i => false));
+            yield return new Sink(nameof(Enumerable.Contains), e => e.Contains(-1));
+            yield return new Sink(nameof(Enumerable.Contains), e => e.Contains(0), shortCircuits: true);
+            yield return new Sink(nameof(Enumerable.Count), e => e.Count());
+            yield return new Sink(nameof(Enumerable.Count), e => e.Count(i => true));
+            yield return new Sink(nameof(Enumerable.ElementAt), e => e.ElementAt(0), shortCircuits: true);
+            yield return new Sink(nameof(Enumerable.ElementAtOrDefault), e => e.ElementAtOrDefault(0), shortCircuits: true);
+            yield return new Sink(nameof(Enumerable.First), e => e.First(), shortCircuits: true);
+            yield return new Sink(nameof(Enumerable.First), e => e.First(i => false));
+            yield return new Sink(nameof(Enumerable.FirstOrDefault), e => e.FirstOrDefault(), shortCircuits: true);
+            yield return new Sink(nameof(Enumerable.FirstOrDefault), e => e.FirstOrDefault(i => false));
+            yield return new Sink(nameof(Enumerable.Last), e => e.Last());
+            yield return new Sink(nameof(Enumerable.Last), e => e.Last(i => true));
+            yield return new Sink(nameof(Enumerable.LastOrDefault), e => e.LastOrDefault());
+            yield return new Sink(nameof(Enumerable.LastOrDefault), e => e.LastOrDefault(i => true));
+            yield return new Sink(nameof(Enumerable.LongCount), e => e.LongCount());
+            yield return new Sink(nameof(Enumerable.LongCount), e => e.LongCount(i => true));
+            yield return new Sink(nameof(Enumerable.Max), e => e.Max());
+            yield return new Sink(nameof(Enumerable.Max), e => e.Max(i => i));
+            yield return new Sink(nameof(Enumerable.Min), e => e.Min());
+            yield return new Sink(nameof(Enumerable.Min), e => e.Min(i => i));
+            yield return new Sink(nameof(Enumerable.SequenceEqual), e => e.SequenceEqual(Enumerable.Range(0, 1)), shortCircuits: true);
+            yield return new Sink(nameof(Enumerable.Single), e => e.Single(), shortCircuits: true);
+            yield return new Sink(nameof(Enumerable.Single), e => e.Single(i => false));
+            yield return new Sink(nameof(Enumerable.SingleOrDefault), e => e.SingleOrDefault());
+            yield return new Sink(nameof(Enumerable.SingleOrDefault), e => e.SingleOrDefault(i => true));
+            yield return new Sink(nameof(Enumerable.SingleOrDefault), e => e.SingleOrDefault(i => false));
+            yield return new Sink(nameof(Enumerable.Sum), e => e.Sum());
+            yield return new Sink(nameof(Enumerable.Sum), e => e.Sum(i => i));
+            yield return new Sink(nameof(Enumerable.ToArray), e => e.ToArray());
+            yield return new Sink(nameof(Enumerable.ToDictionary), e => e.ToDictionary(i => i));
+            yield return new Sink(nameof(Enumerable.ToDictionary), e => e.ToDictionary(i => i, i => i));
+            yield return new Sink(nameof(Enumerable.ToHashSet), e => e.ToHashSet());
+            yield return new Sink(nameof(Enumerable.ToList), e => e.ToList());
+            yield return new Sink(nameof(Enumerable.ToLookup), e => e.ToLookup(i => i));
+            yield return new Sink(nameof(Enumerable.ToLookup), e => e.ToLookup(i => i, i => i));
+            yield return new Sink("foreach", e => { foreach (int item in e) { } });
+            yield return new Sink("nop", e => { }, shortCircuits: true);
+        }
+
+        private sealed class LifecycleTrackingEnumerable<T> : IEnumerable<T>
+        {
+            private readonly IEnumerable<T> _source;
+            private int _enumeratorCtorCalls;
+            private int _enumeratorDisposeCalls;
+
+            public LifecycleTrackingEnumerable(IEnumerable<T> source) => _source = source;
+
+            public int EnumeratorCtorCalls => _enumeratorCtorCalls;
+            public int EnumeratorDisposeCalls => _enumeratorDisposeCalls;
+
+            public IEnumerator<T> GetEnumerator() => new Enumerator(this);
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+            private sealed class Enumerator : IEnumerator<T>
+            {
+                private readonly LifecycleTrackingEnumerable<T> _enumerable;
+                private readonly IEnumerator<T> _enumerator;
+
+                public Enumerator(LifecycleTrackingEnumerable<T> enumerable)
+                {
+                    _enumerable = enumerable;
+
+                    Interlocked.Increment(ref _enumerable._enumeratorCtorCalls);
+                    _enumerator = enumerable._source.GetEnumerator();
+                }
+
+                public void Dispose()
+                {
+                    Interlocked.Increment(ref _enumerable._enumeratorDisposeCalls);
+                    _enumerator.Dispose();
+                }
+
+                public T Current => _enumerator.Current;
+                
+                object IEnumerator.Current => ((IEnumerator)_enumerator).Current;
+
+                public bool MoveNext() => _enumerator.MoveNext();
+
+                public void Reset() => throw new NotSupportedException($"LINQ operators should not invoke {nameof(Reset)}.");
+            }
+        }
+
+        private abstract class Operation
+        {
+            public Operation(string name, bool shortCircuits)
+            {
+                Name = name;
+                ShortCircuits = shortCircuits;
+            }
+
+            public string Name { get; }
+
+            public bool ShortCircuits { get; }
+
+            public override string ToString() => Name;
+        }
+
+        private abstract class Operation<TWork> : Operation
+        {
+            public Operation(string name, TWork operation, bool shortCircuits) : base(name, shortCircuits) => Work = operation;
+
+            public TWork Work { get; }
+        }
+
+        private sealed class Source : Operation<IEnumerable<int>>
+        {
+            public Source(string name, IEnumerable<int> enumerable, bool shortCircuits = false) : base(name, enumerable, shortCircuits) { }
+        }
+
+        private sealed class Unary : Operation<Func<IEnumerable<int>, IEnumerable<int>>>
+        {
+            public Unary(string name, Func<IEnumerable<int>, IEnumerable<int>> unary, bool shortCircuits = false) : base(name, unary, shortCircuits) { }
+        }
+
+        private sealed class Binary : Operation<Func<IEnumerable<int>, IEnumerable<int>, IEnumerable<int>>>
+        {
+            public Binary(string name, Func<IEnumerable<int>, IEnumerable<int>, IEnumerable<int>> binary, bool shortCircuits = false) : base(name, binary, shortCircuits) { }
+        }
+
+        private sealed class Sink : Operation<Action<IEnumerable<int>>>
+        {
+            public Sink(string name, Action<IEnumerable<int>> sink, bool shortCircuits = false) : base(name, sink, shortCircuits) { }
+        }
+    }
+}

--- a/src/System.Linq/tests/LifecycleTests.cs
+++ b/src/System.Linq/tests/LifecycleTests.cs
@@ -93,9 +93,6 @@ namespace System.Linq.Tests
             foreach (int size in new[] { 0, 1, 2 })
             {
                 yield return new Source($"Enumerable{size}", NumberRangeGuaranteedNotCollectionType(0, size));
-                yield return new Source($"Collection{size}", new TestCollection<int>(new int[size]));
-                yield return new Source($"ReadOnlyCollection{size}", new TestReadOnlyCollection<int>(new int[size]));
-                yield return new Source($"NonGenericCollection{size}", new TestNonGenericCollection<int>(new int[size]));
             }
         }
 

--- a/src/System.Linq/tests/System.Linq.Tests.csproj
+++ b/src/System.Linq/tests/System.Linq.Tests.csproj
@@ -4,16 +4,10 @@
     <Configurations>netcoreapp-Debug;netcoreapp-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="AppendPrependTests.cs" />
-    <Compile Include="SkipLastTests.cs" />
-    <Compile Include="TakeLastTests.cs" />
-    <Compile Include="OrderByTests.cs" />
-    <Compile Include="ToHashSetTests.cs" />
-    <Compile Include="SelectManyTests.netcoreapp.cs" />
-    <Compile Include="ZipTests.netcoreapp.cs" />
     <Compile Include="AggregateTests.cs" />
     <Compile Include="AllTests.cs" />
     <Compile Include="AnyTests.cs" />
+    <Compile Include="AppendPrependTests.cs" />
     <Compile Include="AsEnumerableTests.cs" />
     <Compile Include="AverageTests.cs" />
     <Compile Include="CastTests.cs" />
@@ -37,25 +31,30 @@
     <Compile Include="JoinTests.cs" />
     <Compile Include="LastOrDefaultTests.cs" />
     <Compile Include="LastTests.cs" />
+    <Compile Include="LifecycleTests.cs" />
     <Compile Include="LongCountTests.cs" />
     <Compile Include="MaxTests.cs" />
     <Compile Include="MinTests.cs" />
     <Compile Include="OfTypeTests.cs" />
     <Compile Include="OrderByDescendingTests.cs" />
+    <Compile Include="OrderByTests.cs" />
     <Compile Include="OrderedSubsetting.cs" />
     <Compile Include="RangeTests.cs" />
     <Compile Include="RepeatTests.cs" />
     <Compile Include="ReverseTests.cs" />
     <Compile Include="SelectManyTests.cs" />
+    <Compile Include="SelectManyTests.netcoreapp.cs" />
     <Compile Include="SelectTests.cs" />
     <Compile Include="SequenceEqualTests.cs" />
     <Compile Include="ShortCircuitingTests.cs" />
     <Compile Include="Shuffler.cs" />
     <Compile Include="SingleOrDefaultTests.cs" />
     <Compile Include="SingleTests.cs" />
+    <Compile Include="SkipLastTests.cs" />
     <Compile Include="SkipTests.cs" />
     <Compile Include="SkipWhileTests.cs" />
     <Compile Include="SumTests.cs" />
+    <Compile Include="TakeLastTests.cs" />
     <Compile Include="TakeTests.cs" />
     <Compile Include="TakeWhileTests.cs" />
     <Compile Include="TestExtensions.cs" />
@@ -63,11 +62,13 @@
     <Compile Include="ThenByTests.cs" />
     <Compile Include="ToArrayTests.cs" />
     <Compile Include="ToDictionaryTests.cs" />
+    <Compile Include="ToHashSetTests.cs" />
     <Compile Include="ToListTests.cs" />
     <Compile Include="ToLookupTests.cs" />
     <Compile Include="UnionTests.cs" />
     <Compile Include="WhereTests.cs" />
     <Compile Include="ZipTests.cs" />
+    <Compile Include="ZipTests.netcoreapp.cs" />
     <Compile Include="$(CommonTestPath)\System\Linq\SkipTakeData.cs">
       <Link>Common\System\Linq\SkipTakeData.cs</Link>
     </Compile>

--- a/src/System.Linq/tests/UnionTests.cs
+++ b/src/System.Linq/tests/UnionTests.cs
@@ -414,19 +414,5 @@ namespace System.Linq.Tests
             Assert.Equal(new[] { "A", "a" }, input2.Union(input1, EqualityComparer<string>.Default));
             Assert.Equal(new[] { "A" }, input2.Union(input1, StringComparer.OrdinalIgnoreCase));
         }
-
-        [Fact]
-        public void UnionFollowedBySelectOnEmptyEnumerableInvokesDispose()
-        {
-            var enum1 = new DisposeTrackingEnumerable<int>();
-            var enum2 = new DisposeTrackingEnumerable<int>();
-            Assert.False(enum1.EnumeratorDisposed);
-            Assert.False(enum2.EnumeratorDisposed);
-
-            foreach (int value in enum1.Union(enum2)) { }
-
-            Assert.True(enum1.EnumeratorDisposed);
-            Assert.True(enum2.EnumeratorDisposed);
-        }
     }
 }


### PR DESCRIPTION
In response to the issue raised in https://github.com/dotnet/corefx/issues/40384, I wrote tests for the rest of the LINQ methods, on their own and in combination with others, to validate that dispose was properly called in all other cases.  The first commit includes those tests.  Note that I initially had them as theories, but I thought the infrastructure folks might not like my adding another ~400,000 test cases, so I collapsed them into two methods that instead use Assert.All.

The second commit fixes one additional bug these tests surfaced, which is that queries that perform a Select after some other IPartition-creating operation (like a Take) and then followed by a Count() may iterate through the source enumerator twice.

cc: @maryamariyan, @cston