### PR TITLE
Fix some low-hanging fruit boxing in JsonSerializer

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleObject.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleObject.cs
@@ -40,9 +40,7 @@ namespace System.Text.Json
             JsonClassInfo classInfo = state.Current.JsonClassInfo;
             if (classInfo.ClassType != ClassType.Unknown && state.Current.PropertyEnumeratorActive)
             {
-                var kvp = (KeyValuePair<string, JsonPropertyInfo>)state.Current.PropertyEnumerator.Current;
-                JsonPropertyInfo jsonPropertyInfo = kvp.Value;
-                HandleObject(jsonPropertyInfo, options, writer, ref state);
+                HandleObject(state.Current.PropertyEnumerator.Current.Value, options, writer, ref state);
                 return false;
             }
 

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/WriteStackFrame.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/WriteStackFrame.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text.Json.Serialization;
 
@@ -32,7 +33,7 @@ namespace System.Text.Json
         // The current property.
         public bool PropertyEnumeratorActive;
         public ExtensionDataWriteStatus ExtensionDataStatus;
-        public IEnumerator PropertyEnumerator;
+        public Dictionary<string, JsonPropertyInfo>.Enumerator PropertyEnumerator;
         public JsonPropertyInfo JsonPropertyInfo;
 
         public void Initialize(Type type, JsonSerializerOptions options)
@@ -110,7 +111,7 @@ namespace System.Text.Json
             ExtensionDataStatus = ExtensionDataWriteStatus.NotStarted;
             IsIDictionaryConstructible = false;
             JsonClassInfo = null;
-            PropertyEnumerator = null;
+            PropertyEnumerator = default;
             PropertyEnumeratorActive = false;
             PopStackOnEndCollection = false;
             PopStackOnEndObject = false;


### PR DESCRIPTION
It's boxing lots of dictionary enumerators and KeyValuePairs.  Stop doing that.
cc: @steveharter, @ahsonkhan, @layomia 

Before:
![image](https://user-images.githubusercontent.com/2642209/64396893-31da3300-d02d-11e9-8007-ac0a20d4ad33.png)

After:
![image](https://user-images.githubusercontent.com/2642209/64396896-356dba00-d02d-11e9-8199-7b3fa87e7da9.png)

Repro:
```C#
using System.IO;
using System.Text.Json;
using System.Threading.Tasks;

class Program
{
    static async Task Main()
    {
        var ms = new MemoryStream();
        var f = new Foo() { Value1 = 42, Value2 = 84.0 };
        for (int i = 0; i < 100_000; i++)
        {
            ms.Position = 0;
            await JsonSerializer.SerializeAsync(ms, f);
            ms.Position = 0;
            await JsonSerializer.DeserializeAsync<Foo>(ms);
        }
    }
}

public struct Foo
{
    public int Value1 { get; set; }
    public double Value2 { get; set; }
}
```

