### PR TITLE
Remove a few initialization allocations from Cng

### DIFF
--- a/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/BasicSymmetricCipherNCrypt.cs
+++ b/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/BasicSymmetricCipherNCrypt.cs
@@ -120,16 +120,12 @@ namespace Internal.Cryptography
             }
         }
 
-        private static CngProperty CreateCngPropertyForCipherMode(string cipherMode)
-        {
-            byte[] cipherModeBytes = Encoding.Unicode.GetBytes((cipherMode + "\0").ToCharArray());
-            return new CngProperty(Interop.NCrypt.NCRYPT_CHAINING_MODE_PROPERTY, cipherModeBytes, CngPropertyOptions.None);
-        }
-
         private CngKey _cngKey;
         private readonly bool _encrypting;
 
-        private static readonly CngProperty s_ECBMode = CreateCngPropertyForCipherMode(Interop.BCrypt.BCRYPT_CHAIN_MODE_ECB);
-        private static readonly CngProperty s_CBCMode = CreateCngPropertyForCipherMode(Interop.BCrypt.BCRYPT_CHAIN_MODE_CBC);
+        private static readonly CngProperty s_ECBMode =
+            new CngProperty(Interop.NCrypt.NCRYPT_CHAINING_MODE_PROPERTY, Encoding.UTF8.GetBytes(Interop.BCrypt.BCRYPT_CHAIN_MODE_ECB + "\0"), CngPropertyOptions.None);
+        private static readonly CngProperty s_CBCMode =
+            new CngProperty(Interop.NCrypt.NCRYPT_CHAINING_MODE_PROPERTY, Encoding.UTF8.GetBytes(Interop.BCrypt.BCRYPT_CHAIN_MODE_CBC + "\0"), CngPropertyOptions.None);
     }
 }


### PR DESCRIPTION
Save four "startup" allocations in System.Security.Cryptography.Cng.

- Appending the '\0' is better done at the call site, because then the concat is done with two constants at compile time.
- There's no benefit to using ToCharArray instead of just passing in the string.
- Once we get rid of those, we can just inline the construction into the declarations.

cc: @bartonjs 