### PR TITLE
improve two http2 tests

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -1725,17 +1725,18 @@ namespace System.Net.Http.Functional.Tests
             });
         }
 
-        [ConditionalTheory(nameof(SupportsAlpn))]
+        [Theory]
         [InlineData(true)]
         [InlineData(false)]
         public async Task Http2_PendingReceive_SendsReset(bool doRead)
         {
             var cts = new CancellationTokenSource();
-            bool isCanceled = false;
+            var doCancel = new TaskCompletionSource<bool>();
             HttpResponseMessage response = null;
-            await Http2LoopbackServer.CreateClientAndServerAsync(async url =>
+
+            using (HttpClient client = CreateHttpClient())
             {
-                using (HttpClient client = CreateHttpClient())
+                await Http2LoopbackServer.CreateClientAndServerAsync(async url =>
                 {
                     var request = new HttpRequestMessage(HttpMethod.Get, url);
                     request.Version = new Version(2,0);
@@ -1743,57 +1744,56 @@ namespace System.Net.Http.Functional.Tests
                     response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cts.Token);
                     using (Stream stream = await response.Content.ReadAsStreamAsync())
                     {
+                        byte[] buffer = new byte[100];
+
+                        if (doRead)
+                        {
+                            // Start reading response as variation.
+                            _ = await stream.ReadAsync(buffer, cts.Token);
+                        }
+
+                        doCancel.SetResult(true);
+                        _output.WriteLine($"{DateTime.Now} cancellation requested.");
+
+                        // Keep reading response.
                         if (doRead)
                         {
                             try
                             {
-                                int readLength;
-                                do {
-                                    byte[] buffer = new byte[100];
-
-                                    readLength = await stream.ReadAsync(buffer, cts.Token);
-                                } while (readLength != 0);
+                                while (true)
+                                {
+                                    _ = await stream.ReadAsync(buffer, cts.Token);
+                                }
                             }
                             catch (OperationCanceledException) { };
                         }
-
-                        isCanceled = true;
                     }
-                }
-            },
-            async server =>
-            {
-                Http2LoopbackConnection connection = await server.EstablishConnectionAsync();
-
-                (int streamId, HttpRequestData requestData) = await connection.ReadAndParseRequestHeaderAsync(readBody : false);
-                _output.WriteLine($"{DateTime.Now} Connection established");
-                // Cancel client after receiving Headers.
-                await connection.SendResponseHeadersAsync(streamId, endStream: false, HttpStatusCode.OK);
-
-                // Start streaming response
-                DataFrame dataFrame = new DataFrame(new byte[100], FrameFlags.None, 0, streamId);
-                await connection.WriteFrameAsync(dataFrame);
-
-                // Keep sending data until clients cancels
-                while (!isCanceled)
+                },
+                async server =>
                 {
-                    if (response != null)
-                    {
-                        cts.Cancel();
-                    }
+                    Http2LoopbackConnection connection = await server.EstablishConnectionAsync();
+
+                    (int streamId, HttpRequestData requestData) = await connection.ReadAndParseRequestHeaderAsync(readBody : false);
+                    _output.WriteLine($"{DateTime.Now} Connection established");
+
+                    await connection.SendResponseHeadersAsync(streamId, endStream: false, HttpStatusCode.OK);
+                    // Start streaming response
+                    DataFrame dataFrame = new DataFrame(new byte[100], FrameFlags.None, 0, streamId);
                     await connection.WriteFrameAsync(dataFrame);
-                    await Task.Delay(100);
-                }
+                    // Wait for client to start processing response and cancel it.
+                    await doCancel.Task;
+                    cts.Cancel();
 
-                _output.WriteLine($"{DateTime.Now} HttpRequest was canceled");
-                Frame frame;
-                do
-                {
-                    frame = await connection.ReadFrameAsync(TimeSpan.FromMilliseconds(TestHelper.PassingTestTimeoutMilliseconds));
-                    Assert.NotNull(frame); // We should get Rst before closing connection.
-                    Assert.Equal(0, (int)(frame.Flags & FrameFlags.EndStream));
-                 } while (frame.Type != FrameType.RstStream);
-            });
+                    _output.WriteLine($"{DateTime.Now} HttpRequest was canceled");
+                    Frame frame;
+                    do
+                    {
+                        frame = await connection.ReadFrameAsync(TimeSpan.FromMilliseconds(TestHelper.PassingTestTimeoutMilliseconds));
+                        Assert.NotNull(frame); // We should get Rst before closing connection.
+                        Assert.Equal(0, (int)(frame.Flags & FrameFlags.EndStream));
+                    } while (frame.Type != FrameType.RstStream);
+                });
+            }
         }
 
         [ConditionalFact(nameof(SupportsAlpn))]
@@ -2801,7 +2801,16 @@ namespace System.Net.Http.Functional.Tests
                 int maxCount = 120;
                 while (!stopSending && maxCount != 0)
                 {
-                    await connection.SendResponseDataAsync(streamId, Encoding.ASCII.GetBytes(responseContent), endStream: false);
+                   try
+                    {
+                        await connection.SendResponseDataAsync(streamId, Encoding.ASCII.GetBytes(responseContent), endStream: false);
+                    }
+                    catch (IOException)
+                    {
+                        // When client sets stopSending, client will be disposed and sending may fail.
+                        Assert.True(stopSending);
+                        break;
+                    }
                     await Task.Delay(500);
                     maxCount --;
                 }


### PR DESCRIPTION
For `Http2_PendingReceive_SendsReset`, when `isCanceled` was set, client would go out of scope and instance would be disposed. With that, depending on timing, writing data frame could fail.

it is curious that `Write` could fail with `Read` error. 
```
System.IO.IOException : Unable to read data from the transport connection: Broken pipe.\n---- System.Net.Sockets.SocketException : Broken pipe

Stack trace
   at System.Net.Security.SslStream.<WriteSingleChunk>g__CompleteAsync|212_1[TWriteAdapter](ValueTask writeTask, Byte[] bufferToReturn) in /_/src/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs:line 1236
   at System.Net.Security.SslStream.WriteAsyncInternal[TWriteAdapter](TWriteAdapter writeAdapter, ReadOnlyMemory`1 buffer) in /_/src/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs:line 1486
   at System.Net.Test.Common.Http2LoopbackConnection.WriteFrameAsync(Frame frame) in /_/src/Common/tests/System/Net/Http/Http2LoopbackConnection.cs:line 88

```

To solve this, I moved `using HttpClient` above `CreateClientAndServerAsync` so connection could/would be preserved while verifying stream behavior. 
As part of the effort I also updated the test to send predictable amount of data and take predictable time.

I also verified this test can run on MacOS without  `SupportsAlpn` so I removed that condition.

fixes #40474

I also saw 27 failures in last 90 days in `SendAsync_ConcurentSendReceive_Fail` and I was able to reproduce it while working on this. 
Root cause is somewhat similar as when `stopSending = true` is set, client goes out of scope and it is disposed and test can fail with :

```
      System.IO.IOException : Unable to read data from the transport connection: Broken pipe.
      ---- System.Net.Sockets.SocketException : Broken pipe
      Stack Trace:
        /home/furt/github/wfurt-corefx/src/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs(1236,0): at System.Net.Security.SslStream.<WriteSingleChunk>g__CompleteAsync|212_1[TWriteAdapter](ValueTask writeTask, Byte[] bufferToReturn)
        /home/furt/github/wfurt-corefx/src/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs(1486,0): at System.Net.Security.SslStream.WriteAsyncInternal[TWriteAdapter](TWriteAdapter writeAdapter, ReadOnlyMemory`1 buffer)
        /home/furt/github/wfurt-corefx/src/Common/tests/System/Net/Http/Http2LoopbackConnection.cs(88,0): at System.Net.Test.Common.Http2LoopbackConnection.WriteFrameAsync(Frame frame)
        /home/furt/github/wfurt-corefx/src/Common/tests/System/Net/Http/Http2LoopbackConnection.cs(634,0): at System.Net.Test.Common.Http2LoopbackConnection.SendResponseDataAsync(Int32 streamId, ReadOnlyMemory`1 responseData, Boolean endStream)
        /home/furt/github/wfurt-corefx/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs(2804,0): at System.Net.Http.Functional.Tests.HttpClientHandlerTest_Http2.<>c__DisplayClass85_0.<<SendAsync_ConcurentSendReceive_Fail>b__1>d.MoveNext()
        --- End of stack trace from previous location where exception was thrown ---
        /home/furt/github/wfurt-corefx/src/Common/tests/System/Threading/Tasks/TaskTimeoutExtensions.cs(83,0): at System.Threading.Tasks.TaskTimeoutExtensions.WhenAllOrAnyFailed(Task[] tasks)
        /home/furt/github/wfurt-corefx/src/Common/tests/System/Threading/Tasks/TaskTimeoutExtensions.cs(111,0): at System.Threading.Tasks.TaskTimeoutExtensions.WhenAllOrAnyFailed(Task[] tasks)
        /home/furt/github/wfurt-corefx/src/Common/tests/System/Threading/Tasks/TaskTimeoutExtensions.cs(71,0): at System.Threading.Tasks.TaskTimeoutExtensions.WhenAllOrAnyFailed(Task[] tasks, Int32 millisecondsTimeout)
        /home/furt/github/wfurt-corefx/src/Common/tests/System/Net/Http/Http2LoopbackServer.cs(186,0): at System.Net.Test.Common.Http2LoopbackServer.CreateClientAndServerAsync(Func`2 clientFunc, Func`2 serverFunc, Int32 timeout)
        /home/furt/github/wfurt-corefx/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs(2770,0): at System.Net.Http.Functional.Tests.HttpClientHandlerTest_Http2.SendAsync_ConcurentSendReceive_Fail()
        --- End of stack trace from previous location where exception was thrown ---
        ----- Inner Stack Trace -----

```

Since the test really does not care about server side, I wrapped `SendResponseDataAsync` with try/catch and add assert to be sure we ignore failure only if `stopSending` is set.