### PR TITLE
improve socket timout tests

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/SafeSocketHandle.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SafeSocketHandle.Unix.cs
@@ -144,6 +144,14 @@ namespace System.Net.Sockets
             }
         }
 
+        internal bool IsUnderlyingBlocking
+        {
+            get
+            {
+                return !_underlyingHandleNonBlocking;
+            }
+        }
+
         internal int ReceiveTimeout
         {
             get

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -703,6 +703,8 @@ namespace System.Net.Sockets
         public static bool TryCompleteSendTo(SafeSocketHandle socket, ReadOnlySpan<byte> buffer, IList<ArraySegment<byte>> buffers, ref int bufferIndex, ref int offset, ref int count, SocketFlags flags, byte[] socketAddress, int socketAddressLen, ref int bytesSent, out SocketError errorCode)
         {
             bool successfulSend = false;
+            long start = Environment.TickCount64;
+
             while (true)
             {
                 int sent;
@@ -743,6 +745,14 @@ namespace System.Net.Sockets
                     errorCode = SocketError.Success;
                     return true;
                 }
+
+                if (socket.SendTimeout > 0 && (Environment.TickCount64 - start) >= socket.SendTimeout)
+                {
+                    // Timeout is set and reached it while trying to send.
+                    errorCode = SocketError.TimedOut;
+                    return false;
+                }
+
             }
         }
 

--- a/src/System.Net.Sockets/tests/FunctionalTests/TimeoutTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/TimeoutTest.cs
@@ -7,9 +7,9 @@ using Xunit;
 
 namespace System.Net.Sockets.Tests
 {
+    [Collection("NoParallelTests")]
     public class TimeoutTest
     {
-        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void GetAndSet_Success()
         {
@@ -25,7 +25,6 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
         [Fact]
         public void SocketSendTimeout_GetAndSet_Success()
         {
@@ -45,7 +44,6 @@ namespace System.Net.Sockets.Tests
         // but also not so large that it takes too long to run.
         private const int Timeout = 2000;
 
-        [ActiveIssue(23767, TestPlatforms.AnyUnix)]
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [InlineData(true)]
@@ -68,15 +66,14 @@ namespace System.Net.Sockets.Tests
 
                 acceptedSocket.ForceNonBlocking(forceNonBlocking);
 
-                DateTime start = default(DateTime);
+                long start = Environment.TickCount64;
 
                 SocketException sockEx = Assert.Throws<SocketException>(() =>
                 {
-                    start = DateTime.UtcNow;
                     acceptedSocket.Receive(new byte[1]);
                 });
 
-                double elapsed = (DateTime.UtcNow - start).TotalMilliseconds;
+                long elapsed = Environment.TickCount64 - start;
 
                 Assert.Equal(SocketError.TimedOut, sockEx.SocketErrorCode);
                 Assert.True(acceptedSocket.Connected);
@@ -109,7 +106,7 @@ namespace System.Net.Sockets.Tests
 
                 acceptedSocket.ForceNonBlocking(forceNonBlocking);
 
-                var sw = new Stopwatch();
+                long start = Environment.TickCount64;
 
                 // Force Send to timeout by filling the kernel buffer.
                 var sendBuffer = new byte[16 * 1024];
@@ -117,19 +114,19 @@ namespace System.Net.Sockets.Tests
                 {
                     while (true)
                     {
-                        sw.Restart();
+                        start = Environment.TickCount64;
                         acceptedSocket.Send(sendBuffer);
                     }
                 }));
 
-                double elapsed = sw.Elapsed.TotalMilliseconds;
+                long elapsed = Environment.TickCount64 - start;
 
                 Assert.Equal(SocketError.TimedOut, sockEx.SocketErrorCode);
                 Assert.True(acceptedSocket.Connected);
 
                 // Try to ensure that the elapsed timeout is reasonably correct
                 // Sometimes test machines run slowly
-                Assert.InRange(elapsed, Timeout * 0.5, Timeout * 3);
+                Assert.InRange(elapsed, Timeout * 0.75, Timeout * 2);
             }
         }
     }

--- a/src/System.Net.Sockets/tests/FunctionalTests/TimeoutTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/TimeoutTest.cs
@@ -74,13 +74,12 @@ namespace System.Net.Sockets.Tests
                 });
 
                 long elapsed = Environment.TickCount64 - start;
-
                 Assert.Equal(SocketError.TimedOut, sockEx.SocketErrorCode);
                 Assert.True(acceptedSocket.Connected);
 
                 // Try to ensure that the elapsed timeout is reasonably correct
                 // Sometimes test machines run slowly
-                Assert.InRange(elapsed, Timeout * 0.75, Timeout * 2);
+                Assert.InRange(elapsed, Timeout * 0.75, Timeout * 1.9999);
             }
         }
 
@@ -120,13 +119,12 @@ namespace System.Net.Sockets.Tests
                 }));
 
                 long elapsed = Environment.TickCount64 - start;
-
                 Assert.Equal(SocketError.TimedOut, sockEx.SocketErrorCode);
                 Assert.True(acceptedSocket.Connected);
 
                 // Try to ensure that the elapsed timeout is reasonably correct
                 // Sometimes test machines run slowly
-                Assert.InRange(elapsed, Timeout * 0.75, Timeout * 2);
+                Assert.InRange(elapsed, Timeout * 0.75, Timeout * 1.9999);
             }
         }
     }


### PR DESCRIPTION
This is attempt to improve stability of socket timeout tests as well as product improvement to make send timeouts more accurate. 

This removes most of #24844. When I was testing timeout tests, I noticed that for the blocking socket, actual timeouts are consistently about 2x of the value. For timeout 2s it would timeout in ~4s and for 5s timeout it would timeout in 10s and so on including very long timeouts.
Increasing test timeout in #24844 only hides that behavior. 

In case of Unix implementation we set socket timeout and we rely on OS to keep trying for given value. However when we fill up socket buffer OS keeps trying for given time. Then we see we wrote some bytes and we loop and we try to write more incurring set timeout once more. In general case this can go on for time far beyond configured value if we keep dribbling data out.

I added simple check to break from retry loop if we hit timeout value. With that, I changed expected time range back to more strict values.   

#23767 also has example where duration is negative. I think that can be because wall time was adjusted. I switched test to use monolithic TickCount64 to avoid issues with floating time. 

I also excluded timeout tests from parallel run to make execution more predictable as time is very important here. 

I also removed OuterLooop from two GetAndSet tests as there really should be no delay or external dependency. 
