### PR TITLE
Disable NoCallback_RevokedCertificate_NoRevocationChecking_Succeeds

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
@@ -318,6 +318,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(41108)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "UAP doesn't allow revocation checking to be turned off")]
         [OuterLoop("Uses external server")]
         [ConditionalFact(nameof(ClientSupportsDHECipherSuites))]


### PR DESCRIPTION
The remote server "revoked.badssl.com" has a certificate which is not only revoked but also
now untrusted since it has expired.

Disabling test for now

Contributes to #41108