### PR TITLE
Set TreatWarningsAsErrors to false in native build for now

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -35,7 +35,7 @@
       <_BuildNativeProjects Include="src\Native\build-native.proj" />
     </ItemGroup>
 
-    <MSBuild Projects="@(_BuildNativeProjects)" Properties="$(ProjectProperties)" />
+    <MSBuild Projects="@(_BuildNativeProjects)" Properties="$(ProjectProperties);TreatWarningsAsErrors=false" />
   </Target>
 
   <Target Name="BuildManaged">


### PR DESCRIPTION
Relates to: https://github.com/dotnet/corefx/issues/41077

Let's disable warnings as errors for native build completely, as the outer node is now marking it as an error, but the inner node as a warning, which thankfully doesn't stop the build, but it confuses people thinking the build actually did fail, when it didn't.

cc: @stephentoub @ericstj @ViktorHofer 