### PR TITLE
Use slow path for CallInstruction returning enum value #40976

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.Generated.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.Generated.cs
@@ -42,6 +42,7 @@ namespace System.Linq.Expressions.Interpreter
                 return new ActionCallInstruction(target);
             }
 
+            if (t.IsEnum) return SlowCreate(target, pi);
             switch (t.GetTypeCode())
             {
                 case TypeCode.Object:
@@ -84,6 +85,7 @@ namespace System.Linq.Expressions.Interpreter
                 return new FuncCallInstruction<T0>(target);
             }
 
+            if (t.IsEnum) return SlowCreate(target, pi);
             switch (t.GetTypeCode())
             {
                 case TypeCode.Object:
@@ -126,6 +128,7 @@ namespace System.Linq.Expressions.Interpreter
                 return new FuncCallInstruction<T0, T1>(target);
             }
 
+            if (t.IsEnum) return SlowCreate(target, pi);
             switch (t.GetTypeCode())
             {
                 case TypeCode.Object:

--- a/src/System.Linq.Expressions/tests/Call/CallTests.cs
+++ b/src/System.Linq.Expressions/tests/Call/CallTests.cs
@@ -665,36 +665,61 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
-        [Fact]
-        public static void EnumReturnType0()
+        [Theory]
+        [ClassData(typeof(CompilationTypes))]
+        public static void EnumReturnType0(bool useInterpreter)
         {
             Expression<Func<DayOfWeek[]>> expr = () => new[] { ToDayOfWeek0() };
-
-            Assert.Equal(DayOfWeek.Monday, expr.Compile(false)()[0]);
-            Assert.Equal(DayOfWeek.Monday, expr.Compile(true)()[0]);
+            Assert.Equal(DayOfWeek.Monday, expr.Compile(useInterpreter)()[0]);
         }
 
-        [Fact]
-        public static void EnumReturnType1()
+        [Theory]
+        [ClassData(typeof(CompilationTypes))]
+        public static void EnumReturnType1(bool useInterpreter)
         {
             Expression<Func<DayOfWeek[]>> expr = () => new[] { ToDayOfWeek1(1) };
-
-            Assert.Equal(DayOfWeek.Monday, expr.Compile(false)()[0]);
-            Assert.Equal(DayOfWeek.Monday, expr.Compile(true)()[0]);
+            Assert.Equal(DayOfWeek.Monday, expr.Compile(useInterpreter)()[0]);
         }
 
-        [Fact]
-        public static void EnumReturnType2()
+        [Theory]
+        [ClassData(typeof(CompilationTypes))]
+        public static void EnumReturnType2(bool useInterpreter)
         {
             Expression<Func<DayOfWeek[]>> expr = () => new[] { ToDayOfWeek2(0, 1) };
-
-            Assert.Equal(DayOfWeek.Monday, expr.Compile(false)()[0]);
-            Assert.Equal(DayOfWeek.Monday, expr.Compile(true)()[0]);
+            Assert.Equal(DayOfWeek.Monday, expr.Compile(useInterpreter)()[0]);
         }
 
         private static DayOfWeek ToDayOfWeek0() => DayOfWeek.Monday;
         private static DayOfWeek ToDayOfWeek1(int i) => (DayOfWeek)i;
         private static DayOfWeek ToDayOfWeek2(int i, int j) => (DayOfWeek)(i + j);
+
+        [Theory]
+        [ClassData(typeof(CompilationTypes))]
+        public static void NullableEnumReturnType0(bool useInterpreter)
+        {
+            Expression<Func<DayOfWeek?[]>> expr = () => new[] { ToDayOfWeekOpt0() };
+            Assert.Equal(DayOfWeek.Monday, expr.Compile(useInterpreter)()[0].Value);
+        }
+
+        [Theory]
+        [ClassData(typeof(CompilationTypes))]
+        public static void NullableEnumReturnType1(bool useInterpreter)
+        {
+            Expression<Func<DayOfWeek?[]>> expr = () => new[] { ToDayOfWeekOpt1(1) };
+            Assert.Equal(DayOfWeek.Monday, expr.Compile(useInterpreter)()[0].Value);
+        }
+
+        [Theory]
+        [ClassData(typeof(CompilationTypes))]
+        public static void NullableEnumReturnType2(bool useInterpreter)
+        {
+            Expression<Func<DayOfWeek?[]>> expr = () => new[] { ToDayOfWeekOpt2(0, 1) };
+            Assert.Equal(DayOfWeek.Monday, expr.Compile(useInterpreter)()[0].Value);
+        }
+
+        private static DayOfWeek? ToDayOfWeekOpt0() => DayOfWeek.Monday;
+        private static DayOfWeek? ToDayOfWeekOpt1(int i) => (DayOfWeek)i;
+        private static DayOfWeek? ToDayOfWeekOpt2(int i, int j) => (DayOfWeek)(i + j);
 
         public class GenericClass<T>
         {

--- a/src/System.Linq.Expressions/tests/Call/CallTests.cs
+++ b/src/System.Linq.Expressions/tests/Call/CallTests.cs
@@ -665,6 +665,37 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
+        [Fact]
+        public static void EnumReturnType0()
+        {
+            Expression<Func<DayOfWeek[]>> expr = () => new[] { ToDayOfWeek0() };
+
+            Assert.Equal(DayOfWeek.Monday, expr.Compile(false)()[0]);
+            Assert.Equal(DayOfWeek.Monday, expr.Compile(true)()[0]);
+        }
+
+        [Fact]
+        public static void EnumReturnType1()
+        {
+            Expression<Func<DayOfWeek[]>> expr = () => new[] { ToDayOfWeek1(1) };
+
+            Assert.Equal(DayOfWeek.Monday, expr.Compile(false)()[0]);
+            Assert.Equal(DayOfWeek.Monday, expr.Compile(true)()[0]);
+        }
+
+        [Fact]
+        public static void EnumReturnType2()
+        {
+            Expression<Func<DayOfWeek[]>> expr = () => new[] { ToDayOfWeek2(0, 1) };
+
+            Assert.Equal(DayOfWeek.Monday, expr.Compile(false)()[0]);
+            Assert.Equal(DayOfWeek.Monday, expr.Compile(true)()[0]);
+        }
+
+        private static DayOfWeek ToDayOfWeek0() => DayOfWeek.Monday;
+        private static DayOfWeek ToDayOfWeek1(int i) => (DayOfWeek)i;
+        private static DayOfWeek ToDayOfWeek2(int i, int j) => (DayOfWeek)(i + j);
+
         public class GenericClass<T>
         {
             public static void NonGenericMethod() { }


### PR DESCRIPTION
#### Description
The System.Linq.Expressions interpreter treats the result of a call to method that returns an enum value as the underlying type rather than the enum type.
		
#### Customer Impact
Customer reported issue. Interpreting an Expression that calls a method returning an enum value can result in an `InvalidCastException`. See https://github.com/dotnet/corefx/issues/40968.

#### Regression?
Yes, a regression from 2.2.

#### Risk
Low. The fix is to revert an optimization added to the Expression interpreter in 3.0 for enum values.

Port of https://github.com/dotnet/corefx/pull/40976 and https://github.com/dotnet/corefx/pull/41218 to release/3.0.