### PR TITLE
Remove use of non-generic Queue/Stack in System.Private.Xml

### DIFF
--- a/src/System.Private.Xml/src/System/Xml/Schema/ContentValidator.cs
+++ b/src/System.Private.Xml/src/System/Xml/Schema/ContentValidator.cs
@@ -5,9 +5,9 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Text;
-using System.Diagnostics;
 
 namespace System.Xml.Schema
 {
@@ -1080,7 +1080,7 @@ namespace System.Xml.Schema
     {
         private SymbolsDictionary _symbols;
         private Positions _positions;
-        private Stack _stack;                        // parsing context
+        private Stack<SyntaxTreeNode> _stack;                        // parsing context
         private SyntaxTreeNode _contentNode;         // content model points to syntax tree
         private bool _isPartial;                     // whether the closure applies to partial or the whole node that is on top of the stack
         private int _minMaxNodesCount;
@@ -1117,7 +1117,7 @@ namespace System.Xml.Schema
         {
             _symbols = new SymbolsDictionary();
             _positions = new Positions();
-            _stack = new Stack();
+            _stack = new Stack<SyntaxTreeNode>();
         }
 
         public void OpenGroup()
@@ -1127,7 +1127,7 @@ namespace System.Xml.Schema
 
         public void CloseGroup()
         {
-            SyntaxTreeNode node = (SyntaxTreeNode)_stack.Pop();
+            SyntaxTreeNode node = _stack.Pop();
             if (node == null)
             {
                 return;
@@ -1192,7 +1192,7 @@ namespace System.Xml.Schema
 
         public void AddChoice()
         {
-            SyntaxTreeNode node = (SyntaxTreeNode)_stack.Pop();
+            SyntaxTreeNode node = _stack.Pop();
             InteriorNode choice = new ChoiceNode();
             choice.LeftChild = node;
             _stack.Push(choice);
@@ -1200,7 +1200,7 @@ namespace System.Xml.Schema
 
         public void AddSequence()
         {
-            SyntaxTreeNode node = (SyntaxTreeNode)_stack.Pop();
+            SyntaxTreeNode node = _stack.Pop();
             InteriorNode sequence = new SequenceNode();
             sequence.LeftChild = node;
             _stack.Push(sequence);
@@ -1242,7 +1242,7 @@ namespace System.Xml.Schema
         {
             if (_stack.Count > 0)
             {
-                SyntaxTreeNode topNode = (SyntaxTreeNode)_stack.Pop();
+                SyntaxTreeNode topNode = _stack.Pop();
                 InteriorNode inNode = topNode as InteriorNode;
                 if (_isPartial && inNode != null)
                 {
@@ -1520,7 +1520,7 @@ namespace System.Xml.Schema
             stateTable.Add(new BitSet(positionsCount), -1);
 
             // lists unmarked states
-            Queue unmarked = new Queue();
+            var unmarked = new Queue<BitSet>();
 
             // initially, the only unmarked state in Dstates is firstpo(root)
             int state = 0;
@@ -1531,7 +1531,7 @@ namespace System.Xml.Schema
             // while there is an umnarked state T in Dstates do begin
             while (unmarked.Count > 0)
             {
-                BitSet statePosSet = (BitSet)unmarked.Dequeue(); // all positions that constitute DFA state
+                BitSet statePosSet = unmarked.Dequeue(); // all positions that constitute DFA state
                 Debug.Assert(state == (int)stateTable[statePosSet]); // just make sure that statePosSet is for correct state
                 int[] transition = (int[])transitionTable[state];
                 if (statePosSet[endMarkerPos])

--- a/src/System.Private.Xml/src/System/Xml/Schema/SchemaCollectionCompiler.cs
+++ b/src/System.Private.Xml/src/System/Xml/Schema/SchemaCollectionCompiler.cs
@@ -2,19 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Text;
+
 namespace System.Xml.Schema
 {
-    using System;
-    using System.Collections;
-    using System.Globalization;
-    using System.Text;
-    using System.Diagnostics;
-
     internal sealed class SchemaCollectionCompiler : BaseProcessor
     {
         private bool _compileContentModel;
         private readonly XmlSchemaObjectTable _examplars = new XmlSchemaObjectTable();
-        private readonly Stack _complexTypeStack = new Stack();
+        private readonly Stack<XmlSchemaComplexType> _complexTypeStack = new Stack<XmlSchemaComplexType>();
         private XmlSchema _schema;
 
         public SchemaCollectionCompiler(XmlNameTable nameTable, ValidationEventHandler eventHandler)
@@ -237,7 +238,7 @@ namespace System.Xml.Schema
             }
             while (_complexTypeStack.Count > 0)
             {
-                XmlSchemaComplexType type = (XmlSchemaComplexType)_complexTypeStack.Pop();
+                XmlSchemaComplexType type = _complexTypeStack.Pop();
                 CompileCompexTypeElements(type);
             }
             foreach (XmlSchemaType type in _schema.SchemaTypes.Values)

--- a/src/System.Private.Xml/src/System/Xml/Schema/SchemaSetCompiler.cs
+++ b/src/System.Private.Xml/src/System/Xml/Schema/SchemaSetCompiler.cs
@@ -2,14 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using System.Diagnostics;
+
 namespace System.Xml.Schema
 {
-    using System;
-    using System.Collections;
-    using System.Globalization;
-    using System.Text;
-    using System.Diagnostics;
-
     internal sealed class Compiler : BaseProcessor
     {
         private string _restrictionErrorMsg;
@@ -21,7 +22,7 @@ namespace System.Xml.Schema
         private readonly XmlSchemaObjectTable _notations = new XmlSchemaObjectTable();
         private readonly XmlSchemaObjectTable _examplars = new XmlSchemaObjectTable();
         private readonly XmlSchemaObjectTable _identityConstraints = new XmlSchemaObjectTable();
-        private readonly Stack _complexTypeStack = new Stack();
+        private readonly Stack<XmlSchemaComplexType> _complexTypeStack = new Stack<XmlSchemaComplexType>();
         private readonly Hashtable _schemasToCompile = new Hashtable();
 
         private readonly XmlSchema _schemaForSchema;
@@ -228,7 +229,7 @@ namespace System.Xml.Schema
             }
             while (_complexTypeStack.Count > 0)
             {
-                XmlSchemaComplexType type = (XmlSchemaComplexType)_complexTypeStack.Pop();
+                XmlSchemaComplexType type = _complexTypeStack.Pop();
                 CompileComplexTypeElements(type);
             }
 

--- a/src/System.Private.Xml/src/System/Xml/Schema/XsdBuilder.cs
+++ b/src/System.Private.Xml/src/System/Xml/Schema/XsdBuilder.cs
@@ -634,7 +634,7 @@ namespace System.Xml.Schema
         private XsdEntry _nextEntry;
         private bool _hasChild;
         private readonly HWStack _stateHistory = new HWStack(STACK_INCREMENT);
-        private readonly Stack _containerStack = new Stack();
+        private readonly Stack<XmlSchemaObject> _containerStack = new Stack<XmlSchemaObject>();
         private readonly XmlNameTable _nameTable;
         private readonly SchemaNames _schemaNames;
         private readonly XmlNamespaceManager _namespaceManager;
@@ -846,7 +846,7 @@ namespace System.Xml.Schema
 
         private XmlSchemaObject ParentContainer
         {
-            get { return (XmlSchemaObject)_containerStack.Peek(); }
+            get { return _containerStack.Peek(); }
         }
 
         private XmlSchemaObject GetContainer(State state)

--- a/src/System.Private.Xml/src/System/Xml/Serialization/CodeGenerator.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/CodeGenerator.cs
@@ -3,28 +3,25 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.IO;
 using System.Reflection;
+using System.Reflection.Emit;
 using System.Resources;
 using System.Runtime.CompilerServices;
+using System.Xml;
+using System.Xml.Serialization.Configuration;
+using System.Security;
+using System.Text.RegularExpressions;
+using System.Xml.Extensions;
 
 namespace System.Xml.Serialization
 {
-    using System;
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.Configuration;
-    using System.Globalization;
-    using System.Xml;
-    using System.Xml.Serialization.Configuration;
-    using System.Reflection;
-    using System.Reflection.Emit;
-    using System.IO;
-    using System.Security;
-    using System.Text.RegularExpressions;
-    using System.Diagnostics;
-    using System.Diagnostics.CodeAnalysis;
-    using System.Xml.Extensions;
-
     internal class CodeGenerator
     {
         internal static BindingFlags InstancePublicBindingFlags = BindingFlags.Instance | BindingFlags.Public;
@@ -43,7 +40,7 @@ namespace System.Xml.Serialization
         // Stores a queue of free locals available in the context of the method, keyed by
         // type and name of the local
         private Dictionary<Tuple<Type, string>, Queue<LocalBuilder>> _freeLocals;
-        private Stack _blockStack;
+        private Stack<object> _blockStack;
         private Label _methodEndLabel;
 
         internal CodeGenerator(TypeBuilder typeBuilder)
@@ -91,8 +88,8 @@ namespace System.Xml.Serialization
         {
             _methodEndLabel = _ilGen.DefineLabel();
             this.retLabel = _ilGen.DefineLabel();
-            _blockStack = new Stack();
-            _whileStack = new Stack();
+            _blockStack = new Stack<object>();
+            _whileStack = new Stack<WhileState>();
             _currentScope = new LocalScope();
             _freeLocals = new Dictionary<Tuple<Type, string>, Queue<LocalBuilder>>();
             _argList = new Dictionary<string, ArgBuilder>();
@@ -381,7 +378,7 @@ namespace System.Xml.Serialization
             MarkLabel(ifState.EndIf);
         }
 
-        private readonly Stack _leaveLabels = new Stack();
+        private readonly Stack<Label> _leaveLabels = new Stack<Label>();
         internal void BeginExceptionBlock()
         {
             _leaveLabels.Push(DefineLabel());
@@ -396,12 +393,12 @@ namespace System.Xml.Serialization
         internal void EndExceptionBlock()
         {
             _ilGen.EndExceptionBlock();
-            _ilGen.MarkLabel((Label)_leaveLabels.Pop());
+            _ilGen.MarkLabel(_leaveLabels.Pop());
         }
 
         internal void Leave()
         {
-            _ilGen.Emit(OpCodes.Leave, (Label)_leaveLabels.Peek());
+            _ilGen.Emit(OpCodes.Leave, _leaveLabels.Peek());
         }
 
         internal void Call(MethodInfo methodInfo)
@@ -1414,7 +1411,7 @@ namespace System.Xml.Serialization
         // (bool on stack)
         // WhileEndCondition()
         // WhileEnd()
-        private Stack _whileStack;
+        private Stack<WhileState> _whileStack;
         internal void WhileBegin()
         {
             WhileState whileState = new WhileState(this);
@@ -1425,19 +1422,19 @@ namespace System.Xml.Serialization
 
         internal void WhileEnd()
         {
-            WhileState whileState = (WhileState)_whileStack.Pop();
+            WhileState whileState = _whileStack.Pop();
             MarkLabel(whileState.EndLabel);
         }
 
         internal void WhileContinue()
         {
-            WhileState whileState = (WhileState)_whileStack.Peek();
+            WhileState whileState = _whileStack.Peek();
             Br(whileState.CondLabel);
         }
 
         internal void WhileBeginCondition()
         {
-            WhileState whileState = (WhileState)_whileStack.Peek();
+            WhileState whileState = _whileStack.Peek();
             // If there are two MarkLabel ILs consecutively, Labels will converge to one label.
             // This could cause the code to look different.  We insert Nop here specifically
             // that the While label stands out.
@@ -1447,7 +1444,7 @@ namespace System.Xml.Serialization
 
         internal void WhileEndCondition()
         {
-            WhileState whileState = (WhileState)_whileStack.Peek();
+            WhileState whileState = _whileStack.Peek();
             Brtrue(whileState.StartLabel);
         }
     }

--- a/src/System.Private.Xml/src/System/Xml/Xsl/XsltOld/Compiler.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/XsltOld/Compiler.cs
@@ -2,26 +2,26 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Reflection;
+using System.Runtime.Versioning;
+using System.Security;
+using System.Text;
+using System.Xml;
+using System.Xml.XPath;
+using System.Xml.Xsl.Runtime;
+using System.Xml.Xsl.XsltOld.Debugger;
+using MS.Internal.Xml.XPath;
+using KeywordsTable = System.Xml.Xsl.Xslt.KeywordsTable;
+
 namespace System.Xml.Xsl.XsltOld
 {
-    using System;
-    using System.Diagnostics;
-    using System.Globalization;
-    using System.Xml;
-    using System.Xml.XPath;
-    using System.Xml.Xsl.Runtime;
-    using MS.Internal.Xml.XPath;
-    using System.Xml.Xsl.XsltOld.Debugger;
-    using System.Text;
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.Collections.Specialized;
-    using System.IO;
-    using System.Reflection;
-    using System.Security;
-    using KeywordsTable = System.Xml.Xsl.Xslt.KeywordsTable;
-    using System.Runtime.Versioning;
-
     internal class Sort
     {
         internal int select;
@@ -73,7 +73,7 @@ namespace System.Xml.Xsl.XsltOld
 
         //
         // Current import stack
-        private Stack _stylesheets;
+        private Stack<Stylesheet> _stylesheets;
 
         private readonly HybridDictionary _documentURIs = new HybridDictionary();
 
@@ -659,12 +659,7 @@ namespace System.Xml.Xsl.XsltOld
 
         internal void PushStylesheet(Stylesheet stylesheet)
         {
-            if (_stylesheets == null)
-            {
-                _stylesheets = new Stack();
-            }
-            Debug.Assert(_stylesheets != null);
-
+            _stylesheets ??= new Stack<Stylesheet>();
             _stylesheets.Push(stylesheet);
             this.stylesheet = stylesheet;
         }
@@ -672,8 +667,8 @@ namespace System.Xml.Xsl.XsltOld
         internal Stylesheet PopStylesheet()
         {
             Debug.Assert(this.stylesheet == _stylesheets.Peek());
-            Stylesheet stylesheet = (Stylesheet)_stylesheets.Pop();
-            this.stylesheet = (Stylesheet)_stylesheets.Peek();
+            Stylesheet stylesheet = _stylesheets.Pop();
+            this.stylesheet = _stylesheets.Peek();
             return stylesheet;
         }
 


### PR DESCRIPTION
This is the only reason these types are brought into a trimmed default MVC app.

cc: @krwq, @jkotas