### PR TITLE
Fix icon entry selection

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/Icon.Windows.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Icon.Windows.cs
@@ -525,7 +525,7 @@ namespace System.Drawing
                         int thisDelta = Math.Abs(entry.bWidth - width) + Math.Abs(entry.bHeight - height);
 
                         if ((thisDelta < bestDelta) ||
-                            (thisDelta == bestDelta && (0 <= s_bitDepth && 0 > _bestBitDepth || _bestBitDepth > s_bitDepth && 0 < _bestBitDepth)))
+                            (thisDelta == bestDelta && (iconBitDepth <= s_bitDepth && iconBitDepth > _bestBitDepth || _bestBitDepth > s_bitDepth && iconBitDepth < _bestBitDepth)))
                         {
                             fUpdateBestFit = true;
                         }

--- a/src/System.Drawing.Common/tests/IconTests.cs
+++ b/src/System.Drawing.Common/tests/IconTests.cs
@@ -827,5 +827,23 @@ namespace System.Drawing.Tests
                 }
             }
         }
+
+        [ConditionalFact(Helpers.IsDrawingSupported)]
+        public void CorrectColorDepthExtracted()
+        {
+            using (var stream = File.OpenRead(Helpers.GetTestBitmapPath("pngwithheight_icon.ico")))
+            {
+                using (var icon = new Icon(stream, new Size(32, 32)))
+                {
+                    // The first 32x32 icon isn't 32 bit. Checking a few pixels that are in the 32 bit entry.
+                    using (Bitmap bitmap = icon.ToBitmap())
+                    {
+                        // If the first icon entry was picked, the color would be black: 0xFF000000?
+                        Assert.Equal(0x879EE532u, (uint)bitmap.GetPixel(0, 0).ToArgb());
+                        Assert.Equal(0x661CD8B7u, (uint)bitmap.GetPixel(0, 31).ToArgb());
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
We weren't checking the color depth properly when chosing an icon entry to extract from an icon file.

Fix, and add a test.

This is a regression I introduced in 3.0. It will need to work it's way into 3.0.