### PR TITLE
Serializer perf improvements

### DIFF
--- a/src/System.Text.Json/src/Resources/Strings.resx
+++ b/src/System.Text.Json/src/Resources/Strings.resx
@@ -301,7 +301,7 @@
     <value>The provided data of length {0} has remaining bytes {1}.</value>
   </data>
   <data name="DeserializeUnableToConvertValue" xml:space="preserve">
-    <value>The JSON value could not be converted to {0}.</value>
+    <value>The JSON value could not be converted to {0}.$Path</value>
   </data>
   <data name="DeserializeWrongType" xml:space="preserve">
     <value>The specified type {0} must derive from the specific value's type {1}.</value>
@@ -394,13 +394,13 @@
     <value>The converter specified on '{0}' does not derive from JsonConverter or have a public parameterless constructor.</value>
   </data>
   <data name="SerializationConverterRead" xml:space="preserve">
-    <value>The converter '{0}' read too much or not enough.</value>
+    <value>The converter '{0}' read too much or not enough.$Path</value>
   </data>
   <data name="SerializationConverterNotCompatible" xml:space="preserve">
     <value>The converter '{0}' is not compatible with the type '{1}'.</value>
   </data>
   <data name="SerializationConverterWrite" xml:space="preserve">
-    <value>The converter '{0}' wrote too much or not enough.</value>
+    <value>The converter '{0}' wrote too much or not enough.$Path</value>
   </data>
   <data name="SerializerDictionaryKeyNull" xml:space="preserve">
     <value>The dictionary key policy '{0}' cannot return a null key.</value>
@@ -409,7 +409,7 @@
     <value>The attribute '{0}' cannot exist more than once on '{1}'.</value>
   </data>
   <data name="SerializeUnableToSerialize" xml:space="preserve">
-    <value>The object or value could not be serialized. Path: {0}.</value>
+    <value>The object or value could not be serialized.$Path</value>
   </data>
   <data name="FormatByte" xml:space="preserve">
     <value>Either the JSON value is not in a supported format, or is out of bounds for an unsigned byte.</value>

--- a/src/System.Text.Json/src/Resources/Strings.resx
+++ b/src/System.Text.Json/src/Resources/Strings.resx
@@ -301,7 +301,7 @@
     <value>The provided data of length {0} has remaining bytes {1}.</value>
   </data>
   <data name="DeserializeUnableToConvertValue" xml:space="preserve">
-    <value>The JSON value could not be converted to {0}.$Path</value>
+    <value>The JSON value could not be converted to {0}.</value>
   </data>
   <data name="DeserializeWrongType" xml:space="preserve">
     <value>The specified type {0} must derive from the specific value's type {1}.</value>
@@ -394,13 +394,13 @@
     <value>The converter specified on '{0}' does not derive from JsonConverter or have a public parameterless constructor.</value>
   </data>
   <data name="SerializationConverterRead" xml:space="preserve">
-    <value>The converter '{0}' read too much or not enough.$Path</value>
+    <value>The converter '{0}' read too much or not enough.</value>
   </data>
   <data name="SerializationConverterNotCompatible" xml:space="preserve">
     <value>The converter '{0}' is not compatible with the type '{1}'.</value>
   </data>
   <data name="SerializationConverterWrite" xml:space="preserve">
-    <value>The converter '{0}' wrote too much or not enough.$Path</value>
+    <value>The converter '{0}' wrote too much or not enough.</value>
   </data>
   <data name="SerializerDictionaryKeyNull" xml:space="preserve">
     <value>The dictionary key policy '{0}' cannot return a null key.</value>
@@ -409,7 +409,7 @@
     <value>The attribute '{0}' cannot exist more than once on '{1}'.</value>
   </data>
   <data name="SerializeUnableToSerialize" xml:space="preserve">
-    <value>The object or value could not be serialized.$Path</value>
+    <value>The object or value could not be serialized.</value>
   </data>
   <data name="FormatByte" xml:space="preserve">
     <value>Either the JSON value is not in a supported format, or is out of bounds for an unsigned byte.</value>

--- a/src/System.Text.Json/src/System/Text/Json/JsonException.cs
+++ b/src/System.Text.Json/src/System/Text/Json/JsonException.cs
@@ -94,6 +94,11 @@ namespace System.Text.Json
         }
 
         /// <summary>
+        /// Specifies that 'try' logic should append Path information to the exception message.
+        /// </summary>
+        internal bool AppendPathInformation { get; set; }
+
+        /// <summary>
         ///  Sets the <see cref="SerializationInfo"/> with information about the exception.
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/ClassType.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/ClassType.cs
@@ -7,20 +7,20 @@ namespace System.Text.Json
     /// <summary>
     /// Determines how a given class is treated when it is (de)serialized.
     /// </summary>
-    internal enum ClassType
+    internal enum ClassType : uint
     {
         // typeof(object)
-        Unknown = 0,
+        Unknown = 0x1,
         // POCO or rich data type
-        Object = 1,
+        Object = 0x2,
         // Value or object with a converter.
-        Value = 2,
+        Value = 0x4,
         // IEnumerable
-        Enumerable = 3,
+        Enumerable = 0x8,
         // IDictionary
-        Dictionary = 4,
+        Dictionary = 0x10,
         // Is deserialized by passing a IDictionary to its constructor
         // i.e. immutable dictionaries, Hashtable, SortedList,
-        IDictionaryConstructible = 5,
+        IDictionaryConstructible = 0x20,
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/ClassType.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/ClassType.cs
@@ -7,7 +7,11 @@ namespace System.Text.Json
     /// <summary>
     /// Determines how a given class is treated when it is (de)serialized.
     /// </summary>
-    internal enum ClassType : uint
+    /// <remarks>
+    /// Although bit flags are used, a given ClassType can only be one value.
+    /// Bit flags are used to efficiently compare against more than one value.
+    /// </remarks>
+    internal enum ClassType : byte
     {
         // typeof(object)
         Unknown = 0x1,

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
@@ -22,7 +22,7 @@ namespace System.Text.Json
         private static readonly JsonDictionaryConverter s_jsonIDictionaryConverter = new DefaultIDictionaryConverter();
         private static readonly JsonDictionaryConverter s_jsonImmutableDictionaryConverter = new DefaultImmutableDictionaryConverter();
 
-        public static readonly JsonPropertyInfo s_missingProperty = new JsonPropertyInfoNotNullable<object, object, object, object>();
+        public static readonly JsonPropertyInfo s_missingProperty = GetMissingProperty();
 
         private JsonClassInfo _elementClassInfo;
         private JsonClassInfo _runtimeClassInfo;
@@ -33,6 +33,15 @@ namespace System.Text.Json
         public ClassType ClassType;
 
         public abstract JsonConverter ConverterBase { get; set; }
+
+        private static JsonPropertyInfo GetMissingProperty()
+        {
+            JsonPropertyInfo info = new JsonPropertyInfoNotNullable<object, object, object, object>();
+            info.IsPropertyPolicy = false;
+            info.ShouldDeserialize = false;
+            info.ShouldSerialize = false;
+            return info;
+        }
 
         // Copy any settings defined at run-time to the new property.
         public void CopyRuntimeSettingsTo(JsonPropertyInfo other)
@@ -261,6 +270,8 @@ namespace System.Text.Json
         public bool HasGetter { get; set; }
         public bool HasSetter { get; set; }
 
+        public bool HasInternalConverter { get; private set; }
+
         public virtual void Initialize(
             Type parentClassType,
             Type declaredPropertyType,
@@ -284,6 +295,11 @@ namespace System.Text.Json
             if (converter != null)
             {
                 ConverterBase = converter;
+
+                if (converter.GetType().Assembly == GetType().Assembly)
+                {
+                    HasInternalConverter = true;
+                }
 
                 // Avoid calling GetClassType since it will re-ask if there is a converter which is slow.
                 if (runtimePropertyType == typeof(object))
@@ -325,8 +341,8 @@ namespace System.Text.Json
         // Options can be referenced here since all JsonPropertyInfos originate from a JsonClassInfo that is cached on JsonSerializerOptions.
         protected JsonSerializerOptions Options { get; set; }
 
-        protected abstract void OnRead(JsonTokenType tokenType, ref ReadStack state, ref Utf8JsonReader reader);
-        protected abstract void OnReadEnumerable(JsonTokenType tokenType, ref ReadStack state, ref Utf8JsonReader reader);
+        protected abstract void OnRead(ref ReadStack state, ref Utf8JsonReader reader);
+        protected abstract void OnReadEnumerable(ref ReadStack state, ref Utf8JsonReader reader);
         protected abstract void OnWrite(ref WriteStackFrame current, Utf8JsonWriter writer);
         protected virtual void OnWriteDictionary(ref WriteStackFrame current, Utf8JsonWriter writer) { }
         protected abstract void OnWriteEnumerable(ref WriteStackFrame current, Utf8JsonWriter writer);
@@ -345,15 +361,30 @@ namespace System.Text.Json
                 // Forward the setter to the value-based JsonPropertyInfo.
                 propertyInfo.ReadEnumerable(tokenType, ref state, ref reader);
             }
+            // For performance on release build, don't verify converter correctness for internal converters.
+            else if (HasInternalConverter)
+            {
+#if DEBUG
+                JsonTokenType originalTokenType = reader.TokenType;
+                int originalDepth = reader.CurrentDepth;
+                long originalBytesConsumed = reader.BytesConsumed;
+#endif
+
+                OnRead(ref state, ref reader);
+
+#if DEBUG
+                VerifyRead(originalTokenType, originalDepth, originalBytesConsumed, ref reader);
+#endif
+            }
             else
             {
                 JsonTokenType originalTokenType = reader.TokenType;
                 int originalDepth = reader.CurrentDepth;
                 long originalBytesConsumed = reader.BytesConsumed;
 
-                OnRead(tokenType, ref state, ref reader);
+                OnRead(ref state, ref reader);
 
-                VerifyRead(originalTokenType, originalDepth, originalBytesConsumed, ref state, ref reader);
+                VerifyRead(originalTokenType, originalDepth, originalBytesConsumed, ref reader);
             }
         }
 
@@ -361,13 +392,31 @@ namespace System.Text.Json
         {
             Debug.Assert(ShouldDeserialize);
 
-            JsonTokenType originalTokenType = reader.TokenType;
-            int originalDepth = reader.CurrentDepth;
-            long originalBytesConsumed = reader.BytesConsumed;
+            // For performance on release build, don't verify converter correctness for internal converters.
+            if (HasInternalConverter)
+            {
+#if DEBUG
+                JsonTokenType originalTokenType = reader.TokenType;
+                int originalDepth = reader.CurrentDepth;
+                long originalBytesConsumed = reader.BytesConsumed;
+#endif
 
-            OnReadEnumerable(tokenType, ref state, ref reader);
+                OnReadEnumerable(ref state, ref reader);
 
-            VerifyRead(originalTokenType, originalDepth, originalBytesConsumed, ref state, ref reader);
+#if DEBUG
+                VerifyRead(originalTokenType, originalDepth, originalBytesConsumed, ref reader);
+#endif
+            }
+            else
+            {
+                JsonTokenType originalTokenType = reader.TokenType;
+                int originalDepth = reader.CurrentDepth;
+                long originalBytesConsumed = reader.BytesConsumed;
+
+                OnReadEnumerable(ref state, ref reader);
+
+                VerifyRead(originalTokenType, originalDepth, originalBytesConsumed, ref reader);
+            }
         }
 
         public JsonClassInfo RuntimeClassInfo
@@ -403,18 +452,18 @@ namespace System.Text.Json
         public bool ShouldSerialize { get; private set; }
         public bool ShouldDeserialize { get; private set; }
 
-        private void VerifyRead(JsonTokenType tokenType, int depth, long bytesConsumed, ref ReadStack state, ref Utf8JsonReader reader)
+        private void VerifyRead(JsonTokenType tokenType, int depth, long bytesConsumed, ref Utf8JsonReader reader)
         {
             switch (tokenType)
             {
                 case JsonTokenType.StartArray:
                     if (reader.TokenType != JsonTokenType.EndArray)
                     {
-                        ThrowHelper.ThrowJsonException_SerializationConverterRead(reader, state.JsonPath(), ConverterBase.ToString());
+                        ThrowHelper.ThrowJsonException_SerializationConverterRead(ConverterBase.ToString());
                     }
                     else if (depth != reader.CurrentDepth)
                     {
-                        ThrowHelper.ThrowJsonException_SerializationConverterRead(reader, state.JsonPath(), ConverterBase.ToString());
+                        ThrowHelper.ThrowJsonException_SerializationConverterRead(ConverterBase.ToString());
                     }
 
                     // Should not be possible to have not read anything.
@@ -424,11 +473,11 @@ namespace System.Text.Json
                 case JsonTokenType.StartObject:
                     if (reader.TokenType != JsonTokenType.EndObject)
                     {
-                        ThrowHelper.ThrowJsonException_SerializationConverterRead(reader, state.JsonPath(), ConverterBase.ToString());
+                        ThrowHelper.ThrowJsonException_SerializationConverterRead(ConverterBase.ToString());
                     }
                     else if (depth != reader.CurrentDepth)
                     {
-                        ThrowHelper.ThrowJsonException_SerializationConverterRead(reader, state.JsonPath(), ConverterBase.ToString());
+                        ThrowHelper.ThrowJsonException_SerializationConverterRead(ConverterBase.ToString());
                     }
 
                     // Should not be possible to have not read anything.
@@ -439,7 +488,7 @@ namespace System.Text.Json
                     // Reading a single property value.
                     if (reader.BytesConsumed != bytesConsumed)
                     {
-                        ThrowHelper.ThrowJsonException_SerializationConverterRead(reader, state.JsonPath(), ConverterBase.ToString());
+                        ThrowHelper.ThrowJsonException_SerializationConverterRead(ConverterBase.ToString());
                     }
 
                     // Should not be possible to change token type.
@@ -459,42 +508,82 @@ namespace System.Text.Json
                 JsonPropertyInfo propertyInfo = ElementClassInfo.PolicyProperty;
                 propertyInfo.WriteEnumerable(ref state, writer);
             }
-            else
+            // For performance on release build, don't verify converter correctness for internal converters.
+            else if (HasInternalConverter)
             {
+#if DEBUG
                 int originalDepth = writer.CurrentDepth;
+#endif
 
                 OnWrite(ref state.Current, writer);
 
-                if (originalDepth != writer.CurrentDepth)
-                {
-                    ThrowHelper.ThrowJsonException_SerializationConverterWrite(state.PropertyPath(), ConverterBase.ToString());
-                }
+#if DEBUG
+                VerifyWrite(originalDepth, writer);
+#endif
+            }
+            else
+            {
+                int originalDepth = writer.CurrentDepth;
+                OnWrite(ref state.Current, writer);
+                VerifyWrite(originalDepth, writer);
             }
         }
 
         public void WriteDictionary(ref WriteStack state, Utf8JsonWriter writer)
         {
             Debug.Assert(ShouldSerialize);
-            int originalDepth = writer.CurrentDepth;
 
-            OnWriteDictionary(ref state.Current, writer);
-
-            if (originalDepth != writer.CurrentDepth)
+            // For performance on release build, don't verify converter correctness for internal converters.
+            if (HasInternalConverter)
             {
-                ThrowHelper.ThrowJsonException_SerializationConverterWrite(state.PropertyPath(), ConverterBase.ToString());
+#if DEBUG
+                int originalDepth = writer.CurrentDepth;
+#endif
+
+                OnWriteDictionary(ref state.Current, writer);
+
+#if DEBUG
+                VerifyWrite(originalDepth, writer);
+#endif
+            }
+            else
+            {
+                int originalDepth = writer.CurrentDepth;
+                OnWriteDictionary(ref state.Current, writer);
+                VerifyWrite(originalDepth, writer);
             }
         }
 
         public void WriteEnumerable(ref WriteStack state, Utf8JsonWriter writer)
         {
             Debug.Assert(ShouldSerialize);
-            int originalDepth = writer.CurrentDepth;
 
-            OnWriteEnumerable(ref state.Current, writer);
+            // For performance on release build, don't verify converter correctness for internal converters.
+            if (HasInternalConverter)
+            {
+#if DEBUG
+                int originalDepth = writer.CurrentDepth;
+#endif
 
+                OnWriteEnumerable(ref state.Current, writer);
+
+#if DEBUG
+                VerifyWrite(originalDepth, writer);
+#endif
+            }
+            else
+            {
+                int originalDepth = writer.CurrentDepth;
+                OnWriteEnumerable(ref state.Current, writer);
+                VerifyWrite(originalDepth, writer);
+            }
+        }
+
+        private void VerifyWrite(int originalDepth, Utf8JsonWriter writer)
+        {
             if (originalDepth != writer.CurrentDepth)
             {
-                ThrowHelper.ThrowJsonException_SerializationConverterWrite(state.PropertyPath(), ConverterBase.ToString());
+                ThrowHelper.ThrowJsonException_SerializationConverterWrite(ConverterBase.ToString());
             }
         }
     }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
@@ -296,10 +296,7 @@ namespace System.Text.Json
             {
                 ConverterBase = converter;
 
-                if (converter.GetType().Assembly == GetType().Assembly)
-                {
-                    HasInternalConverter = true;
-                }
+                HasInternalConverter = (converter.GetType().Assembly == GetType().Assembly);
 
                 // Avoid calling GetClassType since it will re-ask if there is a converter which is slow.
                 if (runtimePropertyType == typeof(object))
@@ -459,11 +456,11 @@ namespace System.Text.Json
                 case JsonTokenType.StartArray:
                     if (reader.TokenType != JsonTokenType.EndArray)
                     {
-                        ThrowHelper.ThrowJsonException_SerializationConverterRead(ConverterBase.ToString());
+                        ThrowHelper.ThrowJsonException_SerializationConverterRead(ConverterBase);
                     }
                     else if (depth != reader.CurrentDepth)
                     {
-                        ThrowHelper.ThrowJsonException_SerializationConverterRead(ConverterBase.ToString());
+                        ThrowHelper.ThrowJsonException_SerializationConverterRead(ConverterBase);
                     }
 
                     // Should not be possible to have not read anything.
@@ -473,11 +470,11 @@ namespace System.Text.Json
                 case JsonTokenType.StartObject:
                     if (reader.TokenType != JsonTokenType.EndObject)
                     {
-                        ThrowHelper.ThrowJsonException_SerializationConverterRead(ConverterBase.ToString());
+                        ThrowHelper.ThrowJsonException_SerializationConverterRead(ConverterBase);
                     }
                     else if (depth != reader.CurrentDepth)
                     {
-                        ThrowHelper.ThrowJsonException_SerializationConverterRead(ConverterBase.ToString());
+                        ThrowHelper.ThrowJsonException_SerializationConverterRead(ConverterBase);
                     }
 
                     // Should not be possible to have not read anything.
@@ -488,7 +485,7 @@ namespace System.Text.Json
                     // Reading a single property value.
                     if (reader.BytesConsumed != bytesConsumed)
                     {
-                        ThrowHelper.ThrowJsonException_SerializationConverterRead(ConverterBase.ToString());
+                        ThrowHelper.ThrowJsonException_SerializationConverterRead(ConverterBase);
                     }
 
                     // Should not be possible to change token type.
@@ -583,7 +580,7 @@ namespace System.Text.Json
         {
             if (originalDepth != writer.CurrentDepth)
             {
-                ThrowHelper.ThrowJsonException_SerializationConverterWrite(ConverterBase.ToString());
+                ThrowHelper.ThrowJsonException_SerializationConverterWrite(ConverterBase);
             }
         }
     }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNotNullable.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNotNullable.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Text.Json.Serialization;
 
 namespace System.Text.Json
 {
@@ -15,11 +14,11 @@ namespace System.Text.Json
         JsonPropertyInfoCommon<TClass, TDeclaredProperty, TRuntimeProperty, TConverter>
         where TConverter : TDeclaredProperty
     {
-        protected override void OnRead(JsonTokenType tokenType, ref ReadStack state, ref Utf8JsonReader reader)
+        protected override void OnRead(ref ReadStack state, ref Utf8JsonReader reader)
         {
             if (Converter == null)
             {
-                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType, reader, state.JsonPath());
+                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType);
             }
 
             TConverter value = Converter.Read(ref reader, RuntimePropertyType, Options);
@@ -34,28 +33,28 @@ namespace System.Text.Json
             }
         }
 
-        protected override void OnReadEnumerable(JsonTokenType tokenType, ref ReadStack state, ref Utf8JsonReader reader)
+        protected override void OnReadEnumerable(ref ReadStack state, ref Utf8JsonReader reader)
         {
             if (Converter == null)
             {
-                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType, reader, state.JsonPath());
+                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType);
             }
 
-            if (state.Current.KeyName == null && (state.Current.IsProcessingDictionary || state.Current.IsProcessingIDictionaryConstructible))
+            if (state.Current.KeyName == null && state.Current.IsProcessingDictionaryOrIDictionaryConstructible())
             {
-                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType, reader, state.JsonPath());
+                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType);
                 return;
             }
 
             // We need an initialized array in order to store the values.
-            if (state.Current.IsProcessingEnumerable && state.Current.TempEnumerableValues == null && state.Current.ReturnValue == null)
+            if (state.Current.IsProcessingEnumerable() && state.Current.TempEnumerableValues == null && state.Current.ReturnValue == null)
             {
-                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType, reader, state.JsonPath());
+                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType);
                 return;
             }
 
             TConverter value = Converter.Read(ref reader, RuntimePropertyType, Options);
-            JsonSerializer.ApplyValueToEnumerable(ref value, ref state, ref reader);
+            JsonSerializer.ApplyValueToEnumerable(ref value, ref state);
         }
 
         protected override void OnWrite(ref WriteStackFrame current, Utf8JsonWriter writer)

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNotNullableContravariant.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNotNullableContravariant.cs
@@ -14,11 +14,11 @@ namespace System.Text.Json.Serialization
         JsonPropertyInfoCommon<TClass, TDeclaredProperty, TRuntimeProperty, TConverter>
         where TDeclaredProperty : TConverter
     {
-        protected override void OnRead(JsonTokenType tokenType, ref ReadStack state, ref Utf8JsonReader reader)
+        protected override void OnRead(ref ReadStack state, ref Utf8JsonReader reader)
         {
             if (Converter == null)
             {
-                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType, reader, state.JsonPath());
+                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType);
             }
 
             TConverter value = Converter.Read(ref reader, RuntimePropertyType, Options);
@@ -35,28 +35,28 @@ namespace System.Text.Json.Serialization
             return;
         }
 
-        protected override void OnReadEnumerable(JsonTokenType tokenType, ref ReadStack state, ref Utf8JsonReader reader)
+        protected override void OnReadEnumerable(ref ReadStack state, ref Utf8JsonReader reader)
         {
             if (Converter == null)
             {
-                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType, reader, state.JsonPath());
+                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType);
             }
 
-            if (state.Current.KeyName == null && (state.Current.IsProcessingDictionary || state.Current.IsProcessingIDictionaryConstructible))
+            if (state.Current.KeyName == null && state.Current.IsProcessingDictionaryOrIDictionaryConstructible())
             {
-                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType, reader, state.JsonPath());
+                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType);
                 return;
             }
 
             // We need an initialized array in order to store the values.
-            if (state.Current.IsProcessingEnumerable && state.Current.TempEnumerableValues == null && state.Current.ReturnValue == null)
+            if (state.Current.IsProcessingEnumerable() && state.Current.TempEnumerableValues == null && state.Current.ReturnValue == null)
             {
-                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType, reader, state.JsonPath());
+                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType);
                 return;
             }
 
             TConverter value = Converter.Read(ref reader, RuntimePropertyType, Options);
-            JsonSerializer.ApplyValueToEnumerable(ref value, ref state, ref reader);
+            JsonSerializer.ApplyValueToEnumerable(ref value, ref state);
         }
 
         protected override void OnWrite(ref WriteStackFrame current, Utf8JsonWriter writer)

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNullable.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNullable.cs
@@ -5,7 +5,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Text.Json.Serialization;
 
 namespace System.Text.Json
 {
@@ -18,11 +17,11 @@ namespace System.Text.Json
     {
         private static readonly Type s_underlyingType = typeof(TProperty);
 
-        protected override void OnRead(JsonTokenType tokenType, ref ReadStack state, ref Utf8JsonReader reader)
+        protected override void OnRead(ref ReadStack state, ref Utf8JsonReader reader)
         {
             if (Converter == null)
             {
-                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType, reader, state.JsonPath());
+                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType);
             }
 
             TProperty value = Converter.Read(ref reader, s_underlyingType, Options);
@@ -37,16 +36,16 @@ namespace System.Text.Json
             }
         }
 
-        protected override void OnReadEnumerable(JsonTokenType tokenType, ref ReadStack state, ref Utf8JsonReader reader)
+        protected override void OnReadEnumerable(ref ReadStack state, ref Utf8JsonReader reader)
         {
             if (Converter == null)
             {
-                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType, reader, state.JsonPath());
+                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType);
             }
 
             TProperty value = Converter.Read(ref reader, s_underlyingType, Options);
             TProperty? nullableValue = new TProperty?(value);
-            JsonSerializer.ApplyValueToEnumerable(ref nullableValue, ref state, ref reader);
+            JsonSerializer.ApplyValueToEnumerable(ref nullableValue, ref state);
         }
 
         protected override void OnWrite(ref WriteStackFrame current, Utf8JsonWriter writer)

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
@@ -38,10 +38,10 @@ namespace System.Text.Json
             Type arrayType = jsonPropertyInfo.RuntimePropertyType;
             if (!typeof(IEnumerable).IsAssignableFrom(arrayType))
             {
-                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(arrayType, reader, state.JsonPath());
+                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(arrayType);
             }
 
-            Debug.Assert(state.Current.IsProcessingEnumerableOrDictionary);
+            Debug.Assert(state.Current.IsProcessingEnumerableOrDictionary());
 
             if (state.Current.CollectionPropertyInitialized)
             {
@@ -54,35 +54,29 @@ namespace System.Text.Json
 
             state.Current.CollectionPropertyInitialized = true;
 
-            if (state.Current.JsonClassInfo.ClassType == ClassType.Value)
-            {
-                // Custom converter code path.
-                state.Current.JsonPropertyInfo.Read(JsonTokenType.StartObject, ref state, ref reader);
-            }
-            else
-            {
-                // Set or replace the existing enumerable value.
-                object value = ReadStackFrame.CreateEnumerableValue(ref reader, ref state);
+            // We should not be processing custom converters here.
+            Debug.Assert(state.Current.JsonClassInfo.ClassType != ClassType.Value);
 
-                // If value is not null, then we don't have a converter so apply the value.
-                if (value != null)
+            // Set or replace the existing enumerable value.
+            object value = ReadStackFrame.CreateEnumerableValue(ref reader, ref state);
+
+            // If value is not null, then we don't have a converter so apply the value.
+            if (value != null)
+            {
+                if (state.Current.ReturnValue != null)
                 {
-                    if (state.Current.ReturnValue != null)
-                    {
-                        state.Current.JsonPropertyInfo.SetValueAsObject(state.Current.ReturnValue, value);
-                    }
-                    else
-                    {
-                        // Primitive arrays being returned without object
-                        state.Current.SetReturnValue(value);
-                    }
+                    state.Current.JsonPropertyInfo.SetValueAsObject(state.Current.ReturnValue, value);
+                }
+                else
+                {
+                    // Primitive arrays being returned without object
+                    state.Current.SetReturnValue(value);
                 }
             }
         }
 
         private static bool HandleEndArray(
             JsonSerializerOptions options,
-            ref Utf8JsonReader reader,
             ref ReadStack state)
         {
             bool lastFrame = state.IsLastFrame;
@@ -110,7 +104,7 @@ namespace System.Text.Json
                 value = converter.CreateFromList(ref state, (IList)value, options);
                 state.Current.TempEnumerableValues = null;
             }
-            else if (state.Current.IsEnumerableProperty)
+            else if (state.Current.IsProcessingProperty(ClassType.Enumerable))
             {
                 // We added the items to the list already.
                 state.Current.EndProperty();
@@ -126,19 +120,19 @@ namespace System.Text.Json
                     state.Current.ReturnValue = value;
                     return true;
                 }
-                else if (state.Current.IsEnumerable || state.Current.IsDictionary || state.Current.IsIDictionaryConstructible)
+                else if (state.Current.IsProcessingCollectionForClass())
                 {
                     // Returning a non-converted list.
                     return true;
                 }
                 // else there must be an outer object, so we'll return false here.
             }
-            else if (state.Current.IsEnumerable)
+            else if (state.Current.IsProcessing(ClassType.Enumerable))
             {
                 state.Pop();
             }
 
-            ApplyObjectToEnumerable(value, ref state, ref reader);
+            ApplyObjectToEnumerable(value, ref state);
 
             return false;
         }
@@ -147,12 +141,11 @@ namespace System.Text.Json
         internal static void ApplyObjectToEnumerable(
             object value,
             ref ReadStack state,
-            ref Utf8JsonReader reader,
             bool setPropertyDirectly = false)
         {
             Debug.Assert(!state.Current.SkipProperty);
 
-            if (state.Current.IsEnumerable)
+            if (state.Current.IsProcessing(ClassType.Enumerable))
             {
                 if (state.Current.TempEnumerableValues != null)
                 {
@@ -162,13 +155,13 @@ namespace System.Text.Json
                 {
                     if (!(state.Current.ReturnValue is IList list))
                     {
-                        ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(value.GetType(), reader, state.JsonPath());
+                        ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(value.GetType());
                         return;
                     }
                     list.Add(value);
                 }
             }
-            else if (!setPropertyDirectly && state.Current.IsEnumerableProperty)
+            else if (!setPropertyDirectly && state.Current.IsProcessingProperty(ClassType.Enumerable))
             {
                 Debug.Assert(state.Current.JsonPropertyInfo != null);
                 Debug.Assert(state.Current.ReturnValue != null);
@@ -191,7 +184,8 @@ namespace System.Text.Json
                     }
                 }
             }
-            else if (state.Current.IsDictionary || (state.Current.IsDictionaryProperty && !setPropertyDirectly))
+            else if (state.Current.IsProcessing(ClassType.Dictionary) ||
+                (state.Current.IsProcessingProperty(ClassType.Dictionary) && !setPropertyDirectly))
             {
                 Debug.Assert(state.Current.ReturnValue != null);
                 IDictionary dictionary = (IDictionary)state.Current.JsonPropertyInfo.GetValueAsObject(state.Current.ReturnValue);
@@ -200,8 +194,8 @@ namespace System.Text.Json
                 Debug.Assert(!string.IsNullOrEmpty(key));
                 dictionary[key] = value;
             }
-            else if (state.Current.IsIDictionaryConstructible ||
-                (state.Current.IsIDictionaryConstructibleProperty && !setPropertyDirectly))
+            else if (state.Current.IsProcessing(ClassType.IDictionaryConstructible) ||
+                (state.Current.IsProcessingProperty(ClassType.IDictionaryConstructible) && !setPropertyDirectly))
             {
                 Debug.Assert(state.Current.TempDictionaryValues != null);
                 IDictionary dictionary = (IDictionary)state.Current.TempDictionaryValues;
@@ -220,12 +214,11 @@ namespace System.Text.Json
         // If this method is changed, also change ApplyObjectToEnumerable.
         internal static void ApplyValueToEnumerable<TProperty>(
             ref TProperty value,
-            ref ReadStack state,
-            ref Utf8JsonReader reader)
+            ref ReadStack state)
         {
             Debug.Assert(!state.Current.SkipProperty);
 
-            if (state.Current.IsEnumerable)
+            if (state.Current.IsProcessing(ClassType.Enumerable))
             {
                 if (state.Current.TempEnumerableValues != null)
                 {
@@ -236,7 +229,7 @@ namespace System.Text.Json
                     ((IList<TProperty>)state.Current.ReturnValue).Add(value);
                 }
             }
-            else if (state.Current.IsEnumerableProperty)
+            else if (state.Current.IsProcessingProperty(ClassType.Enumerable))
             {
                 Debug.Assert(state.Current.JsonPropertyInfo != null);
                 Debug.Assert(state.Current.ReturnValue != null);
@@ -257,7 +250,7 @@ namespace System.Text.Json
                     }
                 }
             }
-            else if (state.Current.IsProcessingDictionary)
+            else if (state.Current.IsProcessingDictionary())
             {
                 Debug.Assert(state.Current.ReturnValue != null);
                 IDictionary<string, TProperty> dictionary = (IDictionary<string, TProperty>)state.Current.JsonPropertyInfo.GetValueAsObject(state.Current.ReturnValue);
@@ -266,7 +259,7 @@ namespace System.Text.Json
                 Debug.Assert(!string.IsNullOrEmpty(key));
                 dictionary[key] = value;
             }
-            else if (state.Current.IsProcessingIDictionaryConstructible)
+            else if (state.Current.IsProcessingIDictionaryConstructible())
             {
                 Debug.Assert(state.Current.TempDictionaryValues != null);
                 IDictionary<string, TProperty> dictionary = (IDictionary<string, TProperty>)state.Current.TempDictionaryValues;

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
@@ -41,7 +41,7 @@ namespace System.Text.Json
                 ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(arrayType);
             }
 
-            Debug.Assert(state.Current.IsProcessingEnumerableOrDictionary());
+            Debug.Assert(state.Current.IsProcessingCollection());
 
             if (state.Current.CollectionPropertyInitialized)
             {
@@ -120,14 +120,14 @@ namespace System.Text.Json
                     state.Current.ReturnValue = value;
                     return true;
                 }
-                else if (state.Current.IsProcessingCollectionForClass())
+                else if (state.Current.IsProcessingCollectionObject())
                 {
                     // Returning a non-converted list.
                     return true;
                 }
                 // else there must be an outer object, so we'll return false here.
             }
-            else if (state.Current.IsProcessing(ClassType.Enumerable))
+            else if (state.Current.IsProcessingObject(ClassType.Enumerable))
             {
                 state.Pop();
             }
@@ -145,7 +145,7 @@ namespace System.Text.Json
         {
             Debug.Assert(!state.Current.SkipProperty);
 
-            if (state.Current.IsProcessing(ClassType.Enumerable))
+            if (state.Current.IsProcessingObject(ClassType.Enumerable))
             {
                 if (state.Current.TempEnumerableValues != null)
                 {
@@ -184,7 +184,7 @@ namespace System.Text.Json
                     }
                 }
             }
-            else if (state.Current.IsProcessing(ClassType.Dictionary) ||
+            else if (state.Current.IsProcessingObject(ClassType.Dictionary) ||
                 (state.Current.IsProcessingProperty(ClassType.Dictionary) && !setPropertyDirectly))
             {
                 Debug.Assert(state.Current.ReturnValue != null);
@@ -194,7 +194,7 @@ namespace System.Text.Json
                 Debug.Assert(!string.IsNullOrEmpty(key));
                 dictionary[key] = value;
             }
-            else if (state.Current.IsProcessing(ClassType.IDictionaryConstructible) ||
+            else if (state.Current.IsProcessingObject(ClassType.IDictionaryConstructible) ||
                 (state.Current.IsProcessingProperty(ClassType.IDictionaryConstructible) && !setPropertyDirectly))
             {
                 Debug.Assert(state.Current.TempDictionaryValues != null);
@@ -218,7 +218,7 @@ namespace System.Text.Json
         {
             Debug.Assert(!state.Current.SkipProperty);
 
-            if (state.Current.IsProcessing(ClassType.Enumerable))
+            if (state.Current.IsProcessingObject(ClassType.Enumerable))
             {
                 if (state.Current.TempEnumerableValues != null)
                 {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleDictionary.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleDictionary.cs
@@ -10,9 +10,9 @@ namespace System.Text.Json
 {
     public static partial class JsonSerializer
     {
-        private static void HandleStartDictionary(JsonSerializerOptions options, ref Utf8JsonReader reader, ref ReadStack state)
+        private static void HandleStartDictionary(JsonSerializerOptions options, ref ReadStack state)
         {
-            Debug.Assert(!state.Current.IsProcessingEnumerable);
+            Debug.Assert(!state.Current.IsProcessingEnumerable());
 
             JsonPropertyInfo jsonPropertyInfo = state.Current.JsonPropertyInfo;
             if (jsonPropertyInfo == null)
@@ -35,12 +35,12 @@ namespace System.Text.Json
                     jsonPropertyInfo.ElementClassInfo.Type != typeof(object) &&
                     jsonPropertyInfo.ElementClassInfo.Type != typeof(JsonElement))
                 {
-                    ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(state.Current.JsonClassInfo.Type, reader, state.JsonPath());
+                    ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(state.Current.JsonClassInfo.Type);
                 }
 
                 JsonClassInfo classInfo = state.Current.JsonClassInfo;
 
-                if (state.Current.IsProcessingIDictionaryConstructible)
+                if (state.Current.IsProcessingIDictionaryConstructible())
                 {
                     state.Current.TempDictionaryValues = (IDictionary)classInfo.CreateConcreteDictionary();
                 }
@@ -48,7 +48,7 @@ namespace System.Text.Json
                 {
                     if (classInfo.CreateObject == null)
                     {
-                        ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(classInfo.Type, reader, state.JsonPath());
+                        ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(classInfo.Type);
                         return;
                     }
                     state.Current.ReturnValue = classInfo.CreateObject();
@@ -59,7 +59,7 @@ namespace System.Text.Json
 
             state.Current.CollectionPropertyInitialized = true;
 
-            if (state.Current.IsProcessingIDictionaryConstructible)
+            if (state.Current.IsProcessingIDictionaryConstructible())
             {
                 JsonClassInfo dictionaryClassInfo;
                 if (jsonPropertyInfo.DeclaredPropertyType == jsonPropertyInfo.ImplementedPropertyType)
@@ -94,22 +94,18 @@ namespace System.Text.Json
             }
         }
 
-        private static void HandleEndDictionary(JsonSerializerOptions options, ref Utf8JsonReader reader, ref ReadStack state)
+        private static void HandleEndDictionary(JsonSerializerOptions options, ref ReadStack state)
         {
-            if (state.Current.SkipProperty)
-            {
-                // Todo: determine if this is reachable.
-                return;
-            }
+            Debug.Assert(!state.Current.SkipProperty);
 
-            if (state.Current.IsDictionaryProperty)
+            if (state.Current.IsProcessingProperty(ClassType.Dictionary))
             {
                 // Handle special case of DataExtensionProperty where we just added a dictionary element to the extension property.
                 // Since the JSON value is not a dictionary element (it's a normal property in JSON) a JsonTokenType.EndObject
                 // encountered here is from the outer object so forward to HandleEndObject().
                 if (state.Current.JsonClassInfo.DataExtensionProperty == state.Current.JsonPropertyInfo)
                 {
-                    HandleEndObject(ref reader, ref state);
+                    HandleEndObject(ref state);
                 }
                 else
                 {
@@ -117,7 +113,7 @@ namespace System.Text.Json
                     state.Current.EndProperty();
                 }
             }
-            else if (state.Current.IsIDictionaryConstructibleProperty)
+            else if (state.Current.IsProcessingProperty(ClassType.IDictionaryConstructible))
             {
                 Debug.Assert(state.Current.TempDictionaryValues != null);
                 JsonDictionaryConverter converter = state.Current.JsonPropertyInfo.DictionaryConverter;
@@ -146,7 +142,7 @@ namespace System.Text.Json
                 else
                 {
                     state.Pop();
-                    ApplyObjectToEnumerable(value, ref state, ref reader);
+                    ApplyObjectToEnumerable(value, ref state);
                 }
             }
         }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleNull.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleNull.cs
@@ -30,13 +30,13 @@ namespace System.Text.Json
 
             Debug.Assert(jsonPropertyInfo != null);
 
-            if (state.Current.IsCollectionForClass)
+            if (state.Current.IsProcessingCollectionForClass())
             {
                 AddNullToCollection(jsonPropertyInfo, ref reader, ref state);
                 return false;
             }
 
-            if (state.Current.IsCollectionForProperty)
+            if (state.Current.IsProcessingCollectionForProperty())
             {
                 if (state.Current.CollectionPropertyInitialized)
                 {
@@ -46,7 +46,7 @@ namespace System.Text.Json
                 else
                 {
                     // Set the property to null.
-                    ApplyObjectToEnumerable(null, ref state, ref reader, setPropertyDirectly: true);
+                    ApplyObjectToEnumerable(null, ref state, setPropertyDirectly: true);
 
                     // Reset so that `Is*Property` no longer returns true
                     state.Current.EndProperty();
@@ -92,7 +92,7 @@ namespace System.Text.Json
             else
             {
                 // Assume collection types are reference types and can have null assigned.
-                ApplyObjectToEnumerable(null, ref state, ref reader);
+                ApplyObjectToEnumerable(null, ref state);
             }
         }
     }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleNull.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleNull.cs
@@ -30,13 +30,13 @@ namespace System.Text.Json
 
             Debug.Assert(jsonPropertyInfo != null);
 
-            if (state.Current.IsProcessingCollectionForClass())
+            if (state.Current.IsProcessingCollectionObject())
             {
                 AddNullToCollection(jsonPropertyInfo, ref reader, ref state);
                 return false;
             }
 
-            if (state.Current.IsProcessingCollectionForProperty())
+            if (state.Current.IsProcessingCollectionProperty())
             {
                 if (state.Current.CollectionPropertyInitialized)
                 {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleObject.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleObject.cs
@@ -11,9 +11,9 @@ namespace System.Text.Json
     {
         private static void HandleStartObject(JsonSerializerOptions options, ref ReadStack state)
         {
-            Debug.Assert(!state.Current.IsProcessingDictionary && !state.Current.IsProcessingIDictionaryConstructible);
+            Debug.Assert(!state.Current.IsProcessingDictionaryOrIDictionaryConstructible());
 
-            if (state.Current.IsProcessingEnumerable)
+            if (state.Current.IsProcessingEnumerable())
             {
                 // A nested object within an enumerable.
                 Type objType = state.Current.GetElementType();
@@ -42,7 +42,7 @@ namespace System.Text.Json
                 }
             }
 
-            if (state.Current.IsProcessingIDictionaryConstructible)
+            if (state.Current.IsProcessingIDictionaryConstructible())
             {
                 state.Current.TempDictionaryValues = (IDictionary)classInfo.CreateConcreteDictionary();
             }
@@ -52,12 +52,12 @@ namespace System.Text.Json
             }
         }
 
-        private static void HandleEndObject(ref Utf8JsonReader reader, ref ReadStack state)
+        private static void HandleEndObject(ref ReadStack state)
         {
             // Only allow dictionaries to be processed here if this is the DataExtensionProperty.
             Debug.Assert(
-                (!state.Current.IsProcessingDictionary || state.Current.JsonClassInfo.DataExtensionProperty == state.Current.JsonPropertyInfo) &&
-                !state.Current.IsProcessingIDictionaryConstructible);
+                (!state.Current.IsProcessingDictionary() || state.Current.JsonClassInfo.DataExtensionProperty == state.Current.JsonPropertyInfo) &&
+                !state.Current.IsProcessingIDictionaryConstructible());
 
             // Check if we are trying to build the sorted cache.
             if (state.Current.PropertyRefCache != null)
@@ -75,7 +75,7 @@ namespace System.Text.Json
             else
             {
                 state.Pop();
-                ApplyObjectToEnumerable(value, ref state, ref reader);
+                ApplyObjectToEnumerable(value, ref state);
             }
         }
     }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -26,19 +26,19 @@ namespace System.Text.Json
             Debug.Assert(state.Current.ReturnValue != default || state.Current.TempDictionaryValues != default);
             Debug.Assert(state.Current.JsonClassInfo != default);
 
-            if ((state.Current.IsProcessingDictionary || state.Current.IsProcessingIDictionaryConstructible) &&
+            if (state.Current.IsProcessingDictionaryOrIDictionaryConstructible() &&
                 state.Current.JsonClassInfo.DataExtensionProperty != state.Current.JsonPropertyInfo)
             {
-                if (state.Current.IsDictionary || state.Current.IsIDictionaryConstructible)
+                if (state.Current.IsProcessing(ClassType.Dictionary | ClassType.IDictionaryConstructible))
                 {
                     state.Current.JsonPropertyInfo = state.Current.JsonClassInfo.PolicyProperty;
                 }
 
                 Debug.Assert(
-                    state.Current.IsDictionary ||
-                    (state.Current.IsDictionaryProperty && state.Current.JsonPropertyInfo != null) ||
-                    state.Current.IsIDictionaryConstructible ||
-                    (state.Current.IsIDictionaryConstructibleProperty && state.Current.JsonPropertyInfo != null));
+                    state.Current.IsProcessing(ClassType.Dictionary) ||
+                    state.Current.IsProcessingProperty(ClassType.Dictionary) ||
+                    state.Current.IsProcessing(ClassType.IDictionaryConstructible) ||
+                    state.Current.IsProcessingProperty(ClassType.IDictionaryConstructible));
 
                 state.Current.KeyName = reader.GetString();
             }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -29,16 +29,10 @@ namespace System.Text.Json
             if (state.Current.IsProcessingDictionaryOrIDictionaryConstructible() &&
                 state.Current.JsonClassInfo.DataExtensionProperty != state.Current.JsonPropertyInfo)
             {
-                if (state.Current.IsProcessing(ClassType.Dictionary | ClassType.IDictionaryConstructible))
+                if (state.Current.IsProcessingObject(ClassType.Dictionary | ClassType.IDictionaryConstructible))
                 {
                     state.Current.JsonPropertyInfo = state.Current.JsonClassInfo.PolicyProperty;
                 }
-
-                Debug.Assert(
-                    state.Current.IsProcessing(ClassType.Dictionary) ||
-                    state.Current.IsProcessingProperty(ClassType.Dictionary) ||
-                    state.Current.IsProcessing(ClassType.IDictionaryConstructible) ||
-                    state.Current.IsProcessingProperty(ClassType.IDictionaryConstructible));
 
                 state.Current.KeyName = reader.GetString();
             }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs
@@ -92,7 +92,7 @@ namespace System.Text.Json
 
             try
             {
-                int actualByteCount = JsonReaderHelper.GetUtf8FromText(json, utf8);
+                int actualByteCount = JsonReaderHelper.GetUtf8FromText(json.AsSpan(), utf8);
                 utf8 = utf8.Slice(0, actualByteCount);
 
                 var readerState = new JsonReaderState(options.GetReaderOptions());

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
+using System.Diagnostics;
+
 namespace System.Text.Json
 {
     public static partial class JsonSerializer
@@ -25,10 +28,7 @@ namespace System.Text.Json
         /// </remarks>
         public static TValue Deserialize<TValue>(string json, JsonSerializerOptions options = null)
         {
-            if (json == null)
-                throw new ArgumentNullException(nameof(json));
-
-            return (TValue)ParseCore(json, typeof(TValue), options);
+            return (TValue)Deserialize(json, typeof(TValue), options);
         }
 
         /// <summary>
@@ -52,31 +52,60 @@ namespace System.Text.Json
         public static object Deserialize(string json, Type returnType, JsonSerializerOptions options = null)
         {
             if (json == null)
+            {
                 throw new ArgumentNullException(nameof(json));
+            }
 
             if (returnType == null)
+            {
                 throw new ArgumentNullException(nameof(returnType));
+            }
 
-            return ParseCore(json, returnType, options);
-        }
-
-        private static object ParseCore(string json, Type returnType, JsonSerializerOptions options = null)
-        {
             if (options == null)
             {
                 options = JsonSerializerOptions.s_defaultOptions;
             }
 
-            // todo: use an array pool here for smaller requests to avoid the alloc?
-            byte[] jsonBytes = JsonReaderHelper.s_utf8Encoding.GetBytes(json);
-            var readerState = new JsonReaderState(options.GetReaderOptions());
-            var reader = new Utf8JsonReader(jsonBytes, isFinalBlock: true, readerState);
-            object result = ReadCore(returnType, options, ref reader);
+            object result;
+            byte[] tempArray = null;
 
-            if (reader.BytesConsumed != jsonBytes.Length)
+            int maxByteCount;
+            if (json.Length > JsonConstants.MaxEscapedTokenSize / JsonConstants.MaxExpansionFactorWhileTranscoding)
             {
-                ThrowHelper.ThrowJsonException_DeserializeDataRemaining(
-                    jsonBytes.Length, jsonBytes.Length - reader.BytesConsumed);
+                // Get the actual byte count in order to handle large input.
+                maxByteCount = JsonReaderHelper.GetUtf8ByteCount(json);
+            }
+            else
+            {
+                maxByteCount = json.Length * JsonConstants.MaxExpansionFactorWhileTranscoding;
+            }
+
+            Span<byte> utf8 = maxByteCount <= JsonConstants.StackallocThreshold ?
+                stackalloc byte[maxByteCount] :
+                (tempArray = ArrayPool<byte>.Shared.Rent(maxByteCount));
+
+            try
+            {
+                int actualByteCount = JsonReaderHelper.GetUtf8FromText(json, utf8);
+                utf8 = utf8.Slice(0, actualByteCount);
+
+                var readerState = new JsonReaderState(options.GetReaderOptions());
+                var reader = new Utf8JsonReader(utf8, isFinalBlock: true, readerState);
+                result = ReadCore(returnType, options, ref reader);
+
+                if (reader.BytesConsumed != actualByteCount)
+                {
+                    ThrowHelper.ThrowJsonException_DeserializeDataRemaining(
+                        actualByteCount, actualByteCount - reader.BytesConsumed);
+                }
+            }
+            finally
+            {
+                if (tempArray != null)
+                {
+                    utf8.Clear();
+                    ArrayPool<byte>.Shared.Return(tempArray);
+                }
             }
 
             return result;

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.cs
@@ -68,9 +68,9 @@ namespace System.Text.Json
                                 break;
                             }
                         }
-                        else if (readStack.Current.IsProcessingDictionary || readStack.Current.IsProcessingIDictionaryConstructible)
+                        else if (readStack.Current.IsProcessingDictionaryOrIDictionaryConstructible())
                         {
-                            HandleStartDictionary(options, ref reader, ref readStack);
+                            HandleStartDictionary(options, ref readStack);
                         }
                         else
                         {
@@ -87,13 +87,13 @@ namespace System.Text.Json
                             // A non-dictionary property can also have EndProperty() called when completed, although it is redundant.
                             readStack.Current.EndProperty();
                         }
-                        else if (readStack.Current.IsProcessingDictionary || readStack.Current.IsProcessingIDictionaryConstructible)
+                        else if (readStack.Current.IsProcessingDictionaryOrIDictionaryConstructible())
                         {
-                            HandleEndDictionary(options, ref reader, ref readStack);
+                            HandleEndDictionary(options, ref readStack);
                         }
                         else
                         {
-                            HandleEndObject(ref reader, ref readStack);
+                            HandleEndObject(ref readStack);
                         }
                     }
                     else if (tokenType == JsonTokenType.StartArray)
@@ -110,7 +110,7 @@ namespace System.Text.Json
                     }
                     else if (tokenType == JsonTokenType.EndArray)
                     {
-                        HandleEndArray(options, ref reader, ref readStack);
+                        HandleEndArray(options, ref readStack);
                     }
                     else if (tokenType == JsonTokenType.Null)
                     {
@@ -138,7 +138,6 @@ namespace System.Text.Json
             }
 
             readStack.BytesConsumed += reader.BytesConsumed;
-            return;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.cs
@@ -9,8 +9,8 @@ namespace System.Text.Json
     public static partial class JsonSerializer
     {
         // There are three conditions to consider for an object (primitive value, enumerable or object) being processed here:
-        // 1) The object type was specified as the root-level return type to a Parse\Read method.
-        // 2) The object is property on a parent object.
+        // 1) The object type was specified as the root-level return type to a Deserialize method.
+        // 2) The object is a property on a parent object.
         // 3) The object is an element in an enumerable.
         private static bool Write(
             Utf8JsonWriter writer,

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.cs
@@ -25,20 +25,19 @@ namespace System.Text.Json
             {
                 do
                 {
-                    WriteStackFrame current = state.Current;
-                    switch (current.JsonClassInfo.ClassType)
+                    switch (state.Current.JsonClassInfo.ClassType)
                     {
                         case ClassType.Enumerable:
-                            finishedSerializing = HandleEnumerable(current.JsonClassInfo.ElementClassInfo, options, writer, ref state);
+                            finishedSerializing = HandleEnumerable(state.Current.JsonClassInfo.ElementClassInfo, options, writer, ref state);
                             break;
                         case ClassType.Value:
-                            Debug.Assert(current.JsonPropertyInfo.ClassType == ClassType.Value);
-                            current.JsonPropertyInfo.Write(ref state, writer);
+                            Debug.Assert(state.Current.JsonPropertyInfo.ClassType == ClassType.Value);
+                            state.Current.JsonPropertyInfo.Write(ref state, writer);
                             finishedSerializing = true;
                             break;
                         case ClassType.Dictionary:
                         case ClassType.IDictionaryConstructible:
-                            finishedSerializing = HandleDictionary(current.JsonClassInfo.ElementClassInfo, options, writer, ref state);
+                            finishedSerializing = HandleDictionary(state.Current.JsonClassInfo.ElementClassInfo, options, writer, ref state);
                             break;
                         default:
                             Debug.Assert(state.Current.JsonClassInfo.ClassType == ClassType.Object ||

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
@@ -75,12 +75,12 @@ namespace System.Text.Json
 
             if (frame.JsonClassInfo != null)
             {
-                if (frame.IsProcessingDictionary)
+                if (frame.IsProcessingDictionary())
                 {
                     // For dictionaries add the key.
                     AppendPropertyName(sb, frame.KeyName);
                 }
-                else if (frame.IsProcessingEnumerable)
+                else if (frame.IsProcessingEnumerable())
                 {
                     // For enumerables add the index.
                     IList list = frame.TempEnumerableValues;

--- a/src/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -5,12 +5,13 @@
 using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Text.Json.Serialization;
 
 namespace System.Text.Json
 {
     internal static partial class ThrowHelper
     {
+        private const string EmbedPathInfoFlag = "$Path";
+
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowArgumentException_DeserializeWrongType(Type type, object value)
         {
@@ -34,9 +35,9 @@ namespace System.Text.Json
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static void ThrowJsonException_DeserializeUnableToConvertValue(Type propertyType, in Utf8JsonReader reader, string path, Exception innerException = null)
+        public static void ThrowJsonException_DeserializeUnableToConvertValue(Type propertyType)
         {
-            ThrowJsonException(SR.Format(SR.DeserializeUnableToConvertValue, propertyType), in reader, path, innerException);
+            throw new JsonException(SR.Format(SR.DeserializeUnableToConvertValue, propertyType));
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -47,23 +48,21 @@ namespace System.Text.Json
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static void ThrowJsonException_DepthTooLarge(int currentDepth, in WriteStack writeStack, JsonSerializerOptions options)
+        public static void ThrowJsonException_DepthTooLarge(int currentDepth, JsonSerializerOptions options)
         {
-            var ex = new JsonException(SR.Format(SR.DepthTooLarge, currentDepth, options.EffectiveMaxDepth));
-            AddExceptionInformation(writeStack, ex);
-            throw ex;
+            throw new JsonException(SR.Format(SR.DepthTooLarge, currentDepth, options.EffectiveMaxDepth));
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static void ThrowJsonException_SerializationConverterRead(in Utf8JsonReader reader, string path, string converter)
+        public static void ThrowJsonException_SerializationConverterRead(string converter)
         {
-            ThrowJsonException(SR.Format(SR.SerializationConverterRead, converter), reader, path);
+            throw new JsonException(SR.Format(SR.SerializationConverterRead, converter));
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static void ThrowJsonException_SerializationConverterWrite(string path, string converter)
+        public static void ThrowJsonException_SerializationConverterWrite(string converter)
         {
-            ThrowJsonException(SR.Format(SR.SerializationConverterWrite, converter), path);
+            throw new JsonException(SR.Format(SR.SerializationConverterWrite, converter));
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -132,22 +131,6 @@ namespace System.Text.Json
             throw new JsonException(SR.Format(SR.DeserializeDataRemaining, length, bytesRemaining), path: null, lineNumber: null, bytePositionInLine: null);
         }
 
-        // todo: since we now catch and re-throw JsonException and add Path etc, we can clean up callers to this to not pass the reader and path.
-        private static void ThrowJsonException(string message, in Utf8JsonReader reader, string path, Exception innerException = null)
-        {
-            long lineNumber = reader.CurrentState._lineNumber;
-            long bytePositionInLine = reader.CurrentState._bytePositionInLine;
-
-            message += $" Path: {path} | LineNumber: {lineNumber} | BytePositionInLine: {bytePositionInLine}.";
-            throw new JsonException(message, path, lineNumber, bytePositionInLine, innerException);
-        }
-
-        private static void ThrowJsonException(string message, string path, Exception innerException = null)
-        {
-            message += $" Path: {path}.";
-            throw new JsonException(message, path, null, null, innerException);
-        }
-
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ReThrowWithPath(in ReadStack readStack, JsonReaderException ex)
         {
@@ -189,16 +172,26 @@ namespace System.Text.Json
             string path = readStack.JsonPath();
             ex.Path = path;
 
-            // If the message is empty, use a default message with Path, LineNumber and BytePositionInLine.
-            if (string.IsNullOrEmpty(ex.Message))
+            string message = ex.Message;
+
+            // If the message is empty or contains EmbedPathInfoFlag then append the Path, LineNumber and BytePositionInLine.
+            if (string.IsNullOrEmpty(message))
             {
+                // Use a default message.
                 Type propertyType = readStack.Current.JsonPropertyInfo?.RuntimePropertyType;
                 if (propertyType == null)
                 {
                     propertyType = readStack.Current.JsonClassInfo.Type;
                 }
 
-                ex.SetMessage($"{SR.Format(SR.DeserializeUnableToConvertValue, propertyType)} Path: {path} | LineNumber: {lineNumber} | BytePositionInLine: {bytePositionInLine}.");
+                message = $"{SR.Format(SR.DeserializeUnableToConvertValue, propertyType)}";
+            }
+
+            if (message.Contains(EmbedPathInfoFlag))
+            {
+                string pathInfo = $" Path: {path} | LineNumber: {lineNumber} | BytePositionInLine: {bytePositionInLine}.";
+                message = message.Replace(EmbedPathInfoFlag, pathInfo);
+                ex.SetMessage(message);
             }
         }
 
@@ -216,9 +209,17 @@ namespace System.Text.Json
             ex.Path = path;
 
             // If the message is empty, use a default message with the Path.
-            if (string.IsNullOrEmpty(ex.Message))
+            string message = ex.Message;
+            if (string.IsNullOrEmpty(message))
             {
-                ex.SetMessage(SR.Format(SR.SerializeUnableToSerialize, path));
+                message = SR.Format(SR.SerializeUnableToSerialize);
+            }
+
+            if (message.Contains(EmbedPathInfoFlag))
+            {
+                string pathInfo = $" Path: {path}.";
+                message = message.Replace(EmbedPathInfoFlag, pathInfo);
+                ex.SetMessage(message);
             }
         }
 

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using Xunit;
 
 namespace System.Text.Json.Serialization.Tests

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
@@ -3,13 +3,17 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Globalization;
-using System.Runtime.CompilerServices;
 using Xunit;
 
 namespace System.Text.Json.Serialization.Tests
 {
     public static partial class ValueTests
     {
+        public const int MaxEscapedTokenSize = 1_000_000_000;   // Max size for already escaped value.
+        public const int MaxExpansionFactorWhileTranscoding = 3;
+
+        public static bool IsX64 { get; } = IntPtr.Size >= 8;
+
         [Fact]
         public static void ReadPrimitives()
         {
@@ -361,6 +365,26 @@ namespace System.Text.Json.Serialization.Tests
             {
                 Assert.Equal(netcoreExpectedValue, testCode());
             }
+        }
+
+        // NOTE: LongInputString test is constrained to run on Windows and MacOSX because it causes
+        //       problems on Linux due to the way deferred memory allocation works. On Linux, the allocation can
+        //       succeed even if there is not enough memory but then the test may get killed by the OOM killer at the
+        //       time the memory is accessed which triggers the full memory allocation.
+        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX)]
+        [ConditionalTheory(nameof(IsX64))]
+        [InlineData(MaxEscapedTokenSize / MaxExpansionFactorWhileTranscoding)]
+        [InlineData((MaxEscapedTokenSize / MaxExpansionFactorWhileTranscoding) + 1)]
+        [OuterLoop]
+        public static void LongInputString(int length)
+        {
+            // Verify boundary conditions in Deserialize() that inspect the size to determine allocation strategy.
+            string repeated = new string('x', length - 2);
+            string json = $"\"{repeated}\"";
+            Assert.Equal(length, json.Length);
+
+            string str = JsonSerializer.Deserialize<string>(json);
+            Assert.Equal(repeated, str);
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
@@ -9,10 +9,7 @@ namespace System.Text.Json.Serialization.Tests
 {
     public static partial class ValueTests
     {
-        public const int MaxEscapedTokenSize = 1_000_000_000;   // Max size for already escaped value.
-        public const int MaxExpansionFactorWhileTranscoding = 3;
-
-        public static bool IsX64 { get; } = IntPtr.Size >= 8;
+        public static bool IsX64 { get; } = Environment.Is64BitProcess;
 
         [Fact]
         public static void ReadPrimitives()
@@ -371,10 +368,17 @@ namespace System.Text.Json.Serialization.Tests
         //       problems on Linux due to the way deferred memory allocation works. On Linux, the allocation can
         //       succeed even if there is not enough memory but then the test may get killed by the OOM killer at the
         //       time the memory is accessed which triggers the full memory allocation.
+        private const int MaxExpansionFactorWhileTranscoding = 3;
+        private const int MaxArrayLengthBeforeCalculatingSize = int.MaxValue / 2 / MaxExpansionFactorWhileTranscoding;
         [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX)]
         [ConditionalTheory(nameof(IsX64))]
-        [InlineData(MaxEscapedTokenSize / MaxExpansionFactorWhileTranscoding)]
-        [InlineData((MaxEscapedTokenSize / MaxExpansionFactorWhileTranscoding) + 1)]
+        [InlineData(MaxArrayLengthBeforeCalculatingSize - 3)]
+        [InlineData(MaxArrayLengthBeforeCalculatingSize - 2)]
+        [InlineData(MaxArrayLengthBeforeCalculatingSize - 1)]
+        [InlineData(MaxArrayLengthBeforeCalculatingSize)]
+        [InlineData(MaxArrayLengthBeforeCalculatingSize + 1)]
+        [InlineData(MaxArrayLengthBeforeCalculatingSize + 2)]
+        [InlineData(MaxArrayLengthBeforeCalculatingSize + 3)]
         [OuterLoop]
         public static void LongInputString(int length)
         {


### PR DESCRIPTION
Misc changes to gain ~7% on deserialize and ~3% on serialize for a simple, flat object (as in other recent PRs, the `MicroBenchmarks.Serializers.Json_FromString<Location>` and `MicroBenchmarks.Serializers.Json_ToString<Location>` were used.

There is also a gain for deserializing collections (~6%). There is no gain for serializing collections.

There is also a larger gain for deserializing small payloads which are under 85 bytes (255 / 3) since allocations are stack-based instead of pool-based.

Changes include:
- Avoid the byte[] alloc when deserializing strings (the buffer for transcoding string to byte[]). Now a pool or stack alloc is made.
- Removing several parameters due to exception helper changes. Added support to set an internal `AppendPathInformation` property to true which will cause the try\catch logic to add the path automatically. This avoids having to pass the reader and\or "stack state" to lower-level methods which may need to throw an exception that needs path information as part of its message.
- Remove a temporary struct assignment `WriteStackFrame current = state.Current` that caused a copy-by-value.
- Avoid verifying internal converters in release build for correctness (reading too much or too little).
- Improve the "IsProcessing" logic by using bit flags which helps when comparing more than one `ClassType`.
- Improve `SkipProperty()` by avoiding the direct comparison to the "missing property" singleton.
- Misc other one-line changes

**Deserialize Before**

|         Method |     Mean |     Error |    StdDev |   Median |      Min |      Max | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|--------------- |---------:|----------:|----------:|---------:|---------:|---------:|------------:|------------:|------------:|--------------------:|
|       JSON.NET | 2.554 us | 0.0091 us | 0.0081 us | 2.553 us | 2.540 us | 2.567 us |      0.4771 |           - |           - |              3056 B |
| SystemTextJson | 1.465 us | 0.0088 us | 0.0078 us | 1.464 us | 1.450 us | 1.477 us |      0.1053 |           - |           - |               680 B |

**Deserialize After**

|         Method |     Mean |     Error |    StdDev |   Median |      Min |      Max | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|--------------- |---------:|----------:|----------:|---------:|---------:|---------:|------------:|------------:|------------:|--------------------:|
|       JSON.NET | 2.565 us | 0.0151 us | 0.0134 us | 2.564 us | 2.541 us | 2.590 us |      0.4824 |           - |           - |              3056 B |
| SystemTextJson | 1.358 us | 0.0097 us | 0.0081 us | 1.357 us | 1.341 us | 1.375 us |      0.0701 |           - |           - |               448 B |

**Serialize Before**

|         Method |     Mean |     Error |    StdDev |   Median |      Min |      Max | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|--------------- |---------:|----------:|----------:|---------:|---------:|---------:|------------:|------------:|------------:|--------------------:|
|       JSON.NET | 1.438 us | 0.0106 us | 0.0099 us | 1.438 us | 1.414 us | 1.450 us |      0.2751 |           - |           - |              1736 B |
| SystemTextJson | 1.011 us | 0.0084 us | 0.0079 us | 1.007 us | 1.000 us | 1.024 us |      0.0891 |           - |           - |               584 B |

**Serialize After**

|         Method |       Mean |    Error |   StdDev |     Median |        Min |        Max | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|--------------- |-----------:|---------:|---------:|-----------:|-----------:|-----------:|------------:|------------:|------------:|--------------------:|
|       JSON.NET | 1,424.7 ns | 7.607 ns | 7.115 ns | 1,423.7 ns | 1,412.6 ns | 1,439.2 ns |      0.2746 |           - |           - |              1736 B |
| SystemTextJson |   970.9 ns | 7.285 ns | 6.458 ns |   968.5 ns |   964.4 ns |   982.3 ns |      0.0928 |           - |           - |               584 B