### PR TITLE
[release/3.0] Fix TypeConverter for IComponent (#40837)

### DIFF
--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
@@ -136,6 +136,7 @@ namespace System.ComponentModel
             //
             [typeof(Array)] = typeof(ArrayConverter),
             [typeof(ICollection)] = typeof(CollectionConverter),
+            [typeof(IComponent)] = typeof(ComponentConverter),
             [typeof(Enum)] = typeof(EnumConverter),
             [s_intrinsicNullableKey] = typeof(NullableConverter),
         });


### PR DESCRIPTION
A cherry pick of the #40837 fix to unblock dotnet/winforms#1553 for 3.0-GA.

/cc: @danmosemsft @hughbe @zsd4yr @ericstj 



## Customer Impact

Windows Forms customers using `PropertyGrid` control in their apps won't be able to drill down into object trees and expand complex objects.

## Regression?

Yes 

## Risk

Risk is very small; just adding the missing interface registration for the type converter.
