### PR TITLE
Fix SqlParameter with xml schema construction

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameter.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameter.cs
@@ -261,7 +261,7 @@ namespace System.Data.SqlClient
             }
             set
             {
-                bool collectionIsNull = _xmlSchemaCollection != null;
+                bool collectionIsNull = _xmlSchemaCollection is null;
                 if (collectionIsNull)
                 {
                     _xmlSchemaCollection = new SqlMetaDataXmlSchemaCollection();
@@ -281,7 +281,7 @@ namespace System.Data.SqlClient
             }
             set
             {
-                bool collectionIsNull = _xmlSchemaCollection != null;
+                bool collectionIsNull = _xmlSchemaCollection is null;
                 if (collectionIsNull)
                 {
                     _xmlSchemaCollection = new SqlMetaDataXmlSchemaCollection();
@@ -301,7 +301,7 @@ namespace System.Data.SqlClient
             }
             set
             {
-                bool collectionIsNull = _xmlSchemaCollection != null;
+                bool collectionIsNull = _xmlSchemaCollection is null;
                 if (collectionIsNull)
                 {
                     _xmlSchemaCollection = new SqlMetaDataXmlSchemaCollection();

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameter.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameter.cs
@@ -261,12 +261,7 @@ namespace System.Data.SqlClient
             }
             set
             {
-                bool collectionIsNull = _xmlSchemaCollection is null;
-                if (collectionIsNull)
-                {
-                    _xmlSchemaCollection = new SqlMetaDataXmlSchemaCollection();
-                }
-                if (value != null || collectionIsNull)
+                if (ShouldAssignXmlSchemaCollectionValue(value))
                 {
                     _xmlSchemaCollection.Database = value;
                 }
@@ -281,12 +276,7 @@ namespace System.Data.SqlClient
             }
             set
             {
-                bool collectionIsNull = _xmlSchemaCollection is null;
-                if (collectionIsNull)
-                {
-                    _xmlSchemaCollection = new SqlMetaDataXmlSchemaCollection();
-                }
-                if (value != null || collectionIsNull)
+                if (ShouldAssignXmlSchemaCollectionValue(value))
                 {
                     _xmlSchemaCollection.OwningSchema = value;
                 }
@@ -301,12 +291,7 @@ namespace System.Data.SqlClient
             }
             set
             {
-                bool collectionIsNull = _xmlSchemaCollection is null;
-                if (collectionIsNull)
-                {
-                    _xmlSchemaCollection = new SqlMetaDataXmlSchemaCollection();
-                }
-                if (value != null || collectionIsNull)
+                if (ShouldAssignXmlSchemaCollectionValue(value))
                 {
                     _xmlSchemaCollection.Name = value;
                 }
@@ -1975,6 +1960,32 @@ namespace System.Data.SqlClient
                 {
                     throw SQL.InvalidParameterTypeNameFormat();
                 }
+            }
+        }
+
+        /// <summary>
+        /// This method will decide whether the lazy allocated backing object for_xmlSchemaCollection is needed
+        /// and create it if it is needed and is currently null. The return value indicates whether the caller
+        /// should assign the value to the desired property
+        /// </summary>
+        /// <param name="value">the value which is going to be set to one of the properties</param>
+        /// <returns>true means that the assignment is needed. false means that it would result in no visible change</returns>
+        private bool ShouldAssignXmlSchemaCollectionValue(string value)
+        {
+            bool isNull = _xmlSchemaCollection is null;
+            if (!string.IsNullOrEmpty(value))
+            {
+                // not null or empty so we need to make a place to put it if we don't already have one
+                if (isNull)
+                {
+                    _xmlSchemaCollection = new SqlMetaDataXmlSchemaCollection();
+                }
+                return true;
+            }
+            else
+            {
+                // value is null or empty so we only need to assign if we might already have a value to overwrite
+                return !isNull;
             }
         }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameter.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameter.cs
@@ -261,10 +261,8 @@ namespace System.Data.SqlClient
             }
             set
             {
-                if (ShouldAssignXmlSchemaCollectionValue(value))
-                {
-                    _xmlSchemaCollection.Database = value;
-                }
+                EnsureXmlSchemaCollectionExists();
+                _xmlSchemaCollection.Database = value;
             }
         }
 
@@ -276,10 +274,8 @@ namespace System.Data.SqlClient
             }
             set
             {
-                if (ShouldAssignXmlSchemaCollectionValue(value))
-                {
-                    _xmlSchemaCollection.OwningSchema = value;
-                }
+                EnsureXmlSchemaCollectionExists();
+                _xmlSchemaCollection.OwningSchema = value;
             }
         }
 
@@ -291,10 +287,8 @@ namespace System.Data.SqlClient
             }
             set
             {
-                if (ShouldAssignXmlSchemaCollectionValue(value))
-                {
-                    _xmlSchemaCollection.Name = value;
-                }
+                EnsureXmlSchemaCollectionExists();
+                _xmlSchemaCollection.Name = value;
             }
         }
 
@@ -1963,29 +1957,11 @@ namespace System.Data.SqlClient
             }
         }
 
-        /// <summary>
-        /// This method will decide whether the lazy allocated backing object for_xmlSchemaCollection is needed
-        /// and create it if it is needed and is currently null. The return value indicates whether the caller
-        /// should assign the value to the desired property
-        /// </summary>
-        /// <param name="value">the value which is going to be set to one of the properties</param>
-        /// <returns>true means that the assignment is needed. false means that it would result in no visible change</returns>
-        private bool ShouldAssignXmlSchemaCollectionValue(string value)
+        private void EnsureXmlSchemaCollectionExists()
         {
-            bool isNull = _xmlSchemaCollection is null;
-            if (!string.IsNullOrEmpty(value))
+            if (_xmlSchemaCollection is null)
             {
-                // not null or empty so we need to make a place to put it if we don't already have one
-                if (isNull)
-                {
-                    _xmlSchemaCollection = new SqlMetaDataXmlSchemaCollection();
-                }
-                return true;
-            }
-            else
-            {
-                // value is null or empty so we only need to assign if we might already have a value to overwrite
-                return !isNull;
+                _xmlSchemaCollection = new SqlMetaDataXmlSchemaCollection();
             }
         }
 

--- a/src/System.Data.SqlClient/tests/FunctionalTests/SqlParameterTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/SqlParameterTest.cs
@@ -38,5 +38,29 @@ namespace System.Data.SqlClient.Tests
             Assert.Equal(10, parameter.Precision);
             Assert.Equal(5, parameter.Scale);
         }
+
+        [Fact]
+        public void CreateParameterWithXmlSchema()
+        {
+            string xmlDatabase = "database";
+            string xmlSchema = "schema";
+            string xmlName = "name";
+
+            SqlParameter parameter = new SqlParameter("@name", SqlDbType.Int, 4, ParameterDirection.Input, 0, 0, "name", DataRowVersion.Original, false, 1, xmlDatabase, xmlSchema, xmlName);
+
+            Assert.Equal(xmlDatabase, parameter.XmlSchemaCollectionDatabase);
+            Assert.Equal(xmlSchema, parameter.XmlSchemaCollectionOwningSchema);
+            Assert.Equal(xmlName, parameter.XmlSchemaCollectionName);
+        }
+
+        [Fact]
+        public void CreateParameterWithoutXmlSchema()
+        {
+            SqlParameter parameter = new SqlParameter();
+
+            Assert.Equal(string.Empty, parameter.XmlSchemaCollectionDatabase);
+            Assert.Equal(string.Empty, parameter.XmlSchemaCollectionOwningSchema);
+            Assert.Equal(string.Empty, parameter.XmlSchemaCollectionName);
+        }
     }
 }

--- a/src/System.Data.SqlClient/tests/FunctionalTests/SqlParameterTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/SqlParameterTest.cs
@@ -40,7 +40,7 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
-        public void CreateParameterWithXmlSchema()
+        public void CreateParameterWithValidXmlSchema()
         {
             string xmlDatabase = "database";
             string xmlSchema = "schema";
@@ -54,12 +54,52 @@ namespace System.Data.SqlClient.Tests
         }
 
         [Fact]
+        public void CreateParameterWithEmptyXmlSchema()
+        {
+            SqlParameter parameter = new SqlParameter("@name", SqlDbType.Int, 4, ParameterDirection.Input, 0, 0, "name", DataRowVersion.Original, false, 1, string.Empty, string.Empty, string.Empty);
+
+            Assert.Equal(string.Empty, parameter.XmlSchemaCollectionDatabase);
+            Assert.Equal(string.Empty, parameter.XmlSchemaCollectionOwningSchema);
+            Assert.Equal(string.Empty, parameter.XmlSchemaCollectionName);
+        }
+
+        [Fact]
+        public void CreateParameterWithNullXmlSchema()
+        {
+            SqlParameter parameter = new SqlParameter("@name", SqlDbType.Int, 4, ParameterDirection.Input, 0, 0, "name", DataRowVersion.Original, false, 1, null, null, null);
+
+            Assert.Equal(string.Empty, parameter.XmlSchemaCollectionDatabase);
+            Assert.Equal(string.Empty, parameter.XmlSchemaCollectionOwningSchema);
+            Assert.Equal(string.Empty, parameter.XmlSchemaCollectionName);
+        }
+
+        [Fact]
         public void CreateParameterWithoutXmlSchema()
         {
             SqlParameter parameter = new SqlParameter();
 
             Assert.Equal(string.Empty, parameter.XmlSchemaCollectionDatabase);
             Assert.Equal(string.Empty, parameter.XmlSchemaCollectionOwningSchema);
+            Assert.Equal(string.Empty, parameter.XmlSchemaCollectionName);
+        }
+
+        [Fact]
+        public void SetParameterXmlSchema()
+        {
+            SqlParameter parameter = new SqlParameter();
+
+            Assert.Equal(string.Empty, parameter.XmlSchemaCollectionName);
+
+            // verify that if we set it to null we still get an empty string back
+            parameter.XmlSchemaCollectionName = null;
+            Assert.Equal(string.Empty, parameter.XmlSchemaCollectionName);
+
+            // verify that if we set a value we get it back
+            parameter.XmlSchemaCollectionName = "name";
+            Assert.Equal("name", parameter.XmlSchemaCollectionName);
+
+            // verify that if we set it explicitly to null it reverts to empty string
+            parameter.XmlSchemaCollectionName = null;
             Assert.Equal(string.Empty, parameter.XmlSchemaCollectionName);
         }
     }


### PR DESCRIPTION
Fixes issue #41141 which is a bug in the corefx version not ported to Microsoft.Data.SqlClient yet and adds tests to verify the corrected and default behaviour of xml properties on `SqParameter`. The tests will run under CI.

This bug prevents the use of `TableAdapter`s with autogenerated update commands 

/cc reporter HSchwichtenberg, owners @david-engel, @Gary-Zh,  @cheenamalhotra and tracking @ErikEJ