### PR TITLE
Read values from /proc/[pid]/status

### DIFF
--- a/src/Common/src/Interop/Linux/procfs/Interop.ProcFsStat.cs
+++ b/src/Common/src/Interop/Linux/procfs/Interop.ProcFsStat.cs
@@ -26,7 +26,7 @@ internal static partial class Interop
         internal const string SelfCmdLineFilePath = RootPath + "self" + CmdLineFileName;
         internal const string ProcStatFilePath = RootPath + "stat";
 
-        private static char[] Delimiters = { ':', ' ', '\t' };
+        private static readonly char[] s_delimiters = { ':', ' ', '\t' };
         internal struct ParsedStat
         {
             // Commented out fields are available in the stat data file but
@@ -322,8 +322,7 @@ internal static partial class Interop
 
             while (parser.MoveNext())
             {
-                string[] elements = parser.ExtractCurrent().Split(Delimiters, 3, StringSplitOptions.RemoveEmptyEntries);
-                
+                string[] elements = parser.ExtractCurrent().Split(s_delimiters, 3, StringSplitOptions.RemoveEmptyEntries);
                 if (elements.Length < 2)
                 {
                     continue;

--- a/src/Common/src/Interop/Linux/procfs/Interop.ProcFsStat.cs
+++ b/src/Common/src/Interop/Linux/procfs/Interop.ProcFsStat.cs
@@ -235,7 +235,9 @@ internal static partial class Interop
         internal static bool TryReadStatusFile(int pid, out ParsedStatus result, ReusableTextReader reusableReader)
         {
             bool b = TryParseStatusFile(GetStatusFilePathForProcess(pid), out result, reusableReader);
+#if DEBUG
             Debug.Assert(!b || result.Pid == pid, "Expected process ID from status file to match supplied pid");
+#endif
             return b;
         }
 

--- a/src/Common/src/Interop/Linux/procfs/Interop.ProcFsStat.cs
+++ b/src/Common/src/Interop/Linux/procfs/Interop.ProcFsStat.cs
@@ -322,7 +322,10 @@ internal static partial class Interop
 
             ParsedStatus results = default(ParsedStatus);
             ReadOnlySpan<char> statusFileContents = fileContents.AsSpan();
-            int sliceLength = -1;
+            int unitSliceLength = -1;
+#if DEBUG
+            int nonUnitSliceLength = -1;
+#endif
             while (!statusFileContents.IsEmpty)
             {
                 int startIndex = statusFileContents.IndexOf(':');
@@ -338,11 +341,17 @@ internal static partial class Interop
                 if (endIndex == -1)
                 {
                     endIndex = statusFileContents.Length - 1;
-                    sliceLength = statusFileContents.Length;
+                    unitSliceLength = statusFileContents.Length - 3;
+#if DEBUG
+                    nonUnitSliceLength = statusFileContents.Length;
+#endif
                 }
                 else
                 {
-                    sliceLength = endIndex - 3;
+                    unitSliceLength = endIndex - 3;
+#if DEBUG
+                    nonUnitSliceLength = endIndex;
+#endif
                 }
 
                 ReadOnlySpan<char> value = default;
@@ -350,44 +359,44 @@ internal static partial class Interop
 #if DEBUG
                 if (title.SequenceEqual("Pid".AsSpan()))
                 {
-                    value = statusFileContents.Slice(0, sliceLength);
+                    value = statusFileContents.Slice(0, nonUnitSliceLength);
                     valueParsed = int.TryParse(value, out results.Pid);
                 }
 #endif
                 if (title.SequenceEqual("VmHWM".AsSpan()))
                 {
-                    value = statusFileContents.Slice(0, sliceLength);
+                    value = statusFileContents.Slice(0, unitSliceLength);
                     valueParsed = ulong.TryParse(value, out results.VmHWM);
                 }
                 else if (title.SequenceEqual("VmRSS".AsSpan()))
                 {
-                    value = statusFileContents.Slice(0, sliceLength);
+                    value = statusFileContents.Slice(0, unitSliceLength);
                     valueParsed = ulong.TryParse(value, out results.VmRSS);
                 }
                 else if (title.SequenceEqual("VmData".AsSpan()))
                 {
-                    value = statusFileContents.Slice(0, sliceLength);
+                    value = statusFileContents.Slice(0, unitSliceLength);
                     valueParsed = ulong.TryParse(value, out ulong vmData);
                     results.VmData += vmData;
                 }
                 else if (title.SequenceEqual("VmSwap".AsSpan()))
                 {
-                    value = statusFileContents.Slice(0, sliceLength);
+                    value = statusFileContents.Slice(0, unitSliceLength);
                     valueParsed = ulong.TryParse(value, out results.VmSwap);
                 }
                 else if (title.SequenceEqual("VmSize".AsSpan()))
                 {
-                    value = statusFileContents.Slice(0, sliceLength);
+                    value = statusFileContents.Slice(0, unitSliceLength);
                     valueParsed = ulong.TryParse(value, out results.VmSize);
                 }
                 else if (title.SequenceEqual("VmPeak".AsSpan()))
                 {
-                    value = statusFileContents.Slice(0, sliceLength);
+                    value = statusFileContents.Slice(0, unitSliceLength);
                     valueParsed = ulong.TryParse(value, out results.VmPeak);
                 }
                 else if (title.SequenceEqual("VmStk".AsSpan()))
                 {
-                    value = statusFileContents.Slice(0, sliceLength);
+                    value = statusFileContents.Slice(0, unitSliceLength);
                     valueParsed = ulong.TryParse(value, out ulong vmStack);
                     results.VmData += vmStack;
                 }

--- a/src/Common/src/Interop/Linux/procfs/Interop.ProcFsStat.cs
+++ b/src/Common/src/Interop/Linux/procfs/Interop.ProcFsStat.cs
@@ -26,7 +26,7 @@ internal static partial class Interop
         internal const string SelfCmdLineFilePath = RootPath + "self" + CmdLineFileName;
         internal const string ProcStatFilePath = RootPath + "stat";
 
-        private static char[] Delimiters => new char[] { ':', ' ', '\t' };
+        private static char[] Delimiters = { ':', ' ', '\t' };
         internal struct ParsedStat
         {
             // Commented out fields are available in the stat data file but
@@ -323,6 +323,7 @@ internal static partial class Interop
             while (parser.MoveNext())
             {
                 string[] elements = parser.ExtractCurrent().Split(Delimiters, 3, StringSplitOptions.RemoveEmptyEntries);
+                
                 if (elements.Length < 2)
                 {
                     continue;
@@ -331,28 +332,41 @@ internal static partial class Interop
                 switch (elements[0])
                 {
                     case "Pid":
-                        results.Pid = int.Parse(elements[1]);
+                        int.TryParse(elements[1], out results.Pid);
                         break;
+
                     case "VmHWM":
-                        results.VmHWM = ulong.Parse(elements[1]) * 1024;
+                        ulong.TryParse(elements[1], out results.VmHWM);
+                        results.VmHWM *= 1024;
                         break;
+
                     case "VmRSS":
-                        results.VmRSS = ulong.Parse(elements[1]) * 1024;
+                        ulong.TryParse(elements[1], out results.VmRSS);
+                        results.VmRSS *= 1024;
                         break;
+
                     case "VmData":
-                        results.VmData = ulong.Parse(elements[1]) * 1024;
+                        ulong.TryParse(elements[1], out results.VmData);
+                        results.VmData *= 1024;
                         break;
+
                     case "VmSwap":
-                        results.VmSwap = ulong.Parse(elements[1]) * 1024;
+                        ulong.TryParse(elements[1], out results.VmSwap);
+                        results.VmSwap *= 1024;
                         break;
+
                     case "VmSize":
-                        results.VmSize = ulong.Parse(elements[1]) * 1024;
+                        ulong.TryParse(elements[1], out results.VmSize);
+                        results.VmSize *= 1024;
                         break;
+
                     case "VmPeak":
-                        results.VmPeak = ulong.Parse(elements[1]) * 1024;
+                        ulong.TryParse(elements[1], out results.VmPeak);
+                        results.VmPeak *= 1024;
                         break;
                 }
             }
+
             result = results;
             return true;
         }

--- a/src/Common/src/Interop/Linux/procfs/Interop.ProcFsStat.cs
+++ b/src/Common/src/Interop/Linux/procfs/Interop.ProcFsStat.cs
@@ -235,9 +235,7 @@ internal static partial class Interop
         internal static bool TryReadStatusFile(int pid, out ParsedStatus result, ReusableTextReader reusableReader)
         {
             bool b = TryParseStatusFile(GetStatusFilePathForProcess(pid), out result, reusableReader);
-#if DEBUG
             Debug.Assert(!b || result.Pid == pid, "Expected process ID from status file to match supplied pid");
-#endif
             return b;
         }
 

--- a/src/Common/src/Interop/Linux/procfs/Interop.ProcFsStat.cs
+++ b/src/Common/src/Interop/Linux/procfs/Interop.ProcFsStat.cs
@@ -82,7 +82,9 @@ internal static partial class Interop
 
         internal struct ParsedStatus
         {
+#if DEBUG
             internal int Pid;
+#endif
             internal ulong VmHWM;
             internal ulong VmRSS;
             internal ulong VmData;
@@ -234,7 +236,9 @@ internal static partial class Interop
         internal static bool TryReadStatusFile(int pid, out ParsedStatus result, ReusableTextReader reusableReader)
         {
             bool b = TryParseStatusFile(GetStatusFilePathForProcess(pid), out result, reusableReader);
+#if DEBUG
             Debug.Assert(!b || result.Pid == pid, "Expected process ID from status file to match supplied pid");
+#endif
             return b;
         }
 
@@ -330,10 +334,11 @@ internal static partial class Interop
 
                 switch (elements[0])
                 {
+#if DEBUG
                     case "Pid":
                         int.TryParse(elements[1], out results.Pid);
                         break;
-
+#endif
                     case "VmHWM":
                         ulong.TryParse(elements[1], out results.VmHWM);
                         results.VmHWM *= 1024;

--- a/src/Common/src/Interop/Linux/procfs/Interop.ProcFsStat.cs
+++ b/src/Common/src/Interop/Linux/procfs/Interop.ProcFsStat.cs
@@ -82,7 +82,7 @@ internal static partial class Interop
 
         internal struct ParsedStatus
         {
-            internal int pid;
+            internal int Pid;
             internal ulong VmHWM;
             internal ulong VmRSS;
             internal ulong VmData;
@@ -234,7 +234,7 @@ internal static partial class Interop
         internal static bool TryReadStatusFile(int pid, out ParsedStatus result, ReusableTextReader reusableReader)
         {
             bool b = TryParseStatusFile(GetStatusFilePathForProcess(pid), out result, reusableReader);
-            Debug.Assert(!b || result.pid == pid, "Expected process ID from status file to match supplied pid");
+            Debug.Assert(!b || result.Pid == pid, "Expected process ID from status file to match supplied pid");
             return b;
         }
 
@@ -331,7 +331,7 @@ internal static partial class Interop
                 switch (elements[0])
                 {
                     case "Pid":
-                        results.pid = int.Parse(elements[1]);
+                        results.Pid = int.Parse(elements[1]);
                         break;
                     case "VmHWM":
                         results.VmHWM = ulong.Parse(elements[1]) * 1024;

--- a/src/Common/src/Interop/Linux/procfs/Interop.ProcFsStat.cs
+++ b/src/Common/src/Interop/Linux/procfs/Interop.ProcFsStat.cs
@@ -18,6 +18,7 @@ internal static partial class Interop
         private const string CmdLineFileName = "/cmdline";
         private const string StatFileName = "/stat";
         private const string MapsFileName = "/maps";
+        private const string StatusFileName = "/status";
         private const string FileDescriptorDirectoryName = "/fd/";
         private const string TaskDirectoryName = "/task/";
 
@@ -25,6 +26,7 @@ internal static partial class Interop
         internal const string SelfCmdLineFilePath = RootPath + "self" + CmdLineFileName;
         internal const string ProcStatFilePath = RootPath + "stat";
 
+        private static char[] Delimiters => new char[] { ':', ' ', '\t' };
         internal struct ParsedStat
         {
             // Commented out fields are available in the stat data file but
@@ -78,6 +80,17 @@ internal static partial class Interop
             //internal long cguest_time;
         }
 
+        internal struct ParsedStatus
+        {
+            internal int pid;
+            internal ulong VmHWM;
+            internal ulong VmRSS;
+            internal ulong VmData;
+            internal ulong VmSwap;
+            internal ulong VmSize;
+            internal ulong VmPeak;
+        }
+
         internal struct ParsedMapsModule
         {
             internal string FileName;
@@ -97,6 +110,11 @@ internal static partial class Interop
         internal static string GetStatFilePathForProcess(int pid)
         {
             return RootPath + pid.ToString(CultureInfo.InvariantCulture) + StatFileName;
+        }
+
+        internal static string GetStatusFilePathForProcess(int pid)
+        {
+            return RootPath + pid.ToString(CultureInfo.InvariantCulture) + StatusFileName;
         }
 
         internal static string GetMapsFilePathForProcess(int pid)
@@ -209,24 +227,20 @@ internal static partial class Interop
         internal static bool TryReadStatFile(int pid, int tid, out ParsedStat result, ReusableTextReader reusableReader)
         {
             bool b = TryParseStatFile(GetStatFilePathForThread(pid, tid), out result, reusableReader);
-            //
-            // This assert currently fails in the Windows Subsystem For Linux.  See https://github.com/Microsoft/BashOnWindows/issues/967.
-            //
-            //Debug.Assert(!b || result.pid == tid, "Expected thread ID from stat file to match supplied tid");
+            Debug.Assert(!b || result.pid == tid, "Expected thread ID from stat file to match supplied tid");
+            return b;
+        }
+
+        internal static bool TryReadStatusFile(int pid, out ParsedStatus result, ReusableTextReader reusableReader)
+        {
+            bool b = TryParseStatusFile(GetStatusFilePathForProcess(pid), out result, reusableReader);
+            Debug.Assert(!b || result.pid == pid, "Expected process ID from status file to match supplied pid");
             return b;
         }
 
         internal static bool TryParseStatFile(string statFilePath, out ParsedStat result, ReusableTextReader reusableReader)
         {
-            string statFileContents;
-            try
-            {
-                using (var source = new FileStream(statFilePath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 1, useAsync: false))
-                {
-                    statFileContents = reusableReader.ReadAllText(source);
-                }
-            }
-            catch (IOException)
+            if (!TryReadFile(statFilePath, reusableReader, out string statFileContents))
             {
                 // Between the time that we get an ID and the time that we try to read the associated stat
                 // file(s), the process could be gone.
@@ -291,6 +305,73 @@ internal static partial class Interop
 
             result = results;
             return true;
+        }
+
+        internal static bool TryParseStatusFile(string statusFilePath, out ParsedStatus result, ReusableTextReader reusableReader)
+        {
+            if (!TryReadFile(statusFilePath, reusableReader, out string statusFileContents))
+            {
+                // Between the time that we get an ID and the time that we try to read the associated stat
+                // file(s), the process could be gone.
+                result = default(ParsedStatus);
+                return false;
+            }
+
+            var parser = new StringParser(statusFileContents, '\n');
+            var results = default(ParsedStatus);
+
+            while (parser.MoveNext())
+            {
+                string[] elements = parser.ExtractCurrent().Split(Delimiters, 3, StringSplitOptions.RemoveEmptyEntries);
+                if (elements.Length < 2)
+                {
+                    continue;
+                }
+
+                switch (elements[0])
+                {
+                    case "Pid":
+                        results.pid = int.Parse(elements[1]);
+                        break;
+                    case "VmHWM":
+                        results.VmHWM = ulong.Parse(elements[1]) * 1024;
+                        break;
+                    case "VmRSS":
+                        results.VmRSS = ulong.Parse(elements[1]) * 1024;
+                        break;
+                    case "VmData":
+                        results.VmData = ulong.Parse(elements[1]) * 1024;
+                        break;
+                    case "VmSwap":
+                        results.VmSwap = ulong.Parse(elements[1]) * 1024;
+                        break;
+                    case "VmSize":
+                        results.VmSize = ulong.Parse(elements[1]) * 1024;
+                        break;
+                    case "VmPeak":
+                        results.VmPeak = ulong.Parse(elements[1]) * 1024;
+                        break;
+                }
+            }
+            result = results;
+            return true;
+        }
+
+        private static bool TryReadFile(string filePath, ReusableTextReader reusableReader, out string fileContents)
+        {
+            try
+            {
+                using (var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 1, useAsync: false))
+                {
+                    fileContents = reusableReader.ReadAllText(fileStream);
+                    return true;
+                }
+            }
+            catch (IOException)
+            {
+                fileContents = null;
+                return false;
+            }
         }
     }
 }

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Linux.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Linux.cs
@@ -30,11 +30,11 @@ namespace System.Diagnostics
             var processes = new List<Process>();
             foreach (int pid in ProcessManager.EnumerateProcessIds())
             {
-                Interop.procfs.ParsedStat parsedStat;
-                if (Interop.procfs.TryReadStatFile(pid, out parsedStat, reusableReader) &&
+                if (Interop.procfs.TryReadStatFile(pid, out Interop.procfs.ParsedStat parsedStat, reusableReader) &&
+                    Interop.procfs.TryReadStatusFile(pid, out Interop.procfs.ParsedStatus parsedStatus, reusableReader) &&
                     string.Equals(processName, Process.GetUntruncatedProcessName(ref parsedStat), StringComparison.OrdinalIgnoreCase))
                 {
-                    ProcessInfo processInfo = ProcessManager.CreateProcessInfo(ref parsedStat, reusableReader, processName);
+                    ProcessInfo processInfo = ProcessManager.CreateProcessInfo(ref parsedStat, ref parsedStatus, reusableReader, processName);
                     processes.Add(new Process(machineName, false, processInfo.ProcessId, processInfo));
                 }
             }

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Linux.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Linux.cs
@@ -31,8 +31,8 @@ namespace System.Diagnostics
             foreach (int pid in ProcessManager.EnumerateProcessIds())
             {
                 if (Interop.procfs.TryReadStatFile(pid, out Interop.procfs.ParsedStat parsedStat, reusableReader) &&
-                    Interop.procfs.TryReadStatusFile(pid, out Interop.procfs.ParsedStatus parsedStatus, reusableReader) &&
-                    string.Equals(processName, Process.GetUntruncatedProcessName(ref parsedStat), StringComparison.OrdinalIgnoreCase))
+                    string.Equals(processName, Process.GetUntruncatedProcessName(ref parsedStat), StringComparison.OrdinalIgnoreCase) &&
+                    Interop.procfs.TryReadStatusFile(pid, out Interop.procfs.ParsedStatus parsedStatus, reusableReader))
                 {
                     ProcessInfo processInfo = ProcessManager.CreateProcessInfo(ref parsedStat, ref parsedStatus, reusableReader, processName);
                     processes.Add(new Process(machineName, false, processInfo.ProcessId, processInfo));

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
@@ -110,14 +110,11 @@ namespace System.Diagnostics
         /// </summary>
         internal static ProcessInfo CreateProcessInfo(int pid, ReusableTextReader reusableReader = null)
         {
-            if (reusableReader == null)
-            {
-                reusableReader = new ReusableTextReader();
-            }
+            reusableReader ??= new ReusableTextReader();
+            bool readStatFile = Interop.procfs.TryReadStatFile(pid, out Interop.procfs.ParsedStat stat, reusableReader);
+            bool readStatusFile = Interop.procfs.TryReadStatusFile(pid, out Interop.procfs.ParsedStatus status, reusableReader);
 
-            return Interop.procfs.TryReadStatFile(pid, out Interop.procfs.ParsedStat stat, reusableReader) &&
-                   Interop.procfs.TryReadStatusFile(pid, out Interop.procfs.ParsedStatus status, reusableReader) ?
-                   CreateProcessInfo(ref stat, ref status, reusableReader) : null;
+            return readStatFile || readStatusFile ? CreateProcessInfo(ref stat, ref status, reusableReader) : null;
         }
 
         /// <summary>

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
@@ -115,16 +115,15 @@ namespace System.Diagnostics
                 reusableReader = new ReusableTextReader();
             }
 
-            Interop.procfs.ParsedStat stat;
-            return Interop.procfs.TryReadStatFile(pid, out stat, reusableReader) ?
-                CreateProcessInfo(ref stat, reusableReader) :
-                null;
+            return Interop.procfs.TryReadStatFile(pid, out Interop.procfs.ParsedStat stat, reusableReader) &&
+                   Interop.procfs.TryReadStatusFile(pid, out Interop.procfs.ParsedStatus status, reusableReader) ?
+                   CreateProcessInfo(ref stat, ref status, reusableReader) : null;
         }
 
         /// <summary>
         /// Creates a ProcessInfo from the data parsed from a /proc/pid/stat file and the associated tasks directory.
         /// </summary>
-        internal static ProcessInfo CreateProcessInfo(ref Interop.procfs.ParsedStat procFsStat, ReusableTextReader reusableReader, string processName = null)
+        internal static ProcessInfo CreateProcessInfo(ref Interop.procfs.ParsedStat procFsStat, ref Interop.procfs.ParsedStatus procFsStatus, ReusableTextReader reusableReader, string processName = null)
         {
             int pid = procFsStat.pid;
 
@@ -133,10 +132,14 @@ namespace System.Diagnostics
                 ProcessId = pid,
                 ProcessName = processName ?? Process.GetUntruncatedProcessName(ref procFsStat) ?? string.Empty,
                 BasePriority = (int)procFsStat.nice,
-                VirtualBytes = (long)procFsStat.vsize,
-                WorkingSet = procFsStat.rss * Environment.SystemPageSize,
                 SessionId = procFsStat.session,
-
+                PoolPagedBytes = (long)procFsStatus.VmSwap,
+                VirtualBytes = (long)procFsStatus.VmSize,
+                VirtualBytesPeak = (long)procFsStatus.VmPeak,
+                WorkingSetPeak = (long)procFsStatus.VmHWM,
+                WorkingSet = (long)procFsStatus.VmRSS,
+                PageFileBytes = (long)procFsStatus.VmSwap,
+                PrivateBytes = (long)procFsStatus.VmData,
                 // We don't currently fill in the other values.
                 // A few of these could probably be filled in from getrusage,
                 // but only for the current process or its children, not for

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
@@ -111,10 +111,12 @@ namespace System.Diagnostics
         internal static ProcessInfo CreateProcessInfo(int pid, ReusableTextReader reusableReader = null)
         {
             reusableReader ??= new ReusableTextReader();
-            bool readStatFile = Interop.procfs.TryReadStatFile(pid, out Interop.procfs.ParsedStat stat, reusableReader);
-            bool readStatusFile = Interop.procfs.TryReadStatusFile(pid, out Interop.procfs.ParsedStatus status, reusableReader);
-
-            return readStatFile || readStatusFile ? CreateProcessInfo(ref stat, ref status, reusableReader) : null;
+            if (Interop.procfs.TryReadStatFile(pid, out Interop.procfs.ParsedStat stat, reusableReader))
+            {
+                Interop.procfs.TryReadStatusFile(pid, out Interop.procfs.ParsedStatus status, reusableReader);
+                return CreateProcessInfo(ref stat, ref status, reusableReader);
+            }
+            return null;
         }
 
         /// <summary>

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -60,6 +60,18 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        private void AssertNonZeroAllZeroDarwin(long value)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                Assert.Equal(0, value);
+            }
+            else
+            {
+                Assert.NotEqual(0, value);
+            }
+        }
+
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]  // Expected behavior varies on Windows and Unix
         public void TestBasePriorityOnWindows()
@@ -630,7 +642,7 @@ namespace System.Diagnostics.Tests
         {
             CreateDefaultProcess();
 
-            Assert.NotEqual(0, _process.PeakVirtualMemorySize64);
+            AssertNonZeroAllZeroDarwin(_process.PeakVirtualMemorySize64);
         }
 
         [Fact]
@@ -645,7 +657,7 @@ namespace System.Diagnostics.Tests
         {
             CreateDefaultProcess();
 
-            Assert.NotEqual(0, _process.PeakWorkingSet64);
+            AssertNonZeroAllZeroDarwin(_process.PeakWorkingSet64);
         }
 
         [Fact]
@@ -660,7 +672,7 @@ namespace System.Diagnostics.Tests
         {
             CreateDefaultProcess();
 
-            Assert.NotEqual(0, _process.PrivateMemorySize64);
+            AssertNonZeroAllZeroDarwin(_process.PrivateMemorySize64);
         }
 
         [Fact]
@@ -1641,7 +1653,7 @@ namespace System.Diagnostics.Tests
             CreateDefaultProcess();
 
 #pragma warning disable 0618
-            Assert.NotEqual(0, _process.PeakVirtualMemorySize);
+            AssertNonZeroAllZeroDarwin(_process.PeakVirtualMemorySize);
 #pragma warning restore 0618
         }
 
@@ -1660,7 +1672,7 @@ namespace System.Diagnostics.Tests
             CreateDefaultProcess();
 
 #pragma warning disable 0618
-            Assert.NotEqual(0, _process.PeakWorkingSet);
+            AssertNonZeroAllZeroDarwin(_process.PeakWorkingSet);
 #pragma warning restore 0618
         }
 
@@ -1679,7 +1691,7 @@ namespace System.Diagnostics.Tests
             CreateDefaultProcess();
 
 #pragma warning disable 0618
-            Assert.NotEqual(0, _process.PrivateMemorySize);
+            AssertNonZeroAllZeroDarwin(_process.PrivateMemorySize);
 #pragma warning restore 0618
         }
 

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -630,7 +630,7 @@ namespace System.Diagnostics.Tests
         {
             CreateDefaultProcess();
 
-            AssertNonZeroWindowsZeroUnix(_process.PeakVirtualMemorySize64);
+            Assert.NotEqual(0, _process.PeakVirtualMemorySize64);
         }
 
         [Fact]
@@ -645,7 +645,7 @@ namespace System.Diagnostics.Tests
         {
             CreateDefaultProcess();
 
-            AssertNonZeroWindowsZeroUnix(_process.PeakWorkingSet64);
+            Assert.NotEqual(0, _process.PeakWorkingSet64);
         }
 
         [Fact]
@@ -660,7 +660,7 @@ namespace System.Diagnostics.Tests
         {
             CreateDefaultProcess();
 
-            AssertNonZeroWindowsZeroUnix(_process.PrivateMemorySize64);
+            Assert.NotEqual(0, _process.PrivateMemorySize64);
         }
 
         [Fact]
@@ -1641,7 +1641,7 @@ namespace System.Diagnostics.Tests
             CreateDefaultProcess();
 
 #pragma warning disable 0618
-            AssertNonZeroWindowsZeroUnix(_process.PeakVirtualMemorySize);
+            Assert.NotEqual(0, _process.PeakVirtualMemorySize);
 #pragma warning restore 0618
         }
 
@@ -1660,7 +1660,7 @@ namespace System.Diagnostics.Tests
             CreateDefaultProcess();
 
 #pragma warning disable 0618
-            AssertNonZeroWindowsZeroUnix(_process.PeakWorkingSet);
+            Assert.NotEqual(0, _process.PeakWorkingSet);
 #pragma warning restore 0618
         }
 
@@ -1679,7 +1679,7 @@ namespace System.Diagnostics.Tests
             CreateDefaultProcess();
 
 #pragma warning disable 0618
-            AssertNonZeroWindowsZeroUnix(_process.PrivateMemorySize);
+            Assert.NotEqual(0, _process.PrivateMemorySize);
 #pragma warning restore 0618
         }
 


### PR DESCRIPTION
Add support for:

- Process.PeakWorkingSet64
- Process.PrivateMemorySize64
- Process.PagedMemorySize64
- Process.PagedSystemMemorySize64
- Process.PeakVirtualMemorySize64

Improve:

- Process.VirtualMemorySize64
- Process.WorkingSet64

Fixes #23449 
Fixes #36086

UPDATE: Fixes/Additions/ Supports have only been added on Linux. OSX is still unsupported.