### PR TITLE
[release/3.1] Fix SqlParameter with xml schema construction

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameter.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameter.cs
@@ -261,15 +261,8 @@ namespace System.Data.SqlClient
             }
             set
             {
-                bool collectionIsNull = _xmlSchemaCollection != null;
-                if (collectionIsNull)
-                {
-                    _xmlSchemaCollection = new SqlMetaDataXmlSchemaCollection();
-                }
-                if (value != null || collectionIsNull)
-                {
-                    _xmlSchemaCollection.Database = value;
-                }
+                EnsureXmlSchemaCollectionExists();
+                _xmlSchemaCollection.Database = value;
             }
         }
 
@@ -281,15 +274,8 @@ namespace System.Data.SqlClient
             }
             set
             {
-                bool collectionIsNull = _xmlSchemaCollection != null;
-                if (collectionIsNull)
-                {
-                    _xmlSchemaCollection = new SqlMetaDataXmlSchemaCollection();
-                }
-                if (value != null || collectionIsNull)
-                {
-                    _xmlSchemaCollection.OwningSchema = value;
-                }
+                EnsureXmlSchemaCollectionExists();
+                _xmlSchemaCollection.OwningSchema = value;
             }
         }
 
@@ -301,15 +287,8 @@ namespace System.Data.SqlClient
             }
             set
             {
-                bool collectionIsNull = _xmlSchemaCollection != null;
-                if (collectionIsNull)
-                {
-                    _xmlSchemaCollection = new SqlMetaDataXmlSchemaCollection();
-                }
-                if (value != null || collectionIsNull)
-                {
-                    _xmlSchemaCollection.Name = value;
-                }
+                EnsureXmlSchemaCollectionExists();
+                _xmlSchemaCollection.Name = value;
             }
         }
 
@@ -1975,6 +1954,14 @@ namespace System.Data.SqlClient
                 {
                     throw SQL.InvalidParameterTypeNameFormat();
                 }
+            }
+        }
+        
+        private void EnsureXmlSchemaCollectionExists()
+        {
+            if (_xmlSchemaCollection is null)
+            {
+                _xmlSchemaCollection = new SqlMetaDataXmlSchemaCollection();
             }
         }
 

--- a/src/System.Data.SqlClient/tests/FunctionalTests/SqlParameterTest.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/SqlParameterTest.cs
@@ -38,5 +38,69 @@ namespace System.Data.SqlClient.Tests
             Assert.Equal(10, parameter.Precision);
             Assert.Equal(5, parameter.Scale);
         }
+
+        [Fact]
+        public void CreateParameterWithValidXmlSchema()
+        {
+            string xmlDatabase = "database";
+            string xmlSchema = "schema";
+            string xmlName = "name";
+
+            SqlParameter parameter = new SqlParameter("@name", SqlDbType.Int, 4, ParameterDirection.Input, 0, 0, "name", DataRowVersion.Original, false, 1, xmlDatabase, xmlSchema, xmlName);
+
+            Assert.Equal(xmlDatabase, parameter.XmlSchemaCollectionDatabase);
+            Assert.Equal(xmlSchema, parameter.XmlSchemaCollectionOwningSchema);
+            Assert.Equal(xmlName, parameter.XmlSchemaCollectionName);
+        }
+
+        [Fact]
+        public void CreateParameterWithEmptyXmlSchema()
+        {
+            SqlParameter parameter = new SqlParameter("@name", SqlDbType.Int, 4, ParameterDirection.Input, 0, 0, "name", DataRowVersion.Original, false, 1, string.Empty, string.Empty, string.Empty);
+
+            Assert.Equal(string.Empty, parameter.XmlSchemaCollectionDatabase);
+            Assert.Equal(string.Empty, parameter.XmlSchemaCollectionOwningSchema);
+            Assert.Equal(string.Empty, parameter.XmlSchemaCollectionName);
+        }
+
+        [Fact]
+        public void CreateParameterWithNullXmlSchema()
+        {
+            SqlParameter parameter = new SqlParameter("@name", SqlDbType.Int, 4, ParameterDirection.Input, 0, 0, "name", DataRowVersion.Original, false, 1, null, null, null);
+
+            Assert.Equal(string.Empty, parameter.XmlSchemaCollectionDatabase);
+            Assert.Equal(string.Empty, parameter.XmlSchemaCollectionOwningSchema);
+            Assert.Equal(string.Empty, parameter.XmlSchemaCollectionName);
+        }
+
+        [Fact]
+        public void CreateParameterWithoutXmlSchema()
+        {
+            SqlParameter parameter = new SqlParameter();
+
+            Assert.Equal(string.Empty, parameter.XmlSchemaCollectionDatabase);
+            Assert.Equal(string.Empty, parameter.XmlSchemaCollectionOwningSchema);
+            Assert.Equal(string.Empty, parameter.XmlSchemaCollectionName);
+        }
+
+        [Fact]
+        public void SetParameterXmlSchema()
+        {
+            SqlParameter parameter = new SqlParameter();
+
+            Assert.Equal(string.Empty, parameter.XmlSchemaCollectionName);
+
+            // verify that if we set it to null we still get an empty string back
+            parameter.XmlSchemaCollectionName = null;
+            Assert.Equal(string.Empty, parameter.XmlSchemaCollectionName);
+
+            // verify that if we set a value we get it back
+            parameter.XmlSchemaCollectionName = "name";
+            Assert.Equal("name", parameter.XmlSchemaCollectionName);
+
+            // verify that if we set it explicitly to null it reverts to empty string
+            parameter.XmlSchemaCollectionName = null;
+            Assert.Equal(string.Empty, parameter.XmlSchemaCollectionName);
+        }
     }
 }


### PR DESCRIPTION
Ports #41008 for release/3.1

## Description

Fixes a bug in SqlParameter XmlSchemaCollection APIs where setters were not validating initialized xmlSchemaCollection properly. The issue got merged in due to no test coverage on impacted APIs.

## Customer Impact

Below SqlParameter APIs are impacted:
- set_XmlSchemaCollectionDatabase
- set_XmlSchemaCollectionOwningSchema
- set_XmlSchemaCollectionName

## Regression

Yes. This PR fixes a regression reported in #41141 caused with PR #35549 in .NET Core SDK 3.0 Preview3.

## Risk

Small. The change-set is small and the code changes introduced in earlier PR #35363 is being revised here.

## Tests

Tests added to cover missing areas and will now be run as part of PR validations.