### PR TITLE
Remove `readonly` from two `GCHandle` fields

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.ClientCertificateProvider.cs
+++ b/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.ClientCertificateProvider.cs
@@ -15,7 +15,7 @@ namespace System.Net.Http
     {
         internal sealed class ClientCertificateProvider : IDisposable
         {
-            internal readonly GCHandle _gcHandle;
+            internal GCHandle _gcHandle;
             internal readonly Interop.Ssl.ClientCertCallback _callback;
             private readonly X509Certificate2Collection _clientCertificates;
 

--- a/src/System.Net.HttpListener/src/System/Net/Windows/WebSockets/WebSocketBuffer.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/WebSockets/WebSocketBuffer.cs
@@ -32,7 +32,7 @@ namespace System.Net.WebSockets
         // Indicates the range of the pinned byte[] that can be used by the WSPC (nativeBuffer + pinnedSendBuffer)
         private readonly long _startAddress;
         private readonly long _endAddress;
-        private readonly GCHandle _gcHandle;
+        private GCHandle _gcHandle;
         private readonly ArraySegment<byte> _internalBuffer;
         private readonly ArraySegment<byte> _nativeBuffer;
         private readonly ArraySegment<byte> _payloadBuffer;


### PR DESCRIPTION
Due to the `readonly`, the mutations performed by `Free` will be done on a copy rather than on the data stored in the field.