### PR TITLE
Synchronize Http/2 HPack implementation between CoreFx and ASP.NET Core

### DIFF
--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -119,6 +119,7 @@
   <!-- SocketsHttpHandler implementation -->
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
     <Compile Include="System\Net\Http\SocketsHttpHandler\HPack\DynamicTable.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\IHttpHeadersHandler.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HPack\HPackDecoder.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HPack\HPackDecodingException.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HPack\Huffman.cs" />

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -91,6 +91,8 @@
     <Compile Include="System\Net\Http\Headers\WarningHeaderValue.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HPack\HeaderField.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HPack\HPackEncoder.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\HPack\HPackEncodingException.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\HPack\StatusCodes.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HPack\IntegerEncoder.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HPack\StaticTable.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\SystemProxyInfo.cs" />

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/DynamicTable.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/DynamicTable.cs
@@ -69,8 +69,6 @@ namespace System.Net.Http.HPack
 
         public void Resize(int maxSize)
         {
-            // TODO: What would cause us to need to grow the table size? The connection-level limit should prevent this, right?
-            // Understand this better. If we do need to resize, we may want a better resize strategy.
             if (maxSize > _maxSize)
             {
                 var newBuffer = new HeaderField[maxSize / HeaderField.RfcOverhead];

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackDecoder.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackDecoder.cs
@@ -261,7 +261,7 @@ namespace System.Net.Http.HPack
                     {
                         // Can't happen
                         Debug.Fail("Unreachable code");
-                        throw new InvalidOperationException("Unreachable code hit.");
+                        throw new InvalidOperationException("Unreachable code.");
                     }
 
                     break;

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackDecoder.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackDecoder.cs
@@ -111,9 +111,9 @@ namespace System.Net.Http.HPack
             _maxResponseHeadersLength = maxResponseHeadersLength;
             _dynamicTable = dynamicTable;
 
-            _stringOctets = new byte[maxResponseHeadersLength];
-            _headerNameOctets = new byte[maxResponseHeadersLength];
-            _headerValueOctets = new byte[maxResponseHeadersLength];
+            _stringOctets = new byte[DefaultStringOctetsSize];
+            _headerNameOctets = new byte[DefaultStringOctetsSize];
+            _headerValueOctets = new byte[DefaultStringOctetsSize];
         }
 
         public void Decode(in ReadOnlySequence<byte> data, bool endHeaders, IHttpHeadersHandler handler)
@@ -130,7 +130,7 @@ namespace System.Net.Http.HPack
             CheckIncompleteHeaderBlock(endHeaders);
         }
 
-        public void Decode(in ReadOnlySpan<byte> data, bool endHeaders, IHttpHeadersHandler handler)
+        public void Decode(ReadOnlySpan<byte> data, bool endHeaders, IHttpHeadersHandler handler)
         {
             for (int i = 0; i < data.Length; i++)
             {
@@ -261,7 +261,7 @@ namespace System.Net.Http.HPack
                     {
                         // Can't happen
                         Debug.Fail("Unreachable code");
-                        throw new InvalidOperationException();
+                        throw new InvalidOperationException("Unreachable code hit.");
                     }
 
                     break;
@@ -397,7 +397,7 @@ namespace System.Net.Http.HPack
         private void OnIndexedHeaderField(int index, IHttpHeadersHandler handler)
         {
             HeaderField header = GetHeader(index);
-            handler.OnHeader(new Span<byte>(header.Name), new Span<byte>(header.Value));
+            handler.OnHeader(header.Name, header.Value);
             _state = State.Ready;
         }
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackDecoder.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackDecoder.cs
@@ -374,7 +374,7 @@ namespace System.Net.Http.HPack
             var headerNameSpan = new Span<byte>(_headerName, 0, _headerNameLength);
             var headerValueSpan = new Span<byte>(_headerValueOctets, 0, _headerValueLength);
 
-            handler.OnHeader(headerNameSpan, headerValueSpan);
+            handler?.OnHeader(headerNameSpan, headerValueSpan);
 
             if (_index)
             {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackDecoder.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackDecoder.cs
@@ -394,7 +394,7 @@ namespace System.Net.Http.HPack
         private void OnIndexedHeaderField(int index, IHttpHeadersHandler handler)
         {
             HeaderField header = GetHeader(index);
-            handler.OnHeader(header.Name, header.Value);
+            handler?.OnHeader(header.Name, header.Value);
             _state = State.Ready;
         }
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackEncoder.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackEncoder.cs
@@ -2,12 +2,162 @@
 // Licensed under the Apache License, Version 2.0.
 // See THIRD-PARTY-NOTICES.TXT in the project root for license information.
 
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace System.Net.Http.HPack
 {
-    internal static class HPackEncoder
+    internal class HPackEncoder
     {
+        private IEnumerator<KeyValuePair<string, string>> _enumerator;
+
+        public bool BeginEncode(IEnumerable<KeyValuePair<string, string>> headers, Span<byte> buffer, out int length)
+        {
+            _enumerator = headers.GetEnumerator();
+            _enumerator.MoveNext();
+
+            return Encode(buffer, out length);
+        }
+
+        public bool BeginEncode(int statusCode, IEnumerable<KeyValuePair<string, string>> headers, Span<byte> buffer, out int length)
+        {
+            _enumerator = headers.GetEnumerator();
+            _enumerator.MoveNext();
+
+            var statusCodeLength = EncodeStatusCode(statusCode, buffer);
+            var done = Encode(buffer.Slice(statusCodeLength), throwIfNoneEncoded: false, out var headersLength);
+            length = statusCodeLength + headersLength;
+
+            return done;
+        }
+
+        public bool Encode(Span<byte> buffer, out int length)
+        {
+            return Encode(buffer, throwIfNoneEncoded: true, out length);
+        }
+
+        private bool Encode(Span<byte> buffer, bool throwIfNoneEncoded, out int length)
+        {
+            length = 0;
+
+            do
+            {
+                if (!EncodeHeader(_enumerator.Current.Key, _enumerator.Current.Value, buffer.Slice(length), out var headerLength))
+                {
+                    if (length == 0 && throwIfNoneEncoded)
+                    {
+                        throw new HPackEncodingException();
+                    }
+                    return false;
+                }
+
+                length += headerLength;
+            } while (_enumerator.MoveNext());
+
+            return true;
+        }
+
+        private int EncodeStatusCode(int statusCode, Span<byte> buffer)
+        {
+            switch (statusCode)
+            {
+                case 200:
+                case 204:
+                case 206:
+                case 304:
+                case 400:
+                case 404:
+                case 500:
+                    buffer[0] = (byte)(0x80 | StaticTable.StatusIndex[statusCode]);
+                    return 1;
+                default:
+                    // Send as Literal Header Field Without Indexing - Indexed Name
+                    buffer[0] = 0x08;
+
+                    var statusBytes = StatusCodes.ToStatusBytes(statusCode);
+                    buffer[1] = (byte)statusBytes.Length;
+                    ((Span<byte>)statusBytes).CopyTo(buffer.Slice(2));
+
+                    return 2 + statusBytes.Length;
+            }
+        }
+
+        private bool EncodeHeader(string name, string value, Span<byte> buffer, out int length)
+        {
+            var i = 0;
+            length = 0;
+
+            if (buffer.Length == 0)
+            {
+                return false;
+            }
+
+            buffer[i++] = 0;
+
+            if (i == buffer.Length)
+            {
+                return false;
+            }
+
+            if (!EncodeString(name, buffer.Slice(i), out var nameLength, lowercase: true))
+            {
+                return false;
+            }
+
+            i += nameLength;
+
+            if (i >= buffer.Length)
+            {
+                return false;
+            }
+
+            if (!EncodeString(value, buffer.Slice(i), out var valueLength, lowercase: false))
+            {
+                return false;
+            }
+
+            i += valueLength;
+
+            length = i;
+            return true;
+        }
+
+        private bool EncodeString(string s, Span<byte> buffer, out int length, bool lowercase)
+        {
+            const int toLowerMask = 0x20;
+
+            var i = 0;
+            length = 0;
+
+            if (buffer.Length == 0)
+            {
+                return false;
+            }
+
+            buffer[0] = 0;
+
+            if (!IntegerEncoder.Encode(s.Length, 7, buffer, out var nameLength))
+            {
+                return false;
+            }
+
+            i += nameLength;
+
+            // TODO: use huffman encoding
+            for (var j = 0; j < s.Length; j++)
+            {
+                if (i >= buffer.Length)
+                {
+                    return false;
+                }
+
+                buffer[i++] = (byte)(s[j] | (lowercase && s[j] >= (byte)'A' && s[j] <= (byte)'Z' ? toLowerMask : 0));
+            }
+
+            length = i;
+            return true;
+        }
+
         // Things we should add:
         // * Huffman encoding
         //

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackEncoder.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackEncoder.cs
@@ -41,12 +41,14 @@ namespace System.Net.Http.HPack
             int currentLength = 0;
             do
             {
-                if (!EncodeHeader(_enumerator.Current.Key, _enumerator.Current.Value, buffer.Slice(length), out int headerLength))
+                if (!EncodeHeader(_enumerator.Current.Key, _enumerator.Current.Value, buffer.Slice(currentLength), out int headerLength))
                 {
-                    if (length == 0 && throwIfNoneEncoded)
+                    if (currentLength == 0 && throwIfNoneEncoded)
                     {
                         throw new HPackEncodingException();
                     }
+
+                    length = currentLength;
                     return false;
                 }
 
@@ -77,9 +79,9 @@ namespace System.Net.Http.HPack
                     // Send as Literal Header Field Without Indexing - Indexed Name
                     buffer[0] = 0x08;
 
-                    byte[] statusBytes = StatusCodes.ToStatusBytes(statusCode);
+                    ReadOnlySpan<byte> statusBytes = StatusCodes.ToStatusBytes(statusCode);
                     buffer[1] = (byte)statusBytes.Length;
-                    ((Span<byte>)statusBytes).CopyTo(buffer.Slice(2));
+                    statusBytes.CopyTo(buffer.Slice(2));
 
                     return 2 + statusBytes.Length;
             }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackEncoder.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackEncoder.cs
@@ -127,7 +127,7 @@ namespace System.Net.Http.HPack
             return true;
         }
 
-        private bool EncodeString(string s, Span<byte> buffer, out int length, bool lowercase)
+        private bool EncodeString(string value, Span<byte> destination, out int bytesWritten, bool lowercase)
         {
             // From https://tools.ietf.org/html/rfc7541#section-5.2
             // ------------------------------------------------------
@@ -144,7 +144,7 @@ namespace System.Net.Http.HPack
                 if (IntegerEncoder.Encode(value.Length, 7, destination, out int integerLength))
                 {
                     Debug.Assert(integerLength >= 1);
-                    
+
                     destination = destination.Slice(integerLength);
                     if (value.Length <= destination.Length)
                     {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackEncodingException.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackEncodingException.cs
@@ -7,7 +7,6 @@ namespace System.Net.Http.HPack
     internal sealed class HPackEncodingException : Exception
     {
         public HPackEncodingException()
-            : base()
         {
         }
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackEncodingException.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackEncodingException.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+// See THIRD-PARTY-NOTICES.TXT in the project root for license information.
+
+namespace System.Net.Http.HPack
+{
+    internal sealed class HPackEncodingException : Exception
+    {
+        public HPackEncodingException()
+            : base()
+        {
+        }
+
+        public HPackEncodingException(string message)
+            : base(message)
+        {
+        }
+
+        public HPackEncodingException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HeaderField.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HeaderField.cs
@@ -7,7 +7,7 @@ using System.Text;
 
 namespace System.Net.Http.HPack
 {
-    internal struct HeaderField
+    internal readonly struct HeaderField
     {
         // http://httpwg.org/specs/rfc7541.html#rfc.section.4.1
         public const int RfcOverhead = 32;
@@ -34,7 +34,7 @@ namespace System.Net.Http.HPack
 
         public int Length => GetLength(Name.Length, Value.Length);
 
-        public static int GetLength(int nameLength, int valueLenth) => nameLength + valueLenth + RfcOverhead;
+        public static int GetLength(int nameLength, int valueLength) => nameLength + valueLength + RfcOverhead;
 
         public override string ToString()
         {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/Huffman.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/Huffman.cs
@@ -345,13 +345,13 @@ namespace System.Net.Http.HPack
                 if (ch == -1)
                 {
                     // No valid symbol could be decoded with the bits in next
-                    throw new HuffmanDecodingException(/* CoreStrings.HPackHuffmanErrorIncomplete*/);
+                    throw new HuffmanDecodingException();
                 }
                 else if (ch == 256)
                 {
                     // A Huffman-encoded string literal containing the EOS symbol MUST be treated as a decoding error.
                     // http://httpwg.org/specs/rfc7541.html#rfc.section.5.2
-                    throw new HuffmanDecodingException(/*CoreStrings.HPackHuffmanErrorEOS */);
+                    throw new HuffmanDecodingException();
                 }
 
                 if (j == dst.Length)

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/Huffman.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/Huffman.cs
@@ -9,7 +9,7 @@ namespace System.Net.Http.HPack
     internal class Huffman
     {
         // TODO: this can be constructed from _decodingTable
-        private static readonly (uint code, int bitLength)[] s_encodingTable = new (uint code, int bitLength)[]
+        private static readonly (uint code, int bitLength)[] _encodingTable = new (uint code, int bitLength)[]
         {
             (0b11111111_11000000_00000000_00000000, 13),
             (0b11111111_11111111_10110000_00000000, 23),
@@ -270,7 +270,7 @@ namespace System.Net.Http.HPack
             (0b11111111_11111111_11111111_11111100, 30)
         };
 
-        private static readonly (int codeLength, int[] codes)[] s_decodingTable = new[]
+        private static readonly (int codeLength, int[] codes)[] _decodingTable = new[]
         {
             (5, new[] { 48, 49, 50, 97, 99, 101, 105, 111, 115, 116 }),
             (6, new[] { 32, 37, 45, 46, 47, 51, 52, 53, 54, 55, 56, 57, 61, 65, 95, 98, 100, 102, 103, 104, 108, 109, 110, 112, 114, 117 }),
@@ -297,7 +297,7 @@ namespace System.Net.Http.HPack
 
         public static (uint encoded, int bitLength) Encode(int data)
         {
-            return s_encodingTable[data];
+            return _encodingTable[data];
         }
 
         /// <summary>
@@ -345,13 +345,13 @@ namespace System.Net.Http.HPack
                 if (ch == -1)
                 {
                     // No valid symbol could be decoded with the bits in next
-                    throw new HuffmanDecodingException();
+                    throw new HuffmanDecodingException(/* CoreStrings.HPackHuffmanErrorIncomplete*/);
                 }
                 else if (ch == 256)
                 {
                     // A Huffman-encoded string literal containing the EOS symbol MUST be treated as a decoding error.
                     // http://httpwg.org/specs/rfc7541.html#rfc.section.5.2
-                    throw new HuffmanDecodingException();
+                    throw new HuffmanDecodingException(/*CoreStrings.HPackHuffmanErrorEOS */);
                 }
 
                 if (j == dst.Length)
@@ -385,7 +385,7 @@ namespace System.Net.Http.HPack
         /// </param>
         /// <param name="decodedBits">The number of bits decoded from <paramref name="data"/>.</param>
         /// <returns>The decoded symbol.</returns>
-        private static int DecodeValue(uint data, int validBits, out int decodedBits)
+        internal static int DecodeValue(uint data, int validBits, out int decodedBits)
         {
             // The code below implements the decoding logic for a canonical Huffman code.
             //
@@ -406,13 +406,13 @@ namespace System.Net.Http.HPack
 
             int codeMax = 0;
 
-            for (int i = 0; i < s_decodingTable.Length && s_decodingTable[i].codeLength <= validBits; i++)
+            for (int i = 0; i < _decodingTable.Length && _decodingTable[i].codeLength <= validBits; i++)
             {
-                (int codeLength, int[] codes) = s_decodingTable[i];
+                (int codeLength, int[] codes) = _decodingTable[i];
 
                 if (i > 0)
                 {
-                    codeMax <<= codeLength - s_decodingTable[i - 1].codeLength;
+                    codeMax <<= codeLength - _decodingTable[i - 1].codeLength;
                 }
 
                 codeMax += codes.Length;

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HuffmanDecodingException.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HuffmanDecodingException.cs
@@ -8,7 +8,7 @@ namespace System.Net.Http.HPack
 {
     // TODO: Should this be public?
     [Serializable]
-    internal class HuffmanDecodingException : Exception
+    internal class HuffmanDecodingException : Exception, ISerializable
     {
         public HuffmanDecodingException()
         {
@@ -19,9 +19,19 @@ namespace System.Net.Http.HPack
         {
         }
 
-        public HuffmanDecodingException(SerializationInfo info, StreamingContext context)
+        protected HuffmanDecodingException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
+        }
+
+        void ISerializable.GetObjectData(SerializationInfo serializationInfo, StreamingContext streamingContext)
+        {
+            base.GetObjectData(serializationInfo, streamingContext);
+        }
+
+        public override void GetObjectData(SerializationInfo serializationInfo, StreamingContext streamingContext)
+        {
+            base.GetObjectData(serializationInfo, streamingContext);
         }
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HuffmanDecodingException.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HuffmanDecodingException.cs
@@ -14,6 +14,11 @@ namespace System.Net.Http.HPack
         {
         }
 
+        public HuffmanDecodingException(string message)
+            : base(message)
+        {
+        }
+
         public HuffmanDecodingException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/IntegerDecoder.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/IntegerDecoder.cs
@@ -98,8 +98,5 @@ namespace System.Net.Http.HPack
             result = 0;
             return false;
         }
-
-        public static void ThrowIntegerTooBigException()
-            => throw new HPackDecodingException(/*CoreStrings.HPackErrorIntegerTooBig */);
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/IntegerDecoder.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/IntegerDecoder.cs
@@ -12,8 +12,6 @@ namespace System.Net.Http.HPack
         private int _i;
         private int _m;
 
-        public int Value { get; private set; }
-
         /// <summary>
         /// Decodes the first byte of the integer.
         /// </summary>
@@ -25,38 +23,43 @@ namespace System.Net.Http.HPack
         /// integer has been encoded into. Must be between 1 and 8.
         /// Upper bits must be zero.
         /// </param>
+        /// <param name="result">
+        /// If decoded successfully, contains the decoded integer.
+        /// </param>
         /// <returns>
         /// If the integer has been fully decoded, true.
-        /// Otherwise, false -- <see cref="Decode(byte)"/> must be called on subsequent bytes.
+        /// Otherwise, false -- <see cref="TryDecode(byte, out int)"/> must be called on subsequent bytes.
         /// </returns>
         /// <remarks>
         /// The term "prefix" can be confusing. From the HPACK spec:
         /// An integer is represented in two parts: a prefix that fills the current octet and an
         /// optional list of octets that are used if the integer value does not fit within the prefix.
         /// </remarks>
-        public bool StartDecode(byte b, int prefixLength)
+        public bool BeginTryDecode(byte b, int prefixLength, out int result)
         {
             Debug.Assert(prefixLength >= 1 && prefixLength <= 8);
             Debug.Assert((b & ~((1 << prefixLength) - 1)) == 0, "bits other than prefix data must be set to 0.");
 
             if (b < ((1 << prefixLength) - 1))
             {
-                Value = b;
+                result = b;
                 return true;
             }
-            else
-            {
-                _i = b;
-                _m = 0;
-                return false;
-            }
+
+            _i = b;
+            _m = 0;
+            result = 0;
+            return false;
         }
 
         /// <summary>
         /// Decodes subsequent bytes of an integer.
         /// </summary>
-        /// <returns>If the integer has been fully decoded, true. Otherwise, false -- <see cref="Decode(byte)"/> must be called on subsequent bytes.</returns>
-        public bool Decode(byte b)
+        /// <param name="result">
+        /// If decoded successfully, contains the decoded integer.
+        /// </param>
+        /// <returns>If the integer has been fully decoded, true. Otherwise, false -- <see cref="TryDecode(byte, out int)"/> must be called on subsequent bytes.</returns>
+        public bool TryDecode(byte b, out int result)
         {
             // Check if shifting b by _m would result in > 31 bits.
             // No masking is required: if the 8th bit is set, it indicates there is a
@@ -70,7 +73,7 @@ namespace System.Net.Http.HPack
                 throw new HPackDecodingException(SR.net_http_hpack_bad_integer);
             }
 
-            _i = _i + ((b & 127) << _m);
+            _i = _i + ((b & 0x7f) << _m);
 
             // If the addition overflowed, the result will be negative.
             if (_i < 0)
@@ -88,11 +91,15 @@ namespace System.Net.Http.HPack
                     throw new HPackDecodingException(SR.net_http_hpack_bad_integer);
                 }
 
-                Value = _i;
+                result = _i;
                 return true;
             }
 
+            result = 0;
             return false;
         }
+
+        public static void ThrowIntegerTooBigException()
+            => throw new HPackDecodingException(/*CoreStrings.HPackErrorIntegerTooBig */);
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/StaticTable.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/StaticTable.cs
@@ -10,7 +10,7 @@ namespace System.Net.Http.HPack
     internal static class StaticTable
     {
 
-        private static readonly Dictionary<int, int> _statusIndex = new Dictionary<int, int>
+        private static readonly Dictionary<int, int> s_statusIndex = new Dictionary<int, int>
         {
             [200] = 8,
             [204] = 9,
@@ -21,13 +21,13 @@ namespace System.Net.Http.HPack
             [500] = 14,
         };
 
-        public static int Count => _staticDecoderTable.Length;
+        public static int Count => s_staticDecoderTable.Length;
 
-        public static HeaderField Get(int index) => _staticDecoderTable[index];
+        public static HeaderField Get(int index) => s_staticDecoderTable[index];
 
-        public static IReadOnlyDictionary<int, int> StatusIndex => _statusIndex;
+        public static IReadOnlyDictionary<int, int> StatusIndex => s_statusIndex;
 
-        private static readonly HeaderField[] _staticDecoderTable = new HeaderField[]
+        private static readonly HeaderField[] s_staticDecoderTable = new HeaderField[]
         {
             CreateHeaderField(":authority", ""),
             CreateHeaderField(":method", "GET"),

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/StaticTable.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/StaticTable.cs
@@ -2,17 +2,32 @@
 // Licensed under the Apache License, Version 2.0.
 // See THIRD-PARTY-NOTICES.TXT in the project root for license information.
 
+using System.Collections.Generic;
 using System.Text;
 
 namespace System.Net.Http.HPack
 {
     internal static class StaticTable
     {
-        public static int Count => s_staticDecoderTable.Length;
 
-        public static HeaderField Get(int index) => s_staticDecoderTable[index];
+        private static readonly Dictionary<int, int> _statusIndex = new Dictionary<int, int>
+        {
+            [200] = 8,
+            [204] = 9,
+            [206] = 10,
+            [304] = 11,
+            [400] = 12,
+            [404] = 13,
+            [500] = 14,
+        };
 
-        private static readonly HeaderField[] s_staticDecoderTable = new HeaderField[]
+        public static int Count => _staticDecoderTable.Length;
+
+        public static HeaderField Get(int index) => _staticDecoderTable[index];
+
+        public static IReadOnlyDictionary<int, int> StatusIndex => _statusIndex;
+
+        private static readonly HeaderField[] _staticDecoderTable = new HeaderField[]
         {
             CreateHeaderField(":authority", ""),
             CreateHeaderField(":method", "GET"),

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/StaticTable.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/StaticTable.cs
@@ -9,7 +9,6 @@ namespace System.Net.Http.HPack
 {
     internal static class StaticTable
     {
-        
         // Index of status code into s_staticDecoderTable
         private static readonly Dictionary<int, int> s_statusIndex = new Dictionary<int, int>
         {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/StaticTable.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/StaticTable.cs
@@ -9,7 +9,8 @@ namespace System.Net.Http.HPack
 {
     internal static class StaticTable
     {
-
+        
+        // Index of status code into s_staticDecoderTable
         private static readonly Dictionary<int, int> s_statusIndex = new Dictionary<int, int>
         {
             [200] = 8,

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/StatusCodes.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/StatusCodes.cs
@@ -1,0 +1,223 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+// See THIRD-PARTY-NOTICES.TXT in the project root for license information.
+
+using System.Globalization;
+using System.Text;
+
+namespace System.Net.Http.HPack
+{
+    internal static class StatusCodes
+    {
+        private static readonly byte[] _bytesStatus100 = CreateStatusBytes((int)HttpStatusCode.Continue);
+        private static readonly byte[] _bytesStatus101 = CreateStatusBytes((int)HttpStatusCode.SwitchingProtocols);
+        private static readonly byte[] _bytesStatus102 = CreateStatusBytes((int)HttpStatusCode.Processing);
+
+        private static readonly byte[] _bytesStatus200 = CreateStatusBytes((int)HttpStatusCode.OK);
+        private static readonly byte[] _bytesStatus201 = CreateStatusBytes((int)HttpStatusCode.Created);
+        private static readonly byte[] _bytesStatus202 = CreateStatusBytes((int)HttpStatusCode.Accepted);
+        private static readonly byte[] _bytesStatus203 = CreateStatusBytes((int)HttpStatusCode.NonAuthoritativeInformation);
+        private static readonly byte[] _bytesStatus204 = CreateStatusBytes((int)HttpStatusCode.NoContent);
+        private static readonly byte[] _bytesStatus205 = CreateStatusBytes((int)HttpStatusCode.ResetContent);
+        private static readonly byte[] _bytesStatus206 = CreateStatusBytes((int)HttpStatusCode.PartialContent);
+        private static readonly byte[] _bytesStatus207 = CreateStatusBytes((int)HttpStatusCode.MultiStatus);
+        private static readonly byte[] _bytesStatus208 = CreateStatusBytes((int)HttpStatusCode.AlreadyReported);
+        private static readonly byte[] _bytesStatus226 = CreateStatusBytes((int)HttpStatusCode.IMUsed);
+
+        private static readonly byte[] _bytesStatus300 = CreateStatusBytes((int)HttpStatusCode.MultipleChoices);
+        private static readonly byte[] _bytesStatus301 = CreateStatusBytes((int)HttpStatusCode.MovedPermanently);
+        private static readonly byte[] _bytesStatus302 = CreateStatusBytes((int)HttpStatusCode.Found);
+        private static readonly byte[] _bytesStatus303 = CreateStatusBytes((int)HttpStatusCode.SeeOther);
+        private static readonly byte[] _bytesStatus304 = CreateStatusBytes((int)HttpStatusCode.NotModified);
+        private static readonly byte[] _bytesStatus305 = CreateStatusBytes((int)HttpStatusCode.UseProxy);
+        private static readonly byte[] _bytesStatus306 = CreateStatusBytes((int)HttpStatusCode.Unused);
+        private static readonly byte[] _bytesStatus307 = CreateStatusBytes((int)HttpStatusCode.TemporaryRedirect);
+        private static readonly byte[] _bytesStatus308 = CreateStatusBytes((int)HttpStatusCode.PermanentRedirect);
+
+        private static readonly byte[] _bytesStatus400 = CreateStatusBytes((int)HttpStatusCode.BadRequest);
+        private static readonly byte[] _bytesStatus401 = CreateStatusBytes((int)HttpStatusCode.Unauthorized);
+        private static readonly byte[] _bytesStatus402 = CreateStatusBytes((int)HttpStatusCode.PaymentRequired);
+        private static readonly byte[] _bytesStatus403 = CreateStatusBytes((int)HttpStatusCode.Forbidden);
+        private static readonly byte[] _bytesStatus404 = CreateStatusBytes((int)HttpStatusCode.NotFound);
+        private static readonly byte[] _bytesStatus405 = CreateStatusBytes((int)HttpStatusCode.MethodNotAllowed);
+        private static readonly byte[] _bytesStatus406 = CreateStatusBytes((int)HttpStatusCode.NotAcceptable);
+        private static readonly byte[] _bytesStatus407 = CreateStatusBytes((int)HttpStatusCode.ProxyAuthenticationRequired);
+        private static readonly byte[] _bytesStatus408 = CreateStatusBytes((int)HttpStatusCode.RequestTimeout);
+        private static readonly byte[] _bytesStatus409 = CreateStatusBytes((int)HttpStatusCode.Conflict);
+        private static readonly byte[] _bytesStatus410 = CreateStatusBytes((int)HttpStatusCode.Gone);
+        private static readonly byte[] _bytesStatus411 = CreateStatusBytes((int)HttpStatusCode.LengthRequired);
+        private static readonly byte[] _bytesStatus412 = CreateStatusBytes((int)HttpStatusCode.PreconditionFailed);
+        private static readonly byte[] _bytesStatus413 = CreateStatusBytes((int)HttpStatusCode.RequestEntityTooLarge);
+        private static readonly byte[] _bytesStatus414 = CreateStatusBytes((int)HttpStatusCode.RequestUriTooLong);
+        private static readonly byte[] _bytesStatus415 = CreateStatusBytes((int)HttpStatusCode.UnsupportedMediaType);
+        private static readonly byte[] _bytesStatus416 = CreateStatusBytes((int)HttpStatusCode.RequestedRangeNotSatisfiable);
+        private static readonly byte[] _bytesStatus417 = CreateStatusBytes((int)HttpStatusCode.ExpectationFailed);
+        private static readonly byte[] _bytesStatus418 = CreateStatusBytes((int)418);
+        private static readonly byte[] _bytesStatus419 = CreateStatusBytes((int)419);
+        private static readonly byte[] _bytesStatus421 = CreateStatusBytes((int)HttpStatusCode.MisdirectedRequest);
+        private static readonly byte[] _bytesStatus422 = CreateStatusBytes((int)HttpStatusCode.UnprocessableEntity);
+        private static readonly byte[] _bytesStatus423 = CreateStatusBytes((int)HttpStatusCode.Locked);
+        private static readonly byte[] _bytesStatus424 = CreateStatusBytes((int)HttpStatusCode.FailedDependency);
+        private static readonly byte[] _bytesStatus426 = CreateStatusBytes((int)HttpStatusCode.UpgradeRequired);
+        private static readonly byte[] _bytesStatus428 = CreateStatusBytes((int)HttpStatusCode.PreconditionRequired);
+        private static readonly byte[] _bytesStatus429 = CreateStatusBytes((int)HttpStatusCode.TooManyRequests);
+        private static readonly byte[] _bytesStatus431 = CreateStatusBytes((int)HttpStatusCode.RequestHeaderFieldsTooLarge);
+        private static readonly byte[] _bytesStatus451 = CreateStatusBytes((int)HttpStatusCode.UnavailableForLegalReasons);
+
+        private static readonly byte[] _bytesStatus500 = CreateStatusBytes((int)HttpStatusCode.InternalServerError);
+        private static readonly byte[] _bytesStatus501 = CreateStatusBytes((int)HttpStatusCode.NotImplemented);
+        private static readonly byte[] _bytesStatus502 = CreateStatusBytes((int)HttpStatusCode.BadGateway);
+        private static readonly byte[] _bytesStatus503 = CreateStatusBytes((int)HttpStatusCode.ServiceUnavailable);
+        private static readonly byte[] _bytesStatus504 = CreateStatusBytes((int)HttpStatusCode.GatewayTimeout);
+        private static readonly byte[] _bytesStatus505 = CreateStatusBytes((int)HttpStatusCode.HttpVersionNotSupported);
+        private static readonly byte[] _bytesStatus506 = CreateStatusBytes((int)HttpStatusCode.VariantAlsoNegotiates);
+        private static readonly byte[] _bytesStatus507 = CreateStatusBytes((int)HttpStatusCode.InsufficientStorage);
+        private static readonly byte[] _bytesStatus508 = CreateStatusBytes((int)HttpStatusCode.LoopDetected);
+        private static readonly byte[] _bytesStatus510 = CreateStatusBytes((int)HttpStatusCode.NotExtended);
+        private static readonly byte[] _bytesStatus511 = CreateStatusBytes((int)HttpStatusCode.NetworkAuthenticationRequired);
+
+        private static byte[] CreateStatusBytes(int statusCode)
+        {
+            return Encoding.ASCII.GetBytes(statusCode.ToString(CultureInfo.InvariantCulture));
+        }
+
+        public static byte[] ToStatusBytes(int statusCode)
+        {
+            switch (statusCode)
+            {
+                case (int)HttpStatusCode.Continue:
+                    return _bytesStatus100;
+                case (int)HttpStatusCode.SwitchingProtocols:
+                    return _bytesStatus101;
+                case (int)HttpStatusCode.Processing:
+                    return _bytesStatus102;
+
+                case (int)HttpStatusCode.OK:
+                    return _bytesStatus200;
+                case (int)HttpStatusCode.Created:
+                    return _bytesStatus201;
+                case (int)HttpStatusCode.Accepted:
+                    return _bytesStatus202;
+                case (int)HttpStatusCode.NonAuthoritativeInformation:
+                    return _bytesStatus203;
+                case (int)HttpStatusCode.NoContent:
+                    return _bytesStatus204;
+                case (int)HttpStatusCode.ResetContent:
+                    return _bytesStatus205;
+                case (int)HttpStatusCode.PartialContent:
+                    return _bytesStatus206;
+                case (int)HttpStatusCode.MultiStatus:
+                    return _bytesStatus207;
+                case (int)HttpStatusCode.AlreadyReported:
+                    return _bytesStatus208;
+                case (int)HttpStatusCode.IMUsed:
+                    return _bytesStatus226;
+
+                case (int)HttpStatusCode.MultipleChoices:
+                    return _bytesStatus300;
+                case (int)HttpStatusCode.MovedPermanently:
+                    return _bytesStatus301;
+                case (int)HttpStatusCode.Found:
+                    return _bytesStatus302;
+                case (int)HttpStatusCode.SeeOther:
+                    return _bytesStatus303;
+                case (int)HttpStatusCode.NotModified:
+                    return _bytesStatus304;
+                case (int)HttpStatusCode.UseProxy:
+                    return _bytesStatus305;
+                case (int)HttpStatusCode.Unused:
+                    return _bytesStatus306;
+                case (int)HttpStatusCode.TemporaryRedirect:
+                    return _bytesStatus307;
+                case (int)HttpStatusCode.PermanentRedirect:
+                    return _bytesStatus308;
+
+                case (int)HttpStatusCode.BadRequest:
+                    return _bytesStatus400;
+                case (int)HttpStatusCode.Unauthorized:
+                    return _bytesStatus401;
+                case (int)HttpStatusCode.PaymentRequired:
+                    return _bytesStatus402;
+                case (int)HttpStatusCode.Forbidden:
+                    return _bytesStatus403;
+                case (int)HttpStatusCode.NotFound:
+                    return _bytesStatus404;
+                case (int)HttpStatusCode.MethodNotAllowed:
+                    return _bytesStatus405;
+                case (int)HttpStatusCode.NotAcceptable:
+                    return _bytesStatus406;
+                case (int)HttpStatusCode.ProxyAuthenticationRequired:
+                    return _bytesStatus407;
+                case (int)HttpStatusCode.RequestTimeout:
+                    return _bytesStatus408;
+                case (int)HttpStatusCode.Conflict:
+                    return _bytesStatus409;
+                case (int)HttpStatusCode.Gone:
+                    return _bytesStatus410;
+                case (int)HttpStatusCode.LengthRequired:
+                    return _bytesStatus411;
+                case (int)HttpStatusCode.PreconditionFailed:
+                    return _bytesStatus412;
+                case (int)HttpStatusCode.RequestEntityTooLarge:
+                    return _bytesStatus413;
+                case (int)HttpStatusCode.RequestUriTooLong:
+                    return _bytesStatus414;
+                case (int)HttpStatusCode.UnsupportedMediaType:
+                    return _bytesStatus415;
+                case (int)HttpStatusCode.RequestedRangeNotSatisfiable:
+                    return _bytesStatus416;
+                case (int)HttpStatusCode.ExpectationFailed:
+                    return _bytesStatus417;
+                case (int)418:
+                    return _bytesStatus418;
+                case (int)419:
+                    return _bytesStatus419;
+                case (int)HttpStatusCode.MisdirectedRequest:
+                    return _bytesStatus421;
+                case (int)HttpStatusCode.UnprocessableEntity:
+                    return _bytesStatus422;
+                case (int)HttpStatusCode.Locked:
+                    return _bytesStatus423;
+                case (int)HttpStatusCode.FailedDependency:
+                    return _bytesStatus424;
+                case (int)HttpStatusCode.UpgradeRequired:
+                    return _bytesStatus426;
+                case (int)HttpStatusCode.PreconditionRequired:
+                    return _bytesStatus428;
+                case (int)HttpStatusCode.TooManyRequests:
+                    return _bytesStatus429;
+                case (int)HttpStatusCode.RequestHeaderFieldsTooLarge:
+                    return _bytesStatus431;
+                case (int)HttpStatusCode.UnavailableForLegalReasons:
+                    return _bytesStatus451;
+
+                case (int)HttpStatusCode.InternalServerError:
+                    return _bytesStatus500;
+                case (int)HttpStatusCode.NotImplemented:
+                    return _bytesStatus501;
+                case (int)HttpStatusCode.BadGateway:
+                    return _bytesStatus502;
+                case (int)HttpStatusCode.ServiceUnavailable:
+                    return _bytesStatus503;
+                case (int)HttpStatusCode.GatewayTimeout:
+                    return _bytesStatus504;
+                case (int)HttpStatusCode.HttpVersionNotSupported:
+                    return _bytesStatus505;
+                case (int)HttpStatusCode.VariantAlsoNegotiates:
+                    return _bytesStatus506;
+                case (int)HttpStatusCode.InsufficientStorage:
+                    return _bytesStatus507;
+                case (int)HttpStatusCode.LoopDetected:
+                    return _bytesStatus508;
+                case (int)HttpStatusCode.NotExtended:
+                    return _bytesStatus510;
+                case (int)HttpStatusCode.NetworkAuthenticationRequired:
+                    return _bytesStatus511;
+
+                default:
+                    return Encoding.ASCII.GetBytes(statusCode.ToString(CultureInfo.InvariantCulture));
+
+            }
+        }
+    }
+}

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/StatusCodes.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/StatusCodes.cs
@@ -9,210 +9,205 @@ namespace System.Net.Http.HPack
 {
     internal static class StatusCodes
     {
-        private static readonly byte[] _bytesStatus100 = CreateStatusBytes((int)HttpStatusCode.Continue);
-        private static readonly byte[] _bytesStatus101 = CreateStatusBytes((int)HttpStatusCode.SwitchingProtocols);
-        private static readonly byte[] _bytesStatus102 = CreateStatusBytes((int)HttpStatusCode.Processing);
+        private static ReadOnlySpan<byte> BytesStatus100 => new byte[] { (byte)'1', (byte)'0', (byte)'0' };
+        private static ReadOnlySpan<byte> BytesStatus101 => new byte[] { (byte)'1', (byte)'0', (byte)'1' };
+        private static ReadOnlySpan<byte> BytesStatus102 => new byte[] { (byte)'1', (byte)'0', (byte)'2' };
 
-        private static readonly byte[] _bytesStatus200 = CreateStatusBytes((int)HttpStatusCode.OK);
-        private static readonly byte[] _bytesStatus201 = CreateStatusBytes((int)HttpStatusCode.Created);
-        private static readonly byte[] _bytesStatus202 = CreateStatusBytes((int)HttpStatusCode.Accepted);
-        private static readonly byte[] _bytesStatus203 = CreateStatusBytes((int)HttpStatusCode.NonAuthoritativeInformation);
-        private static readonly byte[] _bytesStatus204 = CreateStatusBytes((int)HttpStatusCode.NoContent);
-        private static readonly byte[] _bytesStatus205 = CreateStatusBytes((int)HttpStatusCode.ResetContent);
-        private static readonly byte[] _bytesStatus206 = CreateStatusBytes((int)HttpStatusCode.PartialContent);
-        private static readonly byte[] _bytesStatus207 = CreateStatusBytes((int)HttpStatusCode.MultiStatus);
-        private static readonly byte[] _bytesStatus208 = CreateStatusBytes((int)HttpStatusCode.AlreadyReported);
-        private static readonly byte[] _bytesStatus226 = CreateStatusBytes((int)HttpStatusCode.IMUsed);
+        private static ReadOnlySpan<byte> BytesStatus200 => new byte[] { (byte)'2', (byte)'0', (byte)'0' };
+        private static ReadOnlySpan<byte> BytesStatus201 => new byte[] { (byte)'2', (byte)'0', (byte)'1' };
+        private static ReadOnlySpan<byte> BytesStatus202 => new byte[] { (byte)'2', (byte)'0', (byte)'2' };
+        private static ReadOnlySpan<byte> BytesStatus203 => new byte[] { (byte)'2', (byte)'0', (byte)'3' };
+        private static ReadOnlySpan<byte> BytesStatus204 => new byte[] { (byte)'2', (byte)'0', (byte)'4' };
+        private static ReadOnlySpan<byte> BytesStatus205 => new byte[] { (byte)'2', (byte)'0', (byte)'5' };
+        private static ReadOnlySpan<byte> BytesStatus206 => new byte[] { (byte)'2', (byte)'0', (byte)'6' };
+        private static ReadOnlySpan<byte> BytesStatus207 => new byte[] { (byte)'2', (byte)'0', (byte)'7' };
+        private static ReadOnlySpan<byte> BytesStatus208 => new byte[] { (byte)'2', (byte)'0', (byte)'8' };
+        private static ReadOnlySpan<byte> BytesStatus226 => new byte[] { (byte)'2', (byte)'2', (byte)'6' };
 
-        private static readonly byte[] _bytesStatus300 = CreateStatusBytes((int)HttpStatusCode.MultipleChoices);
-        private static readonly byte[] _bytesStatus301 = CreateStatusBytes((int)HttpStatusCode.MovedPermanently);
-        private static readonly byte[] _bytesStatus302 = CreateStatusBytes((int)HttpStatusCode.Found);
-        private static readonly byte[] _bytesStatus303 = CreateStatusBytes((int)HttpStatusCode.SeeOther);
-        private static readonly byte[] _bytesStatus304 = CreateStatusBytes((int)HttpStatusCode.NotModified);
-        private static readonly byte[] _bytesStatus305 = CreateStatusBytes((int)HttpStatusCode.UseProxy);
-        private static readonly byte[] _bytesStatus306 = CreateStatusBytes((int)HttpStatusCode.Unused);
-        private static readonly byte[] _bytesStatus307 = CreateStatusBytes((int)HttpStatusCode.TemporaryRedirect);
-        private static readonly byte[] _bytesStatus308 = CreateStatusBytes((int)HttpStatusCode.PermanentRedirect);
+        private static ReadOnlySpan<byte> BytesStatus300 => new byte[] { (byte)'3', (byte)'0', (byte)'0' };
+        private static ReadOnlySpan<byte> BytesStatus301 => new byte[] { (byte)'3', (byte)'0', (byte)'1' };
+        private static ReadOnlySpan<byte> BytesStatus302 => new byte[] { (byte)'3', (byte)'0', (byte)'2' };
+        private static ReadOnlySpan<byte> BytesStatus303 => new byte[] { (byte)'3', (byte)'0', (byte)'3' };
+        private static ReadOnlySpan<byte> BytesStatus304 => new byte[] { (byte)'3', (byte)'0', (byte)'4' };
+        private static ReadOnlySpan<byte> BytesStatus305 => new byte[] { (byte)'3', (byte)'0', (byte)'5' };
+        private static ReadOnlySpan<byte> BytesStatus306 => new byte[] { (byte)'3', (byte)'0', (byte)'6' };
+        private static ReadOnlySpan<byte> BytesStatus307 => new byte[] { (byte)'3', (byte)'0', (byte)'7' };
+        private static ReadOnlySpan<byte> BytesStatus308 => new byte[] { (byte)'3', (byte)'0', (byte)'8' };
 
-        private static readonly byte[] _bytesStatus400 = CreateStatusBytes((int)HttpStatusCode.BadRequest);
-        private static readonly byte[] _bytesStatus401 = CreateStatusBytes((int)HttpStatusCode.Unauthorized);
-        private static readonly byte[] _bytesStatus402 = CreateStatusBytes((int)HttpStatusCode.PaymentRequired);
-        private static readonly byte[] _bytesStatus403 = CreateStatusBytes((int)HttpStatusCode.Forbidden);
-        private static readonly byte[] _bytesStatus404 = CreateStatusBytes((int)HttpStatusCode.NotFound);
-        private static readonly byte[] _bytesStatus405 = CreateStatusBytes((int)HttpStatusCode.MethodNotAllowed);
-        private static readonly byte[] _bytesStatus406 = CreateStatusBytes((int)HttpStatusCode.NotAcceptable);
-        private static readonly byte[] _bytesStatus407 = CreateStatusBytes((int)HttpStatusCode.ProxyAuthenticationRequired);
-        private static readonly byte[] _bytesStatus408 = CreateStatusBytes((int)HttpStatusCode.RequestTimeout);
-        private static readonly byte[] _bytesStatus409 = CreateStatusBytes((int)HttpStatusCode.Conflict);
-        private static readonly byte[] _bytesStatus410 = CreateStatusBytes((int)HttpStatusCode.Gone);
-        private static readonly byte[] _bytesStatus411 = CreateStatusBytes((int)HttpStatusCode.LengthRequired);
-        private static readonly byte[] _bytesStatus412 = CreateStatusBytes((int)HttpStatusCode.PreconditionFailed);
-        private static readonly byte[] _bytesStatus413 = CreateStatusBytes((int)HttpStatusCode.RequestEntityTooLarge);
-        private static readonly byte[] _bytesStatus414 = CreateStatusBytes((int)HttpStatusCode.RequestUriTooLong);
-        private static readonly byte[] _bytesStatus415 = CreateStatusBytes((int)HttpStatusCode.UnsupportedMediaType);
-        private static readonly byte[] _bytesStatus416 = CreateStatusBytes((int)HttpStatusCode.RequestedRangeNotSatisfiable);
-        private static readonly byte[] _bytesStatus417 = CreateStatusBytes((int)HttpStatusCode.ExpectationFailed);
-        private static readonly byte[] _bytesStatus418 = CreateStatusBytes((int)418);
-        private static readonly byte[] _bytesStatus419 = CreateStatusBytes((int)419);
-        private static readonly byte[] _bytesStatus421 = CreateStatusBytes((int)HttpStatusCode.MisdirectedRequest);
-        private static readonly byte[] _bytesStatus422 = CreateStatusBytes((int)HttpStatusCode.UnprocessableEntity);
-        private static readonly byte[] _bytesStatus423 = CreateStatusBytes((int)HttpStatusCode.Locked);
-        private static readonly byte[] _bytesStatus424 = CreateStatusBytes((int)HttpStatusCode.FailedDependency);
-        private static readonly byte[] _bytesStatus426 = CreateStatusBytes((int)HttpStatusCode.UpgradeRequired);
-        private static readonly byte[] _bytesStatus428 = CreateStatusBytes((int)HttpStatusCode.PreconditionRequired);
-        private static readonly byte[] _bytesStatus429 = CreateStatusBytes((int)HttpStatusCode.TooManyRequests);
-        private static readonly byte[] _bytesStatus431 = CreateStatusBytes((int)HttpStatusCode.RequestHeaderFieldsTooLarge);
-        private static readonly byte[] _bytesStatus451 = CreateStatusBytes((int)HttpStatusCode.UnavailableForLegalReasons);
+        private static ReadOnlySpan<byte> BytesStatus400 => new byte[] { (byte)'4', (byte)'0', (byte)'0' };
+        private static ReadOnlySpan<byte> BytesStatus401 => new byte[] { (byte)'4', (byte)'0', (byte)'1' };
+        private static ReadOnlySpan<byte> BytesStatus402 => new byte[] { (byte)'4', (byte)'0', (byte)'2' };
+        private static ReadOnlySpan<byte> BytesStatus403 => new byte[] { (byte)'4', (byte)'0', (byte)'3' };
+        private static ReadOnlySpan<byte> BytesStatus404 => new byte[] { (byte)'4', (byte)'0', (byte)'4' };
+        private static ReadOnlySpan<byte> BytesStatus405 => new byte[] { (byte)'4', (byte)'0', (byte)'5' };
+        private static ReadOnlySpan<byte> BytesStatus406 => new byte[] { (byte)'4', (byte)'0', (byte)'6' };
+        private static ReadOnlySpan<byte> BytesStatus407 => new byte[] { (byte)'4', (byte)'0', (byte)'7' };
+        private static ReadOnlySpan<byte> BytesStatus408 => new byte[] { (byte)'4', (byte)'0', (byte)'8' };
+        private static ReadOnlySpan<byte> BytesStatus409 => new byte[] { (byte)'4', (byte)'0', (byte)'9' };
+        private static ReadOnlySpan<byte> BytesStatus410 => new byte[] { (byte)'4', (byte)'1', (byte)'0' };
+        private static ReadOnlySpan<byte> BytesStatus411 => new byte[] { (byte)'4', (byte)'1', (byte)'1' };
+        private static ReadOnlySpan<byte> BytesStatus412 => new byte[] { (byte)'4', (byte)'1', (byte)'2' };
+        private static ReadOnlySpan<byte> BytesStatus413 => new byte[] { (byte)'4', (byte)'1', (byte)'3' };
+        private static ReadOnlySpan<byte> BytesStatus414 => new byte[] { (byte)'4', (byte)'1', (byte)'4' };
+        private static ReadOnlySpan<byte> BytesStatus415 => new byte[] { (byte)'4', (byte)'1', (byte)'5' };
+        private static ReadOnlySpan<byte> BytesStatus416 => new byte[] { (byte)'4', (byte)'1', (byte)'6' };
+        private static ReadOnlySpan<byte> BytesStatus417 => new byte[] { (byte)'4', (byte)'1', (byte)'7' };
+        private static ReadOnlySpan<byte> BytesStatus418 => new byte[] { (byte)'4', (byte)'1', (byte)'8' };
+        private static ReadOnlySpan<byte> BytesStatus419 => new byte[] { (byte)'4', (byte)'1', (byte)'9' };
+        private static ReadOnlySpan<byte> BytesStatus421 => new byte[] { (byte)'4', (byte)'2', (byte)'1' };
+        private static ReadOnlySpan<byte> BytesStatus422 => new byte[] { (byte)'4', (byte)'2', (byte)'2' };
+        private static ReadOnlySpan<byte> BytesStatus423 => new byte[] { (byte)'4', (byte)'2', (byte)'3' };
+        private static ReadOnlySpan<byte> BytesStatus424 => new byte[] { (byte)'4', (byte)'2', (byte)'4' };
+        private static ReadOnlySpan<byte> BytesStatus426 => new byte[] { (byte)'4', (byte)'2', (byte)'6' };
+        private static ReadOnlySpan<byte> BytesStatus428 => new byte[] { (byte)'4', (byte)'2', (byte)'8' };
+        private static ReadOnlySpan<byte> BytesStatus429 => new byte[] { (byte)'4', (byte)'2', (byte)'9' };
+        private static ReadOnlySpan<byte> BytesStatus431 => new byte[] { (byte)'4', (byte)'3', (byte)'1' };
+        private static ReadOnlySpan<byte> BytesStatus451 => new byte[] { (byte)'4', (byte)'5', (byte)'1' };
 
-        private static readonly byte[] _bytesStatus500 = CreateStatusBytes((int)HttpStatusCode.InternalServerError);
-        private static readonly byte[] _bytesStatus501 = CreateStatusBytes((int)HttpStatusCode.NotImplemented);
-        private static readonly byte[] _bytesStatus502 = CreateStatusBytes((int)HttpStatusCode.BadGateway);
-        private static readonly byte[] _bytesStatus503 = CreateStatusBytes((int)HttpStatusCode.ServiceUnavailable);
-        private static readonly byte[] _bytesStatus504 = CreateStatusBytes((int)HttpStatusCode.GatewayTimeout);
-        private static readonly byte[] _bytesStatus505 = CreateStatusBytes((int)HttpStatusCode.HttpVersionNotSupported);
-        private static readonly byte[] _bytesStatus506 = CreateStatusBytes((int)HttpStatusCode.VariantAlsoNegotiates);
-        private static readonly byte[] _bytesStatus507 = CreateStatusBytes((int)HttpStatusCode.InsufficientStorage);
-        private static readonly byte[] _bytesStatus508 = CreateStatusBytes((int)HttpStatusCode.LoopDetected);
-        private static readonly byte[] _bytesStatus510 = CreateStatusBytes((int)HttpStatusCode.NotExtended);
-        private static readonly byte[] _bytesStatus511 = CreateStatusBytes((int)HttpStatusCode.NetworkAuthenticationRequired);
+        private static ReadOnlySpan<byte> BytesStatus500 => new byte[] { (byte)'5', (byte)'0', (byte)'0' };
+        private static ReadOnlySpan<byte> BytesStatus501 => new byte[] { (byte)'5', (byte)'0', (byte)'1' };
+        private static ReadOnlySpan<byte> BytesStatus502 => new byte[] { (byte)'5', (byte)'0', (byte)'2' };
+        private static ReadOnlySpan<byte> BytesStatus503 => new byte[] { (byte)'5', (byte)'0', (byte)'3' };
+        private static ReadOnlySpan<byte> BytesStatus504 => new byte[] { (byte)'5', (byte)'0', (byte)'4' };
+        private static ReadOnlySpan<byte> BytesStatus505 => new byte[] { (byte)'5', (byte)'0', (byte)'5' };
+        private static ReadOnlySpan<byte> BytesStatus506 => new byte[] { (byte)'5', (byte)'0', (byte)'6' };
+        private static ReadOnlySpan<byte> BytesStatus507 => new byte[] { (byte)'5', (byte)'0', (byte)'7' };
+        private static ReadOnlySpan<byte> BytesStatus508 => new byte[] { (byte)'5', (byte)'0', (byte)'8' };
+        private static ReadOnlySpan<byte> BytesStatus510 => new byte[] { (byte)'5', (byte)'1', (byte)'0' };
+        private static ReadOnlySpan<byte> BytesStatus511 => new byte[] { (byte)'5', (byte)'1', (byte)'1' };
 
-        private static byte[] CreateStatusBytes(int statusCode)
-        {
-            return Encoding.ASCII.GetBytes(statusCode.ToString(CultureInfo.InvariantCulture));
-        }
-
-        public static byte[] ToStatusBytes(int statusCode)
+        public static ReadOnlySpan<byte> ToStatusBytes(int statusCode)
         {
             switch (statusCode)
             {
                 case (int)HttpStatusCode.Continue:
-                    return _bytesStatus100;
+                    return BytesStatus100;
                 case (int)HttpStatusCode.SwitchingProtocols:
-                    return _bytesStatus101;
+                    return BytesStatus101;
                 case (int)HttpStatusCode.Processing:
-                    return _bytesStatus102;
+                    return BytesStatus102;
 
                 case (int)HttpStatusCode.OK:
-                    return _bytesStatus200;
+                    return BytesStatus200;
                 case (int)HttpStatusCode.Created:
-                    return _bytesStatus201;
+                    return BytesStatus201;
                 case (int)HttpStatusCode.Accepted:
-                    return _bytesStatus202;
+                    return BytesStatus202;
                 case (int)HttpStatusCode.NonAuthoritativeInformation:
-                    return _bytesStatus203;
+                    return BytesStatus203;
                 case (int)HttpStatusCode.NoContent:
-                    return _bytesStatus204;
+                    return BytesStatus204;
                 case (int)HttpStatusCode.ResetContent:
-                    return _bytesStatus205;
+                    return BytesStatus205;
                 case (int)HttpStatusCode.PartialContent:
-                    return _bytesStatus206;
+                    return BytesStatus206;
                 case (int)HttpStatusCode.MultiStatus:
-                    return _bytesStatus207;
+                    return BytesStatus207;
                 case (int)HttpStatusCode.AlreadyReported:
-                    return _bytesStatus208;
+                    return BytesStatus208;
                 case (int)HttpStatusCode.IMUsed:
-                    return _bytesStatus226;
+                    return BytesStatus226;
 
                 case (int)HttpStatusCode.MultipleChoices:
-                    return _bytesStatus300;
+                    return BytesStatus300;
                 case (int)HttpStatusCode.MovedPermanently:
-                    return _bytesStatus301;
+                    return BytesStatus301;
                 case (int)HttpStatusCode.Found:
-                    return _bytesStatus302;
+                    return BytesStatus302;
                 case (int)HttpStatusCode.SeeOther:
-                    return _bytesStatus303;
+                    return BytesStatus303;
                 case (int)HttpStatusCode.NotModified:
-                    return _bytesStatus304;
+                    return BytesStatus304;
                 case (int)HttpStatusCode.UseProxy:
-                    return _bytesStatus305;
+                    return BytesStatus305;
                 case (int)HttpStatusCode.Unused:
-                    return _bytesStatus306;
+                    return BytesStatus306;
                 case (int)HttpStatusCode.TemporaryRedirect:
-                    return _bytesStatus307;
+                    return BytesStatus307;
                 case (int)HttpStatusCode.PermanentRedirect:
-                    return _bytesStatus308;
+                    return BytesStatus308;
 
                 case (int)HttpStatusCode.BadRequest:
-                    return _bytesStatus400;
+                    return BytesStatus400;
                 case (int)HttpStatusCode.Unauthorized:
-                    return _bytesStatus401;
+                    return BytesStatus401;
                 case (int)HttpStatusCode.PaymentRequired:
-                    return _bytesStatus402;
+                    return BytesStatus402;
                 case (int)HttpStatusCode.Forbidden:
-                    return _bytesStatus403;
+                    return BytesStatus403;
                 case (int)HttpStatusCode.NotFound:
-                    return _bytesStatus404;
+                    return BytesStatus404;
                 case (int)HttpStatusCode.MethodNotAllowed:
-                    return _bytesStatus405;
+                    return BytesStatus405;
                 case (int)HttpStatusCode.NotAcceptable:
-                    return _bytesStatus406;
+                    return BytesStatus406;
                 case (int)HttpStatusCode.ProxyAuthenticationRequired:
-                    return _bytesStatus407;
+                    return BytesStatus407;
                 case (int)HttpStatusCode.RequestTimeout:
-                    return _bytesStatus408;
+                    return BytesStatus408;
                 case (int)HttpStatusCode.Conflict:
-                    return _bytesStatus409;
+                    return BytesStatus409;
                 case (int)HttpStatusCode.Gone:
-                    return _bytesStatus410;
+                    return BytesStatus410;
                 case (int)HttpStatusCode.LengthRequired:
-                    return _bytesStatus411;
+                    return BytesStatus411;
                 case (int)HttpStatusCode.PreconditionFailed:
-                    return _bytesStatus412;
+                    return BytesStatus412;
                 case (int)HttpStatusCode.RequestEntityTooLarge:
-                    return _bytesStatus413;
+                    return BytesStatus413;
                 case (int)HttpStatusCode.RequestUriTooLong:
-                    return _bytesStatus414;
+                    return BytesStatus414;
                 case (int)HttpStatusCode.UnsupportedMediaType:
-                    return _bytesStatus415;
+                    return BytesStatus415;
                 case (int)HttpStatusCode.RequestedRangeNotSatisfiable:
-                    return _bytesStatus416;
+                    return BytesStatus416;
                 case (int)HttpStatusCode.ExpectationFailed:
-                    return _bytesStatus417;
+                    return BytesStatus417;
                 case (int)418:
-                    return _bytesStatus418;
+                    return BytesStatus418;
                 case (int)419:
-                    return _bytesStatus419;
+                    return BytesStatus419;
                 case (int)HttpStatusCode.MisdirectedRequest:
-                    return _bytesStatus421;
+                    return BytesStatus421;
                 case (int)HttpStatusCode.UnprocessableEntity:
-                    return _bytesStatus422;
+                    return BytesStatus422;
                 case (int)HttpStatusCode.Locked:
-                    return _bytesStatus423;
+                    return BytesStatus423;
                 case (int)HttpStatusCode.FailedDependency:
-                    return _bytesStatus424;
+                    return BytesStatus424;
                 case (int)HttpStatusCode.UpgradeRequired:
-                    return _bytesStatus426;
+                    return BytesStatus426;
                 case (int)HttpStatusCode.PreconditionRequired:
-                    return _bytesStatus428;
+                    return BytesStatus428;
                 case (int)HttpStatusCode.TooManyRequests:
-                    return _bytesStatus429;
+                    return BytesStatus429;
                 case (int)HttpStatusCode.RequestHeaderFieldsTooLarge:
-                    return _bytesStatus431;
+                    return BytesStatus431;
                 case (int)HttpStatusCode.UnavailableForLegalReasons:
-                    return _bytesStatus451;
+                    return BytesStatus451;
 
                 case (int)HttpStatusCode.InternalServerError:
-                    return _bytesStatus500;
+                    return BytesStatus500;
                 case (int)HttpStatusCode.NotImplemented:
-                    return _bytesStatus501;
+                    return BytesStatus501;
                 case (int)HttpStatusCode.BadGateway:
-                    return _bytesStatus502;
+                    return BytesStatus502;
                 case (int)HttpStatusCode.ServiceUnavailable:
-                    return _bytesStatus503;
+                    return BytesStatus503;
                 case (int)HttpStatusCode.GatewayTimeout:
-                    return _bytesStatus504;
+                    return BytesStatus504;
                 case (int)HttpStatusCode.HttpVersionNotSupported:
-                    return _bytesStatus505;
+                    return BytesStatus505;
                 case (int)HttpStatusCode.VariantAlsoNegotiates:
-                    return _bytesStatus506;
+                    return BytesStatus506;
                 case (int)HttpStatusCode.InsufficientStorage:
-                    return _bytesStatus507;
+                    return BytesStatus507;
                 case (int)HttpStatusCode.LoopDetected:
-                    return _bytesStatus508;
+                    return BytesStatus508;
                 case (int)HttpStatusCode.NotExtended:
-                    return _bytesStatus510;
+                    return BytesStatus510;
                 case (int)HttpStatusCode.NetworkAuthenticationRequired:
-                    return _bytesStatus511;
+                    return BytesStatus511;
 
                 default:
                     return Encoding.ASCII.GetBytes(statusCode.ToString(CultureInfo.InvariantCulture));

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -16,8 +16,6 @@ using System.Threading.Tasks;
 
 namespace System.Net.Http
 {
-
-
     internal sealed partial class Http2Connection : HttpConnectionBase, IDisposable
     {
         private readonly HttpConnectionPool _pool;

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -16,7 +16,7 @@ namespace System.Net.Http
 {
     internal sealed partial class Http2Connection
     {
-        private sealed class Http2Stream : IValueTaskSource, IHttpTrace
+        private sealed class Http2Stream : IValueTaskSource, IHttpTrace, IHttpHeadersHandler
         {
             private const int InitialStreamBufferSize =
 #if DEBUG
@@ -395,7 +395,7 @@ namespace System.Net.Http
 
             public void OnWindowUpdate(int amount) => _streamWindow.AdjustCredit(amount);
 
-            public void OnResponseHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
+            public void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
             {
                 if (NetEventSource.IsEnabled) Trace($"{Encoding.ASCII.GetString(name)}: {Encoding.ASCII.GetString(value)}");
                 Debug.Assert(name != null && name.Length > 0);
@@ -527,7 +527,7 @@ namespace System.Net.Http
                 }
             }
 
-            public void OnResponseHeadersStart()
+            public void OnHeadersStart()
             {
                 Debug.Assert(!Monitor.IsEntered(SyncObject));
                 lock (SyncObject)
@@ -550,7 +550,7 @@ namespace System.Net.Http
                 }
             }
 
-            public void OnResponseHeadersComplete(bool endStream)
+            public void OnHeadersComplete(bool endStream)
             {
                 Debug.Assert(!Monitor.IsEntered(SyncObject));
                 bool signalWaiter;

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/IHttpHeadersHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/IHttpHeadersHandler.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Net.Http
+{
+    internal interface IHttpHeadersHandler
+    {
+        void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value);
+        void OnHeadersComplete(bool endStream);
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/HPack/HPackIntegerTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/HPack/HPackIntegerTest.cs
@@ -43,17 +43,17 @@ namespace System.Net.Http.Unit.Tests.HPack
             Span<byte> encoded = stackalloc byte[5];
             Assert.True(IntegerEncoder.Encode(value, bits, encoded, out int bytesWritten));
 
-            bool finished = decoder.StartDecode(encoded[0], bits);
+            bool finished = decoder.BeginTryDecode(encoded[0], bits, out int intResult);
 
             int i = 1;
             for (; !finished && i < encoded.Length; ++i)
             {
-                finished = decoder.Decode(encoded[i]);
+                finished = decoder.TryDecode(encoded[i], out intResult);
             }
 
             Assert.True(finished);
             Assert.Equal(bytesWritten, i);
-            Assert.Equal(value, decoder.Value);
+            Assert.Equal(value, intResult);
         }
 
         public static IEnumerable<object[]> IntegerCodecExactSamples()
@@ -85,14 +85,14 @@ namespace System.Net.Http.Unit.Tests.HPack
             {
                 var dec = new IntegerDecoder();
 
-                if (!dec.StartDecode((byte)(encoded[0] & 0x7F), 7))
+                if (!dec.BeginTryDecode((byte)(encoded[0] & 0x7F), 7, out int intResult))
                 {
-                    for (int i = 1; !dec.Decode(encoded[i]); ++i)
+                    for (int i = 1; !dec.TryDecode(encoded[i], out intResult); ++i)
                     {
                     }
                 }
 
-                return dec.Value;
+                return intResult;
             });
         }
     }

--- a/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -350,6 +350,12 @@
     <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\HPack\DynamicTable.cs">
       <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\HPack\DynamicTable.cs</Link>
     </Compile>
+    <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\HPack\HPackEncodingException.cs">
+      <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\HPack\HPackEncodingException.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\HPack\StatusCodes.cs">
+      <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\HPack\StatusCodes.cs</Link>
+    </Compile>
     <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.cs">
       <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.cs</Link>
     </Compile>

--- a/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -317,6 +317,9 @@
     <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\HttpEnvironmentProxy.Windows.cs" Condition=" '$(TargetsWindows)' == 'true' And '$(TargetGroup)' == 'netcoreapp'">
       <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\HttpEnvironmentProxy.Windows.cs</Link>
     </Compile>
+    <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\IHttpHeadersHandler.cs">
+      <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\IHttpHeadersHandler.cs</Link>
+    </Compile>
     <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\HPack\HeaderField.cs">
       <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\HPack\HeaderField.cs</Link>
     </Compile>


### PR DESCRIPTION
Part of https://github.com/aspnet/AspNetCore/issues/13900. Corresponding PR; https://github.com/aspnet/AspNetCore/pull/13931

This PR synchronizes the HTTP/2 HPack implementation between Kestrel and CoreFx. Eventually, we will find a mechanism for sharing this code, but this is a necessary step in creating a shared source. The only remaining differences between aspnetcore and corefx are exceptions and namespaces.

This PR changes the following functionality:
- Introduces an interface IHttpHeadersHandler, which is used to add headers to the Http2Stream. This is what we did in Kestrel; if people prefer a delegate, we can revert back.
- Renames StartDecode/Decode to BeginTryDecode/TryDecode
- The HPackEncoder between Kestrel and HttpClient are fundamentally different. I just merged the two classes together for now.

Open questions:
- The HPackDecoder in HttpClient supports resizing of _headerNameOctets, _headerValueOctets, etc. I think it's a good optimization, but I believe I didn't handle the merge correctly. I'll look into fixing that.
