### PR TITLE
[release/3.0] Move wildcard bind in Socket.ConnectAsync to be Windows-only

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
@@ -85,6 +85,36 @@ namespace System.Net.Sockets
             return disconnectEx_Blocking(socketHandle, overlapped, flags, reserved);
         }
 
+        partial void WildcardBindForConnectIfNecessary(AddressFamily addressFamily)
+        {
+            if (_rightEndPoint != null)
+            {
+                return;
+            }
+
+            // The socket must be bound before using ConnectEx.
+
+            IPAddress address;
+            switch (addressFamily)
+            {
+                case AddressFamily.InterNetwork:
+                    address = IsDualMode ? IPAddress.Any.MapToIPv6() : IPAddress.Any;
+                    break;
+
+                case AddressFamily.InterNetworkV6:
+                    address = IPAddress.IPv6Any;
+                    break;
+
+                default:
+                    return;
+            }
+
+            if (NetEventSource.IsEnabled) NetEventSource.Info(this, address);
+
+            var endPoint = new IPEndPoint(address, 0);
+            DoBind(endPoint, IPEndPointExtensions.Serialize(endPoint));
+        }
+
         internal unsafe bool ConnectEx(SafeSocketHandle socketHandle,
             IntPtr socketAddress,
             int socketAddressSize,


### PR DESCRIPTION
Ports https://github.com/dotnet/corefx/pull/40767 to release/3.0
Resolves #40737 

## Description

Updates `Socket.ConnectAsync` to avoid binding the socket to `IPAddress.Any` when not on Windows. This is necessary only on Windows for `ConnectEx`.

No behavior change should be noticed by users.

## Customer Impact

This change will allow apps to run in MacOS sandbox without the otherwise unnecessary "com.apple.security.network.server" entitlement, which is cause for rejection from app store. Applications do not need to use this method directly to trigger the issue; downstream libraries such as `HttpClient` will exhibit the issue as well.

Affects a partner migrating to 3.0.

## Regression

No, this behavior has existed in System.Net.Sockets since .NET Core 1.0.  It's existed in System.Net.Http since 2.1, when SocketsHttpHandler was written to depend on System.Net.Sockets.

## Risk

Small.

- The changeset is small.
- The method is (mostly indirectly) in wide use.
- A lot of internal `Socket` code interacts with the socket's binding.

## Tests

No tests added as part of this change. May require CI enhancements to do so.