### PR TITLE
[release/3.0] Allow NetworkStream.WriteAsync calls to be canceled asynchronously

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Tasks.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Tasks.cs
@@ -376,7 +376,7 @@ namespace System.Net.Sockets
                 saea.SetBuffer(MemoryMarshal.AsMemory(buffer));
                 saea.SocketFlags = socketFlags;
                 saea.WrapExceptionsInIOExceptions = true;
-                return saea.SendAsyncForNetworkStream(this);
+                return saea.SendAsyncForNetworkStream(this, cancellationToken);
             }
             else
             {
@@ -929,12 +929,13 @@ namespace System.Net.Sockets
                     new ValueTask<int>(Task.FromException<int>(CreateException(error)));
             }
 
-            public ValueTask SendAsyncForNetworkStream(Socket socket)
+            public ValueTask SendAsyncForNetworkStream(Socket socket, CancellationToken cancellationToken)
             {
                 Debug.Assert(Volatile.Read(ref _continuation) == null, $"Expected null continuation to indicate reserved for use");
 
-                if (socket.SendAsync(this))
+                if (socket.SendAsync(this, cancellationToken))
                 {
+                    _cancellationToken = cancellationToken;
                     return new ValueTask(this, _token);
                 }
 


### PR DESCRIPTION
Ports https://github.com/dotnet/corefx/pull/40839 to release/3.0.
cc: @tmds

## Description

In .NET Core 3.0 we enabled Socket Read/WriteAsync calls to be canceled, and as NetworkStream.ReadAsync just calls to Socket.ReadAsync, it's also cancelable.  But NetworkStream.WriteAsync takes a slightly different code path, due to it not returning number of bytes written (whereas Socket's write operation does), and we missed passing the CancellationToken through this path.  The net result is if enough data is written and WriteAsync pends, the provided CancellationToken won't have an effect.

## Customer Impact

NetworkStream.WriteAsync may not be cancelable when a customer expects it to be.

## Regression?

No.

## Testing

All automated tests, including a new one for this specific case. The bulk of the core code paths exercised here are already tested by existing Socket.WriteAsync functionality as well.

## Risk

Relatively low.  The biggest risk is probably the very thing this is fixing: cancellation will actually work, and in theory it's possible that someone wasn't expecting the resulting OperationCanceledExceptions that could now result.  However, that's very unlikely, both because a) the developer had to explicitly pass the token, and b) WriteAsync was already checking the token and thus could already throw an OCE, it just would only do so if the token had cancellation requested by the time WriteAsync was called.