### PR TITLE
HttpClientHandler functional test: replace remote server dependency

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxResponseHeadersLength.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxResponseHeadersLength.cs
@@ -52,9 +52,8 @@ namespace System.Net.Http.Functional.Tests
                 using (HttpClientHandler handler = CreateHttpClientHandler())
                 using (HttpClient client = CreateHttpClient(handler))
                 {
-                    client.BaseAddress = uri;
                     handler.MaxResponseHeadersLength = 1;
-                    (await client.GetStreamAsync("/")).Dispose();
+                    (await client.GetStreamAsync(uri.ToString())).Dispose();
                     Assert.Throws<InvalidOperationException>(() => handler.MaxResponseHeadersLength = 1);
                 }
             },

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxResponseHeadersLength.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxResponseHeadersLength.cs
@@ -49,13 +49,12 @@ namespace System.Net.Http.Functional.Tests
         {
             await LoopbackServerFactory.CreateClientAndServerAsync(async uri =>
             {
-                using (HttpClientHandler handler = CreateHttpClientHandler())
-                using (HttpClient client = CreateHttpClient(handler))
-                {
-                    handler.MaxResponseHeadersLength = 1;
-                    (await client.GetStreamAsync(uri)).Dispose();
-                    Assert.Throws<InvalidOperationException>(() => handler.MaxResponseHeadersLength = 1);
-                }
+                using HttpClientHandler handler = CreateHttpClientHandler();
+                using HttpClient client = CreateHttpClient(handler);
+
+                handler.MaxResponseHeadersLength = 1;
+                (await client.GetStreamAsync(uri)).Dispose();
+                Assert.Throws<InvalidOperationException>(() => handler.MaxResponseHeadersLength = 1);
             },
             server => server.AcceptConnectionSendResponseAndCloseAsync());
         }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxResponseHeadersLength.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxResponseHeadersLength.cs
@@ -47,28 +47,17 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public async Task SetAfterUse_Throws()
         {
-            await LoopbackServer.CreateClientAndServerAsync(async uri =>
+            await LoopbackServerFactory.CreateClientAndServerAsync(async uri =>
             {
                 using (HttpClientHandler handler = CreateHttpClientHandler())
                 using (HttpClient client = CreateHttpClient(handler))
                 {
                     handler.MaxResponseHeadersLength = 1;
-                    (await client.GetStreamAsync(uri.ToString())).Dispose();
+                    (await client.GetStreamAsync(uri)).Dispose();
                     Assert.Throws<InvalidOperationException>(() => handler.MaxResponseHeadersLength = 1);
                 }
             },
-            async server =>
-            {
-                await server.AcceptConnectionAsync(async connection =>
-                {
-                    await connection.ReadRequestHeaderAsync();
-                    await connection.Writer.WriteAsync(
-                        LoopbackServer.GetContentModeResponse(
-                            mode: LoopbackServer.ContentMode.ContentLength,
-                            content: "content",
-                            connectionClose: true));
-                });
-            });
+            server => server.AcceptConnectionSendResponseAndCloseAsync());
         }
 
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Not currently supported on UAP")]


### PR DESCRIPTION
Replaces remote server dependency for `HttpClientHandler_MaxResponseHeadersLength_Test.SetAfterUse_Throws` with LoopbackServer.

Fixes #41148