### PR TITLE
Increase helix timeout on Windows clients

### DIFF
--- a/eng/pipelines/windows.yml
+++ b/eng/pipelines/windows.yml
@@ -107,7 +107,7 @@ stages:
           name: Hosted VS2017
 
         submitToHelix: true
-        # Temporary till we increased the Windows ARM64 queue, https://github.com/dotnet/core-eng/issues/7756
+        # Temporarily until we increase the Windows ARM64 queue, https://github.com/dotnet/core-eng/issues/7756
         timeoutInMinutes: 180
         buildExtraArguments: /p:RuntimeOS=win10
 

--- a/eng/pipelines/windows.yml
+++ b/eng/pipelines/windows.yml
@@ -107,6 +107,8 @@ stages:
           name: Hosted VS2017
 
         submitToHelix: true
+        # Temporary till we reduced workloads on ARM64
+        timeoutInMinutes: 180
         buildExtraArguments: /p:RuntimeOS=win10
 
         variables:

--- a/eng/pipelines/windows.yml
+++ b/eng/pipelines/windows.yml
@@ -107,7 +107,7 @@ stages:
           name: Hosted VS2017
 
         submitToHelix: true
-        # Temporary till we reduced workloads on ARM64
+        # Temporary till we increased the Windows ARM64 queue, https://github.com/dotnet/core-eng/issues/7756
         timeoutInMinutes: 180
         buildExtraArguments: /p:RuntimeOS=win10
 


### PR DESCRIPTION
Depending on the ARM64 windows queue utilization, clients sometimes take longer than the current timeout. Increasing temporarily until the queue has more machines.

Following Matt's recommendation: https://github.com/dotnet/core-eng/issues/7756#issuecomment-528923195