### PR TITLE
[release/3.0] Avoid MemoryMarshal.Cast when transcoding from UTF-16 to UTF-8 while escaping in Utf8JsonWriter.

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Escaping.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Escaping.cs
@@ -79,13 +79,16 @@ namespace System.Text.Json
             return idx;
         }
 
-        public static int NeedsEscaping(ReadOnlySpan<char> value, JavaScriptEncoder encoder)
+        public static unsafe int NeedsEscaping(ReadOnlySpan<char> value, JavaScriptEncoder encoder)
         {
             int idx;
 
             if (encoder != null)
             {
-                idx = encoder.FindFirstCharacterToEncodeUtf8(MemoryMarshal.Cast<char, byte>(value));
+                fixed (char* ptr = value)
+                {
+                    idx = encoder.FindFirstCharacterToEncode(ptr, value.Length);
+                }
                 goto Return;
             }
 

--- a/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Escaping.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Escaping.cs
@@ -83,7 +83,9 @@ namespace System.Text.Json
         {
             int idx;
 
-            if (encoder != null)
+            // Some implementations of JavascriptEncoder.FindFirstCharacterToEncode may not accept
+            // null pointers and gaurd against that. Hence, check up-front and fall down to return -1.
+            if (encoder != null && !value.IsEmpty)
             {
                 fixed (char* ptr = value)
                 {

--- a/src/System.Text.Json/tests/Serialization/Value.WriteTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.WriteTests.cs
@@ -22,6 +22,18 @@ namespace System.Text.Json.Serialization.Tests
             Assert.NotEqual(expected, JsonSerializer.Serialize(inputString));
         }
 
+        // https://github.com/dotnet/corefx/issues/40979
+        [Fact]
+        public static void EscapingShouldntStackOverflow_40979()
+        {
+            var test = new { Name = "\u6D4B\u8A6611" };
+
+            var options = new JsonSerializerOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping, PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+            string result = JsonSerializer.Serialize(test, options);
+
+            Assert.Equal("{\"name\": \"\u6D4B\u8A6611\"}", result);
+        }
+
         [Fact]
         public static void WritePrimitives()
         {

--- a/src/System.Text.Json/tests/Serialization/Value.WriteTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.WriteTests.cs
@@ -31,7 +31,7 @@ namespace System.Text.Json.Serialization.Tests
             var options = new JsonSerializerOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping, PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
             string result = JsonSerializer.Serialize(test, options);
 
-            Assert.Equal("{\"name\": \"\u6D4B\u8A6611\"}", result);
+            Assert.Equal("{\"name\":\"\u6D4B\u8A6611\"}", result);
         }
 
         [Fact]

--- a/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
@@ -59,7 +59,13 @@ namespace System.Text.Json.Tests
         [Fact]
         public static void WritingNullStringsWithCustomEscaping()
         {
-            var writerOptions = new JsonWriterOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
+            var writerOptions = new JsonWriterOptions();
+            WriteNullStringsHelper(writerOptions);
+
+            writerOptions = new JsonWriterOptions { Encoder = JavaScriptEncoder.Default };
+            WriteNullStringsHelper(writerOptions);
+
+            writerOptions = new JsonWriterOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
             WriteNullStringsHelper(writerOptions);
         }
 
@@ -75,25 +81,11 @@ namespace System.Text.Json.Tests
             var output = new ArrayBufferWriter<byte>();
             string str = null;
 
-            using (var writer = new Utf8JsonWriter(output))
-            {
-                writer.WriteStringValue(str);
-            }
-            JsonTestHelper.AssertContents("null", output);
-
-            output.Clear();
             using (var writer = new Utf8JsonWriter(output, writerOptions))
             {
                 writer.WriteStringValue(str);
             }
             JsonTestHelper.AssertContents("null", output);
-
-            output.Clear();
-            using (var writer = new Utf8JsonWriter(output))
-            {
-                writer.WriteStringValue(str.AsSpan());
-            }
-            JsonTestHelper.AssertContents("\"\"", output);
 
             output.Clear();
             using (var writer = new Utf8JsonWriter(output, writerOptions))
@@ -104,13 +96,6 @@ namespace System.Text.Json.Tests
 
             byte[] utf8Str = null;
             output.Clear();
-            using (var writer = new Utf8JsonWriter(output))
-            {
-                writer.WriteStringValue(utf8Str.AsSpan());
-            }
-            JsonTestHelper.AssertContents("\"\"", output);
-
-            output.Clear();
             using (var writer = new Utf8JsonWriter(output, writerOptions))
             {
                 writer.WriteStringValue(utf8Str.AsSpan());
@@ -118,13 +103,6 @@ namespace System.Text.Json.Tests
             JsonTestHelper.AssertContents("\"\"", output);
 
             JsonEncodedText jsonText = JsonEncodedText.Encode(utf8Str.AsSpan());
-            output.Clear();
-            using (var writer = new Utf8JsonWriter(output))
-            {
-                writer.WriteStringValue(jsonText);
-            }
-            JsonTestHelper.AssertContents("\"\"", output);
-
             output.Clear();
             using (var writer = new Utf8JsonWriter(output, writerOptions))
             {

--- a/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
@@ -59,75 +59,20 @@ namespace System.Text.Json.Tests
         [Fact]
         public static void WritingNullStringsWithCustomEscaping()
         {
-            var output = new ArrayBufferWriter<byte>();
             var writerOptions = new JsonWriterOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
-
-            string str = null;
-
-            using (var writer = new Utf8JsonWriter(output))
-            {
-                writer.WriteStringValue(str);
-            }
-            JsonTestHelper.AssertContents("null", output);
-
-            output.Clear();
-            using (var writer = new Utf8JsonWriter(output, writerOptions))
-            {
-                writer.WriteStringValue(str);
-            }
-            JsonTestHelper.AssertContents("null", output);
-
-            output.Clear();
-            using (var writer = new Utf8JsonWriter(output))
-            {
-                writer.WriteStringValue(str.AsSpan());
-            }
-            JsonTestHelper.AssertContents("\"\"", output);
-
-            output.Clear();
-            using (var writer = new Utf8JsonWriter(output, writerOptions))
-            {
-                writer.WriteStringValue(str.AsSpan());
-            }
-            JsonTestHelper.AssertContents("\"\"", output);
-
-            byte[] utf8Str = null;
-            output.Clear();
-            using (var writer = new Utf8JsonWriter(output))
-            {
-                writer.WriteStringValue(utf8Str.AsSpan());
-            }
-            JsonTestHelper.AssertContents("\"\"", output);
-
-            output.Clear();
-            using (var writer = new Utf8JsonWriter(output, writerOptions))
-            {
-                writer.WriteStringValue(utf8Str.AsSpan());
-            }
-            JsonTestHelper.AssertContents("\"\"", output);
-
-            JsonEncodedText jsonText = JsonEncodedText.Encode(utf8Str.AsSpan());
-            output.Clear();
-            using (var writer = new Utf8JsonWriter(output))
-            {
-                writer.WriteStringValue(jsonText);
-            }
-            JsonTestHelper.AssertContents("\"\"", output);
-
-            output.Clear();
-            using (var writer = new Utf8JsonWriter(output, writerOptions))
-            {
-                writer.WriteStringValue(jsonText);
-            }
-            JsonTestHelper.AssertContents("\"\"", output);
+            WriteNullStringsHelper(writerOptions);
         }
 
         [Fact]
         public static void WritingNullStringsWithBuggyJavascriptEncoder()
         {
-            var output = new ArrayBufferWriter<byte>();
             var writerOptions = new JsonWriterOptions { Encoder = new BuggyJavaScriptEncoder() };
+            WriteNullStringsHelper(writerOptions);
+        }
 
+        private static void WriteNullStringsHelper(JsonWriterOptions writerOptions)
+        {
+            var output = new ArrayBufferWriter<byte>();
             string str = null;
 
             using (var writer = new Utf8JsonWriter(output))

--- a/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
@@ -57,6 +57,157 @@ namespace System.Text.Json.Tests
         }
 
         [Fact]
+        public static void WritingNullStringsWithCustomEscaping()
+        {
+            var output = new ArrayBufferWriter<byte>();
+            var writerOptions = new JsonWriterOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
+
+            string str = null;
+
+            using (var writer = new Utf8JsonWriter(output))
+            {
+                writer.WriteStringValue(str);
+            }
+            JsonTestHelper.AssertContents("null", output);
+
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output, writerOptions))
+            {
+                writer.WriteStringValue(str);
+            }
+            JsonTestHelper.AssertContents("null", output);
+
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output))
+            {
+                writer.WriteStringValue(str.AsSpan());
+            }
+            JsonTestHelper.AssertContents("\"\"", output);
+
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output, writerOptions))
+            {
+                writer.WriteStringValue(str.AsSpan());
+            }
+            JsonTestHelper.AssertContents("\"\"", output);
+
+            byte[] utf8Str = null;
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output))
+            {
+                writer.WriteStringValue(utf8Str.AsSpan());
+            }
+            JsonTestHelper.AssertContents("\"\"", output);
+
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output, writerOptions))
+            {
+                writer.WriteStringValue(utf8Str.AsSpan());
+            }
+            JsonTestHelper.AssertContents("\"\"", output);
+
+            JsonEncodedText jsonText = JsonEncodedText.Encode(utf8Str.AsSpan());
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output))
+            {
+                writer.WriteStringValue(jsonText);
+            }
+            JsonTestHelper.AssertContents("\"\"", output);
+
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output, writerOptions))
+            {
+                writer.WriteStringValue(jsonText);
+            }
+            JsonTestHelper.AssertContents("\"\"", output);
+        }
+
+        [Fact]
+        public static void WritingNullStringsWithBuggyJavascriptEncoder()
+        {
+            var output = new ArrayBufferWriter<byte>();
+            var writerOptions = new JsonWriterOptions { Encoder = new BuggyJavaScriptEncoder() };
+
+            string str = null;
+
+            using (var writer = new Utf8JsonWriter(output))
+            {
+                writer.WriteStringValue(str);
+            }
+            JsonTestHelper.AssertContents("null", output);
+
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output, writerOptions))
+            {
+                writer.WriteStringValue(str);
+            }
+            JsonTestHelper.AssertContents("null", output);
+
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output))
+            {
+                writer.WriteStringValue(str.AsSpan());
+            }
+            JsonTestHelper.AssertContents("\"\"", output);
+
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output, writerOptions))
+            {
+                writer.WriteStringValue(str.AsSpan());
+            }
+            JsonTestHelper.AssertContents("\"\"", output);
+
+            byte[] utf8Str = null;
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output))
+            {
+                writer.WriteStringValue(utf8Str.AsSpan());
+            }
+            JsonTestHelper.AssertContents("\"\"", output);
+
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output, writerOptions))
+            {
+                writer.WriteStringValue(utf8Str.AsSpan());
+            }
+            JsonTestHelper.AssertContents("\"\"", output);
+
+            JsonEncodedText jsonText = JsonEncodedText.Encode(utf8Str.AsSpan());
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output))
+            {
+                writer.WriteStringValue(jsonText);
+            }
+            JsonTestHelper.AssertContents("\"\"", output);
+
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output, writerOptions))
+            {
+                writer.WriteStringValue(jsonText);
+            }
+            JsonTestHelper.AssertContents("\"\"", output);
+        }
+
+        public class BuggyJavaScriptEncoder : JavaScriptEncoder
+        {
+            public override int MaxOutputCharactersPerInputCharacter => throw new NotImplementedException();
+
+            public override unsafe int FindFirstCharacterToEncode(char* text, int textLength)
+            {
+                // Access the text pointer even though it might be null and text length is 0.
+                return *text;
+            }
+
+            public override unsafe bool TryEncodeUnicodeScalar(int unicodeScalar, char* buffer, int bufferLength, out int numberOfCharactersWritten)
+            {
+                numberOfCharactersWritten = 0;
+                return false;
+            }
+
+            public override bool WillEncode(int unicodeScalar) => false;
+        }
+
+        [Fact]
         public static void WritingStringsWithCustomEscaping()
         {
             var output = new ArrayBufferWriter<byte>();

--- a/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
@@ -57,6 +57,54 @@ namespace System.Text.Json.Tests
         }
 
         [Fact]
+        public static void WritingStringsWithCustomEscaping()
+        {
+            var output = new ArrayBufferWriter<byte>();
+            var writerOptions = new JsonWriterOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
+
+            using (var writer = new Utf8JsonWriter(output))
+            {
+                writer.WriteStringValue("\u6D4B\u8A6611");
+            }
+            JsonTestHelper.AssertContents("\"\\u6D4B\\u8A6611\"", output);
+
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output, writerOptions))
+            {
+                writer.WriteStringValue("\u6D4B\u8A6611");
+            }
+            JsonTestHelper.AssertContents("\"\u6D4B\u8A6611\"", output);
+
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output))
+            {
+                writer.WriteStringValue("\u00E9\"");
+            }
+            JsonTestHelper.AssertContents("\"\\u00E9\\u0022\"", output);
+
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output, writerOptions))
+            {
+                writer.WriteStringValue("\u00E9\"");
+            }
+            JsonTestHelper.AssertContents("\"\u00E9\\\"\"", output);
+
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output))
+            {
+                writer.WriteStringValue("\u2020\"");
+            }
+            JsonTestHelper.AssertContents("\"\\u2020\\u0022\"", output);
+
+            output.Clear();
+            using (var writer = new Utf8JsonWriter(output, writerOptions))
+            {
+                writer.WriteStringValue("\u2020\"");
+            }
+            JsonTestHelper.AssertContents("\"\u2020\\\"\"", output);
+        }
+
+        [Fact]
         public void WriteJsonWritesToIBWOnDemand_Dispose()
         {
             var output = new ArrayBufferWriter<byte>();


### PR DESCRIPTION
Port of https://github.com/dotnet/corefx/pull/40996 to fix https://github.com/dotnet/corefx/issues/40979

## Description

Instead of using `MemoryMarshal` to re-interpret cast a span of UTF-16 chars to bytes (to pass them to APIs expecting UTF-8 data), call the JavascriptEncoder API that expects UTF-16 chars instead. Casting char to byte doesn't transode it from UTF-16 to UTF-8 which was the previous intention. Doing so results in certain invariants in the code to break since the resulting index that points to the first character to escape would be incorrect (or even out of the bounds of the original span), which results in a negative value being passed in to stackalloc (and hence a stackoverflow). The issue is in the code-path where a custom encoder is passed in (and wouldn't happen by default).

## Customer Impact

The bug was customer-reported where the user observed a stackoverflow in an ASP.NET WebAPI (which uses a custom encoder) when trying to serialize a string that contained non-ascii characters (for example chinese caracters). Generally, any use of the `JsonSerializer` or `Utf8JsonWriter` where a custom encoder is involved for writing .NET strings as JSON is affected. It is imperative that the escaping behavior of the serializer is functionally correct.

## Regression?

Introduced in .NET Core 3.0 - preview 8

## Risk

The risk of this change is around the escaping behavior changing when the user passes in a custom escaper. Be default, the JSON stack uses the default escaper which isn't affected by this change. However, the ASP.NET defaults to a custom escaper so end-users are more likely to be affected by this escaping behavior and fix. There is no easy workaround for the user since passing in a custom/default encoder wouldn't always work either.

## Tests run / added

* Regression test for the serializer was added along with targeted tests of the writer itself (which the serializer uses under the covers).
* Verified end-to-end in an ASP.NET Web API app that writing non-ascii strings with the custom escaper works as expected.

cc @steveharter, @GrabYourPitchforks, @pranavkm, @ericstj  