### PR TITLE
Add some DebuggerDisplay attributes in System.Linq

### DIFF
--- a/src/System.Linq/src/System/Linq/Partition.SpeedOpt.cs
+++ b/src/System.Linq/src/System/Linq/Partition.SpeedOpt.cs
@@ -17,6 +17,7 @@ namespace System.Linq
     /// Returning an instance of this type is useful to quickly handle scenarios where it is known
     /// that an operation will result in zero elements.
     /// </remarks>
+    [DebuggerDisplay("Count = 0")]
     internal sealed class EmptyPartition<TElement> : IPartition<TElement>, IEnumerator<TElement>
     {
         /// <summary>
@@ -150,6 +151,7 @@ namespace System.Linq
         /// An iterator that yields the items of part of an <see cref="IList{TSource}"/>.
         /// </summary>
         /// <typeparam name="TSource">The type of the source list.</typeparam>
+        [DebuggerDisplay("Count = {Count}")]
         private sealed class ListPartition<TSource> : Iterator<TSource>, IPartition<TSource>
         {
             private readonly IList<TSource> _source;

--- a/src/System.Linq/src/System/Linq/Range.cs
+++ b/src/System.Linq/src/System/Linq/Range.cs
@@ -28,6 +28,7 @@ namespace System.Linq
         /// <summary>
         /// An iterator that yields a range of consecutive integers.
         /// </summary>
+        [DebuggerDisplay("Count = {CountForDebugger}")]
         private sealed partial class RangeIterator : Iterator<int>
         {
             private readonly int _start;
@@ -39,6 +40,8 @@ namespace System.Linq
                 _start = start;
                 _end = unchecked(start + count);
             }
+
+            private int CountForDebugger => _end - _start;
 
             public override Iterator<int> Clone() => new RangeIterator(_start, _end - _start);
 

--- a/src/System.Linq/src/System/Linq/Repeat.cs
+++ b/src/System.Linq/src/System/Linq/Repeat.cs
@@ -28,6 +28,7 @@ namespace System.Linq
         /// An iterator that yields the same item multiple times.
         /// </summary>
         /// <typeparam name="TResult">The type of the item.</typeparam>
+        [DebuggerDisplay("Count = {_count}")]
         private sealed partial class RepeatIterator<TResult> : Iterator<TResult>
         {
             private readonly int _count;

--- a/src/System.Linq/src/System/Linq/Select.SpeedOpt.cs
+++ b/src/System.Linq/src/System/Linq/Select.SpeedOpt.cs
@@ -683,6 +683,7 @@ namespace System.Linq
         /// </summary>
         /// <typeparam name="TSource">The type of the source list.</typeparam>
         /// <typeparam name="TResult">The type of the mapped items.</typeparam>
+        [DebuggerDisplay("Count = {Count}")]
         private sealed class SelectListPartitionIterator<TSource, TResult> : Iterator<TResult>, IPartition<TResult>
         {
             private readonly IList<TSource> _source;

--- a/src/System.Linq/src/System/Linq/Select.cs
+++ b/src/System.Linq/src/System/Linq/Select.cs
@@ -156,6 +156,7 @@ namespace System.Linq
         /// </summary>
         /// <typeparam name="TSource">The type of the source array.</typeparam>
         /// <typeparam name="TResult">The type of the mapped items.</typeparam>
+        [DebuggerDisplay("Count = {CountForDebugger}")]
         private sealed partial class SelectArrayIterator<TSource, TResult> : Iterator<TResult>
         {
             private readonly TSource[] _source;
@@ -169,6 +170,8 @@ namespace System.Linq
                 _source = source;
                 _selector = selector;
             }
+
+            private int CountForDebugger => _source.Length;
 
             public override Iterator<TResult> Clone() => new SelectArrayIterator<TSource, TResult>(_source, _selector);
 
@@ -194,6 +197,7 @@ namespace System.Linq
         /// </summary>
         /// <typeparam name="TSource">The type of the source list.</typeparam>
         /// <typeparam name="TResult">The type of the mapped items.</typeparam>
+        [DebuggerDisplay("Count = {CountForDebugger}")]
         private sealed partial class SelectListIterator<TSource, TResult> : Iterator<TResult>
         {
             private readonly List<TSource> _source;
@@ -207,6 +211,8 @@ namespace System.Linq
                 _source = source;
                 _selector = selector;
             }
+
+            private int CountForDebugger => _source.Count;
 
             public override Iterator<TResult> Clone() => new SelectListIterator<TSource, TResult>(_source, _selector);
 
@@ -241,6 +247,7 @@ namespace System.Linq
         /// </summary>
         /// <typeparam name="TSource">The type of the source list.</typeparam>
         /// <typeparam name="TResult">The type of the mapped items.</typeparam>
+        [DebuggerDisplay("Count = {CountForDebugger}")]
         private sealed partial class SelectIListIterator<TSource, TResult> : Iterator<TResult>
         {
             private readonly IList<TSource> _source;
@@ -254,6 +261,8 @@ namespace System.Linq
                 _source = source;
                 _selector = selector;
             }
+
+            private int CountForDebugger => _source.Count;
 
             public override Iterator<TResult> Clone() => new SelectIListIterator<TSource, TResult>(_source, _selector);
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/22520

e.g.
before:
![image](https://user-images.githubusercontent.com/2642209/65766318-a36f4380-e0f8-11e9-978c-f47f2c42139d.png)

after:
![image](https://user-images.githubusercontent.com/2642209/65766268-820e5780-e0f8-11e9-8856-9bdedad93d7f.png)
