### PR TITLE
.NET Core 3.0 Prev9 IntelliSense nupkg version bump

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -75,7 +75,7 @@
     <CoverletConsolePackageVersion>1.5.0</CoverletConsolePackageVersion>
     <DotNetReportGeneratorGlobalToolPackageVersion>4.1.4</DotNetReportGeneratorGlobalToolPackageVersion>
     <!-- Docs -->
-    <MicrosoftPrivateIntellisensePackageVersion>3.0.0-preview8-190819-0</MicrosoftPrivateIntellisensePackageVersion>
+    <MicrosoftPrivateIntellisensePackageVersion>3.0.0-preview9-190909-1</MicrosoftPrivateIntellisensePackageVersion>
     <!-- ILLink -->
     <ILLinkTasksPackageVersion>0.1.5-preview-1461378</ILLinkTasksPackageVersion>
   </PropertyGroup>


### PR DESCRIPTION
@ahsonkhan @safern @ViktorHofer 
Bumping the IntelliSense package version to the the Prev9 nupkg.