### PR TITLE
Disable UWP pkg publishing to fix official builds

### DIFF
--- a/eng/pipelines/windows.yml
+++ b/eng/pipelines/windows.yml
@@ -89,12 +89,14 @@ stages:
                 _architecture: x64
                 _framework: uap
                 _helixQueues: $(uapNetfxQueues)
+                _skipPublishPackages: true # In UWP we don't produce packages
 
               UAP_x86_Release:
                 _BuildConfig: Release
                 _architecture: x86
                 _framework: uap
                 _helixQueues: $(uapNetfxQueues)
+                _skipPublishPackages: true # In UWP we don't produce packages
 
               arm64_Release:
                 _BuildConfig: Release
@@ -181,6 +183,7 @@ stages:
                   _BuildConfig: Release
                   _architecture: arm
                   _framework: uap
+                  _skipPublishPackages: true # In UWP we don't produce packages
 
             pool:
               name: Hosted VS2017


### PR DESCRIPTION
Fixes regression introduced in https://github.com/dotnet/corefx/commit/49ba6ef9cb8120c87eae636fc41b79e07e88e707. We don't publish packages anymore in UWP therefore we need to disable the upload step.

@safern not sure if that's possible, would a directory exists check also work in the upload artifacts condition?

I will merge this after I validated that legs are en queued correctly to unblock failing official builds.