### PR TITLE
Minor deserialization perf improvements for collections

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/DefaultDerivedDictionaryConverter.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/DefaultDerivedDictionaryConverter.cs
@@ -12,7 +12,7 @@ namespace System.Text.Json.Serialization.Converters
         {
             JsonPropertyInfo collectionPropertyInfo = state.Current.JsonPropertyInfo;
             JsonPropertyInfo elementPropertyInfo = options.GetJsonPropertyInfoFromClassInfo(collectionPropertyInfo.ElementType, options);
-            return elementPropertyInfo.CreateDerivedDictionaryInstance(collectionPropertyInfo, sourceDictionary, state.JsonPath, options);
+            return elementPropertyInfo.CreateDerivedDictionaryInstance(ref state, collectionPropertyInfo, sourceDictionary);
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/DefaultDerivedEnumerableConverter.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/DefaultDerivedEnumerableConverter.cs
@@ -12,7 +12,7 @@ namespace System.Text.Json.Serialization.Converters
         {
             JsonPropertyInfo collectionPropertyInfo = state.Current.JsonPropertyInfo;
             JsonPropertyInfo elementPropertyInfo = options.GetJsonPropertyInfoFromClassInfo(collectionPropertyInfo.ElementType, options);
-            return elementPropertyInfo.CreateDerivedEnumerableInstance(collectionPropertyInfo, sourceList, state.JsonPath, options);
+            return elementPropertyInfo.CreateDerivedEnumerableInstance(ref state, collectionPropertyInfo, sourceList);
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/DefaultICollectionConverter.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/DefaultICollectionConverter.cs
@@ -13,7 +13,7 @@ namespace System.Text.Json.Serialization.Converters
             Type enumerableType = state.Current.JsonPropertyInfo.RuntimePropertyType;
             Type elementType = state.Current.JsonPropertyInfo.ElementType;
             JsonPropertyInfo propertyInfo = options.GetJsonPropertyInfoFromClassInfo(elementType, options);
-            return propertyInfo.CreateIEnumerableInstance(enumerableType, sourceList, state.JsonPath, options);
+            return propertyInfo.CreateIEnumerableInstance(ref state, enumerableType, sourceList);
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/DefaultIDictionaryConverter.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/DefaultIDictionaryConverter.cs
@@ -13,7 +13,7 @@ namespace System.Text.Json.Serialization.Converters
             Type dictionaryType = state.Current.JsonPropertyInfo.RuntimePropertyType;
             Type elementType = state.Current.JsonPropertyInfo.ElementType;
             JsonPropertyInfo propertyInfo = options.GetJsonPropertyInfoFromClassInfo(elementType, options);
-            return propertyInfo.CreateIDictionaryInstance(dictionaryType, sourceDictionary, state.JsonPath, options);
+            return propertyInfo.CreateIDictionaryInstance(ref state, dictionaryType, sourceDictionary);
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/DefaultImmutableDictionaryConverter.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/DefaultImmutableDictionaryConverter.cs
@@ -64,7 +64,7 @@ namespace System.Text.Json.Serialization.Converters
             string delegateKey = DefaultImmutableEnumerableConverter.GetDelegateKey(immutableCollectionType, elementType, out _, out _);
 
             JsonPropertyInfo propertyInfo = options.GetJsonPropertyInfoFromClassInfo(elementType, options);
-            return propertyInfo.CreateImmutableDictionaryInstance(immutableCollectionType, delegateKey, sourceDictionary, state.JsonPath, options);
+            return propertyInfo.CreateImmutableDictionaryInstance(ref state, immutableCollectionType, delegateKey, sourceDictionary, options);
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/DefaultImmutableEnumerableConverter.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/DefaultImmutableEnumerableConverter.cs
@@ -110,7 +110,7 @@ namespace System.Text.Json.Serialization.Converters
             string delegateKey = GetDelegateKey(immutableCollectionType, elementType, out _, out _);
 
             JsonPropertyInfo propertyInfo = options.GetJsonPropertyInfoFromClassInfo(elementType, options);
-            return propertyInfo.CreateImmutableCollectionInstance(immutableCollectionType, delegateKey, sourceList, state.JsonPath, options);
+            return propertyInfo.CreateImmutableCollectionInstance(ref state, immutableCollectionType, delegateKey, sourceList, options);
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
@@ -45,17 +45,17 @@ namespace System.Text.Json
 
         public abstract IList CreateConverterList();
 
-        public abstract IEnumerable CreateDerivedEnumerableInstance(JsonPropertyInfo collectionPropertyInfo, IList sourceList, string jsonPath, JsonSerializerOptions options);
+        public abstract IEnumerable CreateDerivedEnumerableInstance(ref ReadStack state, JsonPropertyInfo collectionPropertyInfo, IList sourceList);
 
-        public abstract object CreateDerivedDictionaryInstance(JsonPropertyInfo collectionPropertyInfo, IDictionary sourceDictionary, string jsonPath, JsonSerializerOptions options);
+        public abstract object CreateDerivedDictionaryInstance(ref ReadStack state, JsonPropertyInfo collectionPropertyInfo, IDictionary sourceDictionary);
 
-        public abstract IEnumerable CreateIEnumerableInstance(Type parentType, IList sourceList, string jsonPath, JsonSerializerOptions options);
+        public abstract IEnumerable CreateIEnumerableInstance(ref ReadStack state, Type parentType, IList sourceList);
 
-        public abstract IDictionary CreateIDictionaryInstance(Type parentType, IDictionary sourceDictionary, string jsonPath, JsonSerializerOptions options);
+        public abstract IDictionary CreateIDictionaryInstance(ref ReadStack state, Type parentType, IDictionary sourceDictionary);
 
-        public abstract IEnumerable CreateImmutableCollectionInstance(Type collectionType, string delegateKey, IList sourceList, string propertyPath, JsonSerializerOptions options);
+        public abstract IEnumerable CreateImmutableCollectionInstance(ref ReadStack state, Type collectionType, string delegateKey, IList sourceList, JsonSerializerOptions options);
 
-        public abstract IDictionary CreateImmutableDictionaryInstance(Type collectionType, string delegateKey, IDictionary sourceDictionary, string propertyPath, JsonSerializerOptions options);
+        public abstract IDictionary CreateImmutableDictionaryInstance(ref ReadStack state, Type collectionType, string delegateKey, IDictionary sourceDictionary, JsonSerializerOptions options);
 
         // Create a property that is ignored at run-time. It uses the same type (typeof(sbyte)) to help
         // prevent issues with unsupported types and helps ensure we don't accidently (de)serialize it.

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
@@ -409,11 +409,11 @@ namespace System.Text.Json
                 case JsonTokenType.StartArray:
                     if (reader.TokenType != JsonTokenType.EndArray)
                     {
-                        ThrowHelper.ThrowJsonException_SerializationConverterRead(reader, state.JsonPath, ConverterBase.ToString());
+                        ThrowHelper.ThrowJsonException_SerializationConverterRead(reader, state.JsonPath(), ConverterBase.ToString());
                     }
                     else if (depth != reader.CurrentDepth)
                     {
-                        ThrowHelper.ThrowJsonException_SerializationConverterRead(reader, state.JsonPath, ConverterBase.ToString());
+                        ThrowHelper.ThrowJsonException_SerializationConverterRead(reader, state.JsonPath(), ConverterBase.ToString());
                     }
 
                     // Should not be possible to have not read anything.
@@ -423,11 +423,11 @@ namespace System.Text.Json
                 case JsonTokenType.StartObject:
                     if (reader.TokenType != JsonTokenType.EndObject)
                     {
-                        ThrowHelper.ThrowJsonException_SerializationConverterRead(reader, state.JsonPath, ConverterBase.ToString());
+                        ThrowHelper.ThrowJsonException_SerializationConverterRead(reader, state.JsonPath(), ConverterBase.ToString());
                     }
                     else if (depth != reader.CurrentDepth)
                     {
-                        ThrowHelper.ThrowJsonException_SerializationConverterRead(reader, state.JsonPath, ConverterBase.ToString());
+                        ThrowHelper.ThrowJsonException_SerializationConverterRead(reader, state.JsonPath(), ConverterBase.ToString());
                     }
 
                     // Should not be possible to have not read anything.
@@ -438,7 +438,7 @@ namespace System.Text.Json
                     // Reading a single property value.
                     if (reader.BytesConsumed != bytesConsumed)
                     {
-                        ThrowHelper.ThrowJsonException_SerializationConverterRead(reader, state.JsonPath, ConverterBase.ToString());
+                        ThrowHelper.ThrowJsonException_SerializationConverterRead(reader, state.JsonPath(), ConverterBase.ToString());
                     }
 
                     // Should not be possible to change token type.
@@ -466,7 +466,7 @@ namespace System.Text.Json
 
                 if (originalDepth != writer.CurrentDepth)
                 {
-                    ThrowHelper.ThrowJsonException_SerializationConverterWrite(state.PropertyPath, ConverterBase.ToString());
+                    ThrowHelper.ThrowJsonException_SerializationConverterWrite(state.PropertyPath(), ConverterBase.ToString());
                 }
             }
         }
@@ -480,7 +480,7 @@ namespace System.Text.Json
 
             if (originalDepth != writer.CurrentDepth)
             {
-                ThrowHelper.ThrowJsonException_SerializationConverterWrite(state.PropertyPath, ConverterBase.ToString());
+                ThrowHelper.ThrowJsonException_SerializationConverterWrite(state.PropertyPath(), ConverterBase.ToString());
             }
         }
 
@@ -493,7 +493,7 @@ namespace System.Text.Json
 
             if (originalDepth != writer.CurrentDepth)
             {
-                ThrowHelper.ThrowJsonException_SerializationConverterWrite(state.PropertyPath, ConverterBase.ToString());
+                ThrowHelper.ThrowJsonException_SerializationConverterWrite(state.PropertyPath(), ConverterBase.ToString());
             }
         }
     }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoCommon.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoCommon.cs
@@ -295,7 +295,7 @@ namespace System.Text.Json
             if (!options.TryGetCreateRangeDelegate(delegateKey, out ImmutableCollectionCreator creator) ||
                 !creator.CreateImmutableEnumerable(sourceList, out collection))
             {
-                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(collectionType, state.JsonPath);
+                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(collectionType, state.JsonPath());
             }
 
             return collection;
@@ -311,7 +311,7 @@ namespace System.Text.Json
             if (!options.TryGetCreateRangeDelegate(delegateKey, out ImmutableCollectionCreator creator) ||
                 !creator.CreateImmutableDictionary(sourceDictionary, out collection))
             {
-                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(collectionType, state.JsonPath);
+                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(collectionType, state.JsonPath());
             }
 
             return collection;

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoCommon.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoCommon.cs
@@ -121,7 +121,7 @@ namespace System.Text.Json
             return parentType;
         }
 
-        public override IEnumerable CreateDerivedEnumerableInstance(JsonPropertyInfo collectionPropertyInfo, IList sourceList, string jsonPath, JsonSerializerOptions options)
+        public override IEnumerable CreateDerivedEnumerableInstance(ref ReadStack state, JsonPropertyInfo collectionPropertyInfo, IList sourceList)
         {
             // Implementing types that don't have default constructors are not supported for deserialization.
             if (collectionPropertyInfo.DeclaredTypeClassInfo.CreateObject == null)
@@ -182,7 +182,7 @@ namespace System.Text.Json
                 collectionPropertyInfo.PropertyInfo);
         }
 
-        public override object CreateDerivedDictionaryInstance(JsonPropertyInfo collectionPropertyInfo, IDictionary sourceDictionary, string jsonPath, JsonSerializerOptions options)
+        public override object CreateDerivedDictionaryInstance(ref ReadStack state, JsonPropertyInfo collectionPropertyInfo, IDictionary sourceDictionary)
         {
             // Implementing types that don't have default constructors are not supported for deserialization.
             if (collectionPropertyInfo.DeclaredTypeClassInfo.CreateObject == null)
@@ -228,7 +228,7 @@ namespace System.Text.Json
                 collectionPropertyInfo.PropertyInfo);
         }
 
-        public override IEnumerable CreateIEnumerableInstance(Type parentType, IList sourceList, string jsonPath, JsonSerializerOptions options)
+        public override IEnumerable CreateIEnumerableInstance(ref ReadStack state, Type parentType, IList sourceList)
         {
             if (parentType.IsGenericType)
             {
@@ -272,7 +272,7 @@ namespace System.Text.Json
             }
         }
 
-        public override IDictionary CreateIDictionaryInstance(Type parentType, IDictionary sourceDictionary, string jsonPath, JsonSerializerOptions options)
+        public override IDictionary CreateIDictionaryInstance(ref ReadStack state, Type parentType, IDictionary sourceDictionary)
         {
             if (parentType.FullName == JsonClassInfo.HashtableTypeName)
             {
@@ -288,14 +288,14 @@ namespace System.Text.Json
         // Creates an IEnumerable<TRuntimePropertyType> and populates it with the items in the
         // sourceList argument then uses the delegateKey argument to identify the appropriate cached
         // CreateRange<TRuntimePropertyType> method to create and return the desired immutable collection type.
-        public override IEnumerable CreateImmutableCollectionInstance(Type collectionType, string delegateKey, IList sourceList, string jsonPath, JsonSerializerOptions options)
+        public override IEnumerable CreateImmutableCollectionInstance(ref ReadStack state, Type collectionType, string delegateKey, IList sourceList, JsonSerializerOptions options)
         {
             IEnumerable collection = null;
 
             if (!options.TryGetCreateRangeDelegate(delegateKey, out ImmutableCollectionCreator creator) ||
                 !creator.CreateImmutableEnumerable(sourceList, out collection))
             {
-                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(collectionType, jsonPath);
+                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(collectionType, state.JsonPath);
             }
 
             return collection;
@@ -304,25 +304,17 @@ namespace System.Text.Json
         // Creates an IEnumerable<TRuntimePropertyType> and populates it with the items in the
         // sourceList argument then uses the delegateKey argument to identify the appropriate cached
         // CreateRange<TRuntimePropertyType> method to create and return the desired immutable collection type.
-        public override IDictionary CreateImmutableDictionaryInstance(Type collectionType, string delegateKey, IDictionary sourceDictionary, string jsonPath, JsonSerializerOptions options)
+        public override IDictionary CreateImmutableDictionaryInstance(ref ReadStack state, Type collectionType, string delegateKey, IDictionary sourceDictionary, JsonSerializerOptions options)
         {
             IDictionary collection = null;
 
             if (!options.TryGetCreateRangeDelegate(delegateKey, out ImmutableCollectionCreator creator) ||
                 !creator.CreateImmutableDictionary(sourceDictionary, out collection))
             {
-                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(collectionType, jsonPath);
+                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(collectionType, state.JsonPath);
             }
 
             return collection;
-        }
-
-        private IEnumerable<TRuntimeProperty> CreateGenericTRuntimePropertyIEnumerable(IList sourceList)
-        {
-            foreach (object item in sourceList)
-            {
-                yield return (TRuntimeProperty)item;
-            }
         }
 
         private IEnumerable<TDeclaredProperty> CreateGenericTDeclaredPropertyIEnumerable(IList sourceList)
@@ -330,14 +322,6 @@ namespace System.Text.Json
             foreach (object item in sourceList)
             {
                 yield return (TDeclaredProperty)item;
-            }
-        }
-
-        private IEnumerable<KeyValuePair<string, TRuntimeProperty>> CreateGenericIEnumerableFromDictionary(IDictionary sourceDictionary)
-        {
-            foreach (DictionaryEntry item in sourceDictionary)
-            {
-                yield return new KeyValuePair<string, TRuntimeProperty>((string)item.Key, (TRuntimeProperty)item.Value);
             }
         }
     }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNotNullable.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNotNullable.cs
@@ -19,7 +19,7 @@ namespace System.Text.Json
         {
             if (Converter == null)
             {
-                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType, reader, state.JsonPath);
+                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType, reader, state.JsonPath());
             }
 
             TConverter value = Converter.Read(ref reader, RuntimePropertyType, Options);
@@ -38,19 +38,19 @@ namespace System.Text.Json
         {
             if (Converter == null)
             {
-                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType, reader, state.JsonPath);
+                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType, reader, state.JsonPath());
             }
 
             if (state.Current.KeyName == null && (state.Current.IsProcessingDictionary || state.Current.IsProcessingIDictionaryConstructible))
             {
-                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType, reader, state.JsonPath);
+                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType, reader, state.JsonPath());
                 return;
             }
 
             // We need an initialized array in order to store the values.
             if (state.Current.IsProcessingEnumerable && state.Current.TempEnumerableValues == null && state.Current.ReturnValue == null)
             {
-                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType, reader, state.JsonPath);
+                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType, reader, state.JsonPath());
                 return;
             }
 

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNotNullableContravariant.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNotNullableContravariant.cs
@@ -18,7 +18,7 @@ namespace System.Text.Json.Serialization
         {
             if (Converter == null)
             {
-                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType, reader, state.JsonPath);
+                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType, reader, state.JsonPath());
             }
 
             TConverter value = Converter.Read(ref reader, RuntimePropertyType, Options);
@@ -39,19 +39,19 @@ namespace System.Text.Json.Serialization
         {
             if (Converter == null)
             {
-                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType, reader, state.JsonPath);
+                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType, reader, state.JsonPath());
             }
 
             if (state.Current.KeyName == null && (state.Current.IsProcessingDictionary || state.Current.IsProcessingIDictionaryConstructible))
             {
-                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType, reader, state.JsonPath);
+                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType, reader, state.JsonPath());
                 return;
             }
 
             // We need an initialized array in order to store the values.
             if (state.Current.IsProcessingEnumerable && state.Current.TempEnumerableValues == null && state.Current.ReturnValue == null)
             {
-                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType, reader, state.JsonPath);
+                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType, reader, state.JsonPath());
                 return;
             }
 

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNullable.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNullable.cs
@@ -20,7 +20,7 @@ namespace System.Text.Json
         {
             if (Converter == null)
             {
-                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType, reader, state.JsonPath);
+                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType, reader, state.JsonPath());
             }
 
             TProperty value = Converter.Read(ref reader, s_underlyingType, Options);
@@ -39,7 +39,7 @@ namespace System.Text.Json
         {
             if (Converter == null)
             {
-                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType, reader, state.JsonPath);
+                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType, reader, state.JsonPath());
             }
 
             TProperty value = Converter.Read(ref reader, s_underlyingType, Options);

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
@@ -38,7 +38,7 @@ namespace System.Text.Json
             Type arrayType = jsonPropertyInfo.RuntimePropertyType;
             if (!typeof(IEnumerable).IsAssignableFrom(arrayType))
             {
-                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(arrayType, reader, state.JsonPath);
+                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(arrayType, reader, state.JsonPath());
             }
 
             Debug.Assert(state.Current.IsProcessingEnumerableOrDictionary);
@@ -162,7 +162,7 @@ namespace System.Text.Json
                 {
                     if (!(state.Current.ReturnValue is IList list))
                     {
-                        ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(value.GetType(), reader, state.JsonPath);
+                        ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(value.GetType(), reader, state.JsonPath());
                         return;
                     }
                     list.Add(value);

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleDictionary.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleDictionary.cs
@@ -35,7 +35,7 @@ namespace System.Text.Json
                     jsonPropertyInfo.ElementClassInfo.Type != typeof(object) &&
                     jsonPropertyInfo.ElementClassInfo.Type != typeof(JsonElement))
                 {
-                    ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(state.Current.JsonClassInfo.Type, reader, state.JsonPath);
+                    ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(state.Current.JsonClassInfo.Type, reader, state.JsonPath());
                 }
 
                 JsonClassInfo classInfo = state.Current.JsonClassInfo;
@@ -48,7 +48,7 @@ namespace System.Text.Json
                 {
                     if (classInfo.CreateObject == null)
                     {
-                        ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(classInfo.Type, reader, state.JsonPath);
+                        ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(classInfo.Type, reader, state.JsonPath());
                         return;
                     }
                     state.Current.ReturnValue = classInfo.CreateObject();

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Helpers.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Helpers.cs
@@ -11,11 +11,6 @@ namespace System.Text.Json
             JsonSerializerOptions options,
             ref Utf8JsonReader reader)
         {
-            if (options == null)
-            {
-                options = JsonSerializerOptions.s_defaultOptions;
-            }
-
             ReadStack state = default;
             state.Current.Initialize(returnType, options);
 

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
@@ -8,7 +8,7 @@ using System.Diagnostics;
 
 namespace System.Text.Json
 {
-    [DebuggerDisplay("Current: ClassType.{Current.JsonClassInfo.ClassType}, {Current.JsonClassInfo.Type.Name}")]
+    [DebuggerDisplay("Path:{JsonPath()} Current: ClassType.{Current.JsonClassInfo.ClassType}, {Current.JsonClassInfo.Type.Name}")]
     internal struct ReadStack
     {
         internal static readonly char[] SpecialCharacters = { '.', ' ', '\'', '/', '"', '[', ']', '(', ')', '\t', '\n', '\r', '\f', '\b', '\\', '\u0085', '\u2028', '\u2029' };
@@ -54,20 +54,17 @@ namespace System.Text.Json
         // Return a JSONPath using simple dot-notation when possible. When special characters are present, bracket-notation is used:
         // $.x.y[0].z
         // $['PropertyName.With.Special.Chars']
-        public string JsonPath
+        public string JsonPath()
         {
-            get
+            StringBuilder sb = new StringBuilder("$");
+
+            for (int i = 0; i < _index; i++)
             {
-                StringBuilder sb = new StringBuilder("$");
-
-                for (int i = 0; i < _index; i++)
-                {
-                    AppendStackFrame(sb, _previous[i]);
-                }
-
-                AppendStackFrame(sb, Current);
-                return sb.ToString();
+                AppendStackFrame(sb, _previous[i]);
             }
+
+            AppendStackFrame(sb, Current);
+            return sb.ToString();
         }
 
         private void AppendStackFrame(StringBuilder sb, in ReadStackFrame frame)

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
@@ -187,13 +187,13 @@ namespace System.Text.Json
                 }
                 else
                 {
-                    ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(jsonPropertyInfo.DeclaredPropertyType, reader, state.JsonPath);
+                    ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(jsonPropertyInfo.DeclaredPropertyType, reader, state.JsonPath());
                     return null;
                 }
             }
             else
             {
-                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(propertyType, reader, state.JsonPath);
+                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(propertyType, reader, state.JsonPath());
                 return null;
             }
         }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 
 namespace System.Text.Json
 {
+    [DebuggerDisplay("Path:{PropertyPath()} Current: ClassType.{Current.JsonClassInfo.ClassType}, {Current.JsonClassInfo.Type.Name}")]
     internal struct WriteStack
     {
         // Fields are used instead of properties to avoid value semantics.
@@ -74,20 +75,17 @@ namespace System.Text.Json
         // Return a property path as a simple JSONPath using dot-notation when possible. When special characters are present, bracket-notation is used:
         // $.x.y.z
         // $['PropertyName.With.Special.Chars']
-        public string PropertyPath
+        public string PropertyPath()
         {
-            get
+            StringBuilder sb = new StringBuilder("$");
+
+            for (int i = 0; i < _index; i++)
             {
-                StringBuilder sb = new StringBuilder("$");
-
-                for (int i = 0; i < _index; i++)
-                {
-                    AppendStackFrame(sb, _previous[i]);
-                }
-
-                AppendStackFrame(sb, Current);
-                return sb.ToString();
+                AppendStackFrame(sb, _previous[i]);
             }
+
+            AppendStackFrame(sb, Current);
+            return sb.ToString();
         }
 
         private void AppendStackFrame(StringBuilder sb, in WriteStackFrame frame)

--- a/src/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -153,7 +153,7 @@ namespace System.Text.Json
         {
             Debug.Assert(ex.Path == null);
 
-            string path = readStack.JsonPath;
+            string path = readStack.JsonPath();
             string message = ex.Message;
 
             // Insert the "Path" portion before "LineNumber" and "BytePositionInLine".
@@ -186,7 +186,7 @@ namespace System.Text.Json
             long bytePositionInLine = reader.CurrentState._bytePositionInLine;
             ex.BytePositionInLine = bytePositionInLine;
 
-            string path = readStack.JsonPath;
+            string path = readStack.JsonPath();
             ex.Path = path;
 
             // If the message is empty, use a default message with Path, LineNumber and BytePositionInLine.
@@ -212,7 +212,7 @@ namespace System.Text.Json
 
         public static void AddExceptionInformation(in WriteStack writeStack, JsonException ex)
         {
-            string path = writeStack.PropertyPath;
+            string path = writeStack.PropertyPath();
             ex.Path = path;
 
             // If the message is empty, use a default message with the Path.


### PR DESCRIPTION
- Defer calls to ReadStack.JsonPath until an exception needs that information (avoids String and StringBuilder allocs).
- Remove dead code and unused variables


Benchmarks for deserializing single collection `System.Text.Json.Serialization.Tests.ReadJson<ImmutableDictionary<string, string>>`
```
Before
|                   Method |     Mean |     Error |    StdDev |   Median |      Min |      Max | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|------------------------- |---------:|----------:|----------:|---------:|---------:|---------:|------------:|------------:|------------:|--------------------:|
|    DeserializeFromString | 65.60 us | 0.6393 us | 0.5668 us | 65.50 us | 64.64 us | 66.60 us |      6.6489 |      0.5319 |           - |            40.87 KB |
| DeserializeFromUtf8Bytes | 63.73 us | 0.9506 us | 0.8891 us | 63.58 us | 62.40 us | 65.20 us |      5.5444 |      0.5040 |           - |            35.07 KB |
|    DeserializeFromStream | 64.76 us | 1.2135 us | 1.0758 us | 64.87 us | 63.33 us | 66.52 us |      5.6921 |      0.5175 |           - |            35.14 KB

After
|                   Method |     Mean |     Error |    StdDev |   Median |      Min |      Max | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|------------------------- |---------:|----------:|----------:|---------:|---------:|---------:|------------:|------------:|------------:|--------------------:|
|    DeserializeFromString | 64.71 us | 0.8625 us | 0.8067 us | 64.36 us | 63.72 us | 66.20 us |      6.4317 |      0.7718 |           - |            40.75 KB |
| DeserializeFromUtf8Bytes | 62.82 us | 0.6094 us | 0.5701 us | 62.72 us | 62.14 us | 63.98 us |      5.4781 |      0.7470 |           - |            34.94 KB |
|    DeserializeFromStream | 63.31 us | 0.6213 us | 0.5812 us | 63.20 us | 62.42 us | 64.38 us |      5.5710 |      0.7597 |           - |            35.01 KB |
```