### PR TITLE
Avoid ToCharArray allocation in JsonCamelCaseNamingPolicy

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonCamelCaseNamingPolicy.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonCamelCaseNamingPolicy.cs
@@ -13,8 +13,21 @@ namespace System.Text.Json
                 return name;
             }
 
+#if BUILDING_INBOX_LIBRARY
+            return string.Create(name.Length, name, (chars, name) =>
+            {
+                name.AsSpan().CopyTo(chars);
+                FixCasing(chars);
+            });
+#else
             char[] chars = name.ToCharArray();
+            FixCasing(chars);
+            return new string(chars);
+#endif
+        }
 
+        private static void FixCasing(Span<char> chars)
+        {
             for (int i = 0; i < chars.Length; i++)
             {
                 if (i == 1 && !char.IsUpper(chars[i]))
@@ -38,8 +51,6 @@ namespace System.Text.Json
 
                 chars[i] = char.ToLowerInvariant(chars[i]);
             }
-
-            return new string(chars);
         }
     }
 }


### PR DESCRIPTION
Microbenchmark calling ConvertName with either "PascalCase" or "camelCased":
```
| Method |       Text |      Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------- |----------- |----------:|----------:|----------:|-------:|------:|------:|----------:|
|    Old | PascalCase | 35.724 ns | 1.3263 ns | 3.7410 ns | 0.0458 |     - |     - |      96 B |
|    New | PascalCase | 26.932 ns | 0.7734 ns | 2.2683 ns | 0.0229 |     - |     - |      48 B |
|    Old | camelCased |  3.323 ns | 0.1484 ns | 0.4211 ns |      - |     - |     - |         - |
|    New | camelCased |  2.685 ns | 0.1435 ns | 0.4186 ns |      - |     - |     - |         - |
```
cc: @steveharter, @ahsonkhan 