### PR TITLE
Disable two flaky EventLog tests

### DIFF
--- a/src/System.Diagnostics.EventLog/tests/EventLogTraceListenerTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTraceListenerTests.cs
@@ -113,6 +113,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        [ActiveIssue(40224, TestPlatforms.Windows)]
         [ConditionalTheory(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         [InlineData(TraceEventType.Information, EventLogEntryType.Information, ushort.MaxValue + 1, ushort.MaxValue)]
         [InlineData(TraceEventType.Error, EventLogEntryType.Error, ushort.MinValue - 1, ushort.MinValue)]
@@ -194,6 +195,7 @@ namespace System.Diagnostics.Tests
             yield return new object[] { null, new object[] { "thanks, 00", "i like it...", 111 } };
         }
 
+        [ActiveIssue(40224, TestPlatforms.Windows)]
         [ConditionalTheory(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         [MemberData(nameof(GetTraceEventFormat_MemberData))]
         public void TraceEventFormatAndParams(string format, object[] parameters)


### PR DESCRIPTION
Again disabling those tests. I believed that adding the retry mechanism to Windows 10 as well would fix the failing tests but apparently not as it's failing frequently since re-enabling. Disabling again.

https://github.com/dotnet/corefx/issues/40224
Fixes https://github.com/dotnet/corefx/issues/40799