### PR TITLE
Avoid MemoryMarshal.Cast when transcoding from UTF-16 to UTF-8 while escaping in Utf8JsonWriter.

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Escaping.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Escaping.cs
@@ -79,13 +79,16 @@ namespace System.Text.Json
             return idx;
         }
 
-        public static int NeedsEscaping(ReadOnlySpan<char> value, JavaScriptEncoder encoder)
+        public static unsafe int NeedsEscaping(ReadOnlySpan<char> value, JavaScriptEncoder encoder)
         {
             int idx;
 
             if (encoder != null)
             {
-                idx = encoder.FindFirstCharacterToEncodeUtf8(MemoryMarshal.Cast<char, byte>(value));
+                fixed (char* ptr = value)
+                {
+                    idx = encoder.FindFirstCharacterToEncode(ptr, value.Length);
+                }
                 goto Return;
             }
 

--- a/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Escaping.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Escaping.cs
@@ -83,7 +83,9 @@ namespace System.Text.Json
         {
             int idx;
 
-            if (encoder != null)
+            // Some implementations of JavascriptEncoder.FindFirstCharacterToEncode may not accept
+            // null pointers and gaurd against that. Hence, check up-front and fall down to return -1.
+            if (encoder != null && !value.IsEmpty)
             {
                 fixed (char* ptr = value)
                 {

--- a/src/System.Text.Json/tests/Serialization/Value.WriteTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.WriteTests.cs
@@ -22,6 +22,18 @@ namespace System.Text.Json.Serialization.Tests
             Assert.NotEqual(expected, JsonSerializer.Serialize(inputString));
         }
 
+        // https://github.com/dotnet/corefx/issues/40979
+        [Fact]
+        public static void EscapingShouldntStackOverflow_40979()
+        {
+            var test = new { Name = "\u6D4B\u8A6611" };
+
+            var options = new JsonSerializerOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping, PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+            string result = JsonSerializer.Serialize(test, options);
+
+            Assert.Equal("{\"name\": \"\u6D4B\u8A6611\"}", result);
+        }
+
         [Fact]
         public static void WritePrimitives()
         {

--- a/src/System.Text.Json/tests/Serialization/Value.WriteTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.WriteTests.cs
@@ -31,7 +31,7 @@ namespace System.Text.Json.Serialization.Tests
             var options = new JsonSerializerOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping, PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
             string result = JsonSerializer.Serialize(test, options);
 
-            Assert.Equal("{\"name\": \"\u6D4B\u8A6611\"}", result);
+            Assert.Equal("{\"name\":\"\u6D4B\u8A6611\"}", result);
         }
 
         [Fact]

--- a/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
@@ -59,7 +59,13 @@ namespace System.Text.Json.Tests
         [Fact]
         public static void WritingNullStringsWithCustomEscaping()
         {
-            var writerOptions = new JsonWriterOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
+            var writerOptions = new JsonWriterOptions();
+            WriteNullStringsHelper(writerOptions);
+
+            writerOptions = new JsonWriterOptions { Encoder = JavaScriptEncoder.Default };
+            WriteNullStringsHelper(writerOptions);
+
+            writerOptions = new JsonWriterOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
             WriteNullStringsHelper(writerOptions);
         }
 
@@ -75,25 +81,11 @@ namespace System.Text.Json.Tests
             var output = new ArrayBufferWriter<byte>();
             string str = null;
 
-            using (var writer = new Utf8JsonWriter(output))
-            {
-                writer.WriteStringValue(str);
-            }
-            JsonTestHelper.AssertContents("null", output);
-
-            output.Clear();
             using (var writer = new Utf8JsonWriter(output, writerOptions))
             {
                 writer.WriteStringValue(str);
             }
             JsonTestHelper.AssertContents("null", output);
-
-            output.Clear();
-            using (var writer = new Utf8JsonWriter(output))
-            {
-                writer.WriteStringValue(str.AsSpan());
-            }
-            JsonTestHelper.AssertContents("\"\"", output);
 
             output.Clear();
             using (var writer = new Utf8JsonWriter(output, writerOptions))
@@ -104,13 +96,6 @@ namespace System.Text.Json.Tests
 
             byte[] utf8Str = null;
             output.Clear();
-            using (var writer = new Utf8JsonWriter(output))
-            {
-                writer.WriteStringValue(utf8Str.AsSpan());
-            }
-            JsonTestHelper.AssertContents("\"\"", output);
-
-            output.Clear();
             using (var writer = new Utf8JsonWriter(output, writerOptions))
             {
                 writer.WriteStringValue(utf8Str.AsSpan());
@@ -118,13 +103,6 @@ namespace System.Text.Json.Tests
             JsonTestHelper.AssertContents("\"\"", output);
 
             JsonEncodedText jsonText = JsonEncodedText.Encode(utf8Str.AsSpan());
-            output.Clear();
-            using (var writer = new Utf8JsonWriter(output))
-            {
-                writer.WriteStringValue(jsonText);
-            }
-            JsonTestHelper.AssertContents("\"\"", output);
-
             output.Clear();
             using (var writer = new Utf8JsonWriter(output, writerOptions))
             {

--- a/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
@@ -59,75 +59,20 @@ namespace System.Text.Json.Tests
         [Fact]
         public static void WritingNullStringsWithCustomEscaping()
         {
-            var output = new ArrayBufferWriter<byte>();
             var writerOptions = new JsonWriterOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
-
-            string str = null;
-
-            using (var writer = new Utf8JsonWriter(output))
-            {
-                writer.WriteStringValue(str);
-            }
-            JsonTestHelper.AssertContents("null", output);
-
-            output.Clear();
-            using (var writer = new Utf8JsonWriter(output, writerOptions))
-            {
-                writer.WriteStringValue(str);
-            }
-            JsonTestHelper.AssertContents("null", output);
-
-            output.Clear();
-            using (var writer = new Utf8JsonWriter(output))
-            {
-                writer.WriteStringValue(str.AsSpan());
-            }
-            JsonTestHelper.AssertContents("\"\"", output);
-
-            output.Clear();
-            using (var writer = new Utf8JsonWriter(output, writerOptions))
-            {
-                writer.WriteStringValue(str.AsSpan());
-            }
-            JsonTestHelper.AssertContents("\"\"", output);
-
-            byte[] utf8Str = null;
-            output.Clear();
-            using (var writer = new Utf8JsonWriter(output))
-            {
-                writer.WriteStringValue(utf8Str.AsSpan());
-            }
-            JsonTestHelper.AssertContents("\"\"", output);
-
-            output.Clear();
-            using (var writer = new Utf8JsonWriter(output, writerOptions))
-            {
-                writer.WriteStringValue(utf8Str.AsSpan());
-            }
-            JsonTestHelper.AssertContents("\"\"", output);
-
-            JsonEncodedText jsonText = JsonEncodedText.Encode(utf8Str.AsSpan());
-            output.Clear();
-            using (var writer = new Utf8JsonWriter(output))
-            {
-                writer.WriteStringValue(jsonText);
-            }
-            JsonTestHelper.AssertContents("\"\"", output);
-
-            output.Clear();
-            using (var writer = new Utf8JsonWriter(output, writerOptions))
-            {
-                writer.WriteStringValue(jsonText);
-            }
-            JsonTestHelper.AssertContents("\"\"", output);
+            WriteNullStringsHelper(writerOptions);
         }
 
         [Fact]
         public static void WritingNullStringsWithBuggyJavascriptEncoder()
         {
-            var output = new ArrayBufferWriter<byte>();
             var writerOptions = new JsonWriterOptions { Encoder = new BuggyJavaScriptEncoder() };
+            WriteNullStringsHelper(writerOptions);
+        }
 
+        private static void WriteNullStringsHelper(JsonWriterOptions writerOptions)
+        {
+            var output = new ArrayBufferWriter<byte>();
             string str = null;
 
             using (var writer = new Utf8JsonWriter(output))

--- a/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
@@ -57,6 +57,157 @@ namespace System.Text.Json.Tests
         }
 
         [Fact]
+        public static void WritingNullStringsWithCustomEscaping()
+        {
+            var output = new ArrayBufferWriter<byte>();
+            var writerOptions = new JsonWriterOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
+
+            string str = null;
+
+            using (var writer = new Utf8JsonWriter(output))
+            {
+                writer.WriteStringValue(str);
+            }
+            JsonTestHelper.AssertContents("null", output);
+
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output, writerOptions))
+            {
+                writer.WriteStringValue(str);
+            }
+            JsonTestHelper.AssertContents("null", output);
+
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output))
+            {
+                writer.WriteStringValue(str.AsSpan());
+            }
+            JsonTestHelper.AssertContents("\"\"", output);
+
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output, writerOptions))
+            {
+                writer.WriteStringValue(str.AsSpan());
+            }
+            JsonTestHelper.AssertContents("\"\"", output);
+
+            byte[] utf8Str = null;
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output))
+            {
+                writer.WriteStringValue(utf8Str.AsSpan());
+            }
+            JsonTestHelper.AssertContents("\"\"", output);
+
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output, writerOptions))
+            {
+                writer.WriteStringValue(utf8Str.AsSpan());
+            }
+            JsonTestHelper.AssertContents("\"\"", output);
+
+            JsonEncodedText jsonText = JsonEncodedText.Encode(utf8Str.AsSpan());
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output))
+            {
+                writer.WriteStringValue(jsonText);
+            }
+            JsonTestHelper.AssertContents("\"\"", output);
+
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output, writerOptions))
+            {
+                writer.WriteStringValue(jsonText);
+            }
+            JsonTestHelper.AssertContents("\"\"", output);
+        }
+
+        [Fact]
+        public static void WritingNullStringsWithBuggyJavascriptEncoder()
+        {
+            var output = new ArrayBufferWriter<byte>();
+            var writerOptions = new JsonWriterOptions { Encoder = new BuggyJavaScriptEncoder() };
+
+            string str = null;
+
+            using (var writer = new Utf8JsonWriter(output))
+            {
+                writer.WriteStringValue(str);
+            }
+            JsonTestHelper.AssertContents("null", output);
+
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output, writerOptions))
+            {
+                writer.WriteStringValue(str);
+            }
+            JsonTestHelper.AssertContents("null", output);
+
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output))
+            {
+                writer.WriteStringValue(str.AsSpan());
+            }
+            JsonTestHelper.AssertContents("\"\"", output);
+
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output, writerOptions))
+            {
+                writer.WriteStringValue(str.AsSpan());
+            }
+            JsonTestHelper.AssertContents("\"\"", output);
+
+            byte[] utf8Str = null;
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output))
+            {
+                writer.WriteStringValue(utf8Str.AsSpan());
+            }
+            JsonTestHelper.AssertContents("\"\"", output);
+
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output, writerOptions))
+            {
+                writer.WriteStringValue(utf8Str.AsSpan());
+            }
+            JsonTestHelper.AssertContents("\"\"", output);
+
+            JsonEncodedText jsonText = JsonEncodedText.Encode(utf8Str.AsSpan());
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output))
+            {
+                writer.WriteStringValue(jsonText);
+            }
+            JsonTestHelper.AssertContents("\"\"", output);
+
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output, writerOptions))
+            {
+                writer.WriteStringValue(jsonText);
+            }
+            JsonTestHelper.AssertContents("\"\"", output);
+        }
+
+        public class BuggyJavaScriptEncoder : JavaScriptEncoder
+        {
+            public override int MaxOutputCharactersPerInputCharacter => throw new NotImplementedException();
+
+            public override unsafe int FindFirstCharacterToEncode(char* text, int textLength)
+            {
+                // Access the text pointer even though it might be null and text length is 0.
+                return *text;
+            }
+
+            public override unsafe bool TryEncodeUnicodeScalar(int unicodeScalar, char* buffer, int bufferLength, out int numberOfCharactersWritten)
+            {
+                numberOfCharactersWritten = 0;
+                return false;
+            }
+
+            public override bool WillEncode(int unicodeScalar) => false;
+        }
+
+        [Fact]
         public static void WritingStringsWithCustomEscaping()
         {
             var output = new ArrayBufferWriter<byte>();

--- a/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
@@ -57,6 +57,54 @@ namespace System.Text.Json.Tests
         }
 
         [Fact]
+        public static void WritingStringsWithCustomEscaping()
+        {
+            var output = new ArrayBufferWriter<byte>();
+            var writerOptions = new JsonWriterOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
+
+            using (var writer = new Utf8JsonWriter(output))
+            {
+                writer.WriteStringValue("\u6D4B\u8A6611");
+            }
+            JsonTestHelper.AssertContents("\"\\u6D4B\\u8A6611\"", output);
+
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output, writerOptions))
+            {
+                writer.WriteStringValue("\u6D4B\u8A6611");
+            }
+            JsonTestHelper.AssertContents("\"\u6D4B\u8A6611\"", output);
+
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output))
+            {
+                writer.WriteStringValue("\u00E9\"");
+            }
+            JsonTestHelper.AssertContents("\"\\u00E9\\u0022\"", output);
+
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output, writerOptions))
+            {
+                writer.WriteStringValue("\u00E9\"");
+            }
+            JsonTestHelper.AssertContents("\"\u00E9\\\"\"", output);
+
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output))
+            {
+                writer.WriteStringValue("\u2020\"");
+            }
+            JsonTestHelper.AssertContents("\"\\u2020\\u0022\"", output);
+
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output, writerOptions))
+            {
+                writer.WriteStringValue("\u2020\"");
+            }
+            JsonTestHelper.AssertContents("\"\u2020\\\"\"", output);
+        }
+
+        [Fact]
         public void WriteJsonWritesToIBWOnDemand_Dispose()
         {
             var output = new ArrayBufferWriter<byte>();


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/40979 in master.

This is meant to be a targeted fix to be ported to 3.0.

cc @steveharter, @GrabYourPitchforks, @pranavkm, @ericstj  