### PR TITLE
UWP Backport: QueryDirectoryFile requires 64 bit alignment to work on ARM32

### DIFF
--- a/src/Common/src/Interop/Windows/NtDll/Interop.NtQueryDirectoryFile.cs
+++ b/src/Common/src/Interop/Windows/NtDll/Interop.NtQueryDirectoryFile.cs
@@ -18,7 +18,7 @@ internal partial class Interop
             IntPtr ApcRoutine,
             IntPtr ApcContext,
             out IO_STATUS_BLOCK IoStatusBlock,
-            byte[] FileInformation,
+            IntPtr FileInformation,
             uint Length,
             FILE_INFORMATION_CLASS FileInformationClass,
             BOOLEAN ReturnSingleEntry,

--- a/src/Common/src/Interop/Windows/kernel32/Interop.GetFileInformationByHandleEx.cs
+++ b/src/Common/src/Interop/Windows/kernel32/Interop.GetFileInformationByHandleEx.cs
@@ -11,10 +11,10 @@ internal partial class Interop
     {
         // https://msdn.microsoft.com/en-us/library/windows/desktop/aa364953.aspx
         [DllImport(Libraries.Kernel32, SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true)]
-        public unsafe static extern bool GetFileInformationByHandleEx(
+        public static extern bool GetFileInformationByHandleEx(
             IntPtr hFile,
             FILE_INFO_BY_HANDLE_CLASS FileInformationClass,
-            byte[] lpFileInformation,
+            IntPtr lpFileInformation,
             uint dwBufferSize);
     }
 }

--- a/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.Win32.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.Win32.cs
@@ -22,7 +22,7 @@ namespace System.IO.Enumeration
                 ApcContext: IntPtr.Zero,
                 IoStatusBlock: out Interop.NtDll.IO_STATUS_BLOCK statusBlock,
                 FileInformation: _buffer,
-                Length: (uint)_buffer.Length,
+                Length: (uint)_bufferLength,
                 FileInformationClass: Interop.NtDll.FILE_INFORMATION_CLASS.FileFullDirectoryInformation,
                 ReturnSingleEntry: Interop.BOOLEAN.FALSE,
                 FileName: null,

--- a/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.WinRT.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.WinRT.cs
@@ -16,7 +16,7 @@ namespace System.IO.Enumeration
                 _directoryHandle,
                 Interop.Kernel32.FILE_INFO_BY_HANDLE_CLASS.FileFullDirectoryInfo,
                 _buffer,
-                (uint)_buffer.Length))
+                (uint)_bufferLength))
             {
                 int error = Marshal.GetLastWin32Error();
                 switch (error)

--- a/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemEnumerator.Windows.cs
@@ -28,12 +28,12 @@ namespace System.IO.Enumeration
         private Interop.NtDll.FILE_FULL_DIR_INFORMATION* _entry;
         private TResult _current;
 
-        private byte[] _buffer;
+        private IntPtr _buffer;
+        private int _bufferLength;
         private IntPtr _directoryHandle;
         private string _currentPath;
         private bool _lastEntryFound;
         private Queue<(IntPtr Handle, string Path)> _pending;
-        private GCHandle _pinnedBuffer;
 
         /// <summary>
         /// Encapsulates a find operation.
@@ -61,13 +61,15 @@ namespace System.IO.Enumeration
             _currentPath = _rootDirectory;
 
             int requestedBufferSize = _options.BufferSize;
-            int bufferSize = requestedBufferSize <= 0 ? StandardBufferSize
+            _bufferLength = requestedBufferSize <= 0 ? StandardBufferSize
                 : Math.Max(MinimumBufferSize, requestedBufferSize);
 
             try
             {
-                _buffer = ArrayPool<byte>.Shared.Rent(bufferSize);
-                _pinnedBuffer = GCHandle.Alloc(_buffer, GCHandleType.Pinned);
+                // NtQueryDirectoryFile needs its buffer to be 64bit aligned to work
+                // successfully with FileFullDirectoryInformation on ARM32. AllocHGlobal
+                // will return pointers aligned as such, new byte[] does not.
+                _buffer = Marshal.AllocHGlobal(_bufferLength);
             }
             catch
             {
@@ -203,7 +205,7 @@ namespace System.IO.Enumeration
 
             // We need more data
             if (GetData())
-                _entry = (Interop.NtDll.FILE_FULL_DIR_INFORMATION*)_pinnedBuffer.AddrOfPinnedObject();
+                _entry = (Interop.NtDll.FILE_FULL_DIR_INFORMATION*)_buffer;
         }
 
         private bool DequeueNextDirectory()
@@ -233,13 +235,12 @@ namespace System.IO.Enumeration
                         _pending = null;
                     }
 
-                    if (_pinnedBuffer.IsAllocated)
-                        _pinnedBuffer.Free();
+                    if (_buffer != default)
+                    {
+                        Marshal.FreeHGlobal(_buffer);
+                    }
 
-                    if (_buffer != null)
-                        ArrayPool<byte>.Shared.Return(_buffer);
-
-                    _buffer = null;
+                    _buffer = default;
                 }
             }
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/33563 (requested UWP backport)

Originally addressed in 3.0: https://github.com/dotnet/corefx/pull/33713
And already backported for 2.2: https://github.com/dotnet/corefx/pull/33754

Cherry-picked from: a75f96a105aa6dd6242d84ae40333df9a1d44c1c

Original commit message:
> QueryDirectoryFile requires 64 bit alignment to work on ARM32. Using Marshal.AllocHGlobal instead of byte[] will do that (and avoid the need to pin).

Please add the necessary labels/project/milestone.