### PR TITLE
Fix trimming of System.Net.Ping

### DIFF
--- a/src/System.Net.Ping/src/ILLinkTrim.xml
+++ b/src/System.Net.Ping/src/ILLinkTrim.xml
@@ -1,6 +1,0 @@
-<linker>
-  <assembly fullname="System.Net.Ping">
-    <!-- NetEventSource isn't used by this assembly but tests check for its presence -->
-    <type fullname="System.Net.NetEventSource" />
-  </assembly>
-</linker>

--- a/src/System.Net.Ping/tests/FunctionalTests/LoggingTest.cs
+++ b/src/System.Net.Ping/tests/FunctionalTests/LoggingTest.cs
@@ -12,13 +12,13 @@ namespace System.Net.NetworkInformation.Tests
         [Fact]
         public void EventSource_ExistsWithCorrectId()
         {
-            Type esType = typeof(Ping).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);
-            Assert.NotNull(esType);
-
-            Assert.Equal("Microsoft-System-Net-Ping", EventSource.GetName(esType));
-            Assert.Equal(Guid.Parse("a771ec4a-7260-59ce-0475-db257437ed8c"), EventSource.GetGuid(esType));
-
-            Assert.NotEmpty(EventSource.GenerateManifest(esType, esType.Assembly.Location));
+            Type esType = typeof(Ping).Assembly.GetType("System.Net.NetEventSource", throwOnError: false, ignoreCase: false);
+            if (esType != null)
+            {
+                Assert.Equal("Microsoft-System-Net-Ping", EventSource.GetName(esType));
+                Assert.Equal(Guid.Parse("a771ec4a-7260-59ce-0475-db257437ed8c"), EventSource.GetGuid(esType));
+                Assert.NotEmpty(EventSource.GenerateManifest(esType, esType.Assembly.Location));
+            }
         }
     }
 }


### PR DESCRIPTION
It has an ILLinkTrim.xml file that was keeping a type around for testing, but that's apparently keeping the assembly from being trimmed in a published app.