### PR TITLE
Remove unnecessary passing of RegexOptions.None to Regex ctor

### DIFF
--- a/src/System.Private.Xml/src/System/Xml/Schema/FacetChecker.cs
+++ b/src/System.Private.Xml/src/System/Xml/Schema/FacetChecker.cs
@@ -364,7 +364,7 @@ namespace System.Xml.Schema
                             _regStr.Insert(0, "(");
                             _regStr.Append(")");
                         }
-                        _derivedRestriction.Patterns.Add(new Regex(Preprocess(_regStr.ToString()), RegexOptions.None));
+                        _derivedRestriction.Patterns.Add(new Regex(Preprocess(_regStr.ToString())));
                     }
                     catch (Exception e)
                     {
@@ -1348,7 +1348,7 @@ namespace System.Xml.Schema
             {
                 if (s_languagePattern == null)
                 {
-                    Regex langRegex = new Regex("^([a-zA-Z]{1,8})(-[a-zA-Z0-9]{1,8})*$", RegexOptions.None);
+                    Regex langRegex = new Regex("^([a-zA-Z]{1,8})(-[a-zA-Z0-9]{1,8})*$");
                     Interlocked.CompareExchange(ref s_languagePattern, langRegex, null);
                 }
                 return s_languagePattern;

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateMisc.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateMisc.cs
@@ -1093,7 +1093,7 @@ namespace System.Xml.Tests
         {
             Initialize();
 
-            Regex regex = new Regex(@"^\w+$", RegexOptions.None);
+            Regex regex = new Regex(@"^\w+$");
             string schemaContent = @"<xs:schema elementFormDefault='qualified' xmlns:xs='http://www.w3.org/2001/XMLSchema'>
 <xs:element name='validationTest'>
 <xs:simpleType>


### PR DESCRIPTION
Doing so has no benefit and inhibits the benefits of the changes in https://github.com/dotnet/corefx/pull/41075.

cc: @krwq, @ViktorHofer 