### PR TITLE
.NET Core 3.0 Prev9 Intellisense nupkg version bump

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -77,7 +77,7 @@
     <CoverletConsolePackageVersion>1.5.0</CoverletConsolePackageVersion>
     <DotNetReportGeneratorGlobalToolPackageVersion>4.1.4</DotNetReportGeneratorGlobalToolPackageVersion>
     <!-- Docs -->
-    <MicrosoftPrivateIntellisensePackageVersion>3.0.0-preview8-190819-0</MicrosoftPrivateIntellisensePackageVersion>
+    <MicrosoftPrivateIntellisensePackageVersion>3.0.0-preview9-190909-1</MicrosoftPrivateIntellisensePackageVersion>
     <!-- ILLink -->
     <ILLinkTasksPackageVersion>0.1.5-preview-1461378</ILLinkTasksPackageVersion>
   </PropertyGroup>


### PR DESCRIPTION
This change updates the IntelliSense nuget version to one that includes additional documentation that was merged today (English only).
This is an infrastructure change, no product code involved.
