### PR TITLE
Add file move overrite test for linux

### DIFF
--- a/src/System.IO.FileSystem/tests/File/Move.cs
+++ b/src/System.IO.FileSystem/tests/File/Move.cs
@@ -80,6 +80,18 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        public void BasicMoveWithOverwrite()
+        {
+            FileInfo testFileSource = new FileInfo(GetTestFilePath());
+            testFileSource.Create().Dispose();
+            string testFileDest = GetTestFilePath();
+
+            Move(testFileSource.FullName, testFileDest, overwrite: true);
+            Assert.True(File.Exists(testFileDest));
+            Assert.False(File.Exists(testFileSource.FullName));
+        }
+
+        [Fact]
         public void MoveNonEmptyFile()
         {
             FileInfo testFileSource = new FileInfo(GetTestFilePath());


### PR DESCRIPTION
Fix #41009

1. Add tests for checking if source file is deleted when overwrite is set to true while calling File.Move