### PR TITLE
[release/3.0] Disable ToolboxBitmatAttribute test in netfx (#40901)

### DIFF
--- a/src/System.Drawing.Common/tests/ToolboxBitmapAttributeTests.cs
+++ b/src/System.Drawing.Common/tests/ToolboxBitmapAttributeTests.cs
@@ -46,6 +46,7 @@ namespace System.Drawing.Tests
         [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Ctor_FileName_TestData))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void Ctor_FileName(string fileName, Size size)
         {
             var attribute = new ToolboxBitmapAttribute(fileName);


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/40877

TEST Only change.

cc: @ViktorHofer 