### PR TITLE
Make Add/Remove UnsignedAttribute work with counter signers

### DIFF
--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SignerInfo.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SignerInfo.cs
@@ -835,11 +835,14 @@ namespace System.Security.Cryptography.Pkcs
 
         private static int FindAttributeIndexByOid(AttributeAsn[] attributes, Oid oid, int startIndex = 0)
         {
-            for (int i = startIndex; i < attributes.Length; i++)
+            if (attributes != null)
             {
-                if (attributes[i].AttrType.Value == oid.Value)
+                for (int i = startIndex; i < attributes.Length; i++)
                 {
-                    return i;
+                    if (attributes[i].AttrType.Value == oid.Value)
+                    {
+                        return i;
+                    }
                 }
             }
 
@@ -848,13 +851,16 @@ namespace System.Security.Cryptography.Pkcs
 
         private static int FindAttributeValueIndexByEncodedData(ReadOnlyMemory<byte>[] attributeValues, ReadOnlySpan<byte> asnEncodedData, out bool isOnlyValue)
         {
-            for (int i = 0; i < attributeValues.Length; i++)
+            if (attributeValues != null)
             {
-                ReadOnlySpan<byte> data = attributeValues[i].Span;
-                if (data.SequenceEqual(asnEncodedData))
+                for (int i = 0; i < attributeValues.Length; i++)
                 {
-                    isOnlyValue = attributeValues.Length == 1;
-                    return i;
+                    ReadOnlySpan<byte> data = attributeValues[i].Span;
+                    if (data.SequenceEqual(asnEncodedData))
+                    {
+                        isOnlyValue = attributeValues.Length == 1;
+                        return i;
+                    }
                 }
             }
 
@@ -864,19 +870,22 @@ namespace System.Security.Cryptography.Pkcs
 
         private static (int, int) FindAttributeLocation(AttributeAsn[] attributes, AsnEncodedData attribute, out bool isOnlyValue)
         {
-            for (int outerIndex = 0; ; outerIndex++)
+            if (attributes != null)
             {
-                outerIndex = FindAttributeIndexByOid(attributes, attribute.Oid, outerIndex);
-
-                if (outerIndex == -1)
+                for (int outerIndex = 0; ; outerIndex++)
                 {
-                    break;
-                }
+                    outerIndex = FindAttributeIndexByOid(attributes, attribute.Oid, outerIndex);
 
-                int innerIndex = FindAttributeValueIndexByEncodedData(attributes[outerIndex].AttrValues, attribute.RawData, out isOnlyValue);
-                if (innerIndex != -1)
-                {
-                    return (outerIndex, innerIndex);
+                    if (outerIndex == -1)
+                    {
+                        break;
+                    }
+
+                    int innerIndex = FindAttributeValueIndexByEncodedData(attributes[outerIndex].AttrValues, attribute.RawData, out isOnlyValue);
+                    if (innerIndex != -1)
+                    {
+                        return (outerIndex, innerIndex);
+                    }
                 }
             }
 

--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SignerInfo.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SignerInfo.cs
@@ -146,6 +146,11 @@ namespace System.Security.Cryptography.Pkcs
                 // we are one level deep, we need to update signer and counter signer attributes
                 int parentIdx = _document.SignerInfos.FindIndexForSigner(_parentSignerInfo);
 
+                if (parentIdx == -1)
+                {
+                    throw new CryptographicException(SR.Cryptography_Cms_NoSignerAtIndex);
+                }
+
                 ref SignedDataAsn documentData = ref _document.GetRawData();
                 ref SignerInfoAsn parentData = ref documentData.SignerInfos[parentIdx];
 

--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SubjectIdentifier.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SubjectIdentifier.cs
@@ -132,16 +132,16 @@ namespace System.Security.Cryptography.Pkcs
         {
             SubjectIdentifier currentId = other;
 
+            if (currentId.Type != Type)
+            {
+                return false;
+            }
+
             X509IssuerSerial issuerSerial = default;
 
             if (Type == SubjectIdentifierType.IssuerAndSerialNumber)
             {
                 issuerSerial = (X509IssuerSerial)Value;
-            }
-
-            if (currentId.Type != Type)
-            {
-                return false;
             }
 
             switch (Type)

--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SubjectIdentifier.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SubjectIdentifier.cs
@@ -127,5 +127,40 @@ namespace System.Security.Cryptography.Pkcs
                     throw new CryptographicException();
             }
         }
+
+        internal bool IsEquivalentTo(SubjectIdentifier other)
+        {
+            SubjectIdentifier currentId = other;
+
+            X509IssuerSerial issuerSerial = default;
+
+            if (Type == SubjectIdentifierType.IssuerAndSerialNumber)
+            {
+                issuerSerial = (X509IssuerSerial)Value;
+            }
+
+            if (currentId.Type != Type)
+            {
+                return false;
+            }
+
+            switch (Type)
+            {
+                case SubjectIdentifierType.IssuerAndSerialNumber:
+                    {
+                        X509IssuerSerial currentIssuerSerial = (X509IssuerSerial)currentId.Value;
+
+                        return currentIssuerSerial.IssuerName == issuerSerial.IssuerName &&
+                            currentIssuerSerial.SerialNumber == issuerSerial.SerialNumber;
+                    }
+                case SubjectIdentifierType.SubjectKeyIdentifier:
+                    return (string)Value == (string)currentId.Value;
+                case SubjectIdentifierType.NoSignature:
+                    return true;
+                default:
+                    Debug.Fail($"No match logic for SubjectIdentifierType {Type}");
+                    throw new CryptographicException();
+            }
+        }
     }
 }

--- a/src/System.Security.Cryptography.Pkcs/tests/SignedCms/SignerInfoTests.netcoreapp.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/SignedCms/SignerInfoTests.netcoreapp.cs
@@ -276,6 +276,23 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        public static void SignerInfo_RemoveNonMatchingUnsignedAttributesFromCounterSigner_Throws()
+        {
+            SignedCms cms = new SignedCms();
+            cms.Decode(SignedDocuments.OneRsaSignerTwoRsaCounterSigners);
+
+            int numberOfAttributes = cms.SignerInfos[0].UnsignedAttributes.Count;
+            Assert.NotEqual(0, numberOfAttributes);
+
+            AsnEncodedData fakeAttribute = new AsnEncodedData(
+                cms.SignerInfos[0].UnsignedAttributes[0].Oid,
+                cms.SignerInfos[0].UnsignedAttributes[0].Values[0].RawData.Skip(1).ToArray());
+            Assert.Throws<CryptographicException>(() => cms.SignerInfos[0].CounterSignerInfos[0].RemoveUnsignedAttribute(fakeAttribute));
+
+            Assert.Equal(numberOfAttributes, cms.SignerInfos[0].UnsignedAttributes.Count);
+        }
+
+        [Fact]
         public static void SignerInfo_AddOneUnsignedAttributeToCounterSigner_Adds()
         {
             SignedCms cms = new SignedCms();

--- a/src/System.Security.Cryptography.Pkcs/tests/SignedCms/SignerInfoTests.netcoreapp.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/SignedCms/SignerInfoTests.netcoreapp.cs
@@ -373,8 +373,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
             Assert.Equal(0, cms.SignerInfos[0].CounterSignerInfos[0].UnsignedAttributes.Count);
             Assert.Equal(1, cms.SignerInfos[0].CounterSignerInfos[1].UnsignedAttributes.Count);
             Assert.Equal(2, cms.SignerInfos[0].CounterSignerInfos[1].UnsignedAttributes[0].Values.Count);
-            VerifyAttributesAreEqual(cms.SignerInfos[0].CounterSignerInfos[1].UnsignedAttributes[0].Values[0], attribute1);
-            VerifyAttributesAreEqual(cms.SignerInfos[0].CounterSignerInfos[1].UnsignedAttributes[0].Values[1], attribute2);
+            VerifyAttributesContainsAll(cms.SignerInfos[0].CounterSignerInfos[1].UnsignedAttributes, expectedAttributes);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/41158

Extends #25449 which has added support for adding unsigned attributes to signers to also work with counter-signers which is a valid scenario for people wanting to add a timestamp to their counter-signatures.

FYI: @rrelyea @heng-liu @danmosemsft
cc: @vcsjones

Consider servicing for 3.1