### PR TITLE
Short circuit Clamp when value = min

### DIFF
--- a/src/Common/src/CoreLib/System/Math.cs
+++ b/src/Common/src/CoreLib/System/Math.cs
@@ -235,7 +235,7 @@ namespace System
             {
                 return min;
             }
-            else if (value > max)
+            else if (value >= max)
             {
                 return max;
             }
@@ -295,7 +295,7 @@ namespace System
             {
                 return min;
             }
-            else if (value > max)
+            else if (value >= max)
             {
                 return max;
             }
@@ -315,7 +315,7 @@ namespace System
             {
                 return min;
             }
-            else if (value > max)
+            else if (value >= max)
             {
                 return max;
             }
@@ -335,7 +335,7 @@ namespace System
             {
                 return min;
             }
-            else if (value > max)
+            else if (value >= max)
             {
                 return max;
             }
@@ -356,7 +356,7 @@ namespace System
             {
                 return min;
             }
-            else if (value > max)
+            else if (value >= max)
             {
                 return max;
             }
@@ -397,7 +397,7 @@ namespace System
             {
                 return min;
             }
-            else if (value > max)
+            else if (value >= max)
             {
                 return max;
             }
@@ -418,7 +418,7 @@ namespace System
             {
                 return min;
             }
-            else if (value > max)
+            else if (value >= max)
             {
                 return max;
             }
@@ -439,7 +439,7 @@ namespace System
             {
                 return min;
             }
-            else if (value > max)
+            else if (value >= max)
             {
                 return max;
             }

--- a/src/Common/src/CoreLib/System/Math.cs
+++ b/src/Common/src/CoreLib/System/Math.cs
@@ -231,7 +231,7 @@ namespace System
                 ThrowMinMaxException(min, max);
             }
 
-            if (value < min)
+            if (value <= min)
             {
                 return min;
             }
@@ -291,7 +291,7 @@ namespace System
                 ThrowMinMaxException(min, max);
             }
 
-            if (value < min)
+            if (value <= min)
             {
                 return min;
             }
@@ -311,7 +311,7 @@ namespace System
                 ThrowMinMaxException(min, max);
             }
 
-            if (value < min)
+            if (value <= min)
             {
                 return min;
             }
@@ -331,7 +331,7 @@ namespace System
                 ThrowMinMaxException(min, max);
             }
 
-            if (value < min)
+            if (value <= min)
             {
                 return min;
             }
@@ -352,7 +352,7 @@ namespace System
                 ThrowMinMaxException(min, max);
             }
 
-            if (value < min)
+            if (value <= min)
             {
                 return min;
             }
@@ -393,7 +393,7 @@ namespace System
                 ThrowMinMaxException(min, max);
             }
 
-            if (value < min)
+            if (value <= min)
             {
                 return min;
             }
@@ -414,7 +414,7 @@ namespace System
                 ThrowMinMaxException(min, max);
             }
 
-            if (value < min)
+            if (value <= min)
             {
                 return min;
             }
@@ -435,7 +435,7 @@ namespace System
                 ThrowMinMaxException(min, max);
             }
 
-            if (value < min)
+            if (value <= min)
             {
                 return min;
             }


### PR DESCRIPTION
When `value == min` we can return immediately and not execute the next if statement.

Benchmarks
============
```
|                 Method | value | min | max |      Mean |     Error |    StdDev |
|----------------------- |------ |---- |---- |----------:|----------:|----------:|
|              MathClamp |     0 |   0 |  10 | 0.5672 ns | 0.0073 ns | 0.0068 ns |
|  ShortCircuitMathClamp |     0 |   0 |  10 | 0.2581 ns | 0.0090 ns | 0.0084 ns |
```

Seems to be approximately twice as fast when `value == min`.

I did not alter double, decimal, or float.