### PR TITLE
FileSecurity/DirectorySecurity should support long paths

### DIFF
--- a/src/Common/src/Interop/Windows/Advapi32/Interop.GetSecurityInfoByHandle.cs
+++ b/src/Common/src/Interop/Windows/Advapi32/Interop.GetSecurityInfoByHandle.cs
@@ -9,9 +9,16 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-        [DllImport(Interop.Libraries.Advapi32, EntryPoint = "GetSecurityInfo", CallingConvention = CallingConvention.Winapi,
+        [DllImport(Libraries.Advapi32, EntryPoint = "GetSecurityInfo", CallingConvention = CallingConvention.Winapi,
             SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
-        internal static extern /*DWORD*/ uint GetSecurityInfoByHandle(SafeHandle handle, /*DWORD*/ uint objectType, /*DWORD*/ uint securityInformation,
-            out IntPtr sidOwner, out IntPtr sidGroup, out IntPtr dacl, out IntPtr sacl, out IntPtr securityDescriptor);
+        internal static extern uint GetSecurityInfoByHandle(
+            SafeHandle handle,
+            uint objectType,
+            uint securityInformation,
+            out IntPtr sidOwner,
+            out IntPtr sidGroup,
+            out IntPtr dacl,
+            out IntPtr sacl,
+            out IntPtr securityDescriptor);
     }
 }

--- a/src/Common/src/Interop/Windows/Advapi32/Interop.GetSecurityInfoByName.cs
+++ b/src/Common/src/Interop/Windows/Advapi32/Interop.GetSecurityInfoByName.cs
@@ -9,9 +9,16 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-        [DllImport(Interop.Libraries.Advapi32, EntryPoint = "GetNamedSecurityInfoW", CallingConvention = CallingConvention.Winapi,
+        [DllImport(Libraries.Advapi32, EntryPoint = "GetNamedSecurityInfoW", CallingConvention = CallingConvention.Winapi,
             SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
-        internal static extern /*DWORD*/ uint GetSecurityInfoByName(string name, /*DWORD*/ uint objectType, /*DWORD*/ uint securityInformation,
-            out IntPtr sidOwner, out IntPtr sidGroup, out IntPtr dacl, out IntPtr sacl, out IntPtr securityDescriptor);
+        internal static extern uint GetSecurityInfoByName(
+            string name,
+            uint objectType,
+            uint securityInformation,
+            out IntPtr sidOwner,
+            out IntPtr sidGroup,
+            out IntPtr dacl,
+            out IntPtr sacl,
+            out IntPtr securityDescriptor);
     }
 }

--- a/src/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.cs
+++ b/src/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.cs
@@ -2,9 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Win32.SafeHandles;
 using System.Security.AccessControl;
-using System;
+using Microsoft.Win32.SafeHandles;
 
 namespace System.IO
 {
@@ -56,7 +55,7 @@ namespace System.IO
             {
                 throw new ObjectDisposedException(null, SR.ObjectDisposed_FileClosed);
             }
-            return new FileSecurity(handle, fileStream.Name, AccessControlSections.Access | AccessControlSections.Owner | AccessControlSections.Group);
+            return new FileSecurity(handle, AccessControlSections.Access | AccessControlSections.Owner | AccessControlSections.Group);
         }
 
         public static void SetAccessControl(this FileStream fileStream, FileSecurity fileSecurity)

--- a/src/System.IO.FileSystem.AccessControl/src/System/Security/AccessControl/DirectoryObjectSecurity.cs
+++ b/src/System.IO.FileSystem.AccessControl/src/System/Security/AccessControl/DirectoryObjectSecurity.cs
@@ -11,6 +11,8 @@ namespace System.Security.AccessControl
     /// </summary>
     public abstract class DirectoryObjectSecurity : ObjectSecurity
     {
+        #region Constructors
+
         protected DirectoryObjectSecurity()
             : base(true, true)
         {
@@ -25,6 +27,8 @@ namespace System.Security.AccessControl
                 throw new ArgumentNullException(nameof(securityDescriptor));
             }
         }
+
+        #endregion
 
         #region Private Methods
 
@@ -483,7 +487,7 @@ nameof(modification),
 
 #endregion
 
-#region public Methods
+        #region Public Methods
 
         public virtual AccessRule AccessRuleFactory(IdentityReference identityReference, int accessMask, bool isInherited, InheritanceFlags inheritanceFlags, PropagationFlags propagationFlags, AccessControlType type, Guid objectType, Guid inheritedObjectType)
         {
@@ -518,9 +522,10 @@ nameof(modification),
             //}
             return ModifyAudit(modification, rule as ObjectAuditRule, out modified);
         }
-#endregion
 
-#region Public Methods
+        #endregion
+
+        #region Public Methods
 
         protected void AddAccessRule(ObjectAccessRule rule)
         {
@@ -769,6 +774,6 @@ nameof(modification),
             return GetRules(false, includeExplicit, includeInherited, targetType);
         }
 
-#endregion
+        #endregion
     }
 }

--- a/src/System.IO.FileSystem.AccessControl/src/System/Security/AccessControl/FileSecurity.cs
+++ b/src/System.IO.FileSystem.AccessControl/src/System/Security/AccessControl/FileSecurity.cs
@@ -11,15 +11,10 @@
 **
 ===========================================================*/
 
-using Microsoft.Win32.SafeHandles;
-using Microsoft.Win32;
-using System.Collections;
 using System.IO;
 using System.Runtime.InteropServices;
-using System.Runtime.Versioning;
-using System.Security.AccessControl;
 using System.Security.Principal;
-using System;
+using Microsoft.Win32.SafeHandles;
 
 namespace System.Security.AccessControl
 {
@@ -199,6 +194,7 @@ namespace System.Security.AccessControl
         {
             return (FileSystemRights)accessMask;
         }
+
         #endregion
     }
 
@@ -302,6 +298,7 @@ namespace System.Security.AccessControl
         {
             get { return FileSystemAccessRule.RightsFromAccessMask(base.AccessMask); }
         }
+
         #endregion
     }
 
@@ -314,13 +311,15 @@ namespace System.Security.AccessControl
 
         #endregion
 
+        #region Constructors
+
         internal FileSystemSecurity(bool isContainer)
             : base(isContainer, s_ResourceType, _HandleErrorCode, isContainer)
         {
         }
 
-        internal FileSystemSecurity(bool isContainer, string name, AccessControlSections includeSections, bool isDirectory)
-            : base(isContainer, s_ResourceType, name, includeSections, _HandleErrorCode, isDirectory)
+        internal FileSystemSecurity(bool isContainer, string fileName, AccessControlSections includeSections, bool isDirectory)
+            : base(isContainer, s_ResourceType, fileName, includeSections, _HandleErrorCode, isDirectory)
         {
         }
 
@@ -366,6 +365,8 @@ namespace System.Security.AccessControl
 
             return exception;
         }
+
+        #endregion
 
         #region Factories
 
@@ -584,7 +585,8 @@ namespace System.Security.AccessControl
         }
         #endregion
 
-        #region some overrides
+        #region Overrides
+
         public override Type AccessRightType
         {
             get { return typeof(System.Security.AccessControl.FileSystemRights); }
@@ -599,6 +601,7 @@ namespace System.Security.AccessControl
         {
             get { return typeof(System.Security.AccessControl.FileSystemAuditRule); }
         }
+
         #endregion
     }
 
@@ -608,24 +611,24 @@ namespace System.Security.AccessControl
         #region Constructors
 
         public FileSecurity()
-            : base(false)
+            : base(isContainer: false)
         {
         }
 
         public FileSecurity(string fileName, AccessControlSections includeSections)
-            : base(false, fileName, includeSections, false)
+            : base(isContainer: false, fileName, includeSections, isDirectory: false)
         {
-            string fullPath = Path.GetFullPath(fileName);
         }
 
         // Warning!  Be exceedingly careful with this constructor.  Do not make
         // it public.  We don't want to get into a situation where someone can
         // pass in the string foo.txt and a handle to bar.exe, and we do a
         // demand on the wrong file name.
-        internal FileSecurity(SafeFileHandle handle, string fullPath, AccessControlSections includeSections)
-            : base(false, handle, includeSections, false)
+        internal FileSecurity(SafeFileHandle handle, AccessControlSections includeSections)
+            : base(isContainer: false, handle, includeSections, isDirectory: false)
         {
         }
+
         #endregion
     }
 
@@ -640,10 +643,10 @@ namespace System.Security.AccessControl
         }
 
         public DirectorySecurity(string name, AccessControlSections includeSections)
-            : base(true, name, includeSections, true)
+            : base(isContainer: true, name, includeSections, isDirectory: true)
         {
-            string fullPath = Path.GetFullPath(name);
         }
+
         #endregion
     }
 }

--- a/src/System.Security.AccessControl/src/System/Security/AccessControl/CommonObjectSecurity.cs
+++ b/src/System.Security.AccessControl/src/System/Security/AccessControl/CommonObjectSecurity.cs
@@ -9,11 +9,7 @@
 **
 ===========================================================*/
 
-using Microsoft.Win32;
-using System;
-using System.Collections;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 using System.Security.Principal;
 
 namespace System.Security.AccessControl
@@ -35,6 +31,7 @@ namespace System.Security.AccessControl
         #endregion
 
         #region Private Methods
+
         // Ported from NDP\clr\src\BCL\System\Security\Principal\SID.cs since we can't access System.Security.Principal.IdentityReference's internals
         private static bool IsValidTargetTypeStatic(Type targetType)
         {
@@ -683,6 +680,7 @@ nameof(modification),
         {
             return GetRules(false, includeExplicit, includeInherited, targetType);
         }
+
         #endregion
     }
 }

--- a/src/System.Security.AccessControl/src/System/Security/AccessControl/NativeObjectSecurity.cs
+++ b/src/System.Security.AccessControl/src/System/Security/AccessControl/NativeObjectSecurity.cs
@@ -9,13 +9,8 @@
 **
 ===========================================================*/
 
-using Microsoft.Win32;
-using System;
-using System.Collections;
 using System.Diagnostics;
-using System.Globalization;
 using System.Runtime.InteropServices;
-using System.Runtime.Versioning;
 using System.Security.Principal;
 using FileNotFoundException = System.IO.FileNotFoundException;
 
@@ -32,8 +27,6 @@ namespace System.Security.AccessControl
         private readonly uint ProtectedSystemAcl = 0x40000000;
         private readonly uint UnprotectedDiscretionaryAcl = 0x20000000;
         private readonly uint UnprotectedSystemAcl = 0x10000000;
-
-
 
         #endregion
 
@@ -139,11 +132,9 @@ namespace System.Security.AccessControl
                     }
                     else if (error == Interop.Errors.ERROR_INVALID_NAME)
                     {
-                        exception = new ArgumentException(
-                             SR.Argument_InvalidName,
-nameof(name));
+                        exception = new ArgumentException(SR.Argument_InvalidName, nameof(name));
                     }
-                    else if (error == Interop.Errors.ERROR_FILE_NOT_FOUND)
+                    else if (error == Interop.Errors.ERROR_FILE_NOT_FOUND || error == Interop.Errors.ERROR_PATH_NOT_FOUND)
                     {
                         exception = (name == null ? new FileNotFoundException() : new FileNotFoundException(name));
                     }
@@ -369,6 +360,7 @@ nameof(name));
 
             Persist(null, handle, includeSections, exceptionContext);
         }
+
         #endregion
     }
 }

--- a/src/System.Security.AccessControl/src/System/Security/AccessControl/ObjectSecurity.cs
+++ b/src/System.Security.AccessControl/src/System/Security/AccessControl/ObjectSecurity.cs
@@ -724,6 +724,7 @@ nameof(rule));
         public abstract AccessRule AccessRuleFactory(IdentityReference identityReference, int accessMask, bool isInherited, InheritanceFlags inheritanceFlags, PropagationFlags propagationFlags, AccessControlType type);
 
         public abstract AuditRule AuditRuleFactory(IdentityReference identityReference, int accessMask, bool isInherited, InheritanceFlags inheritanceFlags, PropagationFlags propagationFlags, AuditFlags flags);
+
         #endregion
     }
 }

--- a/src/System.Security.AccessControl/src/System/Security/AccessControl/Win32.cs
+++ b/src/System.Security.AccessControl/src/System/Security/AccessControl/Win32.cs
@@ -2,15 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Win32;
-using Microsoft.Win32.SafeHandles;
-using System;
-using System.Collections;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Runtime.Versioning;
-using System.Security;
 using System.Security.Principal;
 
 namespace System.Security.AccessControl
@@ -125,9 +118,7 @@ namespace System.Security.AccessControl
                 {
                     if (handle.IsInvalid)
                     {
-                        throw new ArgumentException(
-                            SR.Argument_InvalidSafeHandle,
-nameof(handle));
+                        throw new ArgumentException(SR.Argument_InvalidSafeHandle, nameof(handle));
                     }
                     else
                     {


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/29275

Original PR branch got in a weird state so I am submitting again: https://github.com/dotnet/corefx/pull/40921

FileSecurity fails to read permissions from file that have a path length exceeding 259 characters. I discovered that `DirectorySecurity` has the same issue.

Changes in this PR:

- Removed unused `fullPath` string that was being created inside the `FileSecurity` and `DirectorySecurity` constructors that receive a `fileName` string.

- Parent class `NativeObjectSecurity` in `System.Security.AccessControl` throws unhandled `ERROR_PATH_NOT_FOUND` if the file does not exist. Which is weird because we already handle `ERROR_FILE_NOT_FOUND`. SO I added this error to this other existing `else`, so that we keep throwing the same exception.

- Added unit tests for the `FileSecurity` and `DirectorySecurity` constructors that accept a long filename string.

- The `FileSecurity` class had an internal constructor with an unused parameter `fullPath` and a warning about that unused parameter. Removed unused parameter along with the unnecessary warning comment. Made sure to update the only internal usage of that constructor so it uses the new signature.

- `FileSecurity` and `DirectorySecurity` seem to only be available for Windows, but the documentation is not clear about this restriction. I can add a comment indicating that these classes are exclusive for Windows.

- Renamed internal `FileSystemSecurity` constructor's parameter `name` to `fileName` for clarity.
