### PR TITLE
Use ThrowHelper in Utf8JsonReader.GetGuid so that the deserializer can catch the exception and re-throw JsonException.

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
@@ -441,7 +441,7 @@ namespace System.Text.Json
         {
             if (!TryGetGuid(out Guid value))
             {
-                throw ThrowHelper.GetFormatException(DataType.Base64String);
+                throw ThrowHelper.GetFormatException(DataType.Guid);
             }
 
             return value;

--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
@@ -108,7 +108,7 @@ namespace System.Text.Json
         {
             if (!TryGetBytesFromBase64(out byte[] value))
             {
-                throw ThrowHelper.GetFormatException(DateType.Base64String);
+                throw ThrowHelper.GetFormatException(DataType.Base64String);
             }
             return value;
         }
@@ -395,7 +395,7 @@ namespace System.Text.Json
         {
             if (!TryGetDateTime(out DateTime value))
             {
-                throw ThrowHelper.GetFormatException(DateType.DateTime);
+                throw ThrowHelper.GetFormatException(DataType.DateTime);
             }
 
             return value;
@@ -418,7 +418,7 @@ namespace System.Text.Json
         {
             if (!TryGetDateTimeOffset(out DateTimeOffset value))
             {
-                throw ThrowHelper.GetFormatException(DateType.DateTimeOffset);
+                throw ThrowHelper.GetFormatException(DataType.DateTimeOffset);
             }
 
             return value;
@@ -441,7 +441,7 @@ namespace System.Text.Json
         {
             if (!TryGetGuid(out Guid value))
             {
-                throw new FormatException(SR.FormatGuid);
+                throw ThrowHelper.GetFormatException(DataType.Base64String);
             }
 
             return value;

--- a/src/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
+++ b/src/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
@@ -584,20 +584,23 @@ namespace System.Text.Json
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static FormatException GetFormatException(DateType dateType)
+        public static FormatException GetFormatException(DataType dateType)
         {
             string message = "";
 
             switch (dateType)
             {
-                case DateType.DateTime:
+                case DataType.DateTime:
                     message = SR.FormatDateTime;
                     break;
-                case DateType.DateTimeOffset:
+                case DataType.DateTimeOffset:
                     message = SR.FormatDateTimeOffset;
                     break;
-                case DateType.Base64String:
+                case DataType.Base64String:
                     message = SR.CannotDecodeInvalidBase64;
+                    break;
+                case DataType.Guid:
+                    message = SR.FormatGuid;
                     break;
                 default:
                     Debug.Fail($"The DateType enum value: {dateType} is not part of the switch. Add the appropriate case and exception message.");
@@ -670,10 +673,11 @@ namespace System.Text.Json
         Decimal
     }
 
-    internal enum DateType
+    internal enum DataType
     {
         DateTime,
         DateTimeOffset,
-        Base64String
+        Base64String,
+        Guid,
     }
 }

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
@@ -76,6 +76,21 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<int[]>(Encoding.UTF8.GetBytes(@"[1,a]")));
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<int>(@"null"));
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<int>(@""""""));
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<DateTime>("\"abc\""));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<DateTimeOffset>("\"abc\""));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Guid>("\"abc\""));
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<byte>("\"abc\""));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<sbyte>("\"abc\""));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<short>("\"abc\""));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ushort>("\"abc\""));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<int>("\"abc\""));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<uint>("\"abc\""));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<long>("\"abc\""));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ulong>("\"abc\""));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<float>("\"abc\""));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<double>("\"abc\""));
         }
 
         [Theory]

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
@@ -82,13 +82,21 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Guid>("\"abc\""));
 
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<byte>("\"abc\""));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<byte>("1.1"));
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<sbyte>("\"abc\""));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<sbyte>("1.1"));
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<short>("\"abc\""));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<short>("1.1"));
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ushort>("\"abc\""));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ushort>("1.1"));
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<int>("\"abc\""));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<int>("1.1"));
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<uint>("\"abc\""));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<uint>("1.1"));
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<long>("\"abc\""));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<long>("1.1"));
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ulong>("\"abc\""));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ulong>("1.1"));
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<float>("\"abc\""));
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<double>("\"abc\""));
         }


### PR DESCRIPTION
Because we weren't using the ThrowHelper, we weren't setting the source of the exception to `"System.Text.Json.Rethrowable"` so that the Deserializer could catch it and re-throw it as JsonException.

Fixes https://github.com/aspnet/AspNetCore/issues/13811

cc @layomia, @pranavkm, @steveharter 