### PR TITLE
Fix SerialStream.Flush on Unix

### DIFF
--- a/src/System.IO.Ports/src/System/IO/Ports/SerialStream.Unix.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/SerialStream.Unix.cs
@@ -364,7 +364,7 @@ namespace System.IO.Ports
             if (_handle == null) InternalResources.FileNotOpen();
 
             SpinWait sw = new SpinWait();
-            while (!(_readQueue.IsEmpty && _writeQueue.IsEmpty))
+            while (!_writeQueue.IsEmpty)
             {
                 sw.SpinOnce();
             }

--- a/src/System.IO.Ports/src/System/IO/Ports/SerialStream.Unix.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/SerialStream.Unix.cs
@@ -362,7 +362,14 @@ namespace System.IO.Ports
         public override void Flush()
         {
             if (_handle == null) InternalResources.FileNotOpen();
-            Interop.Termios.TermiosDiscard(_handle, Interop.Termios.Queue.AllQueues);
+
+            SpinWait sw = new SpinWait();
+            while (!(_readQueue.IsEmpty && _writeQueue.IsEmpty))
+            {
+                sw.SpinOnce();
+            }
+
+            Interop.Termios.TermiosDrain(_handle);
         }
 
         internal int ReadByte(int timeout)

--- a/src/System.IO.Ports/tests/SerialStream/Write_byte_int_int.cs
+++ b/src/System.IO.Ports/tests/SerialStream/Write_byte_int_int.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IO.PortsTests;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Legacy.Support;
 using Xunit;
 
@@ -247,6 +248,36 @@ namespace System.IO.Ports.Tests
                 com1.Handshake = Handshake.RequestToSend;
 
                 com1.BaseStream.Write(new byte[8], 0, 0);
+            }
+        }
+
+        [ConditionalFact(nameof(HasLoopbackOrNullModem))]
+        public void WriteBreakSequenceDoesNotCorruptData()
+        {
+            using (SerialPort com1 = TCSupport.InitFirstSerialPort())
+            using (SerialPort com2 = TCSupport.InitSecondSerialPort(com1))
+            {
+                com1.Open();
+                if (!com2.IsOpen) // This is necessary since com1 and com2 might be the same port if we are using a loopback
+                    com2.Open();
+
+                byte[] msg = new byte[] { 0x1B, 0x40, 0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64 };
+
+                Task writingTask = Task.Run(() => {
+                    com1.BaseStream.Write(msg, 0, msg.Length);
+                    com1.BaseStream.Flush();
+                });
+
+                byte[] bytes = new byte[msg.Length];
+                int totalBytesRead = 0;
+                while (totalBytesRead < bytes.Length)
+                {
+                    int bytesRead = com2.BaseStream.Read(bytes, totalBytesRead, bytes.Length - totalBytesRead);
+                    totalBytesRead += bytesRead;
+                }
+
+                writingTask.Wait();
+                Assert.Equal(msg, bytes);
             }
         }
         #endregion


### PR DESCRIPTION
Fixes: #37770

cc: @blelem @carlossanlop 

Seems we have accidentally called tcflush instead of tcdrain on Flush. tcflush is causing the data to be discarded while drain is waiting for ops to be completed. Code already had interop defined for tcdrain but it was never called.

I've also added a code to wait for internal queue to be emptied.

We already have tests for this scenario but on some devices (the one I used for testing specifically) tcflush actually didn't do anything observable since the USB driver doesn't have access to clear the queue correctly so likely it was implemented as no-op or only does it before data leaves the driver which makes it very unlikely to happen