### PR TITLE
Add test to verify that JsonEncodedText and Utf8JsonWriter use upper-case hex digits when escaping.

### DIFF
--- a/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
@@ -4012,6 +4012,24 @@ namespace System.Text.Json.Tests
             JsonTestHelper.AssertContents("{" + ValidUtf16Expected + ":" + ValidUtf16Expected + "}", output);
         }
 
+        // Test case from https://github.com/dotnet/corefx/issues/40702
+        [Fact]
+        public void OutputConsistentWithJsonEncodedText()
+        {
+            string jsonEncodedText = $"{{\"{JsonEncodedText.Encode("propertyName+1")}\": \"{JsonEncodedText.Encode("value+1")}\"}}";
+            
+            var output = new ArrayBufferWriter<byte>(1024);
+
+            using (var writer = new Utf8JsonWriter(output))
+            {
+                writer.WriteStartObject();
+                writer.WriteString("propertyName+1", "value+1");
+                writer.WriteEndObject();
+            }
+
+            JsonTestHelper.AssertContents(jsonEncodedText, output);
+        }
+
         public static IEnumerable<object[]> JsonEncodedTextStringsCustomAll
         {
             get


### PR DESCRIPTION
This behavior should be consistent for all platforms (.NET Core 3.0, older .NET Core, and netfx).

Adding a test case from https://github.com/dotnet/corefx/issues/40702
