### PR TITLE
Add test for IComponent typeconverter register in TypeDescriptor

### DIFF
--- a/src/System.ComponentModel.TypeConverter/tests/TypeDescriptorTests.netcoreapp.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/TypeDescriptorTests.netcoreapp.cs
@@ -10,6 +10,7 @@ namespace System.ComponentModel.Tests
     {
         [Theory]
         [InlineData(typeof(Version), typeof(VersionConverter))]
+        [InlineData(typeof(IComponent), typeof(ComponentConverter))]
         public static void GetConverter_NetCoreApp(Type targetType, Type resultConverterType) =>
             GetConverter(targetType, resultConverterType);
     }


### PR DESCRIPTION
In: #40837 we added `ComponentConverter` as `IComponent`'s converter, however we missed to add a  test entry for the `TypeDescriptor`.

cc: @danmosemsft @RussKie @ericstj 