### PR TITLE
Move XLinq specific type description providers into its assembly

### DIFF
--- a/src/System.ComponentModel.TypeConverter/src/ILLinkTrim.xml
+++ b/src/System.ComponentModel.TypeConverter/src/ILLinkTrim.xml
@@ -1,6 +1,5 @@
 <linker>
   <assembly fullname="System.ComponentModel.TypeConverter">
-    <type fullname="MS.Internal.Xml.Linq.ComponentModel.*" />
     <type fullname="System.ComponentModel.TypeDescriptor">
       <!-- called through reflection by System.ComponentModel.DefaultValueAttribute -->
       <method name="ConvertFromInvariantString" />

--- a/src/System.ComponentModel.TypeConverter/src/System.ComponentModel.TypeConverter.csproj
+++ b/src/System.ComponentModel.TypeConverter/src/System.ComponentModel.TypeConverter.csproj
@@ -7,7 +7,6 @@
     <Configurations>netcoreapp-Debug;netcoreapp-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="MS\Internal\Xml\Linq\ComponentModel\XComponentModel.cs" />
     <Compile Include="System\ComponentModel\ArrayConverter.cs" />
     <Compile Include="System\ComponentModel\BaseNumberConverter.cs" />
     <Compile Include="System\ComponentModel\BooleanConverter.cs" />
@@ -265,6 +264,5 @@
     <Reference Include="System.Threading" />
     <Reference Include="System.Threading.Thread" />
     <Reference Include="System.Threading.Timer" />
-    <Reference Include="System.Xml.XDocument" />
   </ItemGroup>
 </Project>

--- a/src/System.Private.Xml.Linq/src/ILLinkTrim.xml
+++ b/src/System.Private.Xml.Linq/src/ILLinkTrim.xml
@@ -1,5 +1,9 @@
 <linker>
   <assembly fullname="System.Private.Xml.Linq">
+    <type fullname="MS.Internal.Xml.Linq.ComponentModel.XTypeDescriptionProvider`1">
+      <!-- Instantiated via reflection -->
+      <method name=".ctor" />
+    </type>
     <type fullname="System.Xml.Linq.XElement">
       <!-- needed by serialization -->
       <method name=".ctor" />

--- a/src/System.Private.Xml.Linq/src/System.Private.Xml.Linq.csproj
+++ b/src/System.Private.Xml.Linq/src/System.Private.Xml.Linq.csproj
@@ -19,6 +19,7 @@
     <Compile Include="System\Xml\Linq\XAttribute.cs" />
     <Compile Include="System\Xml\Linq\XCData.cs" />
     <Compile Include="System\Xml\Linq\XComment.cs" />
+    <Compile Include="System\Xml\Linq\XComponentModel.cs" />
     <Compile Include="System\Xml\Linq\XContainer.cs" />
     <Compile Include="System\Xml\Linq\XDeclaration.cs" />
     <Compile Include="System\Xml\Linq\XDocument.cs" />
@@ -46,6 +47,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Collections" />
+    <Reference Include="System.ComponentModel.TypeConverter" />
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.Diagnostics.Tools" />
     <Reference Include="System.Linq" />

--- a/src/System.Private.Xml.Linq/src/System/Xml/Linq/XAttribute.cs
+++ b/src/System.Private.Xml.Linq/src/System/Xml/Linq/XAttribute.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 
 using CultureInfo = System.Globalization.CultureInfo;
@@ -17,7 +18,7 @@ namespace System.Xml.Linq
     /// An XML attribute is a name/value pair associated with an XML element.
     /// </remarks>
     [SuppressMessage("Microsoft.Naming", "CA1711:IdentifiersShouldNotHaveIncorrectSuffix", Justification = "Reviewed.")]
-    [System.ComponentModel.TypeDescriptionProvider("MS.Internal.Xml.Linq.ComponentModel.XTypeDescriptionProvider`1[[System.Xml.Linq.XAttribute, System.Xml.Linq, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]],System.ComponentModel.TypeConverter")]
+    [TypeDescriptionProvider(typeof(XTypeDescriptionProvider<XAttribute>))]
     public class XAttribute : XObject
     {
         /// <summary>

--- a/src/System.Private.Xml.Linq/src/System/Xml/Linq/XComponentModel.cs
+++ b/src/System.Private.Xml.Linq/src/System/Xml/Linq/XComponentModel.cs
@@ -2,14 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using System.Xml.Linq;
 
-namespace MS.Internal.Xml.Linq.ComponentModel
+namespace System.Xml.Linq
 {
     internal class XTypeDescriptionProvider<T> : TypeDescriptionProvider
     {

--- a/src/System.Private.Xml.Linq/src/System/Xml/Linq/XElement.cs
+++ b/src/System.Private.Xml.Linq/src/System/Xml/Linq/XElement.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -32,7 +33,7 @@ namespace System.Xml.Linq
     ///   </list>
     /// </remarks>
     [XmlSchemaProvider(null, IsAny = true)]
-    [System.ComponentModel.TypeDescriptionProvider("MS.Internal.Xml.Linq.ComponentModel.XTypeDescriptionProvider`1[[System.Xml.Linq.XElement, System.Xml.Linq, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]],System.ComponentModel.TypeConverter")]
+    [TypeDescriptionProvider(typeof(XTypeDescriptionProvider<XElement>))]
     public class XElement : XContainer, IXmlSerializable
     {
         /// <summary>


### PR DESCRIPTION
Avoids cross-assembly private reflection.

@ericstj, does this cause any cyclic problems or anything like that?  I'm suspicious that it wasn't done this way in the first place.

cc: @krwq 