### PR TITLE
Remove use of RuntimeReflectionExtensions from Microsoft.CSharp

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/MethodInfo.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/MethodInfo.cs
@@ -44,7 +44,8 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 }
 
                 // We need to find the associated methodinfo on the instantiated type.
-                foreach (MethodInfo m in type.GetRuntimeMethods())
+                const BindingFlags EverythingBindingFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static;
+                foreach (MethodInfo m in type.GetMethods(EverythingBindingFlags))
                 {
                     if (!m.HasSameMetadataDefinitionAs(methodInfo))
                     {


### PR DESCRIPTION
The wrappers aren't adding any benefit and are causing us to pull in the extensions type unnecessarily (and doing unnecessary null checks); just call the underlying methods directly.

cc: @cston, @jkotas