### PR TITLE
Update StringComparerTests.cs

### DIFF
--- a/src/System.Runtime/tests/System/StringComparerTests.cs
+++ b/src/System.Runtime/tests/System/StringComparerTests.cs
@@ -13,7 +13,6 @@ namespace System.Tests
         public void Create_InvalidArguments_Throws()
         {
             AssertExtensions.Throws<ArgumentNullException>("culture", () => StringComparer.Create(null, ignoreCase: true));
-            AssertExtensions.Throws<ArgumentNullException>("culture", () => StringComparer.Create(null, CompareOptions.IgnoreCase));
         }
 
         [Fact]

--- a/src/System.Runtime/tests/System/StringComparerTests.cs
+++ b/src/System.Runtime/tests/System/StringComparerTests.cs
@@ -13,6 +13,7 @@ namespace System.Tests
         public void Create_InvalidArguments_Throws()
         {
             AssertExtensions.Throws<ArgumentNullException>("culture", () => StringComparer.Create(null, ignoreCase: true));
+            AssertExtensions.Throws<ArgumentNullException>("culture", () => StringComparer.Create(null, CompareOptions.IgnoreCase));
         }
 
         [Fact]

--- a/src/System.Runtime/tests/System/StringComparerTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/StringComparerTests.netcoreapp.cs
@@ -12,7 +12,7 @@ namespace System.Tests
         [Fact]
         public void CreateCultureOptions_InvalidArguments_Throws()
         {
-            Assert.Throws<ArgumentException>(() => StringComparer.Create(null, CompareOptions.None));
+            Assert.Throws<ArgumentNullException>(() => StringComparer.Create(null, CompareOptions.None));
         }
 
         [Fact]


### PR DESCRIPTION
Added test to check that `StringComparer.Create` overload throws `ArgumentNullException` when a `null` culture is provided.

Relates to https://github.com/dotnet/coreclr/pull/26570