### PR TITLE
Enable Stop->Start on HttpListener

### DIFF
--- a/src/System.Net.HttpListener/tests/SimpleHttpTests.cs
+++ b/src/System.Net.HttpListener/tests/SimpleHttpTests.cs
@@ -168,7 +168,6 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        [ActiveIssue(39552)]
         public void ListenerRestart_BeginGetContext_Success()
         {
             using (HttpListenerFactory factory = new HttpListenerFactory())
@@ -182,7 +181,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact]
-        [ActiveIssue(39552)]
         public async Task ListenerRestart_GetContext_Success()
         {
             const string Content = "ListenerRestart_GetContext_Success";


### PR DESCRIPTION
Resolves #39552.

Enables a HttpListener to be restarted once it has been stopped.

Additionally, fixes some race conditions when accessing `DisconnectResults`.