### PR TITLE
HTTP2: Support receiving dynamic table headers

### DIFF
--- a/src/Common/tests/System/Net/Http/GenericLoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/GenericLoopbackServer.cs
@@ -83,6 +83,9 @@ namespace System.Net.Test.Common
 
     public struct HttpHeaderData
     {
+        // http://httpwg.org/specs/rfc7541.html#rfc.section.4.1
+        public const int RfcOverhead = 32;
+
         public string Name { get; }
         public string Value { get; }
         public bool HuffmanEncoded { get; }

--- a/src/Common/tests/System/Net/Http/HPackEncoder.cs
+++ b/src/Common/tests/System/Net/Http/HPackEncoder.cs
@@ -10,6 +10,16 @@ namespace System.Net.Test.Common
     public static class HPackEncoder
     {
         /// <summary>
+        /// Static table indexes are [0..61]. Indexes larger than this are dynamic indexes.
+        /// </summary>
+        public const int LargestStaticIndex = 61;
+
+        /// <summary>
+        /// Dynamic table indexes are [62..], with 62 being the most recently added entry. Indexes smaller than this are static indexes.
+        /// </summary>
+        public const int SmallestDynamicIndex = LargestStaticIndex + 1;
+
+        /// <summary>
         /// Encodes a dynamic table size update.
         /// </summary>
         /// <param name="newMaximumSize">The new maximum size of the dynamic table. This must be less than or equal to the connection's maximum table size setting, which defaults to 4096 bytes.</param>

--- a/src/Common/tests/System/Net/Http/Http2Frames.cs
+++ b/src/Common/tests/System/Net/Http/Http2Frames.cs
@@ -460,6 +460,21 @@ namespace System.Net.Test.Common
         {
             return base.ToString() + $"\nEntry Count: {Entries.Count}";
         }
+
+        public uint GetSettingOrDefault(SettingId settingId, uint defaultValue)
+        {
+            foreach (SettingsEntry setting in Entries)
+            {
+                if (setting.SettingId == settingId)
+                {
+                    defaultValue = setting.Value;
+                }
+            }
+
+            return defaultValue;
+        }
+
+        public int GetHeaderTableSize() => (int)GetSettingOrDefault(SettingId.HeaderTableSize, 4096); // 4096 is RFC default if not set in settings.
     }
 
     public class GoAwayFrame : Frame

--- a/src/Common/tests/System/Net/Http/Http2Frames.cs
+++ b/src/Common/tests/System/Net/Http/Http2Frames.cs
@@ -412,6 +412,8 @@ namespace System.Net.Test.Common
 
     public class SettingsFrame : Frame
     {
+        const int RfcDefaultDynamicTableSize = 4096;
+
         public List<SettingsEntry> Entries;
 
         public SettingsFrame(FrameFlags flags, SettingsEntry[] entries) :
@@ -474,7 +476,7 @@ namespace System.Net.Test.Common
             return defaultValue;
         }
 
-        public int GetHeaderTableSize() => (int)GetSettingOrDefault(SettingId.HeaderTableSize, 4096); // 4096 is RFC default if not set in settings.
+        public int GetHeaderTableSize() => (int)GetSettingOrDefault(SettingId.HeaderTableSize, RfcDefaultDynamicTableSize);
     }
 
     public class GoAwayFrame : Frame

--- a/src/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -295,14 +295,7 @@ namespace System.Net.Test.Common
 
         public async Task<int> ReadRequestHeaderAsync()
         {
-            // Receive HEADERS frame for request.
-            Frame frame = await ReadFrameAsync(Timeout).ConfigureAwait(false);
-            if (frame == null)
-            {
-                throw new IOException("Failed to read Headers frame.");
-            }
-            Assert.Equal(FrameType.Headers, frame.Type);
-            Assert.Equal(FrameFlags.EndHeaders | FrameFlags.EndStream, frame.Flags);
+            HeadersFrame frame = await ReadRequestHeaderFrameAsync();
             return frame.StreamId;
         }
 

--- a/src/System.Net.Http/src/Resources/Strings.resx
+++ b/src/System.Net.Http/src/Resources/Strings.resx
@@ -528,4 +528,10 @@
   <data name="net_http_server_shutdown" xml:space="preserve">
     <value>The server shut down the connection.</value>
   </data>
+  <data name="net_http_hpack_invalid_index" xml:space="preserve">
+    <value>Invalid header index: {0} is outside of static table and no dynamic table entry found.</value>
+  </data>
+  <data name="net_http_hpack_unexpected_end" xml:space="preserve">
+    <value>End of headers reached with incomplete token.</value>
+  </data>
 </root>

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackDecoder.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackDecoder.cs
@@ -370,7 +370,7 @@ namespace System.Net.Http.HPack
             if (_state != State.Ready)
             {
                 // Incomplete header block
-                throw new HPackDecodingException();
+                throw new HPackDecodingException(SR.net_http_hpack_unexpected_end);
             }
         }
 
@@ -470,7 +470,7 @@ namespace System.Net.Http.HPack
             catch (IndexOutOfRangeException)
             {
                 // Header index out of range.
-                throw new HPackDecodingException();
+                throw new HPackDecodingException(SR.Format(SR.net_http_hpack_invalid_index, index));
             }
         }
     }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -105,7 +105,7 @@ namespace System.Net.Http
             _outgoingBuffer = new ArrayBuffer(InitialConnectionBufferSize);
             _headerBuffer = new ArrayBuffer(InitialConnectionBufferSize);
 
-            _hpackDecoder = new HPackDecoder(maxDynamicTableSize: 0, maxResponseHeadersLength: pool.Settings._maxResponseHeadersLength * 1024);
+            _hpackDecoder = new HPackDecoder(maxResponseHeadersLength: pool.Settings._maxResponseHeadersLength * 1024);
 
             _httpStreams = new Dictionary<int, Http2Stream>();
 
@@ -127,7 +127,7 @@ namespace System.Net.Http
         public async Task SetupAsync()
         {
             _outgoingBuffer.EnsureAvailableSpace(s_http2ConnectionPreface.Length +
-                FrameHeader.Size + (FrameHeader.SettingLength * 2) +
+                FrameHeader.Size + FrameHeader.SettingLength +
                 FrameHeader.Size + FrameHeader.WindowUpdateLength);
 
             // Send connection preface
@@ -135,16 +135,10 @@ namespace System.Net.Http
             _outgoingBuffer.Commit(s_http2ConnectionPreface.Length);
 
             // Send SETTINGS frame
-            WriteFrameHeader(new FrameHeader(FrameHeader.SettingLength * 2, FrameType.Settings, FrameFlags.None, 0));
+            WriteFrameHeader(new FrameHeader(FrameHeader.SettingLength, FrameType.Settings, FrameFlags.None, 0));
 
-            // First setting: Disable push promise
+            // Disable push promise
             BinaryPrimitives.WriteUInt16BigEndian(_outgoingBuffer.AvailableSpan, (ushort)SettingId.EnablePush);
-            _outgoingBuffer.Commit(2);
-            BinaryPrimitives.WriteUInt32BigEndian(_outgoingBuffer.AvailableSpan, 0);
-            _outgoingBuffer.Commit(4);
-
-            // Second setting: Set header table size to 0 to disable dynamic header compression
-            BinaryPrimitives.WriteUInt16BigEndian(_outgoingBuffer.AvailableSpan, (ushort)SettingId.HeaderTableSize);
             _outgoingBuffer.Commit(2);
             BinaryPrimitives.WriteUInt32BigEndian(_outgoingBuffer.AvailableSpan, 0);
             _outgoingBuffer.Commit(4);

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net.Security;
@@ -3166,15 +3167,7 @@ namespace System.Net.Http.Functional.Tests
                     (Http2LoopbackConnection con, SettingsFrame settings) = await server.EstablishConnectionGetSettingsAsync();
                     int streamId = await con.ReadRequestHeaderAsync();
 
-                    int headerTableSize = 4096; // Default per HTTP2 spec.
-
-                    foreach (SettingsEntry setting in settings.Entries)
-                    {
-                        if (setting.SettingId == SettingId.HeaderTableSize)
-                        {
-                            headerTableSize = (int)setting.Value;
-                        }
-                    }
+                    int headerTableSize = settings.GetHeaderTableSize();
 
                     byte[] headerData = new byte[16];
                     int headersLen = HPackEncoder.EncodeDynamicTableSizeUpdate(headerTableSize + 1, headerData);
@@ -3183,6 +3176,223 @@ namespace System.Net.Http.Functional.Tests
                     await con.WriteFrameAsync(frame);
                     await con.ShutdownIgnoringErrorsAsync(streamId);
                 });
+        }
+
+        [Fact]
+        public async Task DynamicTable_Reuse_Concat()
+        {
+            await Http2LoopbackServer.CreateClientAndServerAsync(
+                async uri =>
+                {
+                    using HttpClient client = CreateHttpClient();
+                    using HttpResponseMessage response = await client.GetAsync(uri);
+
+                    Assert.True(response.Headers.TryGetValues("my-header", out IEnumerable<string> values));
+                    Assert.True(values.SequenceEqual(new[] { "foo", "bar" }));
+                },
+                async server =>
+                {
+                    byte[] frameData = new byte[16 * 1024];
+
+                    Http2LoopbackConnection con = await server.EstablishConnectionAsync();
+                    int streamId = await con.ReadRequestHeaderAsync();
+
+                    int pos = 0;
+                    pos += HPackEncoder.EncodeHeader(":status", "200", HPackFlags.None, frameData.AsSpan(pos));
+                    pos += HPackEncoder.EncodeHeader("my-header", "foo", HPackFlags.NewIndexed, frameData.AsSpan(pos));
+                    pos += HPackEncoder.EncodeHeader(62, "bar", HPackFlags.None, frameData.AsSpan(pos));
+                    await con.WriteFrameAsync(new HeadersFrame(frameData.AsMemory(0, pos), FrameFlags.EndHeaders | FrameFlags.EndStream, 0, 0, 0, streamId));
+
+                    // Close out connection.
+                    await con.ShutdownIgnoringErrorsAsync(streamId);
+                });
+        }
+
+        [Fact]
+        public async Task DynamicTable_Resize_Success()
+        {
+            await Http2LoopbackServer.CreateClientAndServerAsync(
+                async uri =>
+                {
+                    using HttpClient client = CreateHttpClient();
+
+                    // First request should initialize our dynamic table.
+                    using (HttpResponseMessage response = await client.GetAsync(uri))
+                    {
+                        IEnumerable<string> values;
+
+                        Assert.True(response.Headers.TryGetValues("header-that-gos", out values));
+                        Assert.Equal("bar", Assert.Single(values));
+
+                        Assert.True(response.Headers.TryGetValues("header-that-stays", out values));
+                        Assert.Equal("foo", Assert.Single(values));
+                    }
+
+                    // Second request should reset the dynamic table.
+                    using (HttpResponseMessage response = await client.GetAsync(uri))
+                    {
+                        Assert.True(response.Headers.TryGetValues("new-header", out IEnumerable<string> values));
+                        Assert.Equal("baz", Assert.Single(values));
+                    }
+
+                    // Third request should use the reset values.
+                    using (HttpResponseMessage response = await client.GetAsync(uri))
+                    {
+                        IEnumerable<string> values;
+
+                        Assert.True(response.Headers.TryGetValues("header-that-stays", out values));
+                        Assert.Equal("foo", Assert.Single(values));
+
+                        Assert.True(response.Headers.TryGetValues("new-header", out values));
+                        Assert.Equal("baz", Assert.Single(values));
+                    }
+                },
+                async server =>
+                {
+                    Http2LoopbackConnection con = await server.EstablishConnectionAsync();
+                    byte[] frameData = new byte[16 * 1024];
+
+                    // First stream, create dynamic indexes.
+                    // header-that-goes: 63, header-that-stays: 62
+                    int streamId = await con.ReadRequestHeaderAsync();
+                    int pos = 0;
+                    pos += HPackEncoder.EncodeHeader(":status", "200", HPackFlags.None, frameData.AsSpan(pos));
+                    pos += HPackEncoder.EncodeHeader("header-that-gos", "bar", HPackFlags.NewIndexed, frameData.AsSpan(pos));
+                    pos += HPackEncoder.EncodeHeader("header-that-stays", "foo", HPackFlags.NewIndexed, frameData.AsSpan(pos));
+                    await con.WriteFrameAsync(new HeadersFrame(frameData.AsMemory(0, pos), FrameFlags.EndHeaders | FrameFlags.EndStream, 0, 0, 0, streamId));
+
+                    // Second stream, resize the table so that the header-that-gos is removed from table, and add a new header.
+                    // 1) resize: header-that-stays: 62
+                    // 2) add new header: header-that-stays:63, new-header:62
+                    streamId = await con.ReadRequestHeaderAsync();
+                    pos = 0;
+                    pos += HPackEncoder.EncodeDynamicTableSizeUpdate("header-that-staysfoo".Length + HttpHeaderData.RfcOverhead, frameData.AsSpan(pos));
+                    pos += HPackEncoder.EncodeDynamicTableSizeUpdate(4096, frameData.AsSpan(pos));
+                    pos += HPackEncoder.EncodeHeader(":status", "200", HPackFlags.None, frameData.AsSpan(pos));
+                    pos += HPackEncoder.EncodeHeader("new-header", "baz", HPackFlags.NewIndexed, frameData.AsSpan(pos));
+                    await con.WriteFrameAsync(new HeadersFrame(frameData.AsMemory(0, pos), FrameFlags.EndHeaders | FrameFlags.EndStream, 0, 0, 0, streamId));
+
+                    // Third stream, use the dynamic table established in previous stream.
+                    streamId = await con.ReadRequestHeaderAsync();
+                    pos = 0;
+                    pos += HPackEncoder.EncodeHeader(":status", "200", HPackFlags.None, frameData.AsSpan(pos));
+                    pos += HPackEncoder.EncodeHeader(63, frameData.AsSpan(pos)); // header-that-stays:foo
+                    pos += HPackEncoder.EncodeHeader(62, frameData.AsSpan(pos)); // new-header:baz
+                    await con.WriteFrameAsync(new HeadersFrame(frameData.AsMemory(0, pos), FrameFlags.EndHeaders | FrameFlags.EndStream, 0, 0, 0, streamId));
+
+                    // Close out connection.
+                    await con.ShutdownIgnoringErrorsAsync(streamId);
+                });
+        }
+
+        [Theory]
+        [MemberData(nameof(DynamicTable_Data))]
+        public async Task DynamicTable_Receipt_Success(IEnumerable<HttpHeaderData> headers)
+        {
+            await Http2LoopbackServer.CreateClientAndServerAsync(
+                async uri =>
+                {
+                    using HttpClient client = CreateHttpClient();
+
+                    // First request should initialize our dynamic table.
+                    using (HttpResponseMessage response = await client.GetAsync(uri))
+                    {
+                        AssertExpectedHeaders(response);
+                    }
+
+                    // Second request should use the dynamic table.
+                    using (HttpResponseMessage response = await client.GetAsync(uri))
+                    {
+                        AssertExpectedHeaders(response);
+                    }
+                },
+                async server =>
+                {
+                    (Http2LoopbackConnection con, SettingsFrame settings) = await server.EstablishConnectionGetSettingsAsync();
+
+                    Debug.Assert(settings.GetHeaderTableSize() >= 4096, "Data for this theory requires a header table size of at least 4096.");
+
+                    // First stream, create dynamic indexes.
+                    int streamId = await con.ReadRequestHeaderAsync();
+
+                    byte[] frameData = new byte[16 * 1024];
+                    int pos = 0;
+
+                    foreach (HttpHeaderData header in headers)
+                    {
+                        pos += HPackEncoder.EncodeHeader(header.Name, header.Value, HPackFlags.NewIndexed, frameData.AsSpan(pos));
+                    }
+
+                    await con.WriteFrameAsync(new HeadersFrame(frameData.AsMemory(0, pos), FrameFlags.EndHeaders | FrameFlags.EndStream, 0, 0, 0, streamId));
+
+                    // Second stream, send headers using indexes only.
+                    streamId = await con.ReadRequestHeaderAsync();
+
+                    // Dynamic headers start at index 62 with 62 being the most recently added entry.
+                    pos = 0;
+                    for (int i = 61 + headers.Count(); i > 61; --i)
+                    {
+                        pos += HPackEncoder.EncodeHeader(i, frameData.AsSpan(pos));
+                    }
+
+                    await con.WriteFrameAsync(new HeadersFrame(frameData.AsMemory(0, pos), FrameFlags.EndHeaders | FrameFlags.EndStream, 0, 0, 0, streamId));
+
+                    // Close out connection.
+                    await con.ShutdownIgnoringErrorsAsync(streamId);
+                });
+
+            void AssertExpectedHeaders(HttpResponseMessage response)
+            {
+                var expected = headers.Select(x => (name: x.Name.ToLowerInvariant(), value: x.Value.ToLowerInvariant()));
+                var actual = response.Headers.SelectMany(x => x.Value, (kvp, v) => (name: kvp.Key.ToLowerInvariant(), value: v.ToLowerInvariant()));
+                Assert.Empty(actual.Except(expected));
+            }
+        }
+
+        public static IEnumerable<object[]> DynamicTable_Data()
+        {
+            yield return new object[] { GenerateHeadersWithStatus200(512) };
+            yield return new object[] { GenerateHeadersWithStatus200(4096) };
+        }
+
+        /// <summary>
+        /// Generates headers to an exact dynamic table size.
+        /// </summary>
+        private static IEnumerable<HttpHeaderData> GenerateHeadersWithStatus200(int targetSize)
+        {
+            Debug.Assert(targetSize > 64, $"{nameof(targetSize)} must be more than 64 to account for a status 200 and padding headers.");
+
+            const string NamePrefix = "hn-";
+            const string ValuePrefix = "hv-";
+
+            // Add status 200 and remove its length and overhead.
+            targetSize -= ":status200".Length + HttpHeaderData.RfcOverhead;
+            yield return new HttpHeaderData(":status", "200");
+
+            for (int i = 0; targetSize > 0; ++i)
+            {
+                string s = i.ToString(CultureInfo.InvariantCulture);
+
+                string name = NamePrefix + s;
+                string value;
+
+                int left = targetSize - name.Length - HttpHeaderData.RfcOverhead;
+                if (left < 64)
+                {
+                    // At this point, we pad out to reach the remaining size.
+                    value = ValuePrefix + s.PadLeft(left - ValuePrefix.Length, '0');
+                }
+                else
+                {
+                    value = ValuePrefix + s;
+                }
+
+                yield return new HttpHeaderData(name, value);
+
+                targetSize -= name.Length + value.Length + HttpHeaderData.RfcOverhead;
+            }
+
+            Debug.Assert(targetSize == 0); // Ensure we perfectly filled the target size.
         }
     }
 }


### PR DESCRIPTION
Dynamic table code was actually fixed/tested in 3.0, but the feature was left disabled. This re-enables it and adds functional tests to verify it. Resolves #41208 

A future change might add an API to let users configure the dynamic table size. Currently it is kept at default of 4KiB.