### PR TITLE
Match src param name of BrotliEncoder.GetMaxCompressedLength to ref param name

### DIFF
--- a/src/System.IO.Compression.Brotli/src/System/IO/Compression/enc/BrotliEncoder.cs
+++ b/src/System.IO.Compression.Brotli/src/System/IO/Compression/enc/BrotliEncoder.cs
@@ -92,19 +92,19 @@ namespace System.IO.Compression
             }
         }
 
-        public static int GetMaxCompressedLength(int length)
+        public static int GetMaxCompressedLength(int inputSize)
         {
-            if (length < 0 || length > BrotliUtils.MaxInputSize)
+            if (inputSize < 0 || inputSize > BrotliUtils.MaxInputSize)
             {
-                throw new ArgumentOutOfRangeException(nameof(length));
+                throw new ArgumentOutOfRangeException(nameof(inputSize));
             }
-            if (length == 0)
+            if (inputSize == 0)
                 return 1;
-            int numLargeBlocks = length >> 24;
-            int tail = length & 0xFFFFFF;
+            int numLargeBlocks = inputSize >> 24;
+            int tail = inputSize & 0xFFFFFF;
             int tailOverhead = (tail > (1 << 20)) ? 4 : 3;
             int overhead = 2 + (4 * numLargeBlocks) + tailOverhead + 1;
-            int result = length + overhead;
+            int result = inputSize + overhead;
             return result;
         }
 

--- a/src/System.IO.Compression.Brotli/tests/BrotliEncoderTests.cs
+++ b/src/System.IO.Compression.Brotli/tests/BrotliEncoderTests.cs
@@ -36,8 +36,8 @@ namespace System.IO.Compression.Tests
         [Fact]
         public void GetMaxCompressedSize_Basic()
         {
-            Assert.Throws<ArgumentOutOfRangeException>("length", () => BrotliEncoder.GetMaxCompressedLength(-1));
-            Assert.Throws<ArgumentOutOfRangeException>("length", () => BrotliEncoder.GetMaxCompressedLength(2147483133));
+            Assert.Throws<ArgumentOutOfRangeException>("inputSize", () => BrotliEncoder.GetMaxCompressedLength(-1));
+            Assert.Throws<ArgumentOutOfRangeException>("inputSize", () => BrotliEncoder.GetMaxCompressedLength(2147483133));
             Assert.InRange(BrotliEncoder.GetMaxCompressedLength(2147483132), 0, int.MaxValue);
             Assert.Equal(1, BrotliEncoder.GetMaxCompressedLength(0));
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/39654

This PR addresses the last comment by @bartonjs :

>
> The API review (#25785) brought in `public static int GetMaximumCompressedSize(int inputSize) { throw null; }` and exited with `public static int GetMaxCompressedLength(int length);`, looks like the ref only caught half of that change.

> Given that changing the src is less breaking than the ref, I'd make the src match the ref (and update the exception as well).