### PR TITLE
Add round-trip test to JsonSerializer with overflow that needs to be escaped.

### DIFF
--- a/src/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
+++ b/src/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
@@ -541,6 +541,35 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(JsonValueKind.Object, obj.MyOverflow["MyOverflow"].ValueKind);
         }
 
+        [Fact]
+        public static void SerializerOutputRoundtripsWhenEscaping()
+        {
+            string jsonString = "{\"\u6C49\u5B57\":\"abc\",\"Class\":{\"\u6F22\u5B57\":\"xyz\"},\"\u62DC\u6258\":{\"\u62DC\u6258\u62DC\u6258\":1}}";
+
+            ClassWithEscapedProperty input = JsonSerializer.Deserialize<ClassWithEscapedProperty>(jsonString);
+
+            Assert.Equal("abc", input.汉字);
+            Assert.Equal("xyz", input.Class.漢字);
+
+            string normalizedString = JsonSerializer.Serialize(input);
+
+            Assert.Equal(normalizedString, JsonSerializer.Serialize(JsonSerializer.Deserialize<ClassWithEscapedProperty>(normalizedString)));
+        }
+
+        public class ClassWithEscapedProperty
+        {
+            public string \u6C49\u5B57 { get; set; }
+            public NestedClassWithEscapedProperty Class { get; set; }
+
+            [JsonExtensionData]
+            public Dictionary<string, object> Overflow { get; set; }
+        }
+
+        public class NestedClassWithEscapedProperty
+        {
+            public string \u6F22\u5B57 { get; set; }
+        }
+
         private class ClassWithInvalidExtensionPropertyStringString
         {
             [JsonExtensionData]

--- a/src/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
+++ b/src/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
@@ -548,8 +548,8 @@ namespace System.Text.Json.Serialization.Tests
 
             ClassWithEscapedProperty input = JsonSerializer.Deserialize<ClassWithEscapedProperty>(jsonString);
 
-            Assert.Equal("abc", input.汉字);
-            Assert.Equal("xyz", input.Class.漢字);
+            Assert.Equal("abc", input.\u6C49\u5B57);
+            Assert.Equal("xyz", input.Class.\u6F22\u5B57);
 
             string normalizedString = JsonSerializer.Serialize(input);
 

--- a/src/System.Text.Json/tests/Serialization/WriteValueTests.cs
+++ b/src/System.Text.Json/tests/Serialization/WriteValueTests.cs
@@ -25,5 +25,41 @@ namespace System.Text.Json.Serialization.Tests
             string json = Encoding.UTF8.GetString(memoryStream.ToArray());
             Assert.Equal("{\"test\":[1]}", json);
         }
+
+        public class CustomClassWithEscapedProperty
+        {
+            public int pizza { get; set; }
+            public int hello\u6C49\u5B57 { get; set; }
+            public int normal { get; set; }
+        }
+
+        [Fact]
+        public static void SerializeToWriterRoundTripEscaping()
+        {
+            const string jsonIn = " { \"p\\u0069zza\": 1, \"hello\\u6C49\\u5B57\": 2, \"normal\": 3 }";
+
+            CustomClassWithEscapedProperty input = JsonSerializer.Deserialize<CustomClassWithEscapedProperty>(jsonIn);
+
+            Assert.Equal(1, input.pizza);
+            Assert.Equal(2, input.hello\u6C49\u5B57);
+            Assert.Equal(3, input.normal);
+
+            string normalizedString = JsonSerializer.Serialize(input);
+            Assert.Equal("{\"pizza\":1,\"hello\\u6C49\\u5B57\":2,\"normal\":3}", normalizedString);
+
+            CustomClassWithEscapedProperty inputNormalized = JsonSerializer.Deserialize<CustomClassWithEscapedProperty>(normalizedString);
+            Assert.Equal(1, inputNormalized.pizza);
+            Assert.Equal(2, inputNormalized.hello\u6C49\u5B57);
+            Assert.Equal(3, inputNormalized.normal);
+
+            using MemoryStream memoryStream = new MemoryStream();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
+            JsonSerializer.Serialize(writer, inputNormalized);
+            writer.Flush();
+
+            string json = Encoding.UTF8.GetString(memoryStream.ToArray());
+
+            Assert.Equal(normalizedString, json);
+        }
     }
 }


### PR DESCRIPTION
cc @steveharter, @bartonjs 