### PR TITLE
Use slow path for CallInstruction returning enum value

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.Generated.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.Generated.cs
@@ -42,6 +42,7 @@ namespace System.Linq.Expressions.Interpreter
                 return new ActionCallInstruction(target);
             }
 
+            if (t.IsEnum) return SlowCreate(target, pi);
             switch (t.GetTypeCode())
             {
                 case TypeCode.Object:
@@ -84,6 +85,7 @@ namespace System.Linq.Expressions.Interpreter
                 return new FuncCallInstruction<T0>(target);
             }
 
+            if (t.IsEnum) return SlowCreate(target, pi);
             switch (t.GetTypeCode())
             {
                 case TypeCode.Object:
@@ -126,6 +128,7 @@ namespace System.Linq.Expressions.Interpreter
                 return new FuncCallInstruction<T0, T1>(target);
             }
 
+            if (t.IsEnum) return SlowCreate(target, pi);
             switch (t.GetTypeCode())
             {
                 case TypeCode.Object:

--- a/src/System.Linq.Expressions/tests/Call/CallTests.cs
+++ b/src/System.Linq.Expressions/tests/Call/CallTests.cs
@@ -670,8 +670,8 @@ namespace System.Linq.Expressions.Tests
         {
             Expression<Func<DayOfWeek[]>> expr = () => new[] { ToDayOfWeek0() };
 
-            AssertionException.Equals(DayOfWeek.Monday, expr.Compile(false)()[0]);
-            AssertionException.Equals(DayOfWeek.Monday, expr.Compile(true)()[0]);
+            Assert.Equal(DayOfWeek.Monday, expr.Compile(false)()[0]);
+            Assert.Equal(DayOfWeek.Monday, expr.Compile(true)()[0]);
         }
 
         [Fact]
@@ -679,8 +679,8 @@ namespace System.Linq.Expressions.Tests
         {
             Expression<Func<DayOfWeek[]>> expr = () => new[] { ToDayOfWeek1(1) };
 
-            AssertionException.Equals(DayOfWeek.Monday, expr.Compile(false)()[0]);
-            AssertionException.Equals(DayOfWeek.Monday, expr.Compile(true)()[0]);
+            Assert.Equal(DayOfWeek.Monday, expr.Compile(false)()[0]);
+            Assert.Equal(DayOfWeek.Monday, expr.Compile(true)()[0]);
         }
 
         [Fact]
@@ -688,8 +688,8 @@ namespace System.Linq.Expressions.Tests
         {
             Expression<Func<DayOfWeek[]>> expr = () => new[] { ToDayOfWeek2(0, 1) };
 
-            AssertionException.Equals(DayOfWeek.Monday, expr.Compile(false)()[0]);
-            AssertionException.Equals(DayOfWeek.Monday, expr.Compile(true)()[0]);
+            Assert.Equal(DayOfWeek.Monday, expr.Compile(false)()[0]);
+            Assert.Equal(DayOfWeek.Monday, expr.Compile(true)()[0]);
         }
 
         private static DayOfWeek ToDayOfWeek0() => DayOfWeek.Monday;

--- a/src/System.Linq.Expressions/tests/Call/CallTests.cs
+++ b/src/System.Linq.Expressions/tests/Call/CallTests.cs
@@ -665,6 +665,37 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
+        [Fact]
+        public static void EnumReturnType0()
+        {
+            Expression<Func<DayOfWeek[]>> expr = () => new[] { ToDayOfWeek0() };
+
+            AssertionException.Equals(DayOfWeek.Monday, expr.Compile(false)()[0]);
+            AssertionException.Equals(DayOfWeek.Monday, expr.Compile(true)()[0]);
+        }
+
+        [Fact]
+        public static void EnumReturnType1()
+        {
+            Expression<Func<DayOfWeek[]>> expr = () => new[] { ToDayOfWeek1(1) };
+
+            AssertionException.Equals(DayOfWeek.Monday, expr.Compile(false)()[0]);
+            AssertionException.Equals(DayOfWeek.Monday, expr.Compile(true)()[0]);
+        }
+
+        [Fact]
+        public static void EnumReturnType2()
+        {
+            Expression<Func<DayOfWeek[]>> expr = () => new[] { ToDayOfWeek2(0, 1) };
+
+            AssertionException.Equals(DayOfWeek.Monday, expr.Compile(false)()[0]);
+            AssertionException.Equals(DayOfWeek.Monday, expr.Compile(true)()[0]);
+        }
+
+        private static DayOfWeek ToDayOfWeek0() => DayOfWeek.Monday;
+        private static DayOfWeek ToDayOfWeek1(int i) => (DayOfWeek)i;
+        private static DayOfWeek ToDayOfWeek2(int i, int j) => (DayOfWeek)(i + j);
+
         public class GenericClass<T>
         {
             public static void NonGenericMethod() { }


### PR DESCRIPTION
Fixes #40968

Reverts part of the change made in #28792.