### PR TITLE
Making debugging of packageTesting easier.

### DIFF
--- a/pkg/test/test.msbuild
+++ b/pkg/test/test.msbuild
@@ -6,6 +6,7 @@
   <PropertyGroup>
     <PackageTestProjectsDir Condition="'$(PackageTestProjectsDir)' == ''">$(MSBuildThisFileDirectory)..\projects</PackageTestProjectsDir>
     <_projectProperties>SupportFilesDir=$(MSBuildThisFileDirectory)</_projectProperties>
+    <LocalPackagesPath Condition="'$(LocalPackagesPath)' == ''">$(MSBuildThisFileDirectory)\packages</LocalPackagesPath>
   </PropertyGroup>
 
   <Target Name="GetProjects">
@@ -19,7 +20,7 @@
           Inputs="@(Project)"
           Outputs="@(Project->'%(RootDir)%(Directory)obj\project.assets.json')"
           DependsOnTargets="GetProjects">
-    <MSBuild Projects="@(Project)" Targets="Restore" BuildInParallel="true" Properties="$(_projectProperties)" />
+    <MSBuild Projects="@(Project)" Targets="Restore" BuildInParallel="true" Properties="$(_projectProperties);LocalPackagesPath=$(LocalPackagesPath)" />
     <Touch Files="@(Project->'%(RootDir)%(Directory)obj\project.assets.json')" />
   </Target>
 


### PR DESCRIPTION
Instead of always manually passing the LocalPackagesPath this will pass the default path where generally local built packages are kept.