### PR TITLE
HttpHandlerDiagnosticListener did not send DiagnosticSource Stop event on netfx in W3C mode

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/HttpHandlerDiagnosticListener.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/HttpHandlerDiagnosticListener.cs
@@ -658,7 +658,8 @@ namespace System.Diagnostics
             // Response event could be received several times for the same request in case it was redirected
             // IsLastResponse checks if response is the last one (no more redirects will happen)
             // based on response StatusCode and number or redirects done so far
-            if (request.Headers.Get(RequestIdHeaderName) != null && IsLastResponse(request, response.StatusCode))
+            bool wasRequestInstrumented = request.Headers.Get(TraceParentHeaderName) != null || request.Headers.Get(RequestIdHeaderName) != null;
+            if (wasRequestInstrumented && IsLastResponse(request, response.StatusCode))
             {
                 // only send Stop if request was instrumented
                 this.Write(RequestStopName, new { Request = request, Response = response });

--- a/src/System.Diagnostics.DiagnosticSource/tests/HttpHandlerDiagnosticListenerTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/HttpHandlerDiagnosticListenerTests.cs
@@ -173,6 +173,15 @@ namespace System.Diagnostics.Tests
                     Assert.Matches("^[0-9a-f][0-9a-f]-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f][0-9a-f]$", traceparent);
                     Assert.Null(startRequest.Headers["tracestate"]);
                     Assert.Null(startRequest.Headers["Request-Id"]);
+
+                    KeyValuePair<string, object> stopEvent;
+                    Assert.True(eventRecords.Records.TryDequeue(out stopEvent));
+                    Assert.Equal("System.Net.Http.Desktop.HttpRequestOut.Stop", stopEvent.Key);
+                    HttpWebRequest stopRequest = ReadPublicProperty<HttpWebRequest>(stopEvent.Value, "Request");
+                    Assert.NotNull(stopRequest);
+
+                    HttpWebResponse stopResponse = ReadPublicProperty<HttpWebResponse>(stopEvent.Value, "Response");
+                    Assert.NotNull(stopResponse);
                 }
             }
             finally


### PR DESCRIPTION
HttpHandlerDiagnosticListener monkey-patches WebRequest to enable tracing with DiagnosticSource.

HttpHandlerDiagnosticListener uses presence of tracing headers to determine if a request was initially instrumented (`Activity.Current` which is `AsyncLocal` does not survive in WebRequest callbacks). Based on header presence, when response tarts, it notifies a listener with 'Stop' callback.

In https://github.com/dotnet/corefx/pull/35882 it started to support [W3C trace-context](https://www.w3.org/TR/trace-context/) and now `Stop` event is not sent if a new W3C `traceparent` is present, but old `Request-Id` is not.

This issue only reproduces when tracing is on and W3C mode for Activity is on. By default tracing is off and no events are sent. When tracing is on, default Activity format is the old one, that works with Request-Id header, so problem does not repro.

Tracing tools that enable W3C, can workaround it with adding Request-Id header themselves.



