### PR TITLE
Throw better exception on WSL 1 where /proc/net file cannot be read

### DIFF
--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Connections.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Connections.cs
@@ -43,6 +43,12 @@ namespace System.Net.NetworkInformation
             string tcp6FileContents = File.ReadAllText(tcp6ConnectionsFile);
             string[] v6connections = tcp6FileContents.Split(s_newLineSeparator, StringSplitOptions.RemoveEmptyEntries);
 
+            // On WSL 1 the files are always empty.
+            if (v4connections.Length == 0 || v6connections.Length == 0)
+            {
+                throw new NetworkInformationException(SR.net_FailedToParseNetworkFile);
+            }
+
             // First line is header in each file.
             TcpConnectionInformation[] connections = new TcpConnectionInformation[v4connections.Length + v6connections.Length - 2];
             int index = 0;
@@ -99,6 +105,12 @@ namespace System.Net.NetworkInformation
             string tcp6FileContents = File.ReadAllText(tcp6ConnectionsFile);
             string[] v6connections = tcp6FileContents.Split(s_newLineSeparator, StringSplitOptions.RemoveEmptyEntries);
 
+            // On WSL 1 the files are always empty.
+            if (v4connections.Length == 0 || v6connections.Length == 0)
+            {
+                throw new NetworkInformationException(SR.net_FailedToParseNetworkFile);
+            }
+
             // First line is header in each file.
             IPEndPoint[] endPoints = new IPEndPoint[v4connections.Length + v6connections.Length - 2];
             int index = 0;
@@ -154,6 +166,12 @@ namespace System.Net.NetworkInformation
 
             string udp6FileContents = File.ReadAllText(udp6File);
             string[] v6connections = udp6FileContents.Split(s_newLineSeparator, StringSplitOptions.RemoveEmptyEntries);
+
+            // On WSL 1 the files are always empty.
+            if (v4connections.Length == 0 || v6connections.Length == 0)
+            {
+                throw new NetworkInformationException(SR.net_FailedToParseNetworkFile);
+            }
 
             // First line is header in each file.
             IPEndPoint[] endPoints = new IPEndPoint[v4connections.Length + v6connections.Length - 2];

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Connections.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Connections.cs
@@ -46,7 +46,7 @@ namespace System.Net.NetworkInformation
             // On WSL 1 the files are always empty.
             if (v4connections.Length == 0 || v6connections.Length == 0)
             {
-                throw new NetworkInformationException(SR.net_FailedToParseNetworkFile);
+                throw ExceptionHelper.CreateForParseFailure();
             }
 
             // First line is header in each file.
@@ -108,7 +108,7 @@ namespace System.Net.NetworkInformation
             // On WSL 1 the files are always empty.
             if (v4connections.Length == 0 || v6connections.Length == 0)
             {
-                throw new NetworkInformationException(SR.net_FailedToParseNetworkFile);
+                throw ExceptionHelper.CreateForParseFailure();
             }
 
             // First line is header in each file.
@@ -170,7 +170,7 @@ namespace System.Net.NetworkInformation
             // On WSL 1 the files are always empty.
             if (v4connections.Length == 0 || v6connections.Length == 0)
             {
-                throw new NetworkInformationException(SR.net_FailedToParseNetworkFile);
+                throw ExceptionHelper.CreateForParseFailure();
             }
 
             // First line is header in each file.

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Statistics.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Statistics.cs
@@ -176,6 +176,11 @@ namespace System.Net.NetworkInformation
         // Parses ICMP v4 statistics from /proc/net/snmp
         public static Icmpv4StatisticsTable ParseIcmpv4FromSnmpFile(string filePath)
         {
+            if (!File.Exists(filePath))
+            {
+                throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+            }
+
             string fileContents = File.ReadAllText(filePath);
             int firstIpHeader = fileContents.IndexOf("Icmp:", StringComparison.Ordinal);
             int secondIpHeader = fileContents.IndexOf("Icmp:", firstIpHeader + 1, StringComparison.Ordinal);
@@ -220,6 +225,11 @@ namespace System.Net.NetworkInformation
 
         public static Icmpv6StatisticsTable ParseIcmpv6FromSnmp6File(string filePath)
         {
+            if (!File.Exists(filePath))
+            {
+                throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+            }
+
             string fileContents = File.ReadAllText(filePath);
             RowConfigReader reader = new RowConfigReader(fileContents);
             int Icmp6OutErrorsIdx = fileContents.IndexOf("Icmp6OutErrors", StringComparison.Ordinal);
@@ -263,6 +273,11 @@ namespace System.Net.NetworkInformation
 
         public static IPGlobalStatisticsTable ParseIPv4GlobalStatisticsFromSnmpFile(string filePath)
         {
+            if (!File.Exists(filePath))
+            {
+                throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+            }
+
             string fileContents = File.ReadAllText(filePath);
 
             int firstIpHeader = fileContents.IndexOf("Ip:", StringComparison.Ordinal);
@@ -300,6 +315,11 @@ namespace System.Net.NetworkInformation
 
         internal static IPGlobalStatisticsTable ParseIPv6GlobalStatisticsFromSnmp6File(string filePath)
         {
+            if (!File.Exists(filePath))
+            {
+                throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+            }
+
             // Read the remainder of statistics from snmp6.
             string fileContents = File.ReadAllText(filePath);
             RowConfigReader reader = new RowConfigReader(fileContents);
@@ -328,6 +348,11 @@ namespace System.Net.NetworkInformation
 
         internal static TcpGlobalStatisticsTable ParseTcpGlobalStatisticsFromSnmpFile(string filePath)
         {
+            if (!File.Exists(filePath))
+            {
+                throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+            }
+
             // NOTE: There is no information in the snmp6 file regarding TCP statistics,
             // so the statistics are always pulled from /proc/net/snmp.
             string fileContents = File.ReadAllText(filePath);
@@ -362,6 +387,11 @@ namespace System.Net.NetworkInformation
 
         internal static UdpGlobalStatisticsTable ParseUdpv4GlobalStatisticsFromSnmpFile(string filePath)
         {
+            if (!File.Exists(filePath))
+            {
+                throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+            }
+
             string fileContents = File.ReadAllText(filePath);
             int firstUdpHeader = fileContents.IndexOf("Udp:", StringComparison.Ordinal);
             int secondUdpHeader = fileContents.IndexOf("Udp:", firstUdpHeader + 1, StringComparison.Ordinal);
@@ -386,6 +416,11 @@ namespace System.Net.NetworkInformation
 
         internal static UdpGlobalStatisticsTable ParseUdpv6GlobalStatisticsFromSnmp6File(string filePath)
         {
+            if (!File.Exists(filePath))
+            {
+                throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+            }
+
             string fileContents = File.ReadAllText(filePath);
             RowConfigReader reader = new RowConfigReader(fileContents);
             int udp6ErrorsIdx = fileContents.IndexOf("Udp6SndbufErrors", StringComparison.Ordinal);
@@ -404,6 +439,11 @@ namespace System.Net.NetworkInformation
 
         internal static IPInterfaceStatisticsTable ParseInterfaceStatisticsTableFromFile(string filePath, string name)
         {
+            if (!File.Exists(filePath))
+            {
+                throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+            }
+
             using (StreamReader sr = new StreamReader(new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 0x1000, useAsync: false)))
             {
                 sr.ReadLine();


### PR DESCRIPTION
On WSL 1, the files in `/proc/net/` directory are either empty or missing completely.
In such case, throw better exceptions (`PlatformNotSupportedException` when file is missing and `NetworkInformationException` when file is empty) instead of `FileNotFoundException` or `OverflowException`.

Note that on WSL 2 the files are present and not empty.

Fixes  #30909