### PR TITLE
Serialization performance improvements

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
@@ -237,7 +237,8 @@ namespace System.Text.Json
         public JsonDictionaryConverter DictionaryConverter { get; private set; }
 
         // The escaped name passed to the writer.
-        public JsonEncodedText? EscapedName { get; private set; }
+        // Use a field here (not a property) to avoid value semantics.
+        public JsonEncodedText? EscapedName;
 
         public static TAttribute GetAttribute<TAttribute>(PropertyInfo propertyInfo) where TAttribute : Attribute
         {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
@@ -90,31 +90,25 @@ namespace System.Text.Json
             return result;
         }
 
-        private static string WriteValueCore(Utf8JsonWriter writer, object value, Type type, JsonSerializerOptions options)
+        private static void WriteValueCore(Utf8JsonWriter writer, object value, Type type, JsonSerializerOptions options)
         {
             if (options == null)
             {
                 options = JsonSerializerOptions.s_defaultOptions;
             }
 
-            string result;
-
-            using (var output = new PooledByteBufferWriter(options.DefaultBufferSize))
-            {
-                WriteCore(writer, output, value, type, options);
-                result = JsonReaderHelper.TranscodeHelper(output.WrittenMemory.Span);
-            }
-
-            return result;
+            WriteCore(writer, value, type, options);
         }
 
         private static void WriteCore(PooledByteBufferWriter output, object value, Type type, JsonSerializerOptions options)
         {
-            using var writer = new Utf8JsonWriter(output, options.GetWriterOptions());
-            WriteCore(writer, output, value, type, options);
+            using (var writer = new Utf8JsonWriter(output, options.GetWriterOptions()))
+            {
+                WriteCore(writer, value, type, options);
+            }
         }
 
-        private static void WriteCore(Utf8JsonWriter writer, PooledByteBufferWriter output, object value, Type type, JsonSerializerOptions options)
+        private static void WriteCore(Utf8JsonWriter writer, object value, Type type, JsonSerializerOptions options)
         {
             Debug.Assert(type != null || value == null);
 

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.String.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.String.cs
@@ -18,7 +18,7 @@ namespace System.Text.Json
         /// </remarks>
         public static string Serialize<TValue>(TValue value, JsonSerializerOptions options = null)
         {
-            return ToStringInternal(value, typeof(TValue), options);
+            return WriteCoreString(value, typeof(TValue), options);
         }
 
         /// <summary>
@@ -35,12 +35,6 @@ namespace System.Text.Json
         public static string Serialize(object value, Type inputType, JsonSerializerOptions options = null)
         {
             VerifyValueAndType(value, inputType);
-
-            return ToStringInternal(value, inputType, options);
-        }
-
-        private static string ToStringInternal(object value, Type inputType, JsonSerializerOptions options)
-        {
             return WriteCoreString(value, inputType, options);
         }
     }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.cs
@@ -36,24 +36,21 @@ namespace System.Text.Json
                             current.JsonPropertyInfo.Write(ref state, writer);
                             finishedSerializing = true;
                             break;
-                        case ClassType.Object:
-                            finishedSerializing = WriteObject(options, writer, ref state);
-                            break;
                         case ClassType.Dictionary:
                         case ClassType.IDictionaryConstructible:
                             finishedSerializing = HandleDictionary(current.JsonClassInfo.ElementClassInfo, options, writer, ref state);
                             break;
                         default:
-                            Debug.Assert(state.Current.JsonClassInfo.ClassType == ClassType.Unknown);
+                            Debug.Assert(state.Current.JsonClassInfo.ClassType == ClassType.Object ||
+                                state.Current.JsonClassInfo.ClassType == ClassType.Unknown);
 
-                            // Treat typeof(object) as an empty object.
                             finishedSerializing = WriteObject(options, writer, ref state);
                             break;
                     }
 
                     if (finishedSerializing)
                     {
-                        if (writer.CurrentDepth == 0 || writer.CurrentDepth == originalWriterDepth)
+                        if (writer.CurrentDepth == originalWriterDepth)
                         {
                             break;
                         }
@@ -63,7 +60,7 @@ namespace System.Text.Json
                         ThrowHelper.ThrowInvalidOperationException_SerializerCycleDetected(options.MaxDepth);
                     }
 
-                    // If serialization is not yet end and we surpass beyond flush threshold return false and flush stream.
+                    // If serialization is not finished and we surpass flush threshold then return false which will flush stream.
                     if (flushThreshold >= 0 && writer.BytesPending > flushThreshold)
                     {
                         return false;


### PR DESCRIPTION
Serialization improvements from 15%-28% on existing benchmarks (for simple objects).

Changes in order of most impact to lesser impact:
- Use `[AggressiveInlining]` when processing property values. Required some misc refactoring so that the methods inlined are only called once (instead of twice).
- Using an array instead of Dictionay enumerator to obtain properties to serialize.
- Changing a property to a field (struct for `JsonEncodedTest`) to avoid a copy on read.
- Removing unused return values and misc cleanup.

**WriteJson benchmarks**

| Faster                                                                           | base/diff | Base Median (ns) | Diff Median (ns) | Modality|
|----------------------------------------------------------------------------------|----------:|-----------------:|-----------------:|--------:| 
| System.Text.Json.Serialization.Tests.WriteJson<Location>.SerializeToUtf8Bytes    |      1.41 |          1328.46 |           944.13 |         |
| System.Text.Json.Serialization.Tests.WriteJson<LoginViewModel>.SerializeToString |      1.40 |           592.57 |           422.00 |         |
| System.Text.Json.Serialization.Tests.WriteJson<LoginViewModel>.SerializeToUtf8By |      1.40 |           547.15 |           389.85 |         |
| System.Text.Json.Serialization.Tests.WriteJson<Location>.SerializeToString       |      1.36 |          1372.30 |          1006.11 |         |
| System.Text.Json.Serialization.Tests.WriteJson<LoginViewModel>.SerializeToStream |      1.36 |           653.96 |           480.28 |         |
| System.Text.Json.Serialization.Tests.WriteJson<Location>.SerializeToStream       |      1.35 |          1435.65 |          1061.99 |         |
| System.Text.Json.Serialization.Tests.WriteJson<IndexViewModel>.SerializeToUtf8By |      1.29 |         35629.31 |         27513.08 |         |
| System.Text.Json.Serialization.Tests.WriteJson<IndexViewModel>.SerializeToStream |      1.27 |         34489.63 |         27073.81 |         |
| System.Text.Json.Serialization.Tests.WriteJson<IndexViewModel>.SerializeToString |      1.26 |         36860.43 |         29178.57 |         |
| System.Text.Json.Serialization.Tests.WriteJson<MyEventsListerViewModel>.Serializ |      1.20 |        614502.43 |        513175.55 |         |
| System.Text.Json.Serialization.Tests.WriteJson<MyEventsListerViewModel>.Serializ |      1.19 |        618552.11 |        518655.83 |         |
| System.Text.Json.Serialization.Tests.WriteJson<MyEventsListerViewModel>.Serializ |      1.19 |        663942.62 |        559237.31 |         |


**Comparisons to Json.NET**

MyEventsListerViewModel Before

|         Method |     Mean |    Error |   StdDev |   Median |      Min |      Max | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|--------------- |---------:|---------:|---------:|---------:|---------:|---------:|------------:|------------:|------------:|--------------------:|
|       JSON.NET | 782.3 us | 2.066 us | 1.933 us | 781.6 us | 779.2 us | 785.3 us |     94.6372 |     47.3186 |     47.3186 |           565.39 KB |
| SystemTextJson | 664.6 us | 4.227 us | 3.954 us | 664.6 us | 658.5 us | 673.5 us |     45.0928 |     45.0928 |     45.0928 |           381.33 KB |

MyEventsListerViewModel After

|         Method |     Mean |     Error |    StdDev |   Median |      Min |      Max | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|--------------- |---------:|----------:|----------:|---------:|---------:|---------:|------------:|------------:|------------:|--------------------:|
|       JSON.NET | 787.8 us |  2.807 us |  2.488 us | 786.9 us | 784.9 us | 793.4 us |     94.9367 |     47.4684 |     47.4684 |           564.91 KB |
| SystemTextJson | 574.4 us | 13.518 us | 15.567 us | 568.1 us | 558.8 us | 608.1 us |     45.9770 |     45.9770 |     45.9770 |           380.87 KB |

IndexViewModel Before

|         Method |     Mean |     Error |    StdDev |   Median |      Min |      Max | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|--------------- |---------:|----------:|----------:|---------:|---------:|---------:|------------:|------------:|------------:|--------------------:|
|       JSON.NET | 40.50 us | 0.1701 us | 0.1591 us | 40.48 us | 40.26 us | 40.84 us |      9.6556 |      1.6093 |           - |            59.33 KB |
| SystemTextJson | 36.95 us | 0.1801 us | 0.1597 us | 36.90 us | 36.72 us | 37.32 us |      3.9677 |      0.2939 |           - |            25.13 KB |

IndexViewModel After

|         Method |     Mean |     Error |    StdDev |   Median |      Min |      Max | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|--------------- |---------:|----------:|----------:|---------:|---------:|---------:|------------:|------------:|------------:|--------------------:|
|       JSON.NET | 40.03 us | 0.1336 us | 0.1249 us | 40.00 us | 39.88 us | 40.27 us |      9.5602 |      1.5934 |           - |            59.33 KB |
| SystemTextJson | 27.48 us | 0.1451 us | 0.1211 us | 27.46 us | 27.34 us | 27.79 us |      3.9739 |      0.3312 |           - |            25.01 KB |

Location Before

|         Method |     Mean |     Error |    StdDev |   Median |      Min |      Max | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|--------------- |---------:|----------:|----------:|---------:|---------:|---------:|------------:|------------:|------------:|--------------------:|
|       JSON.NET | 1.439 us | 0.0032 us | 0.0028 us | 1.439 us | 1.434 us | 1.443 us |      0.2758 |           - |           - |              1736 B |
| SystemTextJson | 1.370 us | 0.0038 us | 0.0034 us | 1.370 us | 1.366 us | 1.375 us |      0.0930 |           - |           - |               584 B |

Location After

|         Method |     Mean |     Error |    StdDev |   Median |      Min |      Max | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|--------------- |---------:|----------:|----------:|---------:|---------:|---------:|------------:|------------:|------------:|--------------------:|
|       JSON.NET | 1.429 us | 0.0077 us | 0.0069 us | 1.427 us | 1.422 us | 1.445 us |      0.2724 |           - |           - |              1736 B |
| SystemTextJson | 1.007 us | 0.0029 us | 0.0026 us | 1.006 us | 1.002 us | 1.011 us |      0.0924 |           - |           - |               584 B |

LoginViewModel Before

|         Method |     Mean |    Error |   StdDev |   Median |      Min |      Max | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|--------------- |---------:|---------:|---------:|---------:|---------:|---------:|------------:|------------:|------------:|--------------------:|
|       JSON.NET | 696.4 ns | 3.961 ns | 3.511 ns | 695.3 ns | 692.5 ns | 703.4 ns |      0.2375 |           - |           - |              1504 B |
| SystemTextJson | 599.8 ns | 1.602 ns | 1.420 ns | 599.6 ns | 597.6 ns | 603.2 ns |      0.0527 |           - |           - |               344 B |

LoginViewModel After

|         Method |     Mean |    Error |   StdDev |   Median |      Min |      Max | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|--------------- |---------:|---------:|---------:|---------:|---------:|---------:|------------:|------------:|------------:|--------------------:|
|       JSON.NET | 665.9 ns | 3.070 ns | 2.722 ns | 665.3 ns | 661.1 ns | 670.1 ns |      0.2391 |           - |           - |              1504 B |
| SystemTextJson | 434.6 ns | 1.487 ns | 1.318 ns | 434.6 ns | 432.6 ns | 436.6 ns |      0.0539 |           - |           - |               344 B |
