### PR TITLE
Added snake case naming policy to the JSON serializer

### DIFF
--- a/src/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/System.Text.Json/ref/System.Text.Json.cs
@@ -227,6 +227,7 @@ namespace System.Text.Json
     {
         protected JsonNamingPolicy() { }
         public static System.Text.Json.JsonNamingPolicy CamelCase { get { throw null; } }
+        public static System.Text.Json.JsonNamingPolicy SnakeCase { get { throw null; } }
         public abstract string ConvertName(string name);
     }
     public abstract partial class JsonNode

--- a/src/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/System.Text.Json/src/System.Text.Json.csproj
@@ -121,6 +121,7 @@
     <Compile Include="System\Text\Json\Serialization\JsonSerializer.Write.Utf8JsonWriter.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonSerializerOptions.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonSerializerOptions.Converters.cs" />
+    <Compile Include="System\Text\Json\Serialization\JsonSnakeCaseNamingPolicy.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonStringEnumConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\MemberAccessor.cs" />
     <Compile Include="System\Text\Json\Serialization\PooledByteBufferWriter.cs" />

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonNamingPolicy.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonNamingPolicy.cs
@@ -15,9 +15,14 @@ namespace System.Text.Json
         protected JsonNamingPolicy() { }
 
         /// <summary>
-        /// Returns the naming policy for camel-casing.
+        /// Gets the naming policy for camel-casing.
         /// </summary>
         public static JsonNamingPolicy CamelCase { get; } = new JsonCamelCaseNamingPolicy();
+
+        /// <summary>
+        /// Gets the naming policy for snake-casing.
+        /// </summary>
+        public static JsonNamingPolicy SnakeCase { get; } = new JsonSnakeCaseNamingPolicy();
 
         internal static JsonNamingPolicy Default { get; } = new JsonDefaultNamingPolicy();
 

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSnakeCaseNamingPolicy.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSnakeCaseNamingPolicy.cs
@@ -1,0 +1,74 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+
+namespace System.Text.Json
+{
+    internal sealed class JsonSnakeCaseNamingPolicy : JsonNamingPolicy
+    {
+        public override string ConvertName(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+                return name;
+
+            // Allocates a string builder with the guessed result length,
+            // where 5 is the average word length in English, and
+            // max(2, length / 5) is the number of underscores.
+            StringBuilder builder = new StringBuilder(name.Length + Math.Max(2, name.Length / 5));
+            UnicodeCategory? previousCategory = null;
+
+            for (int currentIndex = 0; currentIndex < name.Length; currentIndex++)
+            {
+                char currentChar = name[currentIndex];
+                if (currentChar == '_')
+                {
+                    builder.Append('_');
+                    previousCategory = null;
+                    continue;
+                }
+
+                UnicodeCategory currentCategory = char.GetUnicodeCategory(currentChar);
+
+                switch (currentCategory)
+                {
+                    case UnicodeCategory.UppercaseLetter:
+                    case UnicodeCategory.TitlecaseLetter:
+                        if (previousCategory == UnicodeCategory.SpaceSeparator ||
+                            previousCategory == UnicodeCategory.LowercaseLetter ||
+                            previousCategory != UnicodeCategory.DecimalDigitNumber &&
+                            currentIndex > 0 &&
+                            currentIndex + 1 < name.Length &&
+                            char.IsLower(name[currentIndex + 1]))
+                        {
+                            builder.Append('_');
+                        }
+
+                        currentChar = char.ToLower(currentChar);
+                        break;
+
+                    case UnicodeCategory.LowercaseLetter:
+                    case UnicodeCategory.DecimalDigitNumber:
+                        if (previousCategory == UnicodeCategory.SpaceSeparator)
+                        {
+                            builder.Append('_');
+                        }
+                        break;
+
+                    default:
+                        if (previousCategory != null)
+                        {
+                            previousCategory = UnicodeCategory.SpaceSeparator;
+                        }
+                        continue;
+                }
+
+                builder.Append(currentChar);
+                previousCategory = currentCategory;
+            }
+
+            return builder.ToString();
+        }
+    }
+}

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSnakeCaseNamingPolicy.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSnakeCaseNamingPolicy.cs
@@ -56,6 +56,9 @@ namespace System.Text.Json
                         }
                         break;
 
+                    case UnicodeCategory.Surrogate:
+                        break;
+
                     default:
                         if (previousCategory != null)
                         {

--- a/src/System.Text.Json/tests/Serialization/SnakeCaseUnitTests.cs
+++ b/src/System.Text.Json/tests/Serialization/SnakeCaseUnitTests.cs
@@ -96,7 +96,8 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("u_ppe_r_case", "UPpeR Case")]
         [InlineData("u_ppe_r_c_a_se", "UPpeR cASe")]
         //
-        [InlineData("\u0467", "\u0467")]
+        [InlineData("ä", "ä")]
+        [InlineData("𝟜𝟚", "𝟜𝟚")]
         public static void Convert_SpecifiedName_MatchesExpected(string expected, string name) =>
             Assert.Equal(expected, JsonNamingPolicy.SnakeCase.ConvertName(name));
 

--- a/src/System.Text.Json/tests/Serialization/SnakeCaseUnitTests.cs
+++ b/src/System.Text.Json/tests/Serialization/SnakeCaseUnitTests.cs
@@ -67,9 +67,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("spaces", "  spaces")]
         [InlineData("spaces", " spaces")]
         //
-        [InlineData("9999_12_31t23_59_59_9999999z", "9999_12_31t23_59_59_9999999z")]
         [InlineData("9999_12_31t23_59_59_9999999z", "9999-12-31T23:59:59.9999999Z")]
-        //
         [InlineData("hi_this_is_text_time_to_test", "Hi!! This is text. Time to test.")]
         //
         [InlineData("is_cia", "IsCIA")]

--- a/src/System.Text.Json/tests/Serialization/SnakeCaseUnitTests.cs
+++ b/src/System.Text.Json/tests/Serialization/SnakeCaseUnitTests.cs
@@ -95,9 +95,12 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("u_ppe_r_case", "UPpeR case")]
         [InlineData("u_ppe_r_case", "UPpeR Case")]
         [InlineData("u_ppe_r_c_a_se", "UPpeR cASe")]
-        //
-        [InlineData("ä", "ä")]
-        [InlineData("𝟜𝟚", "𝟜𝟚")]
+        // Valid unicode
+        [InlineData("\u00E4", "\u00E4")]
+        [InlineData("\uD835\uDFDC", "\uD835\uDFDC")]
+        // Invalid unicode
+        [InlineData("\uDC01", "\uDC01")]
+        [InlineData("\uD801", "\uD801")]
         public static void Convert_SpecifiedName_MatchesExpected(string expected, string name) =>
             Assert.Equal(expected, JsonNamingPolicy.SnakeCase.ConvertName(name));
 

--- a/src/System.Text.Json/tests/Serialization/SnakeCaseUnitTests.cs
+++ b/src/System.Text.Json/tests/Serialization/SnakeCaseUnitTests.cs
@@ -1,0 +1,158 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Text.Json.Serialization.Tests
+{
+    public static class SnakeCaseUnitTests
+    {
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData("", "")]
+        //
+        [InlineData("i", "i")]
+        [InlineData("i", "I")]
+        //
+        [InlineData("ii", "ii")]
+        [InlineData("i_i", "iI")]
+        [InlineData("ii", "Ii")]
+        [InlineData("ii", "II")]
+        //
+        [InlineData("iii", "iii")]
+        [InlineData("ii_i", "iiI")]
+        [InlineData("i_ii", "iIi")]
+        [InlineData("i_ii", "iII")]
+        [InlineData("iii", "Iii")]
+        [InlineData("ii_i", "IiI")]
+        [InlineData("i_ii", "IIi")]
+        [InlineData("iii", "III")]
+        //
+        [InlineData("i_phone", "iPhone")]
+        [InlineData("i_phone", "IPhone")]
+        [InlineData("ip_hone", "IPHone")]
+        [InlineData("iph_one", "IPHOne")]
+        [InlineData("ipho_ne", "IPHONe")]
+        [InlineData("iphone", "IPHONE")]
+        //
+        [InlineData("id", "id")]
+        [InlineData("id", "ID")]
+        //
+        [InlineData("url", "url")]
+        [InlineData("url", "URL")]
+        [InlineData("url_value", "url_value")]
+        [InlineData("url_value", "URLValue")]
+        //
+        [InlineData("xml2json", "xml2json")]
+        [InlineData("xml2json", "Xml2Json")]
+        //
+        [InlineData("already_snake_case", "already_snake_case")]
+        [InlineData("_already_snake_case", "_already_snake_case")]
+        [InlineData("__already_snake_case", "__already_snake_case")]
+        [InlineData("already_snake_case_", "already_snake_case_")]
+        [InlineData("already_snake_case__", "already_snake_case__")]
+        //
+        [InlineData("sn_a__k_ec_as_e", "sn_a__k_ec_as_e")]
+        [InlineData("sn_ak_ec_as_e", "sn_ak_ec_as_e")]
+        [InlineData("sn_a__k_ec_as_e", "SnA__ kEcAsE")]
+        [InlineData("sn_a__k_ec_as_e", "SnA__kEcAsE")]
+        [InlineData("sn_ak_ec_as_e", "SnAkEcAsE")]
+        //
+        [InlineData("spaces", "spaces ")]
+        [InlineData("spaces", "spaces  ")]
+        [InlineData("spaces", "spaces   ")]
+        [InlineData("spaces", "   spaces")]
+        [InlineData("spaces", "  spaces")]
+        [InlineData("spaces", " spaces")]
+        //
+        [InlineData("9999_12_31t23_59_59_9999999z", "9999_12_31t23_59_59_9999999z")]
+        [InlineData("9999_12_31t23_59_59_9999999z", "9999-12-31T23:59:59.9999999Z")]
+        //
+        [InlineData("hi_this_is_text_time_to_test", "Hi!! This is text. Time to test.")]
+        //
+        [InlineData("is_cia", "IsCIA")]
+        [InlineData("is_json_property", "IsJSONProperty")]
+        //
+        [InlineData("lower_case", "lower case")]
+        [InlineData("lower_case", "lower Case")]
+        [InlineData("lower_case", "lowerCase")]
+        [InlineData("lower_c_a_se", "lower cASe")]
+        [InlineData("lowe_r_case", "loweR case")]
+        [InlineData("lowe_r_case", "loweR Case")]
+        [InlineData("lowe_r_c_a_se", "loweR cASe")]
+        [InlineData("upper_case", "Upper case")]
+        [InlineData("upper_case", "Upper Case")]
+        [InlineData("upper_case", "UPPER CASE")]
+        [InlineData("upper_case", "UpperCase")]
+        [InlineData("upper_c_a_se", "Upper cASe")]
+        [InlineData("uppe_r_case", "UppeR case")]
+        [InlineData("uppe_r_case", "UppeR Case")]
+        [InlineData("uppe_r_c_a_se", "UppeR cASe")]
+        [InlineData("u_pper_case", "UPper case")]
+        [InlineData("u_pper_case", "UPper Case")]
+        [InlineData("u_pper_case", "UPperCase")]
+        [InlineData("u_pper_c_a_se", "UPper cASe")]
+        [InlineData("u_ppe_r_case", "UPpeR case")]
+        [InlineData("u_ppe_r_case", "UPpeR Case")]
+        [InlineData("u_ppe_r_c_a_se", "UPpeR cASe")]
+        //
+        [InlineData("\u0467", "\u0467")]
+        public static void Convert_SpecifiedName_MatchesExpected(string expected, string name) =>
+            Assert.Equal(expected, JsonNamingPolicy.SnakeCase.ConvertName(name));
+
+        [Fact]
+        public static void SerializeType_RoundTipping_MatchesOriginal()
+        {
+            var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.SnakeCase };
+
+            string expected = @"{""some_int_property"":42}";
+            string actual = JsonSerializer.Serialize(JsonSerializer.Deserialize<NamingPolictyTestClass>(expected, options), options);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void DeserializeType_RoundTipping_MatchesOriginal()
+        {
+            var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.SnakeCase };
+
+            var expected = new NamingPolictyTestClass { SomeIntProperty = 42 };
+            var actual = JsonSerializer.Deserialize<NamingPolictyTestClass>(JsonSerializer.Serialize(expected, options), options);
+
+            Assert.Equal(
+                expected.SomeIntProperty,
+                actual.SomeIntProperty);
+        }
+
+        private class NamingPolictyTestClass
+        {
+            public int SomeIntProperty { get; set; }
+        }
+
+        [Fact]
+        public static void SerializeDictionary_RoundTipping_MatchesOriginal()
+        {
+            var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.SnakeCase };
+
+            string expected = @"{""some_int_property"":42}";
+            string actual = JsonSerializer.Serialize(JsonSerializer.Deserialize<Dictionary<string, int>>(expected, options), options);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void DeserializeDictionary_RoundTipping_MatchesOriginal()
+        {
+            var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.SnakeCase };
+
+            var expected = new Dictionary<string, int> { ["SomeIntProperty"] = 42 };
+            var actual = JsonSerializer.Deserialize<Dictionary<string, int>>(JsonSerializer.Serialize(expected, options), options);
+
+            Assert.Equal(
+                expected["SomeIntProperty"],
+                actual["SomeIntProperty"]);
+        }
+    }
+}

--- a/src/System.Text.Json/tests/System.Text.Json.Tests.csproj
+++ b/src/System.Text.Json/tests/System.Text.Json.Tests.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Serialization\ReadValueTests.cs" />
     <Compile Include="Serialization\SampleTestData.OrderPayload.cs" />
     <Compile Include="Serialization\SpanTests.cs" />
+    <Compile Include="Serialization\SnakeCaseUnitTests.cs" />
     <Compile Include="Serialization\Stream.ReadTests.cs" />
     <Compile Include="Serialization\Stream.WriteTests.cs" />
     <Compile Include="Serialization\TestClasses.cs" />


### PR DESCRIPTION
Fixes #39564. The code is written some time ago for our ADO.NET driver for PostgreSQL where snake case is the common and default naming style.