### PR TITLE
StreamPipeWriter: don't flush when the writer is completed with an exception.

### DIFF
--- a/src/System.IO.Pipelines/tests/StreamPipeWriterTests.cs
+++ b/src/System.IO.Pipelines/tests/StreamPipeWriterTests.cs
@@ -62,6 +62,40 @@ namespace System.IO.Pipelines.Tests
         }
 
         [Fact]
+        public void DataNotFlushedOnCompleteWithException()
+        {
+            byte[] bytes = Encoding.ASCII.GetBytes("Hello World");
+            var stream = new MemoryStream();
+            PipeWriter writer = PipeWriter.Create(stream, new StreamPipeWriterOptions(leaveOpen: true));
+
+            bytes.AsSpan().CopyTo(writer.GetSpan(bytes.Length));
+            writer.Advance(bytes.Length);
+
+            Assert.Equal(0, stream.Length);
+
+            writer.Complete(new Exception());
+
+            Assert.Equal(0, stream.Length);
+        }
+
+        [Fact]
+        public async Task DataNotFlushedOnCompleteAsyncWithException()
+        {
+            byte[] bytes = Encoding.ASCII.GetBytes("Hello World");
+            var stream = new MemoryStream();
+            PipeWriter writer = PipeWriter.Create(stream, new StreamPipeWriterOptions(leaveOpen: true));
+
+            bytes.AsSpan().CopyTo(writer.GetSpan(bytes.Length));
+            writer.Advance(bytes.Length);
+
+            Assert.Equal(0, stream.Length);
+
+            await writer.CompleteAsync(new Exception());
+
+            Assert.Equal(0, stream.Length);
+        }
+
+        [Fact]
         public async Task CompleteAsyncDoesNotThrowObjectDisposedException()
         {
             byte[] bytes = Encoding.ASCII.GetBytes("Hello World");


### PR DESCRIPTION
This provides a way to discard buffered data without pushing it to the inner Stream.

Fixes https://github.com/dotnet/corefx/issues/40812

CC @davidfowl