### PR TITLE
Add case-sensitive type lookup test to ActivatorTests

### DIFF
--- a/src/System.Runtime/tests/System/ActivatorTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/ActivatorTests.netcoreapp.cs
@@ -226,6 +226,7 @@ namespace System.Tests
             yield return new object[] { null, typeof(PrivateType).FullName, false, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance, Type.DefaultBinder, new object[0], CultureInfo.InvariantCulture, null, typeof(PrivateType).FullName, false };
 
             yield return new object[] { "mscorlib", "System.Nullable`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", true, BindingFlags.Public | BindingFlags.Instance, Type.DefaultBinder, new object[0], CultureInfo.InvariantCulture, null, "", true };
+            yield return new object[] { "mscorlib", "SyStEm.NULLABLE`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", true, BindingFlags.Public | BindingFlags.Instance, Type.DefaultBinder, new object[0], CultureInfo.InvariantCulture, null, "", true };
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsWinRTSupported), nameof(PlatformDetection.IsNotWindows8x), nameof(PlatformDetection.IsNotWindowsServerCore), nameof(PlatformDetection.IsNotWindowsNanoServer), nameof(PlatformDetection.IsNotWindowsIoTCore))]


### PR DESCRIPTION
In the process of fixing this test suite for Mono, I realized that case-insensitive lookups in the exported types table would fail but that we lacked a corresponding test case to trigger that. I didn't bother with all the various permutations like above since I think this should be sufficient, but can add more if you think they would be valuable.

This will fail on Mono master as of the PR, but the test is already ignored so that should not be an issue. Additionally, a PR fixing it should go in shortly.