### PR TITLE
Add Runtime IDs for Fedora 32

### DIFF
--- a/pkg/Microsoft.NETCore.Platforms/runtime.compatibility.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.compatibility.json
@@ -895,6 +895,38 @@
     "any",
     "base"
   ],
+  "fedora.32": [
+    "fedora.32",
+    "fedora",
+    "linux",
+    "unix",
+    "any",
+    "base"
+  ],
+  "fedora.32-arm64": [
+    "fedora.32-arm64",
+    "fedora.32",
+    "fedora-arm64",
+    "fedora",
+    "linux-arm64",
+    "linux",
+    "unix-arm64",
+    "unix",
+    "any",
+    "base"
+  ],
+  "fedora.32-x64": [
+    "fedora.32-x64",
+    "fedora.32",
+    "fedora-x64",
+    "fedora",
+    "linux-x64",
+    "linux",
+    "unix-x64",
+    "unix",
+    "any",
+    "base"
+  ],
   "freebsd": [
     "freebsd",
     "unix",

--- a/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -458,6 +458,23 @@
         "fedora-x64"
       ]
     },
+    "fedora.32": {
+      "#import": [
+        "fedora"
+      ]
+    },
+    "fedora.32-arm64": {
+      "#import": [
+        "fedora.32",
+        "fedora-arm64"
+      ]
+    },
+    "fedora.32-x64": {
+      "#import": [
+        "fedora.32",
+        "fedora-x64"
+      ]
+    },
     "freebsd": {
       "#import": [
         "unix"

--- a/pkg/Microsoft.NETCore.Platforms/runtimeGroups.props
+++ b/pkg/Microsoft.NETCore.Platforms/runtimeGroups.props
@@ -42,7 +42,7 @@
     <RuntimeGroup Include="fedora">
       <Parent>linux</Parent>
       <Architectures>x64;arm64</Architectures>
-      <Versions>23;24;25;26;27;28;29;30;31</Versions>
+      <Versions>23;24;25;26;27;28;29;30;31;32</Versions>
       <TreatVersionsAsCompatible>false</TreatVersionsAsCompatible>
     </RuntimeGroup>
 


### PR DESCRIPTION
Fedora 32 is currently in development:

    $ docker run -it fedora:32 cat /etc/os-release
    ...
    NAME=Fedora
    VERSION="32 (Container Image)"
    ID=fedora
    VERSION_ID=32
    VERSION_CODENAME=""
    PLATFORM_ID="platform:f32"
    PRETTY_NAME="Fedora 32 (Container Image)"
    ANSI_COLOR="0;34"
    LOGO=fedora-logo-icon
    CPE_NAME="cpe:/o:fedoraproject:fedora:32"
    HOME_URL="https://fedoraproject.org/"
    DOCUMENTATION_URL="https://docs.fedoraproject.org/en-US/fedora/rawhide/system-administrators-guide/"
    SUPPORT_URL="https://fedoraproject.org/wiki/Communicating_and_getting_help"
    BUG_REPORT_URL="https://bugzilla.redhat.com/"
    REDHAT_BUGZILLA_PRODUCT="Fedora"
    REDHAT_BUGZILLA_PRODUCT_VERSION=rawhide
    REDHAT_SUPPORT_PRODUCT="Fedora"
    REDHAT_SUPPORT_PRODUCT_VERSION=rawhide
    PRIVACY_POLICY_URL="https://fedoraproject.org/wiki/Legal:PrivacyPolicy"
    VARIANT="Container Image"
    VARIANT_ID=container