### PR TITLE
Port: Fix icon entry selection (#41048)

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/Icon.Windows.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Icon.Windows.cs
@@ -525,7 +525,7 @@ namespace System.Drawing
                         int thisDelta = Math.Abs(entry.bWidth - width) + Math.Abs(entry.bHeight - height);
 
                         if ((thisDelta < bestDelta) ||
-                            (thisDelta == bestDelta && (0 <= s_bitDepth && 0 > _bestBitDepth || _bestBitDepth > s_bitDepth && 0 < _bestBitDepth)))
+                            (thisDelta == bestDelta && (iconBitDepth <= s_bitDepth && iconBitDepth > _bestBitDepth || _bestBitDepth > s_bitDepth && iconBitDepth < _bestBitDepth)))
                         {
                             fUpdateBestFit = true;
                         }

--- a/src/System.Drawing.Common/tests/IconTests.cs
+++ b/src/System.Drawing.Common/tests/IconTests.cs
@@ -26,6 +26,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing.Imaging;
 using System.IO;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
@@ -822,6 +823,57 @@ namespace System.Drawing.Tests
                                 Assert.Equal(e.G, a.G);
                                 Assert.Equal(e.B, a.B);
                             }
+                        }
+                    }
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.IsDrawingSupported)]
+        public void CorrectColorDepthExtracted()
+        {
+            using (var stream = File.OpenRead(Helpers.GetTestBitmapPath("pngwithheight_icon.ico")))
+            {
+                using (var icon = new Icon(stream, new Size(32, 32)))
+                {
+                    // The first 32x32 icon isn't 32 bit. Checking a few pixels that are in the 32 bit entry.
+                    using (Bitmap bitmap = icon.ToBitmap())
+                    {
+                        Assert.Equal(new Size(32, 32), bitmap.Size);
+
+                        int expectedBitDepth;
+                        if (!PlatformDetection.IsWindows)
+                        {
+                            // The Unix implementation currently doesn't try to match the display,
+                            // it will just pick the highest color depth when creating the bitmap.
+                            // (see SaveBestSingleIcon()).
+                            expectedBitDepth = 32;
+                        }
+                        else
+                        {
+                            string fieldName = PlatformDetection.IsFullFramework ? "bitDepth" : "s_bitDepth";
+                            FieldInfo fi = typeof(Icon).GetField(fieldName, BindingFlags.Static | BindingFlags.NonPublic);
+                            expectedBitDepth = (int)fi.GetValue(null);
+                        }
+
+                        // If the first icon entry was picked, the color would be black: 0xFF000000?
+
+                        switch (expectedBitDepth)
+                        {
+                            case 32:
+                                Assert.Equal(0x879EE532u, (uint)bitmap.GetPixel(0, 0).ToArgb());
+                                Assert.Equal(0x661CD8B7u, (uint)bitmap.GetPixel(0, 31).ToArgb());
+                                break;
+                            case 16:
+                            case 8:
+                                // There is no 16 bit 32x32 icon in this file, 8 will be picked
+                                // as the closest match.
+                                Assert.Equal(0x00000000u, (uint)bitmap.GetPixel(0, 0).ToArgb());
+                                Assert.Equal(0xFF000000u, (uint)bitmap.GetPixel(0, 31).ToArgb());
+                                break;
+                            default:
+                                Assert.False(true, $"Unexpected bitmap depth: {expectedBitDepth}");
+                                break;
                         }
                     }
                 }


### PR DESCRIPTION
### Description
We weren't checking the color depth properly when choosing an icon entry to extract from an icon file. This change fixes the regression and adds a test to validate that we're picking the appropriate color-depth.

### Customer Impact
Icons will load the first icon of the correct size, which often will not be the right color depth. WinForms apps may see black & white icons instead of the normal full color icon, for example. Customer reported in https://github.com/dotnet/winforms/issues/1825

### Regression?
Yes.

### Risk
Small, undoing a mistake in the affected line of code.

Fixes #41068