### PR TITLE
StartsWith more edge cases

### DIFF
--- a/src/System.Globalization/tests/CompareInfo/CompareInfoTests.IsPrefix.cs
+++ b/src/System.Globalization/tests/CompareInfo/CompareInfoTests.IsPrefix.cs
@@ -75,6 +75,13 @@ namespace System.Globalization.Tests
             yield return new object[] { s_frenchCompare, "\u0153", "oe", CompareOptions.None, PlatformDetection.IsWindows ? true : false };
             yield return new object[] { s_invariantCompare, "\uD800\uDC00", "\uD800", CompareOptions.None, PlatformDetection.IsWindows ? true : false };
             yield return new object[] { s_invariantCompare, "\uD800\uDC00", "\uD800", CompareOptions.IgnoreCase, PlatformDetection.IsWindows ? true : false };
+
+            // ICU bugs
+            // UInt16 overflow: https://unicode-org.atlassian.net/browse/ICU-20832 fixed in https://github.com/unicode-org/icu/pull/840 (ICU 65)
+            if (PlatformDetection.IsWindows || PlatformDetection.ICUVersion.Major >= 65)
+            {
+                yield return new object[] { s_frenchCompare, "b", new string('a', UInt16.MaxValue + 1), CompareOptions.None, false };
+            }
         }
 
         [Theory]

--- a/src/System.Globalization/tests/CompareInfo/CompareInfoTests.IsPrefix.cs
+++ b/src/System.Globalization/tests/CompareInfo/CompareInfoTests.IsPrefix.cs
@@ -54,6 +54,7 @@ namespace System.Globalization.Tests
             yield return new object[] { s_invariantCompare, "FooBA\u0300R", "FooB\u00C0R", CompareOptions.IgnoreNonSpace, true };
             yield return new object[] { s_invariantCompare, "o\u0308", "o", CompareOptions.None, false };
             yield return new object[] { s_invariantCompare, "o\u0308", "o", CompareOptions.Ordinal, true };
+            yield return new object[] { s_invariantCompare, "o\u0000\u0308", "o", CompareOptions.None, true };
 
             // Surrogates
             yield return new object[] { s_invariantCompare, "\uD800\uDC00", "\uD800\uDC00", CompareOptions.None, true };


### PR DESCRIPTION
Test case for https://github.com/unicode-org/icu/pull/840 to make sure that ICU 65 solves the problem for good.

`"o\u0000\u0308".StartsWith("o")` to make sure https://github.com/dotnet/coreclr/pull/26621 does not break it