### PR TITLE
Enable better trimming of derived XmlReader/Writer-derived types

### DIFF
--- a/src/System.Private.Xml/src/System/Xml/Core/XmlReaderSettings.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlReaderSettings.cs
@@ -13,6 +13,8 @@ namespace System.Xml
     // XmlReaderSettings class specifies basic features of an XmlReader.
     public sealed class XmlReaderSettings
     {
+        internal static readonly XmlReaderSettings s_defaultReaderSettings = new XmlReaderSettings() { ReadOnly = true };
+
         //
         // Fields
         //
@@ -424,11 +426,7 @@ namespace System.Xml
             }
 
             // resolve and open the url
-            XmlResolver tmpResolver = this.GetXmlResolver();
-            if (tmpResolver == null)
-            {
-                tmpResolver = CreateDefaultResolver();
-            }
+            XmlResolver tmpResolver = this.GetXmlResolver() ?? new XmlUrlResolver();
 
             // create text XML reader
             XmlReader reader = new XmlTextReaderImpl(inputUri, this, inputContext, tmpResolver);
@@ -577,11 +575,6 @@ namespace System.Xml
 
             _isReadOnly = false;
             IsXmlResolverSet = false;
-        }
-
-        private static XmlResolver CreateDefaultResolver()
-        {
-            return new XmlUrlResolver();
         }
 
         internal XmlReader AddValidation(XmlReader reader)

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlWriter.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlWriter.cs
@@ -659,68 +659,100 @@ namespace System.Xml
         // Creates an XmlWriter for writing into the provided file.
         public static XmlWriter Create(string outputFileName)
         {
-            return Create(outputFileName, null);
+            if (outputFileName == null)
+            {
+                throw new ArgumentNullException(nameof(outputFileName));
+            }
+
+            // Avoid using XmlWriter.Create(string, XmlReaderSettings), as it references a lot of types
+            // that then can't be trimmed away.
+            var fs = new FileStream(outputFileName, FileMode.Create, FileAccess.Write, FileShare.Read);
+            try
+            {
+                var settings = new XmlWriterSettings() { CloseOutput = true };
+                XmlWriter writer = new XmlEncodedRawTextWriter(fs, settings);
+                return new XmlWellFormedWriter(writer, settings);
+            }
+            catch
+            {
+                fs.Dispose();
+                throw;
+            }
         }
 
         // Creates an XmlWriter for writing into the provided file with the specified settings.
         public static XmlWriter Create(string outputFileName, XmlWriterSettings settings)
         {
-            if (settings == null)
-            {
-                settings = new XmlWriterSettings();
-            }
+            settings ??= XmlWriterSettings.s_defaultWriterSettings;
             return settings.CreateWriter(outputFileName);
         }
 
         // Creates an XmlWriter for writing into the provided stream.
         public static XmlWriter Create(Stream output)
         {
-            return Create(output, null);
+            if (output == null)
+            {
+                throw new ArgumentNullException(nameof(output));
+            }
+
+            // Avoid using XmlWriter.Create(Stream, XmlReaderSettings), as it references a lot of types
+            // that then can't be trimmed away.
+            XmlWriterSettings settings = XmlWriterSettings.s_defaultWriterSettings;
+            XmlWriter writer = new XmlUtf8RawTextWriter(output, settings);
+            return new XmlWellFormedWriter(writer, settings);
         }
 
         // Creates an XmlWriter for writing into the provided stream with the specified settings.
         public static XmlWriter Create(Stream output, XmlWriterSettings settings)
         {
-            if (settings == null)
-            {
-                settings = new XmlWriterSettings();
-            }
+            settings ??= XmlWriterSettings.s_defaultWriterSettings;
             return settings.CreateWriter(output);
         }
 
         // Creates an XmlWriter for writing into the provided TextWriter.
         public static XmlWriter Create(TextWriter output)
         {
-            return Create(output, null);
+            if (output == null)
+            {
+                throw new ArgumentNullException(nameof(output));
+            }
+
+            // Avoid using XmlWriter.Create(TextWriter, XmlReaderSettings), as it references a lot of types
+            // that then can't be trimmed away.
+            XmlWriterSettings settings = XmlWriterSettings.s_defaultWriterSettings;
+            XmlWriter writer = new XmlEncodedRawTextWriter(output, settings);
+            return new XmlWellFormedWriter(writer, settings);
         }
 
         // Creates an XmlWriter for writing into the provided TextWriter with the specified settings.
         public static XmlWriter Create(TextWriter output, XmlWriterSettings settings)
         {
-            if (settings == null)
-            {
-                settings = new XmlWriterSettings();
-            }
+            settings ??= XmlWriterSettings.s_defaultWriterSettings;
             return settings.CreateWriter(output);
         }
 
         // Creates an XmlWriter for writing into the provided StringBuilder.
         public static XmlWriter Create(StringBuilder output)
         {
-            return Create(output, null);
+            if (output == null)
+            {
+                throw new ArgumentNullException(nameof(output));
+            }
+
+            // Avoid using XmlWriter.Create(StringBuilder, XmlReaderSettings), as it references a lot of types
+            // that then can't be trimmed away.
+            return Create(new StringWriter(output, CultureInfo.InvariantCulture));
         }
 
         // Creates an XmlWriter for writing into the provided StringBuilder with the specified settings.
         public static XmlWriter Create(StringBuilder output, XmlWriterSettings settings)
         {
-            if (settings == null)
-            {
-                settings = new XmlWriterSettings();
-            }
             if (output == null)
             {
                 throw new ArgumentNullException(nameof(output));
             }
+
+            settings ??= XmlWriterSettings.s_defaultWriterSettings;
             return settings.CreateWriter(new StringWriter(output, CultureInfo.InvariantCulture));
         }
 
@@ -733,10 +765,7 @@ namespace System.Xml
         // Creates an XmlWriter wrapped around the provided XmlWriter with the specified settings.
         public static XmlWriter Create(XmlWriter output, XmlWriterSettings settings)
         {
-            if (settings == null)
-            {
-                settings = new XmlWriterSettings();
-            }
+            settings ??= XmlWriterSettings.s_defaultWriterSettings;
             return settings.CreateWriter(output);
         }
     }

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlWriterSettings.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlWriterSettings.cs
@@ -43,6 +43,8 @@ namespace System.Xml
     // XmlWriterSettings class specifies basic features of an XmlWriter.
     public sealed class XmlWriterSettings
     {
+        internal static readonly XmlWriterSettings s_defaultWriterSettings = new XmlWriterSettings() { ReadOnly = true };
+
         //
         // Fields
         //

--- a/src/System.Private.Xml/src/System/Xml/Xslt/XslCompiledTransform.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xslt/XslCompiledTransform.cs
@@ -45,9 +45,6 @@ namespace System.Xml.Xsl
 
     public sealed class XslCompiledTransform
     {
-        // Reader settings used when creating XmlReader from inputUri
-        private static readonly XmlReaderSettings s_readerSettings = new XmlReaderSettings();
-
 #if FEATURE_COMPILED_XSL
         // Version for GeneratedCodeAttribute
         private static readonly Version s_version = typeof(XslCompiledTransform).Assembly.GetName().Version;
@@ -362,7 +359,7 @@ namespace System.Xml.Xsl
         public void Transform(string inputUri, XmlWriter results)
         {
             CheckArguments(inputUri, results);
-            using (XmlReader reader = XmlReader.Create(inputUri, s_readerSettings))
+            using (XmlReader reader = XmlReader.Create(inputUri))
             {
                 Transform(reader, (XsltArgumentList)null, results, CreateDefaultResolver());
             }
@@ -372,7 +369,7 @@ namespace System.Xml.Xsl
         public void Transform(string inputUri, XsltArgumentList arguments, XmlWriter results)
         {
             CheckArguments(inputUri, results);
-            using (XmlReader reader = XmlReader.Create(inputUri, s_readerSettings))
+            using (XmlReader reader = XmlReader.Create(inputUri))
             {
                 Transform(reader, arguments, results, CreateDefaultResolver());
             }
@@ -382,7 +379,7 @@ namespace System.Xml.Xsl
         public void Transform(string inputUri, XsltArgumentList arguments, TextWriter results)
         {
             CheckArguments(inputUri, results);
-            using (XmlReader reader = XmlReader.Create(inputUri, s_readerSettings))
+            using (XmlReader reader = XmlReader.Create(inputUri))
             using (XmlWriter writer = XmlWriter.Create(results, OutputSettings))
             {
                 Transform(reader, arguments, writer, CreateDefaultResolver());
@@ -394,7 +391,7 @@ namespace System.Xml.Xsl
         public void Transform(string inputUri, XsltArgumentList arguments, Stream results)
         {
             CheckArguments(inputUri, results);
-            using (XmlReader reader = XmlReader.Create(inputUri, s_readerSettings))
+            using (XmlReader reader = XmlReader.Create(inputUri))
             using (XmlWriter writer = XmlWriter.Create(results, OutputSettings))
             {
                 Transform(reader, arguments, writer, CreateDefaultResolver());
@@ -412,7 +409,7 @@ namespace System.Xml.Xsl
                 throw new ArgumentNullException(nameof(resultsFile));
 
             // SQLBUDT 276415: Prevent wiping out the content of the input file if the output file is the same
-            using (XmlReader reader = XmlReader.Create(inputUri, s_readerSettings))
+            using (XmlReader reader = XmlReader.Create(inputUri))
             using (XmlWriter writer = XmlWriter.Create(resultsFile, OutputSettings))
             {
                 Transform(reader, (XsltArgumentList)null, writer, CreateDefaultResolver());


### PR DESCRIPTION
XmlReader and XmlWriter have a bunch of internal derived types, which are created by the XmlReader/Writer.Create factory methods.  When settings are provided, almost any of these derived types could be created based on the data in the settings.  But when no settings are provided, there's only one answer as to which types are used.  In the XmlReader/Writer.Create overloads that don't take settings, we can avoid delegating to the more general factory and instead just construct the specific types we need; while this adds a small amount of duplication, it also means that if an app only uses the overloads that don't take settings, most of the derived types can be trimmed away by the linker during app publishing, saving ~100K.

(Granted, lots of uses of XmlReader/Writer.Create do need to pass settings, including the reader/writer used by XLINQ, which is used in a default MVC app, and as such in a default MVC app this change has negligable impact.  But it does help a basic console app that just reads and writes an XML file.)

cc: @krwq, @buyaa-n, @jkotas 