### PR TITLE
Set IsShipping only for experimental and IsShippingPackages only for private packages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -382,6 +382,9 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <IsShipping Condition="$(MSBuildProjectName.Contains('Private')) or $(MSBuildProjectName.Contains('Experimental'))">false</IsShipping>
+    <!-- When IsShipping property is set, other IsShipping* properties take its value if they are not set.
+    This is why IsShippingPackage is only set for Private packages, as Experimental are covered with IsShipping -->
+    <IsShipping Condition="$(MSBuildProjectName.Contains('Experimental'))">false</IsShipping>
+    <IsShippingPackage Condition="$(MSBuildProjectName.Contains('Private')) and '$(MSBuildProjectExtension)' == '.pkgproj'">false</IsShippingPackage>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/41315

We only need to set `IsShippingPackages` to false, when we're building a pkgproj and it's name contains, `Experimental` or `Private`. We set `IsShippingPackages=false` only for `Private` and `IsShipping=false` for `Experimental` because `Experimental` should cover both the package and assembly information to be non-stable.

cc: @dagood @mjsabby 