### PR TITLE
[release/3.0] Fix validity encoding for cert dates after 2049

### DIFF
--- a/src/Common/src/System/Security/Cryptography/Asn1/asn.xsd
+++ b/src/Common/src/System/Security/Cryptography/Asn1/asn.xsd
@@ -39,7 +39,7 @@
         <xs:element name="T61String" type="FieldBase" />
         <xs:element name="IA5String" type="FieldBase" />
         <xs:element name="UtcTime" type="UtcTimeType" />
-        <xs:element name="GeneralizedTime" type="FieldBase" />
+        <xs:element name="GeneralizedTime" type="GeneralizedTimeType" />
         <xs:element name="VisibleString" type="FieldBase" />
         <xs:element name="BMPString" type="FieldBase" />
       </xs:choice>
@@ -163,7 +163,7 @@
             <xs:element name="T61String"/>
             <xs:element name="IA5String"/>
             <xs:element name="UtcTime" type="UtcTimeCollectionType" />
-            <xs:element name="GeneralizedTime"/>
+            <xs:element name="GeneralizedTime" type="GeneralizedTimeCollectionType" />
             <xs:element name="VisibleString"/>
             <xs:element name="BMPString"/>
           </xs:choice>
@@ -182,6 +182,18 @@
 
   <xs:complexType name="UtcTimeCollectionType">
     <xs:attribute name="twoDigitYearMax" use="optional" type="xs:unsignedShort" />
+  </xs:complexType>
+
+  <xs:complexType name="GeneralizedTimeType">
+    <xs:complexContent>
+      <xs:extension base="FieldBase">
+        <xs:attribute name="omitFractionalSeconds" default="false" type="xs:boolean" />
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="GeneralizedTimeCollectionType">
+    <xs:attribute name="omitFractionalSeconds" default="false" type="xs:boolean" />
   </xs:complexType>
 
   <xs:simpleType name="QualifiedName">

--- a/src/Common/src/System/Security/Cryptography/Asn1/asn.xslt
+++ b/src/Common/src/System/Security/Cryptography/Asn1/asn.xslt
@@ -863,16 +863,24 @@ namespace <xsl:value-of select="@namespace" />
     <xsl:param name="indent" />
     <xsl:param name="name" select="@name"/>
     <xsl:variable name="nullable" select="@optional | parent::asn:Choice"/>
-    <xsl:if test="1" xml:space="preserve">
-            <xsl:value-of select="$indent"/><xsl:value-of select="$writerName"/>.WriteGeneralizedTime(<xsl:call-template name="MaybeImplicitCallP"/><xsl:value-of select="$name"/><xsl:if test="$nullable">.Value</xsl:if>);</xsl:if>
+    <xsl:choose>
+      <xsl:when test="@omitFractionalSeconds" xml:space="preserve">
+            <xsl:value-of select="$indent"/><xsl:value-of select="$writerName"/>.WriteGeneralizedTime(<xsl:call-template name="MaybeImplicitCallP"/><xsl:value-of select="$name"/><xsl:if test="$nullable">.Value</xsl:if>, omitFractionalSeconds: <xsl:value-of select="@omitFractionalSeconds"/>);</xsl:when>
+      <xsl:otherwise xml:space="preserve">
+            <xsl:value-of select="$indent"/><xsl:value-of select="$writerName"/>.WriteGeneralizedTime(<xsl:call-template name="MaybeImplicitCallP"/><xsl:value-of select="$name"/><xsl:if test="$nullable">.Value</xsl:if>);</xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
   
   <xsl:template match="asn:GeneralizedTime" mode="DecodeSimpleValue" xml:space="default">
     <xsl:param name="readerName" />
     <xsl:param name="indent" />
     <xsl:param name="name" select="concat('decoded.', @name)"/>
-    <xsl:if test="1" xml:space="preserve">
-            <xsl:value-of select="$indent"/><xsl:value-of select="$name"/> = <xsl:value-of select="$readerName"/>.ReadGeneralizedTime(<xsl:call-template name="MaybeImplicitCall0"/>);</xsl:if>
+    <xsl:choose>
+      <xsl:when test="@omitFractionalSeconds" xml:space="preserve">
+            <xsl:value-of select="$indent"/><xsl:value-of select="$name"/> = <xsl:value-of select="$readerName"/>.ReadGeneralizedTime(<xsl:call-template name="MaybeImplicitCallP"/>disallowFractions: <xsl:value-of select="@omitFractionalSeconds"/>);</xsl:when>
+      <xsl:otherwise xml:space="preserve">
+            <xsl:value-of select="$indent"/><xsl:value-of select="$name"/> = <xsl:value-of select="$readerName"/>.ReadGeneralizedTime(<xsl:call-template name="MaybeImplicitCall0"/>);</xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
   
   <xsl:template match="asn:GeneralizedTime" mode="DefaultTag">Asn1Tag.GeneralizedTime</xsl:template>

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/Asn1/TimeAsn.xml
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/Asn1/TimeAsn.xml
@@ -13,5 +13,5 @@
     }
   -->
   <asn:UtcTime name="UtcTime" />
-  <asn:GeneralizedTime name="GeneralTime" />
+  <asn:GeneralizedTime name="GeneralTime" omitFractionalSeconds="true"/>
 </asn:Choice>

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/Asn1/TimeAsn.xml.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/Asn1/TimeAsn.xml.cs
@@ -52,7 +52,7 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
                 if (wroteValue)
                     throw new CryptographicException();
                 
-                writer.WriteGeneralizedTime(GeneralTime.Value);
+                writer.WriteGeneralizedTime(GeneralTime.Value, omitFractionalSeconds: true);
                 wroteValue = true;
             }
 
@@ -85,7 +85,7 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
             else if (tag.HasSameClassAndValue(Asn1Tag.GeneralizedTime))
             {
-                decoded.GeneralTime = reader.ReadGeneralizedTime();
+                decoded.GeneralTime = reader.ReadGeneralizedTime(disallowFractions: true);
             }
             else
             {


### PR DESCRIPTION
During the change from the reflection serializer to asn.xslt generation we lost
the metadata that said that X.509 Time GeneralizedTime values need to ignore
fractional seconds.

That means we're generating fractional seconds when the input DateTimeOffset
has them, which means we violate RFC in our generated certificates.

Port of #41269 to release/3.0.
Fixes #41248.