### PR TITLE
Delete duplicate line after LINQ nullable changes

### DIFF
--- a/src/System.Linq/src/System/Linq/Lookup.cs
+++ b/src/System.Linq/src/System/Linq/Lookup.cs
@@ -214,7 +214,6 @@ namespace System.Linq
 
                 int index = hashCode % _groupings.Length;
                 Grouping<TKey, TElement> g = new Grouping<TKey, TElement>(key, hashCode);
-                g._elements = new TElement[1];
                 g._hashNext = _groupings[index];
                 _groupings[index] = g;
                 if (_lastGrouping == null)


### PR DESCRIPTION
This line was moved into the ctor. Should have been deleted from here. Addresses post-merge PR feedback.