### PR TITLE
Setting version suffix as non empty for building release package versions

### DIFF
--- a/eng/Packaging.targets
+++ b/eng/Packaging.targets
@@ -26,4 +26,8 @@
                       '$(_excludeCompile)' == 'true' AND
                       '%(Dependency.Identity)' != '_._'" />
   </Target>
+ 
+  <PropertyGroup>
+    <VersionSuffix>$(_PreReleaseLabel)$(_BuildNumberLabels)</VersionSuffix>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Currently we are getting this error while building packages in release mode
```
##[error].packages\microsoft.dotnet.build.tasks.packaging\1.0.0-beta.19456.3\build\Packaging.targets(828,5): error : (NETCORE_ENGINEERING_TELEMETRY=Build) No VersionSuffix was set. Ensure it is set before targets in packaging are ran.
```

Corefx does not depend on version suffix property to check if any of the dependencies are stable or not. We use packageIndex.Json file for that check.
We always require version suffix to be not null.
