### PR TITLE
Optimize Enumerable.SkipLast() for IPartition and IList

### DIFF
--- a/src/System.Linq/src/System/Linq/Skip.SizeOpt.cs
+++ b/src/System.Linq/src/System/Linq/Skip.SizeOpt.cs
@@ -19,5 +19,8 @@ namespace System.Linq
                 }
             }
         }
+
+        private static IEnumerable<TSource> SkipLastEnumerableFactory<TSource>(IEnumerable<TSource> source, int count) =>
+            SkipLastIterator<TSource>(source, count);
     }
 }

--- a/src/System.Linq/src/System/Linq/Skip.SpeedOpt.cs
+++ b/src/System.Linq/src/System/Linq/Skip.SpeedOpt.cs
@@ -20,7 +20,7 @@ namespace System.Linq
 
             if (source is IPartition<TSource> partition)
             {
-                int length = partition.GetCount(true);
+                int length = partition.GetCount(onlyIfCheap: true);
 
                 if (length >= 0)
                 {

--- a/src/System.Linq/src/System/Linq/Skip.SpeedOpt.cs
+++ b/src/System.Linq/src/System/Linq/Skip.SpeedOpt.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace System.Linq
 {
@@ -12,5 +13,30 @@ namespace System.Linq
             source is IList<TSource> sourceList ?
                 (IEnumerable<TSource>)new ListPartition<TSource>(sourceList, count, int.MaxValue) :
                 new EnumerablePartition<TSource>(source, count, -1);
+
+        private static IEnumerable<TSource> SkipLastEnumerableFactory<TSource>(IEnumerable<TSource> source, int count)
+        {
+            Debug.Assert(count > 0);
+
+            if (source is IPartition<TSource> partition)
+            {
+                int length = partition.GetCount(true);
+
+                if (length >= 0)
+                {
+                    return length - count > 0 ? partition.Take(length - count) : EmptyPartition<TSource>.Instance;
+                }
+            }
+            else if (source is IList<TSource> sourceList)
+            {
+                int sourceCount = sourceList.Count;
+
+                return sourceCount > count
+                    ? new ListPartition<TSource>(sourceList, 0, sourceCount - count - 1)
+                    : EmptyPartition<TSource>.Instance;
+            }
+
+            return SkipLastIterator<TSource>(source, count);
+        }
     }
 }

--- a/src/System.Linq/src/System/Linq/Skip.SpeedOpt.cs
+++ b/src/System.Linq/src/System/Linq/Skip.SpeedOpt.cs
@@ -24,16 +24,18 @@ namespace System.Linq
 
                 if (length >= 0)
                 {
-                    return length - count > 0 ? partition.Take(length - count) : EmptyPartition<TSource>.Instance;
+                    return length - count > 0 ?
+                        partition.Take(length - count) :
+                        EmptyPartition<TSource>.Instance;
                 }
             }
             else if (source is IList<TSource> sourceList)
             {
                 int sourceCount = sourceList.Count;
 
-                return sourceCount > count
-                    ? new ListPartition<TSource>(sourceList, 0, sourceCount - count - 1)
-                    : EmptyPartition<TSource>.Instance;
+                return sourceCount > count ?
+                    new ListPartition<TSource>(sourceList, 0, sourceCount - count - 1) :
+                    EmptyPartition<TSource>.Instance;
             }
 
             return SkipLastIterator<TSource>(source, count);

--- a/src/System.Linq/src/System/Linq/Skip.cs
+++ b/src/System.Linq/src/System/Linq/Skip.cs
@@ -120,12 +120,9 @@ namespace System.Linq
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (count <= 0)
-            {
-                return source.Skip(0);
-            }
-
-            return SkipLastIterator(source, count);
+            return count <= 0
+                ? source.Skip(0)
+                : SkipLastEnumerableFactory(source, count);
         }
 
         private static IEnumerable<TSource> SkipLastIterator<TSource>(IEnumerable<TSource> source, int count)

--- a/src/System.Linq/src/System/Linq/Skip.cs
+++ b/src/System.Linq/src/System/Linq/Skip.cs
@@ -120,9 +120,9 @@ namespace System.Linq
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            return count <= 0
-                ? source.Skip(0)
-                : SkipLastEnumerableFactory(source, count);
+            return count <= 0 ?
+                source.Skip(0) :
+                SkipLastEnumerableFactory(source, count);
         }
 
         private static IEnumerable<TSource> SkipLastIterator<TSource>(IEnumerable<TSource> source, int count)

--- a/src/System.Linq/src/System/Linq/Take.SpeedOpt.cs
+++ b/src/System.Linq/src/System/Linq/Take.SpeedOpt.cs
@@ -20,7 +20,7 @@ namespace System.Linq
 
             if (source is IPartition<TSource> partition)
             {
-                int length = partition.GetCount(true);
+                int length = partition.GetCount(onlyIfCheap: true);
 
                 if (length >= 0)
                 {

--- a/src/System.Linq/src/System/Linq/Take.SpeedOpt.cs
+++ b/src/System.Linq/src/System/Linq/Take.SpeedOpt.cs
@@ -31,14 +31,9 @@ namespace System.Linq
             {
                 int sourceCount = sourceList.Count;
 
-                if (sourceCount > count)
-                {
-                    return new ListPartition<TSource>(sourceList, sourceCount - count, sourceCount);
-                }
-                else
-                {
-                    return new ListPartition<TSource>(sourceList, 0, sourceCount);
-                }
+                return sourceCount > count
+                    ? new ListPartition<TSource>(sourceList, sourceCount - count, sourceCount)
+                    : new ListPartition<TSource>(sourceList, 0, sourceCount);
             }
 
             return TakeLastIterator<TSource>(source, count);

--- a/src/System.Linq/src/System/Linq/Take.SpeedOpt.cs
+++ b/src/System.Linq/src/System/Linq/Take.SpeedOpt.cs
@@ -31,9 +31,14 @@ namespace System.Linq
             {
                 int sourceCount = sourceList.Count;
 
-                return sourceCount > count
-                    ? new ListPartition<TSource>(sourceList, sourceCount - count, sourceCount)
-                    : new ListPartition<TSource>(sourceList, 0, sourceCount);
+                if (sourceCount > count)
+                {
+                    return new ListPartition<TSource>(sourceList, sourceCount - count, sourceCount);
+                }
+                else
+                {
+                    return new ListPartition<TSource>(sourceList, 0, sourceCount);
+                }
             }
 
             return TakeLastIterator<TSource>(source, count);

--- a/src/System.Linq/src/System/Linq/Take.cs
+++ b/src/System.Linq/src/System/Linq/Take.cs
@@ -90,9 +90,9 @@ namespace System.Linq
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            return count <= 0 ?
-                Empty<TSource>() :
-                TakeLastEnumerableFactory(source, count);
+            return count <= 0
+                ? Empty<TSource>()
+                : TakeLastEnumerableFactory(source, count);
         }
 
         private static IEnumerable<TSource> TakeLastIterator<TSource>(IEnumerable<TSource> source, int count)

--- a/src/System.Linq/src/System/Linq/Take.cs
+++ b/src/System.Linq/src/System/Linq/Take.cs
@@ -90,9 +90,9 @@ namespace System.Linq
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            return count <= 0
-                ? Empty<TSource>()
-                : TakeLastEnumerableFactory(source, count);
+            return count <= 0 ?
+                Empty<TSource>() :
+                TakeLastEnumerableFactory(source, count);
         }
 
         private static IEnumerable<TSource> TakeLastIterator<TSource>(IEnumerable<TSource> source, int count)


### PR DESCRIPTION
Enumerable.SkipLast() can be cast to Enumerable.Take() when source type is IPartition or IList.

performance test see #40014