### PR TITLE
Add CentOS 8 runtime ids

### DIFF
--- a/pkg/Microsoft.NETCore.Platforms/runtime.compatibility.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.compatibility.json
@@ -319,6 +319,32 @@
     "any",
     "base"
   ],
+  "centos.8": [
+    "centos.8",
+    "centos",
+    "rhel.8",
+    "rhel",
+    "linux",
+    "unix",
+    "any",
+    "base"
+  ],
+  "centos.8-x64": [
+    "centos.8-x64",
+    "centos.8",
+    "centos-x64",
+    "rhel.8-x64",
+    "centos",
+    "rhel.8",
+    "rhel-x64",
+    "rhel",
+    "linux-x64",
+    "linux",
+    "unix-x64",
+    "unix",
+    "any",
+    "base"
+  ],
   "debian": [
     "debian",
     "linux",

--- a/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -148,6 +148,19 @@
         "rhel.7-x64"
       ]
     },
+    "centos.8": {
+      "#import": [
+        "centos",
+        "rhel.8"
+      ]
+    },
+    "centos.8-x64": {
+      "#import": [
+        "centos.8",
+        "centos-x64",
+        "rhel.8-x64"
+      ]
+    },
     "debian": {
       "#import": [
         "linux"

--- a/pkg/Microsoft.NETCore.Platforms/runtimeGroups.props
+++ b/pkg/Microsoft.NETCore.Platforms/runtimeGroups.props
@@ -28,8 +28,9 @@
     <RuntimeGroup Include="centos">
       <Parent>rhel</Parent>
       <Architectures>x64</Architectures>
-      <Versions>7</Versions>
+      <Versions>7;8</Versions>
       <ApplyVersionsToParent>true</ApplyVersionsToParent>
+      <TreatVersionsAsCompatible>false</TreatVersionsAsCompatible>
     </RuntimeGroup>
 
     <RuntimeGroup Include="debian">


### PR DESCRIPTION
CentOS 8 has been released:
https://wiki.centos.org/Manuals/ReleaseNotes/CentOSLinux8

    $ cat /etc/os-release
    NAME="CentOS Linux"
    VERSION="8 (Core)"
    ID="centos"
    ID_LIKE="rhel fedora"
    VERSION_ID="8"
    PLATFORM_ID="platform:el8"
    PRETTY_NAME="CentOS Linux 8 (Core)"
    ANSI_COLOR="0;31"
    CPE_NAME="cpe:/o:centos:centos:8"
    HOME_URL="https://www.centos.org/"
    BUG_REPORT_URL="https://bugs.centos.org/"
    CENTOS_MANTISBT_PROJECT="CentOS-8"
    CENTOS_MANTISBT_PROJECT_VERSION="8"
    REDHAT_SUPPORT_PRODUCT="centos"
    REDHAT_SUPPORT_PRODUCT_VERSION="8"