### PR TITLE
Add the DebuggableAttribute to System.Runtime.CompilerServices.Unsafe.

### DIFF
--- a/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.ilproj
+++ b/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.ilproj
@@ -1,10 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.IL">
+  <!-- Make sure that the DebuggableAttribute is set properly. -->
+  <PropertyGroup>
+    <DebugOptimization>IMPL</DebugOptimization>
+    <DebugOptimization Condition="'$(ConfigurationGroup)' == 'Release'">OPT</DebugOptimization>
+  </PropertyGroup>
   <PropertyGroup>
     <DocumentationFile>$(MSBuildThisFileDirectory)System.Runtime.CompilerServices.Unsafe.xml</DocumentationFile>
     <ProjectGuid>{04BA3E3C-6979-4792-B19E-C797AD607F42}</ProjectGuid>
     <IncludePath>include\$(TargetGroup)</IncludePath>
     <IncludePath Condition="'$(TargetGroup)' == 'netcoreapp2.0'">include\netcoreapp</IncludePath>
-    <IlasmFlags>$(IlasmFlags) -INCLUDE=$(IncludePath)</IlasmFlags>
+    <IlasmFlags>$(IlasmFlags) -INCLUDE=$(IncludePath) -DEBUG=$(DebugOptimization)</IlasmFlags>
     <Configurations>netcoreapp-Debug;netcoreapp-Release;netcoreapp2.0-Debug;netcoreapp2.0-Release;netstandard-Debug;netstandard-Release;netstandard1.0-Debug;netstandard1.0-Release</Configurations>
   </PropertyGroup>
 


### PR DESCRIPTION
System.Runtime.CompilerServices.Unsafe.dll is produced from IL rather than C#, and so it does not by default have a DebuggableAttribute.  As such, it is possible to end up in a place where JIT optimizations that are expected to be applied, such as inlining, are not due to the fact that the JIT uses the DebuggableAttribute as part of the calculation at inlining time.  I believe that none of the methods in this assembly are currently affected, as they are all marked as aggressivelyinline, but going forward, any method that is not marked in such a way would likely not be inlined.

This change adds the appropriate DebuggableAttribute to Debug and Release versions of System.Runtime.CompilerServices.Unsafe.dll.  This is the only assembly in the shared framework that does not have a DebuggableAttribute already.  A search of CoreFx turned this assembly up as the only one that is IL-based.

NOTE: This PR is the result of a WPF performance investigation that identified the lack of a DebuggableAttribute as the reason that the JIT didn't inline things that it previously had.  Ultimately, we found that the -DEBUG flag wasn't being passed to ilasm.  Fixing this addressed the regression, and thus the desire to identify any other assemblies that might fall into this trap.