### PR TITLE
Retry eventlog deletion in tests on all platforms

### DIFF
--- a/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
@@ -40,7 +40,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnWin7(() => EventLog.Delete(log));
+                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
             }
         }
 
@@ -65,7 +65,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnWin7(() => EventLog.Delete(log));
+                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
             }
         }
 
@@ -95,7 +95,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnWin7(() => EventLog.Delete(log));
+                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
             }
         }
 
@@ -122,7 +122,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnWin7(() => EventLog.Delete(log));
+                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
             }
         }
     }

--- a/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
@@ -22,17 +22,17 @@ namespace System.Diagnostics.Tests
                 using (EventLog eventLog = new EventLog())
                 {
                     eventLog.Source = source;
-                    Helpers.RetryOnWin7(() => eventLog.WriteEntry(message));
-                    Helpers.RetryOnWin7(() => eventLog.WriteEntry("Further Testing"));
+                    Helpers.Retry(() => eventLog.WriteEntry(message));
+                    Helpers.Retry(() => eventLog.WriteEntry("Further Testing"));
 
                     EventLogEntryCollection entryCollection = eventLog.Entries;
                     EventLogEntry[] entryCollectionCopied = new EventLogEntry[entryCollection.Count];
 
-                    Helpers.RetryOnWin7(() => entryCollection.CopyTo(entryCollectionCopied, 0));
+                    Helpers.Retry(() => entryCollection.CopyTo(entryCollectionCopied, 0));
                     int i = 0;
                     foreach (EventLogEntry entry in entryCollection)
                     {
-                        Assert.Equal(entry.Message, Helpers.RetryOnWin7(() => entryCollectionCopied[i].Message));
+                        Assert.Equal(entry.Message, Helpers.Retry(() => entryCollectionCopied[i].Message));
                         i += 1;
                     }
                 }
@@ -40,7 +40,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
+                Helpers.Retry(() => EventLog.Delete(log));
             }
         }
 
@@ -56,16 +56,16 @@ namespace System.Diagnostics.Tests
                 using (EventLog eventLog = new EventLog())
                 {
                     eventLog.Source = source;
-                    Helpers.RetryOnWin7(() => eventLog.WriteEntry(message));
+                    Helpers.Retry(() => eventLog.WriteEntry(message));
                     Helpers.WaitForEventLog(eventLog, 1);
-                    EventLogEntry entry = Helpers.RetryOnWin7(() => eventLog.Entries[eventLog.Entries.Count - 1]);
+                    EventLogEntry entry = Helpers.Retry(() => eventLog.Entries[eventLog.Entries.Count - 1]);
                     Assert.False(entry.Equals(null));
                 }
             }
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
+                Helpers.Retry(() => EventLog.Delete(log));
             }
         }
 
@@ -81,21 +81,21 @@ namespace System.Diagnostics.Tests
                 using (EventLog eventLog = new EventLog())
                 {
                     eventLog.Source = source;
-                    Helpers.RetryOnWin7(() => eventLog.WriteEntry(message));
+                    Helpers.Retry(() => eventLog.WriteEntry(message));
                     Helpers.WaitForEventLog(eventLog, 1);  //There is latency between writing and getting the entry
-                    EventLogEntry entry = Helpers.RetryOnWin7(() => eventLog.Entries[eventLog.Entries.Count - 1]);
+                    EventLogEntry entry = Helpers.Retry(() => eventLog.Entries[eventLog.Entries.Count - 1]);
                     Assert.True(entry.Equals(entry));
 
-                    Helpers.RetryOnWin7(() => eventLog.WriteEntry(message));
+                    Helpers.Retry(() => eventLog.WriteEntry(message));
                     Helpers.WaitForEventLog(eventLog, 2);
-                    EventLogEntry secondEntry = Helpers.RetryOnWin7(() => eventLog.Entries[eventLog.Entries.Count - 1]);
+                    EventLogEntry secondEntry = Helpers.Retry(() => eventLog.Entries[eventLog.Entries.Count - 1]);
                     Assert.Equal(entry.Index + 1, secondEntry.Index);
                 }
             }
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
+                Helpers.Retry(() => EventLog.Delete(log));
             }
         }
 
@@ -111,18 +111,18 @@ namespace System.Diagnostics.Tests
                 using (EventLog eventLog = new EventLog())
                 {
                     eventLog.Source = source;
-                    Helpers.RetryOnWin7(() => eventLog.WriteEntry(message));
-                    Helpers.RetryOnWin7(() => eventLog.WriteEntry(message));
+                    Helpers.Retry(() => eventLog.WriteEntry(message));
+                    Helpers.Retry(() => eventLog.WriteEntry(message));
                     Helpers.WaitForEventLog(eventLog, 2);
-                    EventLogEntry entry = Helpers.RetryOnWin7(() => eventLog.Entries[eventLog.Entries.Count - 1]);
-                    EventLogEntry secondEntry = Helpers.RetryOnWin7(() => eventLog.Entries[eventLog.Entries.Count - 2]);
+                    EventLogEntry entry = Helpers.Retry(() => eventLog.Entries[eventLog.Entries.Count - 1]);
+                    EventLogEntry secondEntry = Helpers.Retry(() => eventLog.Entries[eventLog.Entries.Count - 2]);
                     Assert.False(entry.Equals(secondEntry));
                 }
             }
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
+                Helpers.Retry(() => EventLog.Delete(log));
             }
         }
     }

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogEntryWrittenTest.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogEntryWrittenTest.cs
@@ -48,7 +48,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnWin7(() => EventLog.Delete(log));
+                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
             }
         }
 

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogEntryWrittenTest.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogEntryWrittenTest.cs
@@ -30,8 +30,8 @@ namespace System.Diagnostics.Tests
                         eventCounter += 1;
                         signal.Set();
                     });
-                    Helpers.RetryOnWin7(() => eventLog.EnableRaisingEvents = waitOnEvent);
-                    Helpers.RetryOnWin7(() => eventLog.WriteEntry(message, EventLogEntryType.Information));
+                    Helpers.Retry(() => eventLog.EnableRaisingEvents = waitOnEvent);
+                    Helpers.Retry(() => eventLog.WriteEntry(message, EventLogEntryType.Information));
                     if (waitOnEvent)
                     {
                         if (!signal.WaitOne(6000))
@@ -48,7 +48,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
+                Helpers.Retry(() => EventLog.Delete(log));
             }
         }
 

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogSourceCreationTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogSourceCreationTests.cs
@@ -21,7 +21,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnWin7(() => EventLog.Delete(log));
+                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
             }
 
             Assert.False(EventLog.SourceExists(source));
@@ -47,9 +47,9 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(firstSource);
-                Helpers.RetryOnWin7(() => EventLog.Delete(firstLog));
+                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(firstLog));
                 EventLog.DeleteEventSource(secondSource);
-                Helpers.RetryOnWin7(() => EventLog.Delete(secondLog));
+                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(secondLog));
             }
         }
 
@@ -71,7 +71,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(firstSource);
-                Helpers.RetryOnWin7(() => EventLog.Delete(firstLog));
+                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(firstLog));
             }
         }
 
@@ -155,7 +155,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnWin7(() => EventLog.Delete(log));
+                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
             }
         }
 

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogSourceCreationTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogSourceCreationTests.cs
@@ -21,7 +21,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
+                Helpers.Retry(() => EventLog.Delete(log));
             }
 
             Assert.False(EventLog.SourceExists(source));
@@ -47,9 +47,9 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(firstSource);
-                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(firstLog));
+                Helpers.Retry(() => EventLog.Delete(firstLog));
                 EventLog.DeleteEventSource(secondSource);
-                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(secondLog));
+                Helpers.Retry(() => EventLog.Delete(secondLog));
             }
         }
 
@@ -71,7 +71,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(firstSource);
-                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(firstLog));
+                Helpers.Retry(() => EventLog.Delete(firstLog));
             }
         }
 
@@ -155,7 +155,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
+                Helpers.Retry(() => EventLog.Delete(log));
             }
         }
 

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
@@ -34,17 +34,17 @@ namespace System.Diagnostics.Tests
                 using (EventLog eventLog = new EventLog())
                 {
                     eventLog.Source = source;
-                    Helpers.RetryOnWin7(() => eventLog.Clear());
-                    Assert.Equal(0, Helpers.RetryOnWin7((() => eventLog.Entries.Count)));
-                    Helpers.RetryOnWin7(() => eventLog.WriteEntry("Writing to event log."));
+                    Helpers.Retry(() => eventLog.Clear());
+                    Assert.Equal(0, Helpers.Retry((() => eventLog.Entries.Count)));
+                    Helpers.Retry(() => eventLog.WriteEntry("Writing to event log."));
                     Helpers.WaitForEventLog(eventLog, 1);
-                    Assert.Equal(1, Helpers.RetryOnWin7((() => eventLog.Entries.Count)));
+                    Assert.Equal(1, Helpers.Retry((() => eventLog.Entries.Count)));
                 }
             }
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
+                Helpers.Retry(() => EventLog.Delete(log));
             }
         }
 
@@ -53,7 +53,7 @@ namespace System.Diagnostics.Tests
         {
             using (EventLog eventLog = new EventLog("Application"))
             {
-                Assert.InRange(Helpers.RetryOnWin7((() => eventLog.Entries.Count)), 1, int.MaxValue);
+                Assert.InRange(Helpers.Retry((() => eventLog.Entries.Count)), 1, int.MaxValue);
             }
         }
 
@@ -71,7 +71,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
+                Helpers.Retry(() => EventLog.Delete(log));
                 Assert.False(EventLog.Exists(log));
             }
         }
@@ -147,7 +147,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
+                Helpers.Retry(() => EventLog.Delete(log));
             }
         }
 
@@ -186,7 +186,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
+                Helpers.Retry(() => EventLog.Delete(log));
             }
         }
 
@@ -213,7 +213,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
+                Helpers.Retry(() => EventLog.Delete(log));
             }
         }
 
@@ -273,7 +273,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
+                Helpers.Retry(() => EventLog.Delete(log));
             }
         }
 
@@ -331,7 +331,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
+                Helpers.Retry(() => EventLog.Delete(log));
             }
         }
 
@@ -357,7 +357,7 @@ namespace System.Diagnostics.Tests
             foreach (var eventLog in EventLog.GetEventLogs())
             {
                 // Accessing eventlog properties should not throw.
-                Assert.True(Helpers.RetryOnWin7(() => eventLog.Entries.Count) >= 0);
+                Assert.True(Helpers.Retry(() => eventLog.Entries.Count) >= 0);
             }
         }
 

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
@@ -44,7 +44,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnWin7(() => EventLog.Delete(log));
+                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
             }
         }
 
@@ -71,7 +71,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnWin7(() => EventLog.Delete(log));
+                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
                 Assert.False(EventLog.Exists(log));
             }
         }
@@ -147,7 +147,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnWin7(() => EventLog.Delete(log));
+                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
             }
         }
 
@@ -186,7 +186,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnWin7(() => EventLog.Delete(log));
+                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
             }
         }
 
@@ -213,7 +213,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnWin7(() => EventLog.Delete(log));
+                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
             }
         }
 
@@ -273,7 +273,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnWin7(() => EventLog.Delete(log));
+                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
             }
         }
 
@@ -331,7 +331,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnWin7(() => EventLog.Delete(log));
+                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
             }
         }
 

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
@@ -22,30 +22,30 @@ namespace System.Diagnostics.Tests
                 eventLog.Source = source;
                 if (instance)
                 {
-                    Helpers.RetryOnWin7(() => EventLog.WriteEvent(source, eventInstance));
+                    Helpers.Retry(() => EventLog.WriteEvent(source, eventInstance));
                     if (data)
                     {
-                        Helpers.RetryOnWin7(() => eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId, rawData));
+                        Helpers.Retry(() => eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId, rawData));
                         return eventLog.Entries.LastOrDefault();
                     }
                     else if (category)
                     {
-                        Helpers.RetryOnWin7(() => eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId));
+                        Helpers.Retry(() => eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId));
                         return eventLog.Entries.LastOrDefault();
                     }
                     else
                     {
-                        Helpers.RetryOnWin7(() => eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId));
+                        Helpers.Retry(() => eventLog.WriteEntry(message, EventLogEntryType.Warning, (int)eventInstance.InstanceId));
                         return eventLog.Entries.LastOrDefault();
                     }
                 }
                 else if (type)
                 {
-                    Helpers.RetryOnWin7(() => eventLog.WriteEntry(message, EventLogEntryType.Warning));
+                    Helpers.Retry(() => eventLog.WriteEntry(message, EventLogEntryType.Warning));
                 }
                 else
                 {
-                    Helpers.RetryOnWin7(() => eventLog.WriteEntry(message));
+                    Helpers.Retry(() => eventLog.WriteEntry(message));
                 }
 
                 return eventLog.Entries.LastOrDefault();
@@ -59,30 +59,30 @@ namespace System.Diagnostics.Tests
                 eventLog.Source = source;
                 if (instance)
                 {
-                    Helpers.RetryOnWin7(() => EventLog.WriteEvent(source, eventInstance));
+                    Helpers.Retry(() => EventLog.WriteEvent(source, eventInstance));
                     if (data)
                     {
-                        Helpers.RetryOnWin7(() => EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId, rawData));
+                        Helpers.Retry(() => EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId, rawData));
                         return eventLog.Entries.LastOrDefault();
                     }
                     else if (category)
                     {
-                        Helpers.RetryOnWin7(() => EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId));
+                        Helpers.Retry(() => EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId, (short)eventInstance.CategoryId));
                         return eventLog.Entries.LastOrDefault();
                     }
                     else
                     {
-                        Helpers.RetryOnWin7(() => EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId));
+                        Helpers.Retry(() => EventLog.WriteEntry(source, message, EventLogEntryType.Warning, (int)eventInstance.InstanceId));
                         return eventLog.Entries.LastOrDefault();
                     }
                 }
                 else if (type)
                 {
-                    Helpers.RetryOnWin7(() => EventLog.WriteEntry(source, message, EventLogEntryType.Warning));
+                    Helpers.Retry(() => EventLog.WriteEntry(source, message, EventLogEntryType.Warning));
                 }
                 else
                 {
-                    Helpers.RetryOnWin7(() => EventLog.WriteEntry(source, message));
+                    Helpers.Retry(() => EventLog.WriteEntry(source, message));
                 }
 
                 return eventLog.Entries.LastOrDefault();
@@ -93,11 +93,11 @@ namespace System.Diagnostics.Tests
         {
             if (data)
             {
-                Helpers.RetryOnWin7(() => EventLog.WriteEvent(source, eventInstance, rawData, insertStrings));
+                Helpers.Retry(() => EventLog.WriteEvent(source, eventInstance, rawData, insertStrings));
             }
             else
             {
-                Helpers.RetryOnWin7(() => EventLog.WriteEvent(source, eventInstance, insertStrings));
+                Helpers.Retry(() => EventLog.WriteEvent(source, eventInstance, insertStrings));
             }
             using (EventLog eventLog = new EventLog())
             {
@@ -113,9 +113,9 @@ namespace System.Diagnostics.Tests
                 string[] insertStringsSingleton = { "ExtraText" };
                 eventLog.Source = source;
                 if (data)
-                    Helpers.RetryOnWin7(() => eventLog.WriteEvent(eventInstance, rawData, insertStringsSingleton));
+                    Helpers.Retry(() => eventLog.WriteEvent(eventInstance, rawData, insertStringsSingleton));
                 else
-                    Helpers.RetryOnWin7(() => eventLog.WriteEvent(eventInstance, insertStringsSingleton));
+                    Helpers.Retry(() => eventLog.WriteEvent(eventInstance, insertStringsSingleton));
 
                 return eventLog.Entries.LastOrDefault();
             }
@@ -149,7 +149,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
+                Helpers.Retry(() => EventLog.Delete(log));
             }
         }
 
@@ -178,7 +178,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
+                Helpers.Retry(() => EventLog.Delete(log));
             }
         }
 
@@ -207,7 +207,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
+                Helpers.Retry(() => EventLog.Delete(log));
             }
         }
 
@@ -242,7 +242,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
+                Helpers.Retry(() => EventLog.Delete(log));
             }
         }
 
@@ -271,7 +271,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
+                Helpers.Retry(() => EventLog.Delete(log));
             }
         }
 
@@ -324,7 +324,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
+                Helpers.Retry(() => EventLog.Delete(log));
             }
         }
 
@@ -351,7 +351,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
+                Helpers.Retry(() => EventLog.Delete(log));
             }
         }
 
@@ -359,7 +359,7 @@ namespace System.Diagnostics.Tests
         public void WriteEventInstanceNull()
         {
             string source = "Source_" + nameof(WriteEventInstanceNull);
-            Helpers.RetryOnWin7(() => Assert.Throws<ArgumentNullException>(() => EventLog.WriteEvent(source, null, insertStrings)));
+            Helpers.Retry(() => Assert.Throws<ArgumentNullException>(() => EventLog.WriteEvent(source, null, insertStrings)));
         }
 
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
@@ -368,7 +368,7 @@ namespace System.Diagnostics.Tests
             string source = "Source_" + nameof(WriteEventMessageValues_OutOfRange);
             string[] message = new string[1];
             message[0] = new string('c', 32767);
-            Helpers.RetryOnWin7(() => Assert.Throws<ArgumentException>(() => EventLog.WriteEvent(source, eventInstance, message)));
+            Helpers.Retry(() => Assert.Throws<ArgumentException>(() => EventLog.WriteEvent(source, eventInstance, message)));
         }
 
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
@@ -377,7 +377,7 @@ namespace System.Diagnostics.Tests
             string source = "Source_" + nameof(WriteWithoutExistingSource);
             try
             {
-                Helpers.RetryOnWin7(() => EventLog.WriteEvent(source, eventInstance, rawData, null));
+                Helpers.Retry(() => EventLog.WriteEvent(source, eventInstance, rawData, null));
                 Assert.Equal("Application", EventLog.LogNameFromSourceName(source, "."));
             }
             finally
@@ -398,7 +398,7 @@ namespace System.Diagnostics.Tests
     {
         internal static EventLogEntry LastOrDefault(this EventLogEntryCollection elec)
         {
-            return Helpers.RetryOnWin7(() => elec.Count > 0 ? elec[elec.Count - 1] : null);
+            return Helpers.Retry(() => elec.Count > 0 ? elec[elec.Count - 1] : null);
         }
     }
 }

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
@@ -149,7 +149,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnWin7(() => EventLog.Delete(log));
+                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
             }
         }
 
@@ -178,7 +178,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnWin7(() => EventLog.Delete(log));
+                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
             }
         }
 
@@ -207,7 +207,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnWin7(() => EventLog.Delete(log));
+                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
             }
         }
 
@@ -242,7 +242,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnWin7(() => EventLog.Delete(log));
+                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
             }
         }
 
@@ -271,7 +271,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnWin7(() => EventLog.Delete(log));
+                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
             }
         }
 
@@ -324,7 +324,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnWin7(() => EventLog.Delete(log));
+                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
             }
         }
 
@@ -351,7 +351,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnWin7(() => EventLog.Delete(log));
+                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
             }
         }
 

--- a/src/System.Diagnostics.EventLog/tests/EventLogTraceListenerTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTraceListenerTests.cs
@@ -109,11 +109,10 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnWin7(() => EventLog.Delete(log));
+                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
             }
         }
 
-        [ActiveIssue(40224, TestPlatforms.Windows)]
         [ConditionalTheory(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         [InlineData(TraceEventType.Information, EventLogEntryType.Information, ushort.MaxValue + 1, ushort.MaxValue)]
         [InlineData(TraceEventType.Error, EventLogEntryType.Error, ushort.MinValue - 1, ushort.MinValue)]
@@ -142,7 +141,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnWin7(() => EventLog.Delete(log));
+                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
             }
         }
 
@@ -174,7 +173,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnWin7(() => EventLog.Delete(log));
+                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
             }
         }
 
@@ -195,7 +194,6 @@ namespace System.Diagnostics.Tests
             yield return new object[] { null, new object[] { "thanks, 00", "i like it...", 111 } };
         }
 
-        [ActiveIssue(40224, TestPlatforms.Windows)]
         [ConditionalTheory(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         [MemberData(nameof(GetTraceEventFormat_MemberData))]
         public void TraceEventFormatAndParams(string format, object[] parameters)
@@ -247,7 +245,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnWin7(() => EventLog.Delete(log));
+                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
             }
         }
 
@@ -292,7 +290,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnWin7(() => EventLog.Delete(log));
+                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
             }
         }
 

--- a/src/System.Diagnostics.EventLog/tests/EventLogTraceListenerTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTraceListenerTests.cs
@@ -98,18 +98,18 @@ namespace System.Diagnostics.Tests
                 using (var listener = new EventLogTraceListener(source))
                 {
                     string message = "A little message for the log";
-                    Helpers.RetryOnWin7(() => listener.Write(message));
+                    Helpers.Retry(() => listener.Write(message));
                     ValidateLastEntryMessage(listener, message, source);
 
                     message = "One more message for my friend";
-                    Helpers.RetryOnWin7(() => listener.WriteLine(message));
+                    Helpers.Retry(() => listener.WriteLine(message));
                     ValidateLastEntryMessage(listener, message, source);
                 }
             }
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
+                Helpers.Retry(() => EventLog.Delete(log));
             }
         }
 
@@ -141,7 +141,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
+                Helpers.Retry(() => EventLog.Delete(log));
             }
         }
 
@@ -173,7 +173,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
+                Helpers.Retry(() => EventLog.Delete(log));
             }
         }
 
@@ -245,7 +245,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
+                Helpers.Retry(() => EventLog.Delete(log));
             }
         }
 
@@ -290,7 +290,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
+                Helpers.Retry(() => EventLog.Delete(log));
             }
         }
 

--- a/src/System.Diagnostics.EventLog/tests/Helpers.cs
+++ b/src/System.Diagnostics.EventLog/tests/Helpers.cs
@@ -18,24 +18,12 @@ namespace System.Diagnostics.Tests
         public static bool IsElevatedAndSupportsEventLogs { get => AdminHelpers.IsProcessElevated() && SupportsEventLogs; }
         public static bool SupportsEventLogs { get => PlatformDetection.IsNotWindowsNanoServer && PlatformDetection.IsNotWindowsIoTCore; }
 
-        public static void RetryOnWin7(Action func)
+        public static void Retry(Action func)
         {
-            RetryOnWin7<object>(() => { func(); return null; });
+            Retry<object>(() => { func(); return null; });
         }
 
-        public static T RetryOnWin7<T>(Func<T> func)
-        {
-            if (!PlatformDetection.IsWindows7)
-            {
-                return func();
-            }
-
-            return RetryOnAllPlatforms(func);
-            // We are retrying on windows 7 because it throws win32exception while some operations like Writing,retrieving and Deleting log.
-            // So We just try to do the operation again in case of this exception
-        }
-
-        public static T RetryOnAllPlatforms<T>(Func<T> func)
+        public static T Retry<T>(Func<T> func)
         {
             // Harden the tests increasing the retry count and the timeout.
             T result = default;
@@ -51,7 +39,7 @@ namespace System.Diagnostics.Tests
         {
             int tries = 1;
             Stopwatch stopwatch = Stopwatch.StartNew();
-            while (RetryOnAllPlatforms((() => eventLog.Entries.Count)) < entriesExpected && tries <= 50)
+            while (Retry((() => eventLog.Entries.Count)) < entriesExpected && tries <= 50)
             {
                 if (tries == 50)
                 {
@@ -67,7 +55,7 @@ namespace System.Diagnostics.Tests
             if (stopwatch.ElapsedMilliseconds / 1000 >= 5)
                 Console.WriteLine($"{stopwatch.ElapsedMilliseconds / 1000 } seconds");
 
-            Assert.Equal(entriesExpected, RetryOnWin7((() => eventLog.Entries.Count)));
+            Assert.Equal(entriesExpected, Retry((() => eventLog.Entries.Count)));
         }
 
         internal static EventBookmark GetBookmark(string log, PathType pathType)

--- a/src/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/EventLogSessionTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/EventLogSessionTests.cs
@@ -95,9 +95,9 @@ namespace System.Diagnostics.Tests
                     {
                         eventLog.Source = source;
                         eventLog.WriteEntry("Writing to event log.");
-                        Assert.NotEqual(0, Helpers.RetryOnWin7((() => eventLog.Entries.Count)));
+                        Assert.NotEqual(0, Helpers.Retry((() => eventLog.Entries.Count)));
                         session.ClearLog(logName: log);
-                        Assert.Equal(0,  Helpers.RetryOnWin7((() => eventLog.Entries.Count)));
+                        Assert.Equal(0,  Helpers.Retry((() => eventLog.Entries.Count)));
                     }
                 }
                 finally

--- a/src/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/EventLogWatcherTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/EventLogWatcherTests.cs
@@ -90,7 +90,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnWin7(() => EventLog.Delete(log));
+                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
             }
         }
 

--- a/src/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/EventLogWatcherTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/EventLogWatcherTests.cs
@@ -79,8 +79,8 @@ namespace System.Diagnostics.Tests
                         Assert.True(e.EventException != null || e.EventRecord != null);
                         signal.Set();
                     };
-                    Helpers.RetryOnWin7(() => eventLogWatcher.Enabled = waitOnEvent);
-                    Helpers.RetryOnWin7(() => eventLog.WriteEntry(message, EventLogEntryType.Information));
+                    Helpers.Retry(() => eventLogWatcher.Enabled = waitOnEvent);
+                    Helpers.Retry(() => eventLog.WriteEntry(message, EventLogEntryType.Information));
                     if (waitOnEvent)
                     {
                         Assert.True(signal.WaitOne(6000));
@@ -90,7 +90,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetryOnAllPlatforms(() => EventLog.Delete(log));
+                Helpers.Retry(() => EventLog.Delete(log));
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/40224
Fixes https://github.com/dotnet/corefx/issues/38803

"A device attached to the system is not functioning." errors are causing failures on Windows 10 - 19H1 when trying to delete an EventLog. I'm changing the retry logic from Windows 7 to all platforms and re-enable two tests that shouldn't fail anymore with the retry.