### PR TITLE
Disable S.N.Security tests on arm64 Windows

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -1,161 +1,164 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
+    <AllowUnsafeBlocks Condition="'$(TargetsUnix)' == 'true'">true</AllowUnsafeBlocks>
     <Configurations>netcoreapp-OSX-Debug;netcoreapp-OSX-Release;netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetsUnix)' == 'true' ">
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="NotifyReadVirtualNetworkStream.cs" />
-    <Compile Include="DummyTcpServer.cs" />
-    <Compile Include="TestConfiguration.cs" />
-    <!-- SslStream Tests -->
-    <Compile Include="CertificateValidationClientServer.cs" />
-    <Compile Include="CertificateValidationRemoteServer.cs" />
-    <Compile Include="ClientAsyncAuthenticateTest.cs" />
-    <Compile Include="ClientDefaultEncryptionTest.cs" />
-    <Compile Include="ParameterValidationTest.cs" />
-    <Compile Include="ServerAllowNoEncryptionTest.cs" />
-    <Compile Include="ServerAsyncAuthenticateTest.cs" />
-    <Compile Include="ServerNoEncryptionTest.cs" />
-    <Compile Include="ServerRequireEncryptionTest.cs" />
-    <Compile Include="SslStreamStreamToStreamTest.cs" />
-    <Compile Include="SslStreamNetworkStreamTest.cs" />
-    <Compile Include="TransportContextTest.cs" />
-    <!-- NegotiateStream Tests -->
-    <Compile Include="NegotiateStreamInvalidOperationTest.cs" />
-    <Compile Include="NegotiateStreamStreamToStreamTest.cs" />
-    <Compile Include="ServiceNameCollectionTest.cs" />
-    <Compile Include="NegotiateStreamKerberosTest.cs" />
-    <!-- Common test files -->
-    <Compile Include="$(CommonTestPath)\System\IO\DelegateStream.cs">
-      <Link>Common\System\IO\DelegateStream.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Capability.Security.cs">
-      <Link>Common\System\Net\Capability.Security.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\SslStreamCertificatePolicy.cs">
-      <Link>Common\System\Net\SslStreamCertificatePolicy.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Configuration.cs">
-      <Link>Common\System\Net\Configuration.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Configuration.Security.cs">
-      <Link>Common\System\Net\Configuration.Security.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Configuration.Certificates.cs">
-      <Link>Common\System\Net\Configuration.Certificates.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\Configuration.Http.cs">
-      <Link>Common\System\Net\Configuration.Http.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\HttpsTestClient.cs">
-      <Link>Common\System\Net\HttpsTestClient.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\HttpsTestServer.cs">
-      <Link>Common\System\Net\HttpsTestServer.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\SslProtocolSupport.cs">
-      <Link>Common\System\Net\SslProtocolSupport.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\TestLogging.cs">
-      <Link>Common\System\Net\TestLogging.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\VerboseTestLogging.cs">
-      <Link>Common\System\Net\VerboseTestLogging.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\EventSourceTestLogging.cs">
-      <Link>Common\System\Net\EventSourceTestLogging.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\VirtualNetwork\VirtualNetwork.cs">
-      <Link>Common\System\Net\VirtualNetwork\VirtualNetwork.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonTestPath)\System\Net\VirtualNetwork\VirtualNetworkStream.cs">
-      <Link>Common\System\Net\VirtualNetwork\VirtualNetworkStream.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonTestPath)\System\Threading\Tasks\TaskTimeoutExtensions.cs">
-      <Link>Common\System\Threading\Tasks\TaskTimeoutExtensions.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\CoreLib\System\Threading\Tasks\TaskToApm.cs">
-      <Link>ProductionCode\Common\CoreLib\System\Threading\Tasks\TaskToApm.cs</Link>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netcoreapp'">
-    <Compile Include="..\..\src\System\Net\Security\SniHelper.cs">
-      <Link>src\SniHelper.cs</Link>
-    </Compile>
-    <Compile Include="SniHelperTest.cs" />
-    <Compile Include="SslAuthenticationOptionsTest.cs" />
-    <Compile Include="SslStreamAlertsTest.cs" />
-    <Compile Include="SslStreamAllowRenegotiationTests.cs" />
-    <Compile Include="SslStreamAlpnTests.cs" />
-    <Compile Include="SslStreamDisposeTest.cs" />
-    <Compile Include="SslStreamSniTest.cs" />
-    <Compile Include="SslStreamEKUTest.cs" />
-    <Compile Include="SslStreamNegotiatedCipherSuiteTest.cs" />
-    <Compile Include="SslStreamSchSendAuxRecordTest.cs" />
-    <Compile Include="SslStreamCredentialCacheTest.cs" />
-    <Compile Include="SslStreamSystemDefaultsTest.cs" />
-    <Compile Include="SslStreamStreamToStreamTest.netcoreapp.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="LoggingTest.cs" />
-    <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs">
-      <Link>Common\System\Diagnostics\Tracing\TestEventListener.cs</Link>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' ">
-    <Compile Include="IdentityValidator.Windows.cs" />
-    <Compile Include="$(CommonTestPath)\System\Net\Capability.Security.Windows.cs">
-      <Link>Common\System\Net\Capability.Security.Windows.cs</Link>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
-    <Compile Include="IdentityValidator.Unix.cs" />
-    <Compile Include="$(CommonTestPath)\System\Net\Capability.Security.Unix.cs">
-      <Link>Common\System\Net\Capability.Security.Unix.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.IsNtlmInstalled.cs">
-      <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.IsNtlmInstalled.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
-      <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetsLinux)' == 'true' ">
-    <None Include="..\Scripts\Unix\setup-kdc.sh">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="..\Scripts\Unix\krb5.conf">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="..\Scripts\Unix\kdc.conf.ubuntu">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="..\Scripts\Unix\kdc.conf.centos">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="..\Scripts\Unix\kdc.conf.opensuse">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <Compile Include="NegotiateStreamTest.Linux.cs" />
-    <Compile Include="UnixGssFakeNegotiateStream.cs" />
-    <Compile Include="UnixGssFakeStreamFramer.cs" />
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.GssApiException.cs">
-      <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.GssApiException.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.GssBuffer.cs">
-      <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.GssBuffer.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\GssSafeHandles.cs">
-      <Link>Common\Microsoft\Win32\SafeHandles\GssSafeHandles.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.cs">
-      <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.cs</Link>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="System.Net.TestData" Version="$(SystemNetTestDataPackageVersion)" />
-  </ItemGroup>
+  <Choose>
+    <!-- Disable the whole workitem on Windows arm64 until https://github.com/dotnet/core-eng/issues/5118 is fixed. -->
+    <When Condition="'$(ArchGroup)' != 'arm64' or '$(TargetsWindows)' != 'true'">
+      <ItemGroup>
+        <Compile Include="NotifyReadVirtualNetworkStream.cs" />
+        <Compile Include="DummyTcpServer.cs" />
+        <Compile Include="TestConfiguration.cs" />
+        <!-- SslStream Tests -->
+        <Compile Include="CertificateValidationClientServer.cs" />
+        <Compile Include="CertificateValidationRemoteServer.cs" />
+        <Compile Include="ClientAsyncAuthenticateTest.cs" />
+        <Compile Include="ClientDefaultEncryptionTest.cs" />
+        <Compile Include="ParameterValidationTest.cs" />
+        <Compile Include="ServerAllowNoEncryptionTest.cs" />
+        <Compile Include="ServerAsyncAuthenticateTest.cs" />
+        <Compile Include="ServerNoEncryptionTest.cs" />
+        <Compile Include="ServerRequireEncryptionTest.cs" />
+        <Compile Include="SslStreamStreamToStreamTest.cs" />
+        <Compile Include="SslStreamNetworkStreamTest.cs" />
+        <Compile Include="TransportContextTest.cs" />
+        <!-- NegotiateStream Tests -->
+        <Compile Include="NegotiateStreamInvalidOperationTest.cs" />
+        <Compile Include="NegotiateStreamStreamToStreamTest.cs" />
+        <Compile Include="ServiceNameCollectionTest.cs" />
+        <Compile Include="NegotiateStreamKerberosTest.cs" />
+        <!-- Common test files -->
+        <Compile Include="$(CommonTestPath)\System\IO\DelegateStream.cs">
+          <Link>Common\System\IO\DelegateStream.cs</Link>
+        </Compile>
+        <Compile Include="$(CommonTestPath)\System\Net\Capability.Security.cs">
+          <Link>Common\System\Net\Capability.Security.cs</Link>
+        </Compile>
+        <Compile Include="$(CommonTestPath)\System\Net\SslStreamCertificatePolicy.cs">
+          <Link>Common\System\Net\SslStreamCertificatePolicy.cs</Link>
+        </Compile>
+        <Compile Include="$(CommonTestPath)\System\Net\Configuration.cs">
+          <Link>Common\System\Net\Configuration.cs</Link>
+        </Compile>
+        <Compile Include="$(CommonTestPath)\System\Net\Configuration.Security.cs">
+          <Link>Common\System\Net\Configuration.Security.cs</Link>
+        </Compile>
+        <Compile Include="$(CommonTestPath)\System\Net\Configuration.Certificates.cs">
+          <Link>Common\System\Net\Configuration.Certificates.cs</Link>
+        </Compile>
+        <Compile Include="$(CommonTestPath)\System\Net\Configuration.Http.cs">
+          <Link>Common\System\Net\Configuration.Http.cs</Link>
+        </Compile>
+        <Compile Include="$(CommonTestPath)\System\Net\HttpsTestClient.cs">
+          <Link>Common\System\Net\HttpsTestClient.cs</Link>
+        </Compile>
+        <Compile Include="$(CommonTestPath)\System\Net\HttpsTestServer.cs">
+          <Link>Common\System\Net\HttpsTestServer.cs</Link>
+        </Compile>
+        <Compile Include="$(CommonTestPath)\System\Net\SslProtocolSupport.cs">
+          <Link>Common\System\Net\SslProtocolSupport.cs</Link>
+        </Compile>
+        <Compile Include="$(CommonTestPath)\System\Net\TestLogging.cs">
+          <Link>Common\System\Net\TestLogging.cs</Link>
+        </Compile>
+        <Compile Include="$(CommonTestPath)\System\Net\VerboseTestLogging.cs">
+          <Link>Common\System\Net\VerboseTestLogging.cs</Link>
+        </Compile>
+        <Compile Include="$(CommonTestPath)\System\Net\EventSourceTestLogging.cs">
+          <Link>Common\System\Net\EventSourceTestLogging.cs</Link>
+        </Compile>
+        <Compile Include="$(CommonTestPath)\System\Net\VirtualNetwork\VirtualNetwork.cs">
+          <Link>Common\System\Net\VirtualNetwork\VirtualNetwork.cs</Link>
+        </Compile>
+        <Compile Include="$(CommonTestPath)\System\Net\VirtualNetwork\VirtualNetworkStream.cs">
+          <Link>Common\System\Net\VirtualNetwork\VirtualNetworkStream.cs</Link>
+        </Compile>
+        <Compile Include="$(CommonTestPath)\System\Threading\Tasks\TaskTimeoutExtensions.cs">
+          <Link>Common\System\Threading\Tasks\TaskTimeoutExtensions.cs</Link>
+        </Compile>
+        <Compile Include="$(CommonPath)\CoreLib\System\Threading\Tasks\TaskToApm.cs">
+          <Link>ProductionCode\Common\CoreLib\System\Threading\Tasks\TaskToApm.cs</Link>
+        </Compile>
+      </ItemGroup>
+      <ItemGroup Condition="'$(TargetsNetCoreApp)' == 'true'">
+        <Compile Include="..\..\src\System\Net\Security\SniHelper.cs">
+          <Link>src\SniHelper.cs</Link>
+        </Compile>
+        <Compile Include="SniHelperTest.cs" />
+        <Compile Include="SslAuthenticationOptionsTest.cs" />
+        <Compile Include="SslStreamAlertsTest.cs" />
+        <Compile Include="SslStreamAllowRenegotiationTests.cs" />
+        <Compile Include="SslStreamAlpnTests.cs" />
+        <Compile Include="SslStreamDisposeTest.cs" />
+        <Compile Include="SslStreamSniTest.cs" />
+        <Compile Include="SslStreamEKUTest.cs" />
+        <Compile Include="SslStreamNegotiatedCipherSuiteTest.cs" />
+        <Compile Include="SslStreamSchSendAuxRecordTest.cs" />
+        <Compile Include="SslStreamCredentialCacheTest.cs" />
+        <Compile Include="SslStreamSystemDefaultsTest.cs" />
+        <Compile Include="SslStreamStreamToStreamTest.netcoreapp.cs" />
+      </ItemGroup>
+      <ItemGroup>
+        <Compile Include="LoggingTest.cs" />
+        <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs">
+          <Link>Common\System\Diagnostics\Tracing\TestEventListener.cs</Link>
+        </Compile>
+      </ItemGroup>
+      <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
+        <Compile Include="IdentityValidator.Windows.cs" />
+        <Compile Include="$(CommonTestPath)\System\Net\Capability.Security.Windows.cs">
+          <Link>Common\System\Net\Capability.Security.Windows.cs</Link>
+        </Compile>
+      </ItemGroup>
+      <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
+        <Compile Include="IdentityValidator.Unix.cs" />
+        <Compile Include="$(CommonTestPath)\System\Net\Capability.Security.Unix.cs">
+          <Link>Common\System\Net\Capability.Security.Unix.cs</Link>
+        </Compile>
+        <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.IsNtlmInstalled.cs">
+          <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.IsNtlmInstalled.cs</Link>
+        </Compile>
+        <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+          <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
+        </Compile>
+      </ItemGroup>
+      <ItemGroup Condition="'$(TargetsLinux)' == 'true'">
+        <None Include="..\Scripts\Unix\setup-kdc.sh">
+          <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+        <None Include="..\Scripts\Unix\krb5.conf">
+          <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+        <None Include="..\Scripts\Unix\kdc.conf.ubuntu">
+          <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+        <None Include="..\Scripts\Unix\kdc.conf.centos">
+          <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+        <None Include="..\Scripts\Unix\kdc.conf.opensuse">
+          <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+        <Compile Include="NegotiateStreamTest.Linux.cs" />
+        <Compile Include="UnixGssFakeNegotiateStream.cs" />
+        <Compile Include="UnixGssFakeStreamFramer.cs" />
+        <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.GssApiException.cs">
+          <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.GssApiException.cs</Link>
+        </Compile>
+        <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.GssBuffer.cs">
+          <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.GssBuffer.cs</Link>
+        </Compile>
+        <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\GssSafeHandles.cs">
+          <Link>Common\Microsoft\Win32\SafeHandles\GssSafeHandles.cs</Link>
+        </Compile>
+        <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.cs">
+          <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.cs</Link>
+        </Compile>
+      </ItemGroup>
+      <ItemGroup>
+        <PackageReference Include="System.Net.TestData" Version="$(SystemNetTestDataPackageVersion)" />
+      </ItemGroup>
+    </When>
+  </Choose>
 </Project>


### PR DESCRIPTION
Disabling the `System.Net.Security.Tests` workitem on arm64 on Windows until the arm64 queue is updated: https://github.com/dotnet/core-eng/issues/5118. This is achieved by removing all sources from the test assembly.

cc @safern 