### PR TITLE
Fix TypeConverter for IComponent

### DIFF
--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
@@ -136,6 +136,7 @@ namespace System.ComponentModel
             //
             [typeof(Array)] = typeof(ArrayConverter),
             [typeof(ICollection)] = typeof(CollectionConverter),
+            [typeof(IComponent)] = typeof(ComponentConverter),
             [typeof(Enum)] = typeof(EnumConverter),
             [s_intrinsicNullableKey] = typeof(NullableConverter),
         });


### PR DESCRIPTION
Should fix https://github.com/dotnet/winforms/issues/1553

We can't add `[TypeConverter(typeof(ComponentConverter))]` to `IComponent` because `IComponent` lives in `System.ComponentModel.Primitives` and `ComponentConverter` exists above it in `System.ComponentModel.ComponentConverter`

/cc @russkie @weltkante 