### PR TITLE
[release/3.0] Disable XML crypto test failing on Windows 10

### DIFF
--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAKeyExchangeFormatter.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAKeyExchangeFormatter.cs
@@ -23,6 +23,7 @@ namespace System.Security.Cryptography.Rsa.Tests
             }
         }
 
+        [ActiveIssue(40434, TestPlatforms.Windows)]
         [Fact]
         public static void VerifyDecryptKeyExchangePkcs1()
         {
@@ -53,6 +54,7 @@ namespace System.Security.Cryptography.Rsa.Tests
             }
         }
 
+        [ActiveIssue(40434, TestPlatforms.Windows)]
         [Fact]
         public static void TestKnownValuePkcs1()
         {

--- a/src/System.Security.Cryptography.Xml/tests/Samples/EncryptingDecryptingAsymmetric.cs
+++ b/src/System.Security.Cryptography.Xml/tests/Samples/EncryptingDecryptingAsymmetric.cs
@@ -78,10 +78,16 @@ namespace System.Security.Cryptography.Xml.Tests
             encrypted.DecryptDocument();
         }
 
-        [Theory]
-        [InlineData(true)] // OAEP is recommended
-        [InlineData(false)]
-        public void AsymmetricEncryptionRoundtrip(bool useOAEP)
+        [Fact]
+        public void AsymmetricEncryptionRoundtripUseOAEP() =>
+            AsymmetricEncryptionRoundtrip(useOAEP: true); // OAEP is recommended
+
+        [ActiveIssue(40759, TestPlatforms.Windows)]
+        [Fact]
+        public void AsymmetricEncryptionRoundtrip() =>
+            AsymmetricEncryptionRoundtrip(useOAEP: false);
+
+        private void AsymmetricEncryptionRoundtrip(bool useOAEP)
         {
             const string testString = "some text node";
             const string exampleXmlRootElement = "example";


### PR DESCRIPTION
Disabling an RSAES-PKCS#1-based test failing due to an OS issue (tracked by #40759).

Port of #40775.