### PR TITLE
CryptoNative_EvpDigestUpdate count as int32_t instead of size_t

### DIFF
--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_evp.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_evp.c
@@ -40,9 +40,9 @@ int32_t CryptoNative_EvpDigestReset(EVP_MD_CTX* ctx, const EVP_MD* type)
     return EVP_DigestInit_ex(ctx, type, NULL);
 }
 
-int32_t CryptoNative_EvpDigestUpdate(EVP_MD_CTX* ctx, const void* d, size_t cnt)
+int32_t CryptoNative_EvpDigestUpdate(EVP_MD_CTX* ctx, const void* d, int32_t cnt)
 {
-    return EVP_DigestUpdate(ctx, d, cnt);
+    return EVP_DigestUpdate(ctx, d, (size_t)cnt);
 }
 
 int32_t CryptoNative_EvpDigestFinalEx(EVP_MD_CTX* ctx, uint8_t* md, uint32_t* s)

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_evp.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_evp.h
@@ -40,7 +40,7 @@ EvpDigestUpdate
 
 Direct shim to EVP_DigestUpdate.
 */
-DLLEXPORT int32_t CryptoNative_EvpDigestUpdate(EVP_MD_CTX* ctx, const void* d, size_t cnt);
+DLLEXPORT int32_t CryptoNative_EvpDigestUpdate(EVP_MD_CTX* ctx, const void* d, int32_t cnt);
 
 /*
 Function:


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/41219

Also checked the other pal-headers in this cmake-project for any use of `size_t` in the signatures --> didn't find any.

/cc: @bartonjs 