### PR TITLE
Fix DeflateStream.CopyTo for concatenated payloads

### DIFF
--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
@@ -908,7 +908,7 @@ namespace System.IO.Compression
                 try
                 {
                     // Flush any existing data in the inflater to the destination stream.
-                    while (_deflateStream._inflater.Finished())
+                    while (!_deflateStream._inflater.Finished())
                     {
                         int bytesRead = _deflateStream._inflater.Inflate(_arrayPoolBuffer, 0, _arrayPoolBuffer.Length);
                         if (bytesRead > 0)
@@ -939,7 +939,7 @@ namespace System.IO.Compression
                 try
                 {
                     // Flush any existing data in the inflater to the destination stream.
-                    while (_deflateStream._inflater.Finished())
+                    while (!_deflateStream._inflater.Finished())
                     {
                         int bytesRead = _deflateStream._inflater.Inflate(_arrayPoolBuffer, 0, _arrayPoolBuffer.Length);
                         if (bytesRead > 0)
@@ -983,7 +983,7 @@ namespace System.IO.Compression
                 _deflateStream._inflater.SetInput(buffer, offset, count);
 
                 // While there's more decompressed data available, forward it to the buffer stream.
-                while (_deflateStream._inflater.Finished())
+                while (!_deflateStream._inflater.Finished())
                 {
                     int bytesRead = _deflateStream._inflater.Inflate(new Span<byte>(_arrayPoolBuffer));
                     if (bytesRead > 0)
@@ -1019,7 +1019,7 @@ namespace System.IO.Compression
                 _deflateStream._inflater.SetInput(buffer, offset, count);
 
                 // While there's more decompressed data available, forward it to the buffer stream.
-                while (_deflateStream._inflater.Finished())
+                while (!_deflateStream._inflater.Finished())
                 {
                     int bytesRead = _deflateStream._inflater.Inflate(new Span<byte>(_arrayPoolBuffer));
                     if (bytesRead > 0)

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
@@ -295,7 +295,7 @@ namespace System.IO.Compression
                         throw new InvalidDataException(SR.GenericInvalidData);
                     }
 
-                     _inflater.SetInput(_buffer, 0, bytes);
+                    _inflater.SetInput(_buffer, 0, bytes);
                 }
             }
 
@@ -908,16 +908,16 @@ namespace System.IO.Compression
                 try
                 {
                     // Flush any existing data in the inflater to the destination stream.
-                    while (true)
+                    while (_deflateStream._inflater.Finished())
                     {
                         int bytesRead = _deflateStream._inflater.Inflate(_arrayPoolBuffer, 0, _arrayPoolBuffer.Length);
                         if (bytesRead > 0)
                         {
                             await _destination.WriteAsync(new ReadOnlyMemory<byte>(_arrayPoolBuffer, 0, bytesRead), _cancellationToken).ConfigureAwait(false);
                         }
-
-                        if (_deflateStream._inflater.NeedsInput() || _deflateStream._inflater.Finished())
+                        else if (_deflateStream._inflater.NeedsInput())
                         {
+                            // only break if we read 0 and ran out of input, if input is still available it may be another GZip payload
                             break;
                         }
                     }
@@ -939,16 +939,16 @@ namespace System.IO.Compression
                 try
                 {
                     // Flush any existing data in the inflater to the destination stream.
-                    while (true)
+                    while (_deflateStream._inflater.Finished())
                     {
                         int bytesRead = _deflateStream._inflater.Inflate(_arrayPoolBuffer, 0, _arrayPoolBuffer.Length);
                         if (bytesRead > 0)
                         {
                             _destination.Write(_arrayPoolBuffer, 0, bytesRead);
                         }
-
-                        if (_deflateStream._inflater.NeedsInput() || _deflateStream._inflater.Finished())
+                        else if (_deflateStream._inflater.NeedsInput())
                         {
+                            // only break if we read 0 and ran out of input, if input is still available it may be another GZip payload
                             break;
                         }
                     }
@@ -983,7 +983,7 @@ namespace System.IO.Compression
                 _deflateStream._inflater.SetInput(buffer, offset, count);
 
                 // While there's more decompressed data available, forward it to the buffer stream.
-                while (true)
+                while (_deflateStream._inflater.Finished())
                 {
                     int bytesRead = _deflateStream._inflater.Inflate(new Span<byte>(_arrayPoolBuffer));
                     if (bytesRead > 0)
@@ -992,11 +992,7 @@ namespace System.IO.Compression
                     }
                     else if (_deflateStream._inflater.NeedsInput())
                     {
-                        break;
-                    }
-
-                    if (_deflateStream._inflater.Finished())
-                    {
+                        // only break if we read 0 and ran out of input, if input is still available it may be another GZip payload
                         break;
                     }
                 }
@@ -1023,7 +1019,7 @@ namespace System.IO.Compression
                 _deflateStream._inflater.SetInput(buffer, offset, count);
 
                 // While there's more decompressed data available, forward it to the buffer stream.
-                while (true)
+                while (_deflateStream._inflater.Finished())
                 {
                     int bytesRead = _deflateStream._inflater.Inflate(new Span<byte>(_arrayPoolBuffer));
                     if (bytesRead > 0)
@@ -1032,11 +1028,7 @@ namespace System.IO.Compression
                     }
                     else if (_deflateStream._inflater.NeedsInput())
                     {
-                        break;
-                    }
-
-                    if (_deflateStream._inflater.Finished())
-                    {
+                        // only break if we read 0 and ran out of input, if input is still available it may be another GZip payload
                         break;
                     }
                 }

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
@@ -295,7 +295,7 @@ namespace System.IO.Compression
                         throw new InvalidDataException(SR.GenericInvalidData);
                     }
 
-                    _inflater.SetInput(_buffer, 0, bytes);
+                     _inflater.SetInput(_buffer, 0, bytes);
                 }
             }
 
@@ -915,7 +915,8 @@ namespace System.IO.Compression
                         {
                             await _destination.WriteAsync(new ReadOnlyMemory<byte>(_arrayPoolBuffer, 0, bytesRead), _cancellationToken).ConfigureAwait(false);
                         }
-                        else
+
+                        if (_deflateStream._inflater.NeedsInput() || _deflateStream._inflater.Finished())
                         {
                             break;
                         }
@@ -945,7 +946,8 @@ namespace System.IO.Compression
                         {
                             _destination.Write(_arrayPoolBuffer, 0, bytesRead);
                         }
-                        else
+
+                        if (_deflateStream._inflater.NeedsInput() || _deflateStream._inflater.Finished())
                         {
                             break;
                         }
@@ -988,10 +990,11 @@ namespace System.IO.Compression
                     {
                         await _destination.WriteAsync(new ReadOnlyMemory<byte>(_arrayPoolBuffer, 0, bytesRead), cancellationToken).ConfigureAwait(false);
                     }
-                    else
+                    else if (_deflateStream._inflater.NeedsInput())
                     {
                         break;
                     }
+
                     if (_deflateStream._inflater.Finished())
                     {
                         break;
@@ -1027,10 +1030,11 @@ namespace System.IO.Compression
                     {
                         _destination.Write(_arrayPoolBuffer, 0, bytesRead);
                     }
-                    else
+                    else if (_deflateStream._inflater.NeedsInput())
                     {
                         break;
                     }
+
                     if (_deflateStream._inflater.Finished())
                     {
                         break;

--- a/src/System.IO.Compression/tests/CompressionStreamUnitTests.Gzip.cs
+++ b/src/System.IO.Compression/tests/CompressionStreamUnitTests.Gzip.cs
@@ -63,11 +63,8 @@ namespace System.IO.Compression
         /// A derived MemoryStream that avoid's MemoryStream's fast path in CopyTo
         /// that bypasses buffering.
         /// </summary>
-        class DerivedMemoryStream : MemoryStream
-        {
-            public DerivedMemoryStream() : base()
-            { }
-        }
+        private class DerivedMemoryStream : MemoryStream
+        { }
 
         [Fact]
         public async Task ConcatenatedEmptyGzipStreams()

--- a/src/System.IO.Compression/tests/CompressionStreamUnitTests.Gzip.cs
+++ b/src/System.IO.Compression/tests/CompressionStreamUnitTests.Gzip.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -58,40 +59,136 @@ namespace System.IO.Compression
             }
         }
 
-        [Theory]
-        [InlineData(1000, false, false, 1000, 1)]
-        [InlineData(1000, false, true, 0, 1)]
-        [InlineData(1000, true, false, 1000, 1)]
-        [InlineData(1000, false, false, 1, 1)]
-        [InlineData(1000, true, false, 1, 1)]
-        [InlineData(1000, false, false, 1001 * 24, 1)]
-        [InlineData(1000, true, false, 1001 * 24, 1)]
-        public async Task ManyConcatenatedGzipStreams(int streamCount, bool useAsync, bool useReadByte, int bufferSize, int bytesPerStream)
+        /// <summary>
+        /// A derived MemoryStream that avoid's MemoryStream's fast path in CopyTo
+        /// that bypasses buffering.
+        /// </summary>
+        class DerivedMemoryStream : MemoryStream
         {
-            await TestConcatenatedGzipStreams(streamCount, useAsync, useReadByte, bufferSize, bytesPerStream);
+            public DerivedMemoryStream() : base()
+            { }
+        }
+
+        [Fact]
+        public async Task ConcatenatedEmptyGzipStreams()
+        {
+            const int copyToBufferSizeRequested = 0x8000;
+
+            // we'll request a specific size buffer, but we cannot garuntee that's the size
+            // that will be used since CopyTo will rent from the array pool
+            // take advantage of this knowledge to find out what size it will actually use
+            var rentedBuffer = ArrayPool<byte>.Shared.Rent(copyToBufferSizeRequested);
+            int actualBufferSize = rentedBuffer.Length;
+            ArrayPool<byte>.Shared.Return(rentedBuffer);
+
+            // use 3 buffers-full so that we can prime the stream with the first buffer-full,
+            // test that CopyTo successfully flushes this at the beginning of the operation, 
+            // then populates the second buffer-full and reads its entirety despite every
+            // payload being 0 length before it reads the final buffer-full.
+            int minCompressedSize = 3 * actualBufferSize;
+
+            using (Stream compressedStream = new DerivedMemoryStream())
+            {
+                using (var gz = new GZipStream(compressedStream, CompressionLevel.NoCompression, leaveOpen: true))
+                {
+                    // write one byte in order to allow us to prime the inflater buffer
+                    gz.WriteByte(3);
+                }
+
+                while (compressedStream.Length < minCompressedSize)
+                {
+                    using (var gz = new GZipStream(compressedStream, CompressionLevel.NoCompression, leaveOpen: true))
+                    {
+                        gz.Write(Array.Empty<byte>());
+                    }
+                }
+
+                compressedStream.Seek(0, SeekOrigin.Begin);
+                using (Stream gz = new GZipStream(compressedStream, CompressionMode.Decompress, leaveOpen: true))
+                using (Stream decompressedData = new DerivedMemoryStream())
+                {
+                    // read one byte in order to fill the inflater bufffer before copy
+                    Assert.Equal(3, gz.ReadByte());
+
+                    gz.CopyTo(decompressedData, copyToBufferSizeRequested);
+                    Assert.Equal(0, decompressedData.Length);
+                }
+
+                compressedStream.Seek(0, SeekOrigin.Begin);
+                using (Stream gz = new GZipStream(compressedStream, CompressionMode.Decompress, leaveOpen: true))
+                using (Stream decompressedData = new DerivedMemoryStream())
+                {
+                    // read one byte in order to fill the inflater bufffer before copy
+                    Assert.Equal(3, gz.ReadByte());
+
+                    await gz.CopyToAsync(decompressedData, copyToBufferSizeRequested);
+                    Assert.Equal(0, decompressedData.Length);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(1000, TestScenario.Read, 1000, 1)]
+        [InlineData(1000, TestScenario.ReadByte, 0, 1)]
+        [InlineData(1000, TestScenario.ReadAsync, 1000, 1)]
+        [InlineData(1000, TestScenario.Copy, 1000, 1)]
+        [InlineData(1000, TestScenario.CopyAsync, 1000, 1)]
+        [InlineData(10, TestScenario.Read, 1000, 2000)]
+        [InlineData(10, TestScenario.ReadByte, 0, 2000)]
+        [InlineData(10, TestScenario.ReadAsync, 1000, 2000)]
+        [InlineData(10, TestScenario.Copy, 1000, 2000)]
+        [InlineData(10, TestScenario.CopyAsync, 1000, 2000)]
+        [InlineData(2, TestScenario.Copy, 1000, 0x2000-30)]
+        [InlineData(2, TestScenario.CopyAsync, 1000, 0x2000 - 30)]
+        [InlineData(1000, TestScenario.Read, 1, 1)]
+        [InlineData(1000, TestScenario.ReadAsync, 1, 1)]
+        [InlineData(1000, TestScenario.Read, 1001 * 24, 1)]
+        [InlineData(1000, TestScenario.ReadAsync, 1001 * 24, 1)]
+        [InlineData(1000, TestScenario.Copy, 1001 * 24, 1)]
+        [InlineData(1000, TestScenario.CopyAsync, 1001 * 24, 1)]
+        public async Task ManyConcatenatedGzipStreams(int streamCount, TestScenario scenario, int bufferSize, int bytesPerStream)
+        {
+            await TestConcatenatedGzipStreams(streamCount, scenario, bufferSize, bytesPerStream);
         }
 
         [Theory]
         [OuterLoop("Tests take a very long time to complete")]
-        [InlineData(400000, false, false, 1000, 1)]
-        [InlineData(400000, true, false, 1000, 1)]
-        [InlineData(1000, false, false, 1000, 20000)]
-        [InlineData(1000, false, true, 0, 20000)]
-        [InlineData(1000, true, false, 1000, 9000)]
-        [InlineData(1000, false, false, 1, 9000)]
-        [InlineData(1000, true, false, 1, 9000)]
-        [InlineData(1000, false, false, 1001 * 24, 9000)]
-        [InlineData(1000, true, false, 1001 * 24, 9000)]
-        public async Task ManyManyConcatenatedGzipStreams(int streamCount, bool useAsync, bool useReadByte, int bufferSize, int bytesPerStream)
+        [InlineData(400000, TestScenario.Read, 1000, 1)]
+        [InlineData(400000, TestScenario.ReadAsync, 1000, 1)]
+        [InlineData(400000, TestScenario.Copy, 1000, 1)]
+        [InlineData(400000, TestScenario.CopyAsync, 1000, 1)]
+        [InlineData(1000, TestScenario.Read, 1000, 20000)]
+        [InlineData(1000, TestScenario.ReadByte, 0, 20000)]
+        [InlineData(1000, TestScenario.ReadAsync, 1000, 9000)]
+        [InlineData(1000, TestScenario.Read, 1, 9000)]
+        [InlineData(1000, TestScenario.ReadAsync, 1, 9000)]
+        [InlineData(1000, TestScenario.Read, 1001 * 24, 9000)]
+        [InlineData(1000, TestScenario.ReadAsync, 1001 * 24, 9000)]
+        [InlineData(1000, TestScenario.Copy, 1001 * 24, 9000)]
+        [InlineData(1000, TestScenario.CopyAsync, 1001 * 24, 9000)]
+        public async Task ManyManyConcatenatedGzipStreams(int streamCount, TestScenario scenario, int bufferSize, int bytesPerStream)
         {
-            await TestConcatenatedGzipStreams(streamCount, useAsync, useReadByte, bufferSize, bytesPerStream);
+            await TestConcatenatedGzipStreams(streamCount, scenario, bufferSize, bytesPerStream);
         }
 
-        private async Task TestConcatenatedGzipStreams(int streamCount, bool useAsync, bool useReadByte, int bufferSize, int bytesPerStream = 1)
+        public enum TestScenario
         {
-            using (var correctDecompressedOutput = new MemoryStream())
-            using (var compressedStream = new MemoryStream())
-            using (var decompressorOutput = new MemoryStream())
+            ReadByte,
+            Read,
+            ReadAsync,
+            Copy,
+            CopyAsync
+        }
+
+        private async Task TestConcatenatedGzipStreams(int streamCount, TestScenario scenario, int bufferSize, int bytesPerStream = 1)
+        {
+            bool isCopy = scenario == TestScenario.Copy || scenario == TestScenario.CopyAsync;
+
+            using (MemoryStream correctDecompressedOutput = new MemoryStream())
+            // For copy scenarios use a derived MemoryStream to avoid MemoryStream's Copy optimization 
+            // that turns the Copy into a single Write passing the backing buffer
+            using (MemoryStream compressedStream = isCopy ? new DerivedMemoryStream() : new MemoryStream())  
+            using (MemoryStream decompressorOutput = new MemoryStream())
             {
                 for (int i = 0; i < streamCount; i++)
                 {
@@ -100,7 +197,7 @@ namespace System.IO.Compression
                         for (int j = 0; j < bytesPerStream; j++)
                         {
                             byte b = (byte)((i * j) % 256);
-                            gz.WriteByte( b);
+                            gz.WriteByte(b);
                             correctDecompressedOutput.WriteByte(b);
                         }
                     }
@@ -108,46 +205,55 @@ namespace System.IO.Compression
                 compressedStream.Seek(0, SeekOrigin.Begin);
 
                 var decompressor = CreateStream(compressedStream, CompressionMode.Decompress);
-                //Thread.Sleep(10000);
 
                 var bytes = new byte[bufferSize];
                 bool finished = false;
                 int retCount = 0, totalRead = 0;
                 while (!finished)
                 {
-                    if (useAsync)
+                    switch (scenario)
                     {
-                        try
-                        {
-                            retCount = await decompressor.ReadAsync(bytes, 0, bufferSize);
-                            totalRead += retCount;
-                            if (retCount != 0)
-                                await decompressorOutput.WriteAsync(bytes, 0, retCount);
+                        case TestScenario.ReadAsync:
+                            try
+                            {
+                                retCount = await decompressor.ReadAsync(bytes, 0, bufferSize);
+                                totalRead += retCount;
+                                if (retCount != 0)
+                                    await decompressorOutput.WriteAsync(bytes, 0, retCount);
+                                else
+                                    finished = true;
+                            }
+                            catch (Exception)
+                            {
+                                throw new Exception(retCount + " " + totalRead);
+                            }
+                            break;
+                        case TestScenario.ReadByte:
+                            int b = decompressor.ReadByte();
+
+                            if (b != -1)
+                                decompressorOutput.WriteByte((byte)b);
                             else
                                 finished = true;
-                        }
-                        catch (Exception)
-                        {
-                            throw new Exception(retCount + " " + totalRead);
-                        }
-                    }
-                    else if (useReadByte)
-                    {
-                        int b = decompressor.ReadByte();
 
-                        if (b != -1)
-                            decompressorOutput.WriteByte((byte)b);
-                        else
-                            finished = true;
-                    }
-                    else
-                    {
-                        retCount = decompressor.Read(bytes, 0, bufferSize);
+                            break;
+                        case TestScenario.Read:
+                            retCount = decompressor.Read(bytes, 0, bufferSize);
 
-                        if (retCount != 0)
-                            decompressorOutput.Write(bytes, 0, retCount);
-                        else
+                            if (retCount != 0)
+                                decompressorOutput.Write(bytes, 0, retCount);
+                            else
+                                finished = true;
+
+                            break;
+                        case TestScenario.Copy:
+                            decompressor.CopyTo(decompressorOutput, bufferSize);
                             finished = true;
+                            break;
+                        case TestScenario.CopyAsync:
+                            await decompressor.CopyToAsync(decompressorOutput, bufferSize);
+                            finished = true;
+                            break;
                     }
                 }
                 decompressor.Dispose();

--- a/src/System.IO.Compression/tests/CompressionStreamUnitTests.Gzip.cs
+++ b/src/System.IO.Compression/tests/CompressionStreamUnitTests.Gzip.cs
@@ -60,7 +60,7 @@ namespace System.IO.Compression
         }
 
         /// <summary>
-        /// A derived MemoryStream that avoid's MemoryStream's fast path in CopyTo
+        /// A derived MemoryStream that avoids MemoryStream's fast path in CopyTo
         /// that bypasses buffering.
         /// </summary>
         private class DerivedMemoryStream : MemoryStream
@@ -71,7 +71,7 @@ namespace System.IO.Compression
         {
             const int copyToBufferSizeRequested = 0x8000;
 
-            // we'll request a specific size buffer, but we cannot garuntee that's the size
+            // we'll request a specific size buffer, but we cannot guarantee that's the size
             // that will be used since CopyTo will rent from the array pool
             // take advantage of this knowledge to find out what size it will actually use
             var rentedBuffer = ArrayPool<byte>.Shared.Rent(copyToBufferSizeRequested);


### PR DESCRIPTION
Support for concatenated payloads was added in 55f2293ddda3c972fcc2d94915b03bc8556e8c9b.

With this DeflateStream will continue to attempt to read after it
encounters a payload footer if it has more data left and that data
begins with the proper header format.

This caused a bug in CopyTo where it assumed that if the inflater
returned 0 bytes inflated it was done with that buffer.
This can happen in a couple cases:
1. The footer for a payload occurs on a buffer boundary, such that the
first call to Inflate for that buffer reads only the footer and returns
0 data. This was reported by a customer.
2. One of the concatenated payloads is 0 length.

Previously the CopyTo implementation would skip the remainder of the
buffer in this case, then proceed with a new buffer.  This new buffer
would start and an arbitrary offset in the compressed data, which likely
isn't a valid header, and an exception would be thrown:
```
System.IO.InvalidDataException : The archive entry was compressed using an unsupported compression method.
```

Fix this by continuing to copy so long as the we haven't run out of
data, regardless of wether or not the inflater happens to read a 0
length chunk.

Fixes https://github.com/dotnet/corefx/issues/40710