### PR TITLE
Test demonstrating that on disposing HttpClient affects outgoing stream

### DIFF
--- a/src/Common/tests/System/Net/Http/GenericLoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/GenericLoopbackServer.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -52,6 +53,8 @@ namespace System.Net.Test.Common
 
     public abstract class GenericLoopbackConnection : IDisposable
     {
+        public abstract Stream Stream { get; }
+
         public abstract void Dispose();
 
         /// <summary>Read request Headers and optionally request body as well.</summary>

--- a/src/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -29,6 +29,8 @@ namespace System.Net.Test.Common
         public string PrefixString => Encoding.UTF8.GetString(_prefix, 0, _prefix.Length);
         public bool IsInvalid => _connectionSocket == null;
 
+        public override Stream Stream => _connectionStream;
+
         public Http2LoopbackConnection(Socket socket, Http2Options httpOptions)
         {
             _connectionSocket = socket;

--- a/src/Common/tests/System/Net/Http/LoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/LoopbackServer.cs
@@ -417,7 +417,7 @@ namespace System.Net.Test.Common
             }
 
             public Socket Socket => _socket;
-            public Stream Stream => _stream;
+            public override Stream Stream => _stream;
             public StreamWriter Writer => _writer;
 
             public async Task<int> ReadAsync(Memory<byte> buffer, int offset, int size)

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Finalization.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Finalization.cs
@@ -87,7 +87,6 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public async Task ClientNotDisposed_ClientSendsSecondRequest_ClientHangs()
         {
-            Diagnostics.Debugger.Launch();
             using (HttpClient client = new HttpClient())
             {
                 var requestRead = new AutoResetEvent(false);


### PR DESCRIPTION
This PR demonstrates a unexpected behavior of HttpClient which I ran into while working on #15460 . I'm not sure if these are real bugs in HttpClient behavior or just nuances of our test framework (meaning, no prod scenarios affected), so, as we discussed previously, I created this PR which reliably reproduces issues found to get feedback from all the corefx contributors and decide if there any bugs to be fixed or not.

**Important.** All investigations were done **only for HTTP 1.1** by running 2 tests: SocketsHttpHandler_HttpClientHandler_Finalization_Http11_Test.ClientNotDisposed_ServerReadsFromStream_ServerHangs and SocketsHttpHandler_HttpClientHandler_Finalization_Http11_Test.ClientNotDisposed_ClientSendsSecondRequest_ClientHangs

Specifically, the issues I found are:

1. Disposing HttpClient affects the pooled connection the last request was made on. It's demonstrated in the test ClientNotDisposed_ServerReadsFromStream_ServerHangs where the server waits to read a next byte from the stream and this operation gets cancelled when HttpClient gets disposed, not when the read operation timeout is reached. I would expect that HttpClient always return a connection to the pool after an HTTP request completes, so disposing it should not affect the connection in any way.

2. Making a second request to the LoopbackServer on the same HttpClient hangs indefinitely despite the fact I closed the first response stream. It's demonstrated in the test ClientNotDisposed_ClientSendsSecondRequest_ClientHangs. If I understand this correctly, when I make the second GetStreamAsync call a connection should be retrieved from the pool regardless of whether or not the first one is closed, and the request should be sent to the server again, however the second request never reaches the server.