### PR TITLE
Remove System.Net.Requests dependency from System.Private.Xml

### DIFF
--- a/src/System.Private.Xml/src/System.Private.Xml.csproj
+++ b/src/System.Private.Xml/src/System.Private.Xml.csproj
@@ -580,7 +580,6 @@
     <Reference Include="System.Linq.Expressions" />
     <Reference Include="System.Memory" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Requests" />
     <Reference Include="System.Net.Primitives" />
     <Reference Include="System.ObjectModel" />
     <Reference Include="System.Reflection.Primitives" />

--- a/src/System.Private.Xml/src/System/Xml/XmlDownloadManager.cs
+++ b/src/System.Private.Xml/src/System/Xml/XmlDownloadManager.cs
@@ -5,14 +5,12 @@
 using System;
 using System.IO;
 using System.Net;
-using System.Net.Cache;
-using System.Net.Http;
 
 namespace System.Xml
 {
     internal partial class XmlDownloadManager
     {
-        internal Stream GetStream(Uri uri, ICredentials credentials, IWebProxy proxy, RequestCachePolicy cachePolicy)
+        internal Stream GetStream(Uri uri, ICredentials credentials, IWebProxy proxy)
         {
             if (uri.Scheme == "file")
             {
@@ -20,31 +18,9 @@ namespace System.Xml
             }
             else
             {
-                return GetNonFileStream(uri, credentials, proxy, cachePolicy);
-            }
-        }
-
-        private Stream GetNonFileStream(Uri uri, ICredentials credentials, IWebProxy proxy, RequestCachePolicy cachePolicy)
-        {
-            using (var handler = new SocketsHttpHandler())
-            using (var client = new HttpClient(handler))
-            {
-                if (credentials != null)
-                {
-                    handler.Credentials = credentials;
-                }
-                if (proxy != null)
-                {
-                    handler.Proxy = proxy;
-                }
-
-                using (Stream respStream = client.GetStreamAsync(uri).GetAwaiter().GetResult())
-                {
-                    var result = new MemoryStream();
-                    respStream.CopyTo(result);
-                    result.Position = 0;
-                    return result;
-                }
+                // This code should be changed if HttpClient ever gets real synchronous methods.  For now,
+                // we just use the asynchronous methods and block waiting for them to complete.
+                return GetNonFileStreamAsync(uri, credentials, proxy).GetAwaiter().GetResult();
             }
         }
     }

--- a/src/System.Private.Xml/src/System/Xml/XmlUrlResolverAsync.cs
+++ b/src/System.Private.Xml/src/System/Xml/XmlUrlResolverAsync.cs
@@ -14,12 +14,10 @@ namespace System.Xml
         {
             if (ofObjectToReturn == null || ofObjectToReturn == typeof(System.IO.Stream) || ofObjectToReturn == typeof(object))
             {
-                return await DownloadManager.GetStreamAsync(absoluteUri, _credentials, _proxy, _cachePolicy).ConfigureAwait(false);
+                return await DownloadManager.GetStreamAsync(absoluteUri, _credentials, _proxy).ConfigureAwait(false);
             }
-            else
-            {
-                throw new XmlException(SR.Xml_UnsupportedClass, string.Empty);
-            }
+
+            throw new XmlException(SR.Xml_UnsupportedClass, string.Empty);
         }
     }
 }

--- a/src/System.Private.Xml/tests/XmlReader/Tests/AsyncReaderLateInitTests.cs
+++ b/src/System.Private.Xml/tests/XmlReader/Tests/AsyncReaderLateInitTests.cs
@@ -74,7 +74,7 @@ namespace System.Xml.Tests
         {
             using (XmlReader reader = XmlReader.Create("http://test.test/test.html", new XmlReaderSettings() { Async = true }))
             {
-                Assert.Throws<System.Net.WebException>(() => reader.ReadAsync().GetAwaiter().GetResult());
+                Assert.Throws<System.Net.Http.HttpRequestException>(() => reader.ReadAsync().GetAwaiter().GetResult());
             }
         }
 
@@ -83,14 +83,14 @@ namespace System.Xml.Tests
         {
             using (XmlReader reader = XmlReader.Create("http://test.test/test.html", new XmlReaderSettings() { Async = true }))
             {
-                Assert.Throws<System.Net.WebException>(() => reader.Read());
+                Assert.Throws<System.Net.Http.HttpRequestException>(() => reader.Read());
             }
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue(11057)]
         public static void InitializationWithUriOnNonAsyncReaderTrows()
         {
-            Assert.Throws<System.Net.WebException>(() => XmlReader.Create("http://test.test/test.html", new XmlReaderSettings() { Async = false }));
+            Assert.Throws<System.Net.Http.HttpRequestException>(() => XmlReader.Create("http://test.test/test.html", new XmlReaderSettings() { Async = false }));
         }
 
         [Fact]

--- a/src/System.Private.Xml/tests/XmlReader/XmlResolver/XmlSystemPathResolverTests.cs
+++ b/src/System.Private.Xml/tests/XmlReader/XmlResolver/XmlSystemPathResolverTests.cs
@@ -90,10 +90,13 @@ namespace System.Xml.Tests
             AssertInvalidPath("??");
         }
 
-        [Fact]
-        public static void TestResolveInvalidPath()
+        [Theory]
+        [InlineData("http://notfound.invalid.corp.microsoft.com")]
+        [InlineData("ftp://host.invalid")]
+        [InlineData("notsupported://host.invalid")]
+        public static void TestResolveInvalidPath(string invalidUri)
         {
-            Assert.ThrowsAny<Exception>(() => XmlReader.Create("ftp://host.invalid"));
+            Assert.ThrowsAny<Exception>(() => XmlReader.Create(invalidUri));
         }
 
         [Fact]

--- a/src/System.Private.Xml/tests/XmlReader/XmlResolver/XmlSystemPathResolverTests.cs
+++ b/src/System.Private.Xml/tests/XmlReader/XmlResolver/XmlSystemPathResolverTests.cs
@@ -93,7 +93,7 @@ namespace System.Xml.Tests
         [Fact]
         public static void TestResolveInvalidPath()
         {
-            Assert.Throws<System.Net.WebException>(() => XmlReader.Create("ftp://host.invalid"));
+            Assert.ThrowsAny<Exception>(() => XmlReader.Create("ftp://host.invalid"));
         }
 
         [Fact]


### PR DESCRIPTION
Anything that uses System.Xml ends up implicitly referencing this System.Net.Requests.dll, which in a trimmed default MVC app is 97K (plus, System.Net.Requests.dll in turn references a whole bunch of stuff that's otherwise unused).  The only thing it's used for is as part of XmlResolver to download the specified url.  We can instead remove the usage of WebRequest.Create and replace it with usage of HttpClient, which is already brought in because System.Net.Requests uses it to implement HttpWebRequest.

@krwq, @buyaa-n, there are two breaking changes here (which is also why I've temporarily marked this as no-merge, until we can discuss it appropriately):
- Previously you could have specified a url with a scheme other than file, http, or https, and it may have worked.  To my knowledge the only other scheme that had built-in support was ftp, but you could also use WebRequest.RegisterPrefix to register a custom scheme handler, and then it seems that this XmlDownloadManager would have been able to use it.  How important is it to keep this functionality?  Have you ever seen or heard of someone using it with XmlResolver?
- Because we're now using HttpClient instead of HttpWebRequest, download failures that would have previously thrown WebException will now throw HttpRequestException.  How do we feel about that?  If you think it'll be impactful, we could push System.Net.WebException down to a lower-assembly, like System.Net.Primitives, but that'd be a bit unfortunate.

cc: @jkotas, @davidsh, @danmosemsft 