### PR TITLE
make sure BindDuringTcpWait_Succeeds does not run with other tests

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -420,32 +420,6 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [Fact]
-        public void BindDuringTcpWait_Succeeds()
-        {
-            int port = 0;
-            using (Socket a = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
-            {
-                a.Bind(new IPEndPoint(IPAddress.Loopback, 0));
-                port = (a.LocalEndPoint as IPEndPoint).Port;
-                a.Listen(10);
-
-                // Connect a client
-                using (Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
-                {
-                    client.Connect(new IPEndPoint(IPAddress.Loopback, port));
-                    // accept socket and close it with zero linger time.
-                    a.Accept().Close(0);
-                }
-            }
-
-            // Bind a socket to the same address we just used.
-            using (Socket b = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
-            {
-                b.Bind(new IPEndPoint(IPAddress.Loopback, port));
-            }
-        }
-
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue(11057)]
         public void ExclusiveAddressUseTcp()
         {
@@ -545,6 +519,38 @@ namespace System.Net.Sockets.Tests
             using (var socket = new Socket(family, SocketType.Stream, ProtocolType.Tcp))
             {
                 AssertExtensions.Throws<ArgumentException>("level", () => socket.SetIPProtectionLevel(IPProtectionLevel.Unspecified));
+            }
+        }
+    }
+
+    [Collection("NoParallelTests")]
+    // Set of tests to not run  together with any other tests.
+    public class NoParallelTests
+    {
+        [Fact]
+        public void BindDuringTcpWait_Succeeds()
+        {
+            int port = 0;
+            using (Socket a = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                a.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                port = (a.LocalEndPoint as IPEndPoint).Port;
+                a.Listen(10);
+
+                // Connect a client
+                using (Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+                {
+                    client.Connect(new IPEndPoint(IPAddress.Loopback, port));
+                    // accept socket and close it with zero linger time.
+                    a.Accept().Close(0);
+                }
+            }
+
+            // Bind a socket to the same address we just used.
+            // To avoid conflict with other tests, this is part of the NoParallelTests test collection.
+            using (Socket b = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                b.Bind(new IPEndPoint(IPAddress.Loopback, port));
             }
         }
     }

--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketTestHelper.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketTestHelper.cs
@@ -11,6 +11,10 @@ using Xunit.Abstractions;
 
 namespace System.Net.Sockets.Tests
 {
+
+    // Define test collection for tests to avoid all other tests.
+    [CollectionDefinition("NoParallelTests", DisableParallelization = true)]
+
     // Abstract base class for various different socket "modes" (sync, async, etc)
     // See SendReceive.cs for usage
     public abstract class SocketHelperBase


### PR DESCRIPTION
I check run log and the test runs at the end as @bradwilson described. This should avoid conflicts with other tests. 

Right now it is only one test but I put CollectionDefinition to HelperBase so it is easy to add more as we find mode cases like this.  

```      
      System.Net.Sockets.Tests.NoParallelTests.BindDuringTcpWait_Succeeds [STARTING]
      System.Net.Sockets.Tests.NoParallelTests.BindDuringTcpWait_Succeeds [FINISHED] Time: 0.0012822s
    Finished:    System.Net.Sockets.Tests
  === TEST EXECUTION SUMMARY ===
     System.Net.Sockets.Tests  Total: 920, Errors: 0, Failed: 0, Skipped: 7, Time: 6.013s
```

fixes  #40475
