### PR TITLE
Update HttpClientHandler to respect TransferEncondingChunked = false on HttpContent.

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Core.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Core.cs
@@ -110,7 +110,7 @@ namespace System.Net.Http
 
             if (shouldBufferContent)
             {
-                var computedLength = request.Content.GetComputedOrBufferLength();
+                long? computedLength = request.Content.GetComputedOrBufferLength();
 
                 if (!computedLength.HasValue)
                 {

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Core.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Core.cs
@@ -109,7 +109,9 @@ namespace System.Net.Http
         {
             // Don't buffer if there's nothing to buffer or the length is already defined.
             if (request.Content == null || request.Content.Headers.ContentLength != null)
+            {
                 return false;
+            }
 
             // Buffer HTTP 1.0 regardless of TransferEncodingChunked.
             if (request.Version.Minor == 0 && request.Version.Major == 1)

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Core.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Core.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Globalization;
+using System.Threading.Tasks;
 
 namespace System.Net.Http
 {
@@ -61,6 +63,70 @@ namespace System.Net.Http
             {
                 throw new InvalidOperationException(SR.net_http_operation_started);
             }
+        }
+
+        private static async Task<Exception> ValidateAndNormalizeRequestAsync(HttpRequestMessage request)
+        {
+            bool shouldBufferContent = false;
+
+            // Add headers to define content transfer, if not present
+            if (request.HasHeaders && request.Headers.TransferEncodingChunked.GetValueOrDefault())
+            {
+                if (request.Content == null)
+                {
+                    return new HttpRequestException(SR.net_http_client_execution_error,
+                        new InvalidOperationException(SR.net_http_chunked_not_allowed_with_empty_content));
+                }
+
+                // Since the user explicitly set TransferEncodingChunked to true, we need to remove
+                // the Content-Length header if present, as sending both is invalid.
+                request.Content.Headers.ContentLength = null;
+            }
+            else if (request.Content != null && request.Content.Headers.ContentLength == null && request.Headers.TransferEncodingChunked == false)
+            {
+                // We have content, but Content-Length is not set and Transfer-Encoding was explicitly unset.
+                shouldBufferContent = true;
+            }
+            else if (request.Content != null && request.Content.Headers.ContentLength == null && request.Headers.TransferEncodingChunked == null)
+            {
+                // We have content, but Content-Length is not set and Transfer-Encoding was not specified.
+                request.Headers.TransferEncodingChunked = true;
+            }
+
+            if (request.Version.Minor == 0 && request.Version.Major == 1 && request.HasHeaders)
+            {
+                // HTTP 1.0 does not support chunking
+                if (request.Content != null && request.Headers.TransferEncodingChunked == true)
+                {
+                    shouldBufferContent = true;
+                }
+
+                // HTTP 1.0 does not support Expect: 100-continue; just disable it.
+                if (request.Headers.ExpectContinue == true)
+                {
+                    request.Headers.ExpectContinue = false;
+                }
+            }
+
+            if (shouldBufferContent)
+            {
+                var computedLength = request.Content.GetComputedOrBufferLength();
+
+                if (!computedLength.HasValue)
+                {
+                    await request.Content.LoadIntoBufferAsync().ConfigureAwait(false);
+
+                    computedLength = request.Content.GetComputedOrBufferLength();
+                }
+
+
+                Debug.Assert(computedLength.HasValue, "Buffering should necessarily ensure that GetComputedOrBufferLength() will return a non-null value.");
+
+                request.Headers.TransferEncodingChunked = false;
+                request.Content.Headers.ContentLength = computedLength;
+            }
+
+            return null;
         }
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Core.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Core.cs
@@ -65,7 +65,7 @@ namespace System.Net.Http
             }
         }
 
-        private static async Task<Exception> ValidateAndNormalizeRequestAsync(HttpRequestMessage request)
+        private static Exception ValidateAndNormalizeRequest(HttpRequestMessage request)
         {
             bool shouldBufferContent = false;
 
@@ -114,7 +114,7 @@ namespace System.Net.Http
 
                 if (!computedLength.HasValue)
                 {
-                    await request.Content.LoadIntoBufferAsync().ConfigureAwait(false);
+                    request.Content.LoadIntoBufferAsync().GetAwaiter().GetResult();
 
                     computedLength = request.Content.GetComputedOrBufferLength();
                 }

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Core.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Core.cs
@@ -53,7 +53,7 @@ namespace System.Net.Http
         {
             if (request == null)
             {
-                throw new ArgumentNullException(nameof(request), SR.net_http_handler_norequest);
+                return Task.FromException<HttpResponseMessage>(new ArgumentNullException(nameof(request), SR.net_http_handler_norequest));
             }
 
             if (ShouldBufferContent(request))

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Unix.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Unix.cs
@@ -408,7 +408,7 @@ namespace System.Net.Http
                 throw new ArgumentNullException(nameof(request), SR.net_http_handler_norequest);
             }
 
-            var error = await ValidateAndNormalizeRequestAsync(request).ConfigureAwait(false);
+            Exception error = await ValidateAndNormalizeRequestAsync(request).ConfigureAwait(false);
 
             if (error != null)
             {

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Unix.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Unix.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Net.Security;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Unix.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Unix.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Net.Security;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
@@ -401,23 +402,20 @@ namespace System.Net.Http
             _curlHandler.Properties :
             _socketsHttpHandler.Properties;
 
-        protected internal override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        protected internal override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            if (request == null)
-            {
-                throw new ArgumentNullException(nameof(request), SR.net_http_handler_norequest);
-            }
+            Debug.Assert(request != null);
 
-            Exception error = await ValidateAndNormalizeRequestAsync(request).ConfigureAwait(false);
+            Exception error = ValidateAndNormalizeRequest(request);
 
             if (error != null)
             {
                 throw error;
             }
 
-            return DiagnosticsHandler.IsEnabled() ? await _diagnosticsHandler.SendAsync(request, cancellationToken).ConfigureAwait(false) :
-                _curlHandler != null ? await _curlHandler.SendAsync(request, cancellationToken).ConfigureAwait(false) :
-                await _socketsHttpHandler.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            return DiagnosticsHandler.IsEnabled() ? _diagnosticsHandler.SendAsync(request, cancellationToken) :
+                _curlHandler != null ? _curlHandler.SendAsync(request, cancellationToken) :
+                _socketsHttpHandler.SendAsync(request, cancellationToken);
         }
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Unix.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Unix.cs
@@ -402,20 +402,9 @@ namespace System.Net.Http
             _curlHandler.Properties :
             _socketsHttpHandler.Properties;
 
-        protected internal override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            Debug.Assert(request != null);
-
-            Exception error = ValidateAndNormalizeRequest(request);
-
-            if (error != null)
-            {
-                throw error;
-            }
-
-            return DiagnosticsHandler.IsEnabled() ? _diagnosticsHandler.SendAsync(request, cancellationToken) :
-                _curlHandler != null ? _curlHandler.SendAsync(request, cancellationToken) :
-                _socketsHttpHandler.SendAsync(request, cancellationToken);
-        }
+        private Task<HttpResponseMessage> SendWithPlatformHandlerAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            DiagnosticsHandler.IsEnabled() ? _diagnosticsHandler.SendAsync(request, cancellationToken) :
+            _curlHandler != null ? _curlHandler.SendAsync(request, cancellationToken) :
+            _socketsHttpHandler.SendAsync(request, cancellationToken);
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
@@ -443,18 +443,8 @@ namespace System.Net.Http
             _winHttpHandler.Properties :
             _socketsHttpHandler.Properties;
 
-        protected internal override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
-            CancellationToken cancellationToken)
+        private Task<HttpResponseMessage> SendWithPlatformHandlerAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            Debug.Assert(request != null);
-
-            Exception error = ValidateAndNormalizeRequest(request);
-
-            if (error != null)
-            {
-                throw error;
-            }
-
             if (_winHttpHandler != null)
             {
                 // Get current value of WindowsProxyUsePolicy.  Only call its WinHttpHandler

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Net.Security;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
@@ -450,7 +450,7 @@ namespace System.Net.Http
                 throw new ArgumentNullException(nameof(request), SR.net_http_handler_norequest);
             }
 
-            var error = await ValidateAndNormalizeRequestAsync(request).ConfigureAwait(false);
+            Exception error = await ValidateAndNormalizeRequestAsync(request).ConfigureAwait(false);
 
             if (error != null)
             {

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Net.Security;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
@@ -442,15 +443,12 @@ namespace System.Net.Http
             _winHttpHandler.Properties :
             _socketsHttpHandler.Properties;
 
-        protected internal override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+        protected internal override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
-            if (request == null)
-            {
-                throw new ArgumentNullException(nameof(request), SR.net_http_handler_norequest);
-            }
+            Debug.Assert(request != null);
 
-            Exception error = await ValidateAndNormalizeRequestAsync(request).ConfigureAwait(false);
+            Exception error = ValidateAndNormalizeRequest(request);
 
             if (error != null)
             {
@@ -489,14 +487,14 @@ namespace System.Net.Http
                 }
 
                 return DiagnosticsHandler.IsEnabled() ?
-                    await _diagnosticsHandler.SendAsync(request, cancellationToken).ConfigureAwait(false) :
-                    await _winHttpHandler.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                    _diagnosticsHandler.SendAsync(request, cancellationToken) :
+                    _winHttpHandler.SendAsync(request, cancellationToken);
             }
             else
             {
                 return DiagnosticsHandler.IsEnabled() ?
-                    await _diagnosticsHandler.SendAsync(request, cancellationToken).ConfigureAwait(false) :
-                    await _socketsHttpHandler.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                    _diagnosticsHandler.SendAsync(request, cancellationToken) :
+                    _socketsHttpHandler.SendAsync(request, cancellationToken);
             }
         }
     }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
@@ -333,6 +333,11 @@ namespace System.Net.Http
         protected internal override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request, CancellationToken cancellationToken)
         {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request), SR.net_http_handler_norequest);
+            }
+
             CheckDisposed();
             HttpMessageHandler handler = _handler ?? SetupHandlerChain();
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
@@ -333,11 +333,6 @@ namespace System.Net.Http
         protected internal override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            if (request == null)
-            {
-                throw new ArgumentNullException(nameof(request), SR.net_http_handler_norequest);
-            }
-
             CheckDisposed();
             HttpMessageHandler handler = _handler ?? SetupHandlerChain();
 

--- a/src/System.Net.Http/src/uap/System/Net/HttpClientHandler.cs
+++ b/src/System.Net.Http/src/uap/System/Net/HttpClientHandler.cs
@@ -581,7 +581,7 @@ namespace System.Net.Http
 
         #region Request Execution
 
-        protected internal override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+        private async Task<HttpResponseMessage> SendWithPlatformHandlerAsync(HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
             CheckDisposed();


### PR DESCRIPTION
Resolves #39544 .

Updates HttpClientHandler to handle requestMessage.Headers.TransferEncodingChunked = false differently from requestMessage.Headers.TransferEncodingChunked = null.  

I decided to explicitly **not** directly apply this logic to the individual platform implementations nor the socket-based implementation because of the complications of implementing it consistently across individual implementations see #40695 for a failed implementation doing that.

