### PR TITLE
Adds a new regex option - RegexOptions.AnyNewLine.

### DIFF
--- a/src/System.Text.RegularExpressions/ref/System.Text.RegularExpressions.cs
+++ b/src/System.Text.RegularExpressions/ref/System.Text.RegularExpressions.cs
@@ -236,6 +236,7 @@ namespace System.Text.RegularExpressions
         RightToLeft = 64,
         ECMAScript = 256,
         CultureInvariant = 512,
+        AnyNewLine = 1024,
     }
     public abstract partial class RegexRunner
     {

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -24,7 +24,7 @@ namespace System.Text.RegularExpressions
     /// </summary>
     public partial class Regex : ISerializable
     {
-        internal const int MaxOptionShift = 10;
+        internal const int MaxOptionShift = 11;
 
         protected internal string pattern;                   // The string pattern provided
         protected internal RegexOptions roptions;            // the top-level options from the options string
@@ -95,7 +95,8 @@ namespace System.Text.RegularExpressions
                              RegexOptions.IgnoreCase |
                              RegexOptions.Multiline |
                              RegexOptions.Compiled |
-                             RegexOptions.CultureInvariant
+                             RegexOptions.CultureInvariant |
+                             RegexOptions.AnyNewLine
 #if DEBUG
                            | RegexOptions.Debug
 #endif

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCode.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCode.cs
@@ -53,7 +53,7 @@ namespace System.Text.RegularExpressions
         public const int Beginning = 18;          //                          \A
         public const int Start = 19;              //                          \G
         public const int EndZ = 20;               //                          \Z
-        public const int End = 21;                //                          \Z
+        public const int End = 21;                //                          \z
 
         public const int Nothing = 22;            //                          Reject!
 
@@ -81,6 +81,9 @@ namespace System.Text.RegularExpressions
 
         public const int ECMABoundary = 41;       //                          \b
         public const int NonECMABoundary = 42;    //                          \B
+
+        public const int AnyEndZ = 43;            //                          \Z
+        public const int AnyEol = 44;             //                          $
 
         // Modifiers for alternate modes
         public const int Mask = 63;   // Mask to get unmodified ordinary operator
@@ -160,6 +163,7 @@ namespace System.Text.RegularExpressions
                 case Nothing:
                 case Bol:
                 case Eol:
+                case AnyEol:
                 case Boundary:
                 case Nonboundary:
                 case ECMABoundary:
@@ -167,6 +171,7 @@ namespace System.Text.RegularExpressions
                 case Beginning:
                 case Start:
                 case EndZ:
+                case AnyEndZ:
                 case End:
                 case Nullmark:
                 case Setmark:
@@ -229,6 +234,7 @@ namespace System.Text.RegularExpressions
 #if ECMA
             "ECMABoundary", "NonECMABoundary",
 #endif
+            "AnyEndZ", "AnyEol", // FIXME
         };
 
         private static string OperatorDescription(int Opcode)

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCode.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCode.cs
@@ -231,10 +231,8 @@ namespace System.Text.RegularExpressions
             "Nullmark", "Setmark", "Capturemark", "Getmark",
             "Setjump", "Backjump", "Forejump", "Testref", "Goto",
             "Prune", "Stop",
-#if ECMA
             "ECMABoundary", "NonECMABoundary",
-#endif
-            "AnyEndZ", "AnyEol", // FIXME
+            "AnyEndZ", "AnyEol",
         };
 
         private static string OperatorDescription(int Opcode)

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -2428,16 +2428,12 @@ namespace System.Text.RegularExpressions
                     //:     break Backward;
                     {
                         Label l1 = _labels[NextCodepos()];
-                        Label l2 = DefineLabel();
                         Ldloc(_textposV);
                         Ldloc(_textendV);
                         Bge(l1);
                         Rightchar();
                         Ldc((int)'\n');
-                        Bne(l2);
-                        Br(l1);
-
-                        MarkLabel(l2);
+                        Beq(l1);
                         Rightchar();
                         Ldc((int)'\r');
                         BneFar(_backtrack);

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -1213,6 +1213,9 @@ namespace System.Text.RegularExpressions
                         Br(l3);
 
                         MarkLabel(l2);
+                        Ldloc(diff);
+                        Ldc(1);
+                        Blt(l3);
                         Ldthisfld(s_textF);
                         Ldthisfld(s_textposF);
                         Callvirt(s_getcharM);

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFCD.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFCD.cs
@@ -33,6 +33,9 @@ namespace System.Text.RegularExpressions
         public const int Boundary = 0x0040;
         public const int ECMABoundary = 0x0080;
 
+        public const int AnyEndZ = 0x0100;
+        public const int AnyEol = 0x0200;
+
         private readonly List<RegexFC> _fcStack;
         private ValueListBuilder<int> _intStack;    // must not be readonly
         private bool _skipAllChildren;              // don't process any more children at the current level
@@ -125,11 +128,13 @@ namespace System.Text.RegularExpressions
 
                     case RegexNode.Bol:
                     case RegexNode.Eol:
+                    case RegexNode.AnyEol:
                     case RegexNode.Boundary:
                     case RegexNode.ECMABoundary:
                     case RegexNode.Beginning:
                     case RegexNode.Start:
                     case RegexNode.EndZ:
+                    case RegexNode.AnyEndZ:
                     case RegexNode.End:
                     case RegexNode.Empty:
                     case RegexNode.Require:
@@ -180,11 +185,13 @@ namespace System.Text.RegularExpressions
 
                     case RegexNode.Bol:
                     case RegexNode.Eol:
+                    case RegexNode.AnyEol:
                     case RegexNode.Boundary:
                     case RegexNode.ECMABoundary:
                     case RegexNode.Beginning:
                     case RegexNode.Start:
                     case RegexNode.EndZ:
+                    case RegexNode.AnyEndZ:
                     case RegexNode.End:
                         return result | AnchorFromType(curNode.NType);
 
@@ -212,11 +219,13 @@ namespace System.Text.RegularExpressions
             {
                 RegexNode.Bol => Bol,
                 RegexNode.Eol => Eol,
+                RegexNode.AnyEol => AnyEol,
                 RegexNode.Boundary => Boundary,
                 RegexNode.ECMABoundary => ECMABoundary,
                 RegexNode.Beginning => Beginning,
                 RegexNode.Start => Start,
                 RegexNode.EndZ => EndZ,
+                RegexNode.AnyEndZ => AnyEndZ,
                 RegexNode.End => End,
                 _ => 0,
             };
@@ -238,10 +247,14 @@ namespace System.Text.RegularExpressions
                 sb.Append(", ECMABoundary");
             if (0 != (anchors & Eol))
                 sb.Append(", Eol");
+            if (0 != (anchors & AnyEol))
+                sb.Append(", AnyEol");
             if (0 != (anchors & End))
                 sb.Append(", End");
             if (0 != (anchors & EndZ))
                 sb.Append(", EndZ");
+            if (0 != (anchors & AnyEndZ))
+                sb.Append(", AnyEndZ");
 
             if (sb.Length >= 2)
                 return (sb.ToString(2, sb.Length - 2));
@@ -502,6 +515,7 @@ namespace System.Text.RegularExpressions
                 case RegexNode.Nothing:
                 case RegexNode.Bol:
                 case RegexNode.Eol:
+                case RegexNode.AnyEol:
                 case RegexNode.Boundary:
                 case RegexNode.Nonboundary:
                 case RegexNode.ECMABoundary:
@@ -509,6 +523,7 @@ namespace System.Text.RegularExpressions
                 case RegexNode.Beginning:
                 case RegexNode.Start:
                 case RegexNode.EndZ:
+                case RegexNode.AnyEndZ:
                 case RegexNode.End:
                     PushFC(new RegexFC(true));
                     break;

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
@@ -824,6 +824,12 @@ namespace System.Text.RegularExpressions
                         advance = 0;
                         continue;
 
+                    case RegexCode.AnyEol:
+                        if (Rightchars() > 0 && CharAt(Textpos()) != '\n' && CharAt(Textpos()) != '\r')
+                            break;
+                        advance = 0;
+                        continue;
+
                     case RegexCode.Boundary:
                         if (!IsBoundary(Textpos(), runtextbeg, runtextend))
                             break;
@@ -862,6 +868,17 @@ namespace System.Text.RegularExpressions
 
                     case RegexCode.EndZ:
                         if (Rightchars() > 1 || Rightchars() == 1 && CharAt(Textpos()) != '\n')
+                            break;
+                        advance = 0;
+                        continue;
+
+                    case RegexCode.AnyEndZ:
+                        int rightChars = Rightchars();
+                        if (rightChars > 2)
+                            break;
+                        if (rightChars == 1 && CharAt(Textpos()) != '\r' && CharAt(Textpos()) != '\n')
+                            break;
+                        if (rightChars == 2 && CharAt(Textpos()) != '\r' && CharAt(Textpos()+1) != '\n')
                             break;
                         advance = 0;
                         continue;

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
@@ -353,7 +353,7 @@ namespace System.Text.RegularExpressions
             return runtext[j];
         }
 
-        protected override bool FindFirstChar()
+        protected override bool FindFirstChar() // FIXME handle anyendz
         {
             if (0 != (_code.Anchors & (RegexFCD.Beginning | RegexFCD.Start | RegexFCD.EndZ | RegexFCD.End)))
             {
@@ -878,7 +878,7 @@ namespace System.Text.RegularExpressions
                             break;
                         if (rightChars == 1 && CharAt(Textpos()) != '\r' && CharAt(Textpos()) != '\n')
                             break;
-                        if (rightChars == 2 && CharAt(Textpos()) != '\r' && CharAt(Textpos()+1) != '\n')
+                        if (rightChars == 2 && (CharAt(Textpos()) != '\r' || CharAt(Textpos()+1) != '\n'))
                             break;
                         advance = 0;
                         continue;

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
@@ -353,9 +353,10 @@ namespace System.Text.RegularExpressions
             return runtext[j];
         }
 
-        protected override bool FindFirstChar() // FIXME handle anyendz
+        protected override bool FindFirstChar()
         {
-            if (0 != (_code.Anchors & (RegexFCD.Beginning | RegexFCD.Start | RegexFCD.EndZ | RegexFCD.End)))
+            if (0 != (_code.Anchors & (RegexFCD.Beginning | RegexFCD.Start |
+                RegexFCD.EndZ | RegexFCD.AnyEndZ | RegexFCD.End)))
             {
                 if (!_code.RightToLeft)
                 {
@@ -365,7 +366,7 @@ namespace System.Text.RegularExpressions
                         runtextpos = runtextend;
                         return false;
                     }
-                    if (0 != (_code.Anchors & RegexFCD.EndZ) && runtextpos < runtextend - 1)
+                    if (0 != (_code.Anchors & (RegexFCD.EndZ | RegexFCD.AnyEndZ)) && runtextpos < runtextend - 1)
                     {
                         runtextpos = runtextend - 1;
                     }
@@ -379,6 +380,11 @@ namespace System.Text.RegularExpressions
                     if ((0 != (_code.Anchors & RegexFCD.End) && runtextpos < runtextend) ||
                         (0 != (_code.Anchors & RegexFCD.EndZ) && (runtextpos < runtextend - 1 ||
                                                                (runtextpos == runtextend - 1 && CharAt(runtextpos) != '\n'))) ||
+                        (0 != (_code.Anchors & RegexFCD.AnyEndZ) && (runtextpos < runtextend - 2 ||
+                                                                (runtextpos == runtextend - 2 && (CharAt(runtextpos) != '\r'
+                                                                    || CharAt(runtextpos+1) != '\n')) ||
+                                                                (runtextpos == runtextend - 1 && CharAt(runtextpos) != '\n'
+                                                                    && CharAt(runtextpos) != '\r'))) ||
                         (0 != (_code.Anchors & RegexFCD.Start) && runtextpos < runtextstart))
                     {
                         runtextpos = runtextbeg;

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
@@ -884,7 +884,7 @@ namespace System.Text.RegularExpressions
                             break;
                         if (rightChars == 1 && CharAt(Textpos()) != '\r' && CharAt(Textpos()) != '\n')
                             break;
-                        if (rightChars == 2 && (CharAt(Textpos()) != '\r' || CharAt(Textpos()+1) != '\n'))
+                        if (rightChars == 2 && (CharAt(Textpos()) != '\r' || CharAt(Textpos() + 1) != '\n'))
                             break;
                         advance = 0;
                         continue;

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
@@ -68,6 +68,7 @@ namespace System.Text.RegularExpressions
 
         public const int Bol = RegexCode.Bol;                         //          ^
         public const int Eol = RegexCode.Eol;                         //          $
+        public const int AnyEol = RegexCode.AnyEol;                   //          $
         public const int Boundary = RegexCode.Boundary;               //          \b
         public const int Nonboundary = RegexCode.Nonboundary;         //          \B
         public const int ECMABoundary = RegexCode.ECMABoundary;       // \b
@@ -75,6 +76,7 @@ namespace System.Text.RegularExpressions
         public const int Beginning = RegexCode.Beginning;             //          \A
         public const int Start = RegexCode.Start;                     //          \G
         public const int EndZ = RegexCode.EndZ;                       //          \Z
+        public const int AnyEndZ = RegexCode.AnyEndZ;                 //          \Z
         public const int End = RegexCode.End;                         //          \z
 
         // Interior nodes do not correspond to primitive operations, but
@@ -564,9 +566,9 @@ namespace System.Text.RegularExpressions
             "Onelazy", "Notonelazy", "Setlazy",
             "One", "Notone", "Set",
             "Multi", "Ref",
-            "Bol", "Eol", "Boundary", "Nonboundary",
+            "Bol", "Eol", "AnyEol", "Boundary", "Nonboundary",
             "ECMABoundary", "NonECMABoundary",
-            "Beginning", "Start", "EndZ", "End",
+            "Beginning", "Start", "EndZ", "AnyEndZ", "End",
             "Nothing", "Empty",
             "Alternate", "Concatenate",
             "Loop", "Lazyloop",
@@ -593,6 +595,8 @@ namespace System.Text.RegularExpressions
                 ArgSb.Append("-X");
             if ((Options & RegexOptions.ECMAScript) != 0)
                 ArgSb.Append("-E");
+            if ((Options & RegexOptions.AnyNewLine) != 0)
+                ArgSb.Append("-A");
 
             switch (NType)
             {

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexOptions.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexOptions.cs
@@ -22,5 +22,6 @@ namespace System.Text.RegularExpressions
 
         ECMAScript              = 0x0100, // "e"
         CultureInvariant        = 0x0200,
+        AnyNewLine              = 0x0400, // "a", Treat "$" as (?=[\r\n]|\z)
     }
 }

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexOptions.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexOptions.cs
@@ -22,6 +22,6 @@ namespace System.Text.RegularExpressions
 
         ECMAScript              = 0x0100, // "e"
         CultureInvariant        = 0x0200,
-        AnyNewLine              = 0x0400, // "a", Treat "$" as (?=[\r\n]|\z)
+        AnyNewLine              = 0x0400, // "a", Treat "$" as (?=\r\z|\n\z|\r\n\z|\z)
     }
 }

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -360,7 +360,10 @@ namespace System.Text.RegularExpressions
                         break;
 
                     case '$':
-                        AddUnitType(UseOptionM() ? RegexNode.Eol : RegexNode.EndZ);
+                        if (UseOptionA())
+                            AddUnitType(UseOptionM() ? RegexNode.AnyEol : RegexNode.AnyEndZ);
+                        else
+                            AddUnitType(UseOptionM() ? RegexNode.Eol : RegexNode.EndZ);
                         break;
 
                     case '.':
@@ -1627,6 +1630,7 @@ namespace System.Text.RegularExpressions
                 'd' => RegexOptions.Debug,
 #endif
                 'e' => RegexOptions.ECMAScript,
+                'a' => RegexOptions.AnyNewLine,
                 _ => 0,
             };
         }
@@ -1937,6 +1941,15 @@ namespace System.Text.RegularExpressions
         private bool UseOptionE()
         {
             return (_options & RegexOptions.ECMAScript) != 0;
+        }
+
+        /*
+         * True if A option altering meaning of $ to match both Windows'
+         * Environment.NewLine and UNIX' Environment.NewLine is on.
+         */
+        private bool UseOptionA()
+        {
+            return (_options & RegexOptions.AnyNewLine) != 0;
         }
 
         private const byte Q = 5;    // quantifier

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -370,7 +370,19 @@ namespace System.Text.RegularExpressions
                         if (UseOptionS())
                             AddUnitSet(RegexCharClass.AnyClass);
                         else
-                            AddUnitNotone('\n');
+                        {
+                            if (UseOptionA())
+                            {
+                                // Allow everything from RegexCharClass.AnyClass except '\r' and '\n'
+                                RegexCharClass anyClass = RegexCharClass.Parse(RegexCharClass.AnyClass);
+                                RegexCharClass lecc = new RegexCharClass(); // line ending character class
+                                lecc.AddChar('\r');
+                                lecc.AddChar('\n');
+                                AddUnitSet(anyClass.AddSubtraction(lecc).ToStringClass());
+                            }
+                            else
+                                AddUnitNotone('\n');
+                        }
                         break;
 
                     case '{':

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexWriter.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexWriter.cs
@@ -480,6 +480,7 @@ namespace System.Text.RegularExpressions
                 case RegexNode.Nothing:
                 case RegexNode.Bol:
                 case RegexNode.Eol:
+                case RegexNode.AnyEol:
                 case RegexNode.Boundary:
                 case RegexNode.Nonboundary:
                 case RegexNode.ECMABoundary:
@@ -487,6 +488,7 @@ namespace System.Text.RegularExpressions
                 case RegexNode.Beginning:
                 case RegexNode.Start:
                 case RegexNode.EndZ:
+                case RegexNode.AnyEndZ:
                 case RegexNode.End:
                     Emit(node.NType);
                     break;

--- a/src/System.Text.RegularExpressions/tests/Regex.Ctor.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Ctor.Tests.cs
@@ -63,8 +63,8 @@ namespace System.Text.RegularExpressions.Tests
             AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => new Regex("foo", (RegexOptions)(-1)));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => new Regex("foo", (RegexOptions)(-1), new TimeSpan()));
 
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => new Regex("foo", (RegexOptions)0x400));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => new Regex("foo", (RegexOptions)0x400, new TimeSpan()));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => new Regex("foo", (RegexOptions)0x800));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => new Regex("foo", (RegexOptions)0x800, new TimeSpan()));
 
             AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => new Regex("foo", RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant | RegexOptions.RightToLeft));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => new Regex("foo", RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture));

--- a/src/System.Text.RegularExpressions/tests/Regex.Ctor.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Ctor.Tests.cs
@@ -18,7 +18,7 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { "foo", RegexOptions.None, Timeout.InfiniteTimeSpan };
             yield return new object[] { "foo", RegexOptions.RightToLeft, Timeout.InfiniteTimeSpan };
             yield return new object[] { "foo", RegexOptions.Compiled, Timeout.InfiniteTimeSpan };
-            yield return new object[] { "foo", RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant, Timeout.InfiniteTimeSpan };
+            yield return new object[] { "foo", RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.AnyNewLine | RegexOptions.Multiline | RegexOptions.CultureInvariant, Timeout.InfiniteTimeSpan };
             yield return new object[] { "foo", RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.CultureInvariant | RegexOptions.Compiled, Timeout.InfiniteTimeSpan };
             yield return new object[] { "foo", RegexOptions.None, new TimeSpan(1) };
             yield return new object[] { "foo", RegexOptions.None, TimeSpan.FromMilliseconds(int.MaxValue - 1) };

--- a/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -298,6 +298,30 @@ namespace System.Text.RegularExpressions.Tests
 
             // Surrogate pairs splitted up into UTF-16 code units.
             yield return new object[] { @"(\uD82F[\uDCA0-\uDCA3])", "\uD82F\uDCA2", RegexOptions.CultureInvariant, 0, 2, true, "\uD82F\uDCA2" };
+
+            // AnyNewLine (with none of the special characters used as line ending)
+            yield return new object[] { @"line3\nline4$", "line1\nline2\nline3\nline4", RegexOptions.AnyNewLine, 0, 23, true, "line3\nline4" };
+
+            // AnyNewLine (with '\n' used as line ending)
+            yield return new object[] { @"line3\nline4$", "line1\nline2\nline3\nline4\n", RegexOptions.AnyNewLine, 0, 24, true, "line3\nline4" };
+
+            // AnyNewLine (with '\r' used as line ending)
+            yield return new object[] { @"line3\nline4$", "line1\nline2\nline3\nline4\r", RegexOptions.AnyNewLine, 0, 24, true, "line3\nline4" };
+
+            // AnyNewLine (with '\r\n' used as line ending)
+            yield return new object[] { @"line3\nline4$", "line1\nline2\nline3\nline4\r\n", RegexOptions.AnyNewLine, 0, 25, true, "line3\nline4" };
+
+            // AnyNewLine | Multiline (with none of the special characters used as line ending)
+            yield return new object[] { @"line3\nline4$", "line1\nline2\nline3\nline4", RegexOptions.Multiline | RegexOptions.AnyNewLine, 0, 23, true, "line3\nline4" };
+
+            // AnyNewLine | Multiline (with '\n' used as line ending)
+            yield return new object[] { @"line3\nline4$", "line1\nline2\nline3\nline4\n", RegexOptions.Multiline | RegexOptions.AnyNewLine, 0, 24, true, "line3\nline4" };
+
+            // AnyNewLine | Multiline (with '\r' used as line ending)
+            yield return new object[] { @"line3\nline4$", "line1\nline2\nline3\nline4\r", RegexOptions.Multiline | RegexOptions.AnyNewLine, 0, 24, true, "line3\nline4" };
+
+            // AnyNewLine | Multiline (with '\r\n' used as line ending)
+            yield return new object[] { @"line3\nline4$", "line1\nline2\nline3\nline4\r\n", RegexOptions.Multiline | RegexOptions.AnyNewLine, 0, 25, true, "line3\nline4" };
         }
 
         [Theory]

--- a/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -599,7 +599,37 @@ namespace System.Text.RegularExpressions.Tests
                 }
             };
 
-            // Mutliline
+            // AnyEndZ (with '\n' used as line ending)
+            yield return new object[]
+            {
+                "line3\nline4$", "line1\nline2\nline3\nline4\n", RegexOptions.AnyNewLine, 0, 24,
+                new CaptureData[]
+                {
+                    new CaptureData("line3\nline4", 12, 11)
+                }
+            };
+
+            // AnyEndZ (with '\r' used as line ending)
+            yield return new object[]
+            {
+                "line3\nline4$", "line1\nline2\nline3\nline4\r", RegexOptions.AnyNewLine, 0, 24,
+                new CaptureData[]
+                {
+                    new CaptureData("line3\nline4", 12, 11)
+                }
+            };
+
+            // AnyEndZ (with '\r\n' used as line ending)
+            yield return new object[]
+            {
+                "line3\nline4$", "line1\nline2\nline3\nline4\r\n", RegexOptions.AnyNewLine, 0, 25,
+                new CaptureData[]
+                {
+                    new CaptureData("line3\nline4", 12, 11)
+                }
+            };
+
+            // Multiline
             yield return new object[]
             {
                 "(line2$\n)line3", "line1\nline2\nline3\n\nline4", RegexOptions.Multiline, 0, 24,
@@ -610,7 +640,7 @@ namespace System.Text.RegularExpressions.Tests
                 }
             };
 
-            // Mutliline
+            // Multiline
             yield return new object[]
             {
                 "(line2\n^)line3", "line1\nline2\nline3\n\nline4", RegexOptions.Multiline, 0, 24,
@@ -621,10 +651,10 @@ namespace System.Text.RegularExpressions.Tests
                 }
             };
 
-            // Mutliline
+            // Multiline (with '\n' used as line ending)
             yield return new object[]
             {
-                "(line3\n$\n)line4", "line1\nline2\nline3\n\nline4", RegexOptions.Multiline, 0, 24,
+                "(line3\n$\n)line4", "line1\nline2\nline3\n\nline4", RegexOptions.Multiline | RegexOptions.AnyNewLine, 0, 24,
                 new CaptureData[]
                 {
                     new CaptureData("line3\n\nline4", 12, 12),
@@ -632,7 +662,29 @@ namespace System.Text.RegularExpressions.Tests
                 }
             };
 
-            // Mutliline
+            // Multiline (with '\r\n' used as line ending)
+            yield return new object[]
+            {
+                "(line3$\r\n)line4", "line1\nline2\nline3\r\nline4", RegexOptions.Multiline | RegexOptions.AnyNewLine, 0, 24,
+                new CaptureData[]
+                {
+                    new CaptureData("line3\r\nline4", 12, 12),
+                    new CaptureData("line3\r\n", 12, 7)
+                }
+            };
+
+            // Multiline (with '\r' used as line ending)
+            yield return new object[]
+            {
+                "(line3$\r)line4", "line1\nline2\nline3\rline4", RegexOptions.Multiline | RegexOptions.AnyNewLine, 0, 23,
+                new CaptureData[]
+                {
+                    new CaptureData("line3\rline4", 12, 11),
+                    new CaptureData("line3\r", 12, 6)
+                }
+            };
+
+            // Multiline
             yield return new object[]
             {
                 "(line3\n^\n)line4", "line1\nline2\nline3\n\nline4", RegexOptions.Multiline, 0, 24,
@@ -643,7 +695,7 @@ namespace System.Text.RegularExpressions.Tests
                 }
             };
 
-            // Mutliline
+            // Multiline
             yield return new object[]
             {
                 "(line2$\n^)line3", "line1\nline2\nline3\n\nline4", RegexOptions.Multiline, 0, 24,

--- a/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -322,6 +322,12 @@ namespace System.Text.RegularExpressions.Tests
 
             // AnyNewLine | Multiline (with '\r\n' used as line ending)
             yield return new object[] { @"line3\nline4$", "line1\nline2\nline3\nline4\r\n", RegexOptions.Multiline | RegexOptions.AnyNewLine, 0, 25, true, "line3\nline4" };
+
+            // AnyNewLine (tests FindFirstChar())
+            yield return new object[] { @"$", "line1\nline2\nline3\nline4\r\n", RegexOptions.AnyNewLine, 0, 25, true, "" };
+
+            // AnyNewLine | RightToLeft (tests FindFirstChar())
+            yield return new object[] { @"$", "line1\nline2\nline3\nline4\r\n", RegexOptions.RightToLeft | RegexOptions.AnyNewLine, 0, 25, true, "" };
         }
 
         [Theory]

--- a/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -323,11 +323,14 @@ namespace System.Text.RegularExpressions.Tests
             // AnyNewLine | Multiline (with '\r\n' used as line ending)
             yield return new object[] { @"line3\nline4$", "line1\nline2\nline3\nline4\r\n", RegexOptions.Multiline | RegexOptions.AnyNewLine, 0, 25, true, "line3\nline4" };
 
-            // AnyNewLine (tests FindFirstChar())
+            // AnyNewLine
             yield return new object[] { @"$", "line1\nline2\nline3\nline4\r\n", RegexOptions.AnyNewLine, 0, 25, true, "" };
 
-            // AnyNewLine | RightToLeft (tests FindFirstChar())
+            // AnyNewLine | RightToLeft
             yield return new object[] { @"$", "line1\nline2\nline3\nline4\r\n", RegexOptions.RightToLeft | RegexOptions.AnyNewLine, 0, 25, true, "" };
+
+            // AnyNewLine | Multiline ('.' will match everything except \r and \n)
+            yield return new object[] { @".*$", "foo\r\nbar", RegexOptions.AnyNewLine | RegexOptions.Multiline, 0, 8, true, "foo" };
         }
 
         [Theory]

--- a/src/System.Text.RegularExpressions/tests/Regex.MultipleMatches.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.MultipleMatches.Tests.cs
@@ -217,8 +217,8 @@ namespace System.Text.RegularExpressions.Tests
             // Options are invalid
             AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => Regex.Matches("input", "pattern", (RegexOptions)(-1)));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => Regex.Matches("input", "pattern", (RegexOptions)(-1), TimeSpan.FromSeconds(1)));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => Regex.Matches("input", "pattern", (RegexOptions)0x400));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => Regex.Matches("input", "pattern", (RegexOptions)0x400, TimeSpan.FromSeconds(1)));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => Regex.Matches("input", "pattern", (RegexOptions)0x800));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => Regex.Matches("input", "pattern", (RegexOptions)0x800, TimeSpan.FromSeconds(1)));
 
             // MatchTimeout is invalid
             AssertExtensions.Throws<ArgumentOutOfRangeException>("matchTimeout", () => Regex.Matches("input", "pattern", RegexOptions.None, TimeSpan.Zero));

--- a/src/System.Text.RegularExpressions/tests/Regex.MultipleMatches.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.MultipleMatches.Tests.cs
@@ -140,6 +140,35 @@ namespace System.Text.RegularExpressions.Tests
                     new CaptureData("C789", 10, 4),
                 }
             };
+
+            yield return new object[]
+            {
+                "^line3$\nline4", "line1\nline2\nline3\nline4\nline3\nline4\n", RegexOptions.Multiline,
+                new CaptureData[]
+                {
+                    new CaptureData("line3\nline4", 12, 11),
+                    new CaptureData("line3\nline4", 24, 11),
+                }
+            };
+
+            yield return new object[]
+            {
+                "^line3$", "line1\nline2\nline3\r\nline4\nline3\nline4\n", RegexOptions.Multiline | RegexOptions.AnyNewLine,
+                new CaptureData[]
+                {
+                    new CaptureData("line3", 12, 5),
+                    new CaptureData("line3", 25, 5),
+                }
+            };
+
+            yield return new object[]
+            {
+                "line3$", "line1\nline2\nline3\r\nline4\nline3\r", RegexOptions.AnyNewLine,
+                new CaptureData[]
+                {
+                    new CaptureData("line3", 25, 5),
+                }
+            };
         }
 
         [Theory]


### PR DESCRIPTION
Adds a new regex option - RegexOptions.AnyNewLine, which supports '\r' (old mac), '\n' (unix), and '\r\n' (windows) as line endings for the '$' (EOL) operator.

Fixes #28410