### PR TITLE
Hide/Redefine inherited NameValueCollection.HasKeys() method for WebHeaderCollection class

### DIFF
--- a/src/System.Net.WebHeaderCollection/ref/System.Net.WebHeaderCollection.cs
+++ b/src/System.Net.WebHeaderCollection/ref/System.Net.WebHeaderCollection.cs
@@ -84,7 +84,7 @@ namespace System.Net
         Vary = 28,
         WwwAuthenticate = 29,
     }
-    public partial class WebHeaderCollection : System.Collections.Specialized.NameValueCollection, System.Collections.IEnumerable, System.Runtime.Serialization.ISerializable
+    public partial class WebHeaderCollection : System.Collections.Specialized.NameValueCollection, System.Runtime.Serialization.ISerializable
     {
         public WebHeaderCollection() { }
         protected WebHeaderCollection(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
@@ -107,6 +107,7 @@ namespace System.Net
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
         public override string[] GetValues(int index) { throw null; }
         public override string[] GetValues(string header) { throw null; }
+        public new bool HasKeys() { throw null; }
         public static bool IsRestricted(string headerName) { throw null; }
         public static bool IsRestricted(string headerName, bool response) { throw null; }
         public override void OnDeserialization(object sender) { }

--- a/src/System.Net.WebHeaderCollection/src/System/Net/WebHeaderCollection.cs
+++ b/src/System.Net.WebHeaderCollection/src/System/Net/WebHeaderCollection.cs
@@ -299,6 +299,15 @@ namespace System.Net
             return InnerCollection.GetKey(index);
         }
 
+        public new bool HasKeys()
+        {
+            if (_innerCollection == null)
+            {
+                return false;
+            }
+            return _innerCollection.HasKeys();
+        }
+
         public override void Clear()
         {
             InvalidateCachedArrays();

--- a/src/System.Net.WebHeaderCollection/tests/WebHeaderCollectionTest.cs
+++ b/src/System.Net.WebHeaderCollection/tests/WebHeaderCollectionTest.cs
@@ -634,11 +634,13 @@ namespace System.Net.Tests
             w.Add(HttpRequestHeader.Warning, "Warning1");
 
             Assert.Equal(1, w.Count);
+            Assert.True(w.HasKeys());
             Assert.Equal("Warning1", w[HttpRequestHeader.Warning]);
             Assert.Equal("Warning", w.AllKeys[0]);
 
             w.Remove(HttpRequestHeader.Warning);
             Assert.Equal(0, w.Count);
+            Assert.False(w.HasKeys());
         }
 
         [Fact]
@@ -704,6 +706,7 @@ namespace System.Net.Tests
             w.Add(HttpRequestHeader.ContentLength, "10");
             w.Add(HttpRequestHeader.ContentType, "text/html");
             Assert.Equal(2,w.Count);
+            Assert.True(w.HasKeys());
         }
 
         [Fact]
@@ -713,6 +716,7 @@ namespace System.Net.Tests
             w.Add(HttpRequestHeader.ContentLength, "10");
             w.Add(HttpRequestHeader.ContentType, "text/html");
             Assert.Equal(2, w.Keys.Count);
+            Assert.True(w.HasKeys());
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #33628

Earlier, HasKeys() behavior was changed by overriding InternalHasKeys().