### PR TITLE
improve portability of GetAsync_InvalidUrl_ExpectedExceptionThrown test

### DIFF
--- a/src/Common/tests/System/Net/Configuration.Sockets.cs
+++ b/src/Common/tests/System/Net/Configuration.Sockets.cs
@@ -9,6 +9,8 @@ namespace System.Net.Test.Common
         public static partial class Sockets
         {
            public static Uri SocketServer => GetUriValue("COREFX_NET_SOCKETS_SERVERURI", new Uri("http://" + DefaultAzureServer));
+
+           public static string InvalidHost => GetValue("COREFX_NET_SOCKETS_INVALIDSERVER", "notahostname.invalid.corp.microsoft.com");
         }
     }
 }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -2681,7 +2681,7 @@ namespace System.Net.Http.Functional.Tests
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue(11057)]
         public async Task GetAsync_InvalidUrl_ExpectedExceptionThrown()
         {
-            string invalidUri = $"http://_{Guid.NewGuid().ToString("N")}";
+            string invalidUri = $"http://{Configuration.Sockets.InvalidHost}";
             _output.WriteLine($"{DateTime.Now} connecting to {invalidUri}");
             using (HttpClient client = CreateHttpClient())
             {

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -58,6 +58,9 @@
     <Compile Include="$(CommonTestPath)\System\Net\Configuration.Security.cs">
       <Link>Common\System\Net\Configuration.Security.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Net\Configuration.Sockets.cs">
+      <Link>Common\System\Net\Configuration.Sockets.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Net\TestWebProxies.cs">
       <Link>Common\System\Net\TestWebProxies.cs</Link>
     </Compile>

--- a/src/System.Net.Sockets/tests/FunctionalTests/DnsEndPointTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DnsEndPointTest.cs
@@ -10,6 +10,8 @@ using Xunit.Abstractions;
 
 namespace System.Net.Sockets.Tests
 {
+    using Configuration = System.Net.Test.Common.Configuration;
+
     public class DnsEndPointTest : DualModeBase
     {
         private void OnConnectAsyncCompleted(object sender, SocketAsyncEventArgs args)
@@ -60,7 +62,7 @@ namespace System.Net.Sockets.Tests
             {
                 SocketException ex = Assert.ThrowsAny<SocketException>(() =>
                 {
-                    sock.Connect(new DnsEndPoint("notahostname.invalid.corp.microsoft.com", UnusedPort));
+                    sock.Connect(new DnsEndPoint(Configuration.Sockets.InvalidHost, UnusedPort));
                 });
 
                 SocketError errorCode = ex.SocketErrorCode;
@@ -150,7 +152,7 @@ namespace System.Net.Sockets.Tests
             {
                 SocketException ex = Assert.ThrowsAny<SocketException>(() =>
                 {
-                    IAsyncResult result = sock.BeginConnect(new DnsEndPoint("notahostname.invalid.corp.microsoft.com", UnusedPort), null, null);
+                    IAsyncResult result = sock.BeginConnect(new DnsEndPoint(Configuration.Sockets.InvalidHost, UnusedPort), null, null);
                     sock.EndConnect(result);
                 });
 
@@ -256,7 +258,7 @@ namespace System.Net.Sockets.Tests
             Assert.True(Capability.IPv4Support());
 
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new DnsEndPoint("notahostname.invalid.corp.microsoft.com", UnusedPort);
+            args.RemoteEndPoint = new DnsEndPoint(Configuration.Sockets.InvalidHost, UnusedPort);
             args.Completed += OnConnectAsyncCompleted;
 
             using (Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
@@ -356,7 +358,7 @@ namespace System.Net.Sockets.Tests
         public void Socket_StaticConnectAsync_HostNotFound()
         {
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new DnsEndPoint("notahostname.invalid.corp.microsoft.com", UnusedPort);
+            args.RemoteEndPoint = new DnsEndPoint(Configuration.Sockets.InvalidHost, UnusedPort);
             args.Completed += OnConnectAsyncCompleted;
 
             ManualResetEvent complete = new ManualResetEvent(false);


### PR DESCRIPTION
GetAsync_InvalidUrl_ExpectedExceptionThrown test uses guid to construct invalid name. In my case, my ISP would happily resolve that name and it would redirect me to server serving adds.

```
macik2:FunctionalTests furt$ curl -v http://_9c036a244c4e4c47a3f86e0e35065793/
*   Trying 198.105.244.23...
* TCP_NODELAY set
* Connected to _9c036a244c4e4c47a3f86e0e35065793 (198.105.244.23) port 80 (#0)
> GET / HTTP/1.1
> Host: _9c036a244c4e4c47a3f86e0e35065793
> User-Agent: curl/7.54.0
> Accept: */*
>
< HTTP/1.1 301 Moved Permanently
< Server: nginx
< Date: Fri, 13 Sep 2019 05:25:30 GMT
< Content-Type: text/html

```

while this is not problem with CI, it forced me to manually disable this test if I want to get clean pass. 

We already have passinfg tests with invalid name so I rte-factor them a little bit and I updated GetAsync_InvalidUrl_ExpectedExceptionThrown to use same name instead of generated guid. 