### PR TITLE
Address misc feedback and issues from recent perf changes

### DIFF
--- a/src/System.Text.Json/src/Resources/Strings.resx
+++ b/src/System.Text.Json/src/Resources/Strings.resx
@@ -297,9 +297,6 @@
   <data name="ZeroDepthAtEnd" xml:space="preserve">
     <value>Expected depth to be zero at the end of the JSON payload. There is an open JSON object or array that should be closed.</value>
   </data>
-  <data name="DeserializeDataRemaining" xml:space="preserve">
-    <value>The provided data of length {0} has remaining bytes {1}.</value>
-  </data>
   <data name="DeserializeUnableToConvertValue" xml:space="preserve">
     <value>The JSON value could not be converted to {0}.</value>
   </data>

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
@@ -438,9 +438,15 @@ namespace System.Text.Json
                 key = MemoryMarshal.Read<ulong>(propertyName);
 
                 // Max out the length byte.
-                // The comparison logic tests for equality against the full contents instead of just
-                // the key if the property name length is >7.
+                // This will cause the comparison logic to always test for equality against the full contents
+                // when the first 7 bytes are the same.
                 key |= 0xFF00000000000000;
+
+                // It is also possible to include the length up to 0xFF in order to prevent false positives
+                // when the first 7 bytes match but a different length (up to 0xFF). However the extra logic
+                // slows key generation in the majority of cases:
+                // key &= 0x00FFFFFFFFFFFFFF;
+                // key |= (ulong) 7 << Math.Max(length, 0xFF);
             }
             else if (length > 3)
             {
@@ -448,25 +454,25 @@ namespace System.Text.Json
 
                 if (length == 7)
                 {
-                    key |= (ulong) propertyName[6] << (6 * BitsInByte)
-                        | (ulong) propertyName[5] << (5 * BitsInByte)
-                        | (ulong) propertyName[4] << (4 * BitsInByte)
-                        | (ulong) 7 << (7 * BitsInByte);
+                    key |= (ulong)propertyName[6] << (6 * BitsInByte)
+                        | (ulong)propertyName[5] << (5 * BitsInByte)
+                        | (ulong)propertyName[4] << (4 * BitsInByte)
+                        | (ulong)7 << (7 * BitsInByte);
                 }
                 else if (length == 6)
                 {
-                    key |= (ulong) propertyName[5] << (5 * BitsInByte)
-                        | (ulong) propertyName[4] << (4 * BitsInByte)
-                        | (ulong) 6 << (7 * BitsInByte);
+                    key |= (ulong)propertyName[5] << (5 * BitsInByte)
+                        | (ulong)propertyName[4] << (4 * BitsInByte)
+                        | (ulong)6 << (7 * BitsInByte);
                 }
                 else if (length == 5)
                 {
-                    key |= (ulong) propertyName[4] << (4 * BitsInByte)
-                        | (ulong) 5 << (7 * BitsInByte);
+                    key |= (ulong)propertyName[4] << (4 * BitsInByte)
+                        | (ulong)5 << (7 * BitsInByte);
                 }
                 else
                 {
-                    key |= (ulong) 4 << (7 * BitsInByte);
+                    key |= (ulong)4 << (7 * BitsInByte);
                 }
             }
             else if (length > 1)
@@ -475,18 +481,18 @@ namespace System.Text.Json
 
                 if (length == 3)
                 {
-                    key |= (ulong) propertyName[2] << (2 * BitsInByte)
-                        | (ulong) 3 << (7 * BitsInByte);
+                    key |= (ulong)propertyName[2] << (2 * BitsInByte)
+                        | (ulong)3 << (7 * BitsInByte);
                 }
                 else
                 {
-                    key |= (ulong) 2 << (7 * BitsInByte);
+                    key |= (ulong)2 << (7 * BitsInByte);
                 }
             }
             else if (length == 1)
             {
                 key = propertyName[0]
-                    | (ulong) 1 << (7 * BitsInByte);
+                    | (ulong)1 << (7 * BitsInByte);
             }
             else
             {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
@@ -353,7 +353,8 @@ namespace System.Text.Json
             Debug.Assert(ShouldDeserialize);
 
             JsonPropertyInfo propertyInfo;
-            if (ElementClassInfo != null && (propertyInfo = ElementClassInfo.PolicyProperty) != null)
+            JsonClassInfo elementClassInfo = ElementClassInfo;
+            if (elementClassInfo != null && (propertyInfo = elementClassInfo.PolicyProperty) != null)
             {
                 // Forward the setter to the value-based JsonPropertyInfo.
                 propertyInfo.ReadEnumerable(tokenType, ref state, ref reader);

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
@@ -54,7 +54,7 @@ namespace System.Text.Json
 
             state.Current.CollectionPropertyInitialized = true;
 
-            // We should not be processing custom converters here.
+            // We should not be processing custom converters here (converters are of ClassType.Value).
             Debug.Assert(state.Current.JsonClassInfo.ClassType != ClassType.Value);
 
             // Set or replace the existing enumerable value.

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleDictionary.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleDictionary.cs
@@ -31,11 +31,13 @@ namespace System.Text.Json
                 state.Current.CollectionPropertyInitialized = true;
 
                 ClassType classType = state.Current.JsonClassInfo.ClassType;
-                if (classType == ClassType.Value &&
-                    jsonPropertyInfo.ElementClassInfo.Type != typeof(object) &&
-                    jsonPropertyInfo.ElementClassInfo.Type != typeof(JsonElement))
+                if (classType == ClassType.Value)
                 {
-                    ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(state.Current.JsonClassInfo.Type);
+                    Type elementClassInfoType = jsonPropertyInfo.ElementClassInfo.Type;
+                    if (elementClassInfoType != typeof(object) && elementClassInfoType != typeof(JsonElement))
+                    {
+                        ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(state.Current.JsonClassInfo.Type);
+                    }
                 }
 
                 JsonClassInfo classInfo = state.Current.JsonClassInfo;

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -26,10 +26,11 @@ namespace System.Text.Json
             Debug.Assert(state.Current.ReturnValue != default || state.Current.TempDictionaryValues != default);
             Debug.Assert(state.Current.JsonClassInfo != default);
 
-            if (state.Current.IsProcessingDictionaryOrIDictionaryConstructible() &&
+            bool isProcessingDictObject = state.Current.IsProcessingDictionaryOrIDictionaryConstructibleObject();
+            if ((isProcessingDictObject || state.Current.IsProcessingDictionaryOrIDictionaryConstructibleProperty()) &&
                 state.Current.JsonClassInfo.DataExtensionProperty != state.Current.JsonPropertyInfo)
             {
-                if (state.Current.IsProcessingObject(ClassType.Dictionary | ClassType.IDictionaryConstructible))
+                if (isProcessingDictObject)
                 {
                     state.Current.JsonPropertyInfo = state.Current.JsonClassInfo.PolicyProperty;
                 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Span.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Span.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+
 namespace System.Text.Json
 {
     public static partial class JsonSerializer
@@ -56,10 +58,8 @@ namespace System.Text.Json
             var reader = new Utf8JsonReader(utf8Json, isFinalBlock: true, readerState);
             object result = ReadCore(returnType, options, ref reader);
 
-            if (reader.BytesConsumed != utf8Json.Length)
-            {
-                ThrowHelper.ThrowJsonException_DeserializeDataRemaining(utf8Json.Length, utf8Json.Length - reader.BytesConsumed);
-            }
+            // The reader should have thrown if we have remaining bytes.
+            Debug.Assert(reader.BytesConsumed == utf8Json.Length);
 
             return result;
         }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
@@ -194,10 +194,8 @@ namespace System.Text.Json
                 ArrayPool<byte>.Shared.Return(buffer);
             }
 
-            if (bytesInBuffer != 0)
-            {
-                ThrowHelper.ThrowJsonException_DeserializeDataRemaining(totalBytesRead, bytesInBuffer);
-            }
+            // The reader should have thrown if we have remaining bytes.
+            Debug.Assert(bytesInBuffer == 0);
 
             return (TValue)readStack.Current.ReturnValue;
         }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs
@@ -75,7 +75,8 @@ namespace System.Text.Json
             Span<byte> utf8 = json.Length <= (ArrayPoolMaxSizeBeforeUsingNormalAlloc / JsonConstants.MaxExpansionFactorWhileTranscoding) ?
                 // Use a pooled alloc.
                 tempArray = ArrayPool<byte>.Shared.Rent(json.Length * JsonConstants.MaxExpansionFactorWhileTranscoding) :
-                // Use normal alloc since the pool would create a normal alloc anyway (per current implementation).
+                // Use a normal alloc since the pool would create a normal alloc anyway based on the threshold (per current implementation)
+                // and by using a normal alloc we can avoid the Clear().
                 new byte[JsonReaderHelper.GetUtf8ByteCount(json.AsSpan())];
 
             try

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Utf8JsonReader.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Utf8JsonReader.cs
@@ -303,10 +303,8 @@ namespace System.Text.Json
 
                 ReadCore(options, ref newReader, ref readStack);
 
-                if (newReader.BytesConsumed != length)
-                {
-                    ThrowHelper.ThrowJsonException_DeserializeDataRemaining(length, length - newReader.BytesConsumed);
-                }
+                // The reader should have thrown if we have remaining bytes.
+                Debug.Assert(newReader.BytesConsumed == length);
             }
             catch (JsonException)
             {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleObject.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleObject.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Text.Json.Serialization;
 
 namespace System.Text.Json
 {
@@ -28,7 +29,6 @@ namespace System.Text.Json
                 }
 
                 state.Current.WriteObjectOrArrayStart(ClassType.Object, writer, options);
-                state.Current.PropertyEnumeratorActive = true;
                 state.Current.MoveToNextProperty = true;
             }
 
@@ -38,7 +38,7 @@ namespace System.Text.Json
             }
 
             // Determine if we are done enumerating properties.
-            if (state.Current.PropertyEnumeratorActive)
+            if (state.Current.ExtensionDataStatus != ExtensionDataWriteStatus.Finished)
             {
                 // If ClassType.Unknown at this point, we are typeof(object) which should not have any properties.
                 Debug.Assert(state.Current.JsonClassInfo.ClassType != ClassType.Unknown);
@@ -58,10 +58,6 @@ namespace System.Text.Json
             if (state.Current.PopStackOnEndObject)
             {
                 state.Pop();
-            }
-            else
-            {
-                state.Current.EndObject();
             }
 
             return true;

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
@@ -88,6 +88,22 @@ namespace System.Text.Json
         }
 
         /// <summary>
+        /// Is the current object a Dictionary or IDictionaryConstructible.
+        /// </summary>
+        public bool IsProcessingDictionaryOrIDictionaryConstructibleObject()
+        {
+            return IsProcessingObject(ClassType.Dictionary | ClassType.IDictionaryConstructible);
+        }
+
+        /// <summary>
+        /// Is the current property a Dictionary or IDictionaryConstructible.
+        /// </summary>
+        public bool IsProcessingDictionaryOrIDictionaryConstructibleProperty()
+        {
+            return IsProcessingProperty(ClassType.Dictionary | ClassType.IDictionaryConstructible);
+        }
+
+        /// <summary>
         /// Is the current object or property a Dictionary or IDictionaryConstructible.
         /// </summary>
         public bool IsProcessingDictionaryOrIDictionaryConstructible()

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
@@ -221,9 +221,10 @@ namespace System.Text.Json
             if (jsonPropertyInfo.EnumerableConverter != null)
             {
                 IList converterList;
-                if (jsonPropertyInfo.ElementClassInfo.ClassType == ClassType.Value)
+                JsonClassInfo elementClassInfo = jsonPropertyInfo.ElementClassInfo;
+                if (elementClassInfo.ClassType == ClassType.Value)
                 {
-                    converterList = jsonPropertyInfo.ElementClassInfo.PolicyProperty.CreateConverterList();
+                    converterList = elementClassInfo.PolicyProperty.CreateConverterList();
                 }
                 else
                 {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/WriteStackFrame.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/WriteStackFrame.cs
@@ -140,10 +140,12 @@ namespace System.Text.Json
         {
             EndProperty();
 
-            int len = JsonClassInfo.PropertyCacheArray.Length;
-            if (++PropertyEnumeratorIndex >= len)
+            int maxPropertyIndex = JsonClassInfo.PropertyCacheArray.Length;
+
+            ++PropertyEnumeratorIndex;
+            if (PropertyEnumeratorIndex >= maxPropertyIndex)
             {
-                if (PropertyEnumeratorIndex > len)
+                if (PropertyEnumeratorIndex > maxPropertyIndex)
                 {
                     ExtensionDataStatus = ExtensionDataWriteStatus.Finished;
                 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/WriteStackFrame.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/WriteStackFrame.cs
@@ -31,7 +31,6 @@ namespace System.Text.Json
         public bool MoveToNextProperty;
 
         // The current property.
-        public bool PropertyEnumeratorActive;
         public int PropertyEnumeratorIndex;
         public ExtensionDataWriteStatus ExtensionDataStatus;
         public JsonPropertyInfo JsonPropertyInfo;
@@ -102,20 +101,15 @@ namespace System.Text.Json
         public void Reset()
         {
             CurrentValue = null;
-            EndObject();
-        }
-
-        public void EndObject()
-        {
             CollectionEnumerator = null;
             ExtensionDataStatus = ExtensionDataWriteStatus.NotStarted;
             IsIDictionaryConstructible = false;
             JsonClassInfo = null;
             PropertyEnumeratorIndex = 0;
-            PropertyEnumeratorActive = false;
             PopStackOnEndCollection = false;
             PopStackOnEndObject = false;
             StartObjectWritten = false;
+
             EndProperty();
         }
 
@@ -146,27 +140,17 @@ namespace System.Text.Json
         {
             EndProperty();
 
-            if (PropertyEnumeratorActive)
+            int len = JsonClassInfo.PropertyCacheArray.Length;
+            if (++PropertyEnumeratorIndex >= len)
             {
-                int len = JsonClassInfo.PropertyCacheArray.Length;
-                if (PropertyEnumeratorIndex < len)
+                if (PropertyEnumeratorIndex > len)
                 {
-                    if ((PropertyEnumeratorIndex == len - 1) && JsonClassInfo.DataExtensionProperty != null)
-                    {
-                        ExtensionDataStatus = ExtensionDataWriteStatus.Writing;
-                    }
-
-                    PropertyEnumeratorIndex++;
-                    PropertyEnumeratorActive = true;
+                    ExtensionDataStatus = ExtensionDataWriteStatus.Finished;
                 }
-                else
+                else if (JsonClassInfo.DataExtensionProperty != null)
                 {
-                    PropertyEnumeratorActive = false;
+                    ExtensionDataStatus = ExtensionDataWriteStatus.Writing;
                 }
-            }
-            else
-            {
-                ExtensionDataStatus = ExtensionDataWriteStatus.Finished;
             }
         }
     }

--- a/src/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -131,11 +131,6 @@ namespace System.Text.Json
             throw new InvalidOperationException(SR.Format(SR.SerializerDictionaryKeyNull, policyType));
         }
 
-        public static void ThrowJsonException_DeserializeDataRemaining(long length, long bytesRemaining)
-        {
-            throw new JsonException(SR.Format(SR.DeserializeDataRemaining, length, bytesRemaining), path: null, lineNumber: null, bytePositionInLine: null);
-        }
-
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ReThrowWithPath(in ReadStack readStack, JsonReaderException ex)
         {
@@ -179,7 +174,6 @@ namespace System.Text.Json
 
             string message = ex.Message;
 
-            // If the message is empty or contains EmbedPathInfoFlag then append the Path, LineNumber and BytePositionInLine.
             if (string.IsNullOrEmpty(message))
             {
                 // Use a default message.
@@ -213,10 +207,10 @@ namespace System.Text.Json
             string path = writeStack.PropertyPath();
             ex.Path = path;
 
-            // If the message is empty, use a default message with the Path.
             string message = ex.Message;
             if (string.IsNullOrEmpty(message))
             {
+                // Use a default message.
                 message = SR.Format(SR.SerializeUnableToSerialize);
                 ex.AppendPathInformation = true;
             }

--- a/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using Xunit;

--- a/src/System.Text.Json/tests/Serialization/ReadValueTests.cs
+++ b/src/System.Text.Json/tests/Serialization/ReadValueTests.cs
@@ -3,8 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Buffers;
-using System.DirectoryServices.Protocols;
 using System.IO;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace System.Text.Json.Serialization.Tests
@@ -511,7 +511,7 @@ namespace System.Text.Json.Serialization.Tests
             // Using a reader directly doesn't throw.
             Utf8JsonReader reader = new Utf8JsonReader(jsonBytes);
             JsonSerializer.Deserialize<int>(ref reader);
-            Assert.NotEqual(jsonBytes.Length, reader.BytesConsumed);
+            Assert.Equal(1, reader.BytesConsumed);
         }
 
         [Theory]
@@ -527,7 +527,7 @@ namespace System.Text.Json.Serialization.Tests
             // Using a reader directly doesn't throw.
             Utf8JsonReader reader = new Utf8JsonReader(jsonBytes);
             JsonSerializer.Deserialize<int>(ref reader);
-            Assert.NotEqual(jsonBytes.Length, reader.BytesConsumed);
+            Assert.Equal(1, reader.BytesConsumed);
 
             // Use JsonCommentHandling.Skip
 
@@ -540,7 +540,7 @@ namespace System.Text.Json.Serialization.Tests
             // Using a reader directly doesn't throw.
             reader = new Utf8JsonReader(jsonBytes);
             JsonSerializer.Deserialize<int>(ref reader, options);
-            Assert.NotEqual(jsonBytes.Length, reader.BytesConsumed);
+            Assert.Equal(1, reader.BytesConsumed);
         }
 
         [Theory]

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
@@ -365,29 +365,18 @@ namespace System.Text.Json.Serialization.Tests
             }
         }
 
-        // NOTE: LongInputString test is constrained to run on Windows and MacOSX because it causes
-        //       problems on Linux due to the way deferred memory allocation works. On Linux, the allocation can
-        //       succeed even if there is not enough memory but then the test may get killed by the OOM killer at the
-        //       time the memory is accessed which triggers the full memory allocation.
-        internal const int BufferSizeDefault = 16 * 1024; // options.DefaultBufferSize
+        private const long ArrayPoolMaxSizeBeforeUsingNormalAlloc = 1024 * 1024;
         private const int MaxExpansionFactorWhileTranscoding = 3;
-        internal const int MaxInt = int.MaxValue / MaxExpansionFactorWhileTranscoding;
-        [ConditionalTheory(nameof(IsX64))]
-        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX)]
-        [InlineData(BufferSizeDefault + 3)]
-        [InlineData(BufferSizeDefault - 3)]
-        [InlineData(BufferSizeDefault - 2)]
-        [InlineData(BufferSizeDefault - 1)]
-        [InlineData(BufferSizeDefault)]
-        [InlineData(BufferSizeDefault + 1)]
-        [InlineData(BufferSizeDefault + 2)]
-        [InlineData(MaxInt - 3)]
-        [InlineData(MaxInt - 2)]
-        [InlineData(MaxInt - 1)]
-        [InlineData(MaxInt)]
-        [InlineData(MaxInt + 1)]
-        [InlineData(MaxInt + 2)]
-        [OuterLoop]
+        private const long Theshold = ArrayPoolMaxSizeBeforeUsingNormalAlloc / MaxExpansionFactorWhileTranscoding;
+
+        [Theory]
+        [InlineData(Theshold - 3)]
+        [InlineData(Theshold - 2)]
+        [InlineData(Theshold - 1)]
+        [InlineData(Theshold)]
+        [InlineData(Theshold + 1)]
+        [InlineData(Theshold + 2)]
+        [InlineData(Theshold + 3)]
         public static void LongInputString(int length)
         {
             // Verify boundary conditions in Deserialize() that inspect the size to determine allocation strategy.

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
@@ -369,17 +369,24 @@ namespace System.Text.Json.Serialization.Tests
         //       problems on Linux due to the way deferred memory allocation works. On Linux, the allocation can
         //       succeed even if there is not enough memory but then the test may get killed by the OOM killer at the
         //       time the memory is accessed which triggers the full memory allocation.
+        internal const int BufferSizeDefault = 16 * 1024; // options.DefaultBufferSize
         private const int MaxExpansionFactorWhileTranscoding = 3;
-        private const int MaxArrayLengthBeforeCalculatingSize = int.MaxValue / 2 / MaxExpansionFactorWhileTranscoding;
-        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX)]
+        internal const int MaxInt = int.MaxValue / MaxExpansionFactorWhileTranscoding;
         [ConditionalTheory(nameof(IsX64))]
-        [InlineData(MaxArrayLengthBeforeCalculatingSize - 3)]
-        [InlineData(MaxArrayLengthBeforeCalculatingSize - 2)]
-        [InlineData(MaxArrayLengthBeforeCalculatingSize - 1)]
-        [InlineData(MaxArrayLengthBeforeCalculatingSize)]
-        [InlineData(MaxArrayLengthBeforeCalculatingSize + 1)]
-        [InlineData(MaxArrayLengthBeforeCalculatingSize + 2)]
-        [InlineData(MaxArrayLengthBeforeCalculatingSize + 3)]
+        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX)]
+        [InlineData(BufferSizeDefault + 3)]
+        [InlineData(BufferSizeDefault - 3)]
+        [InlineData(BufferSizeDefault - 2)]
+        [InlineData(BufferSizeDefault - 1)]
+        [InlineData(BufferSizeDefault)]
+        [InlineData(BufferSizeDefault + 1)]
+        [InlineData(BufferSizeDefault + 2)]
+        [InlineData(MaxInt - 3)]
+        [InlineData(MaxInt - 2)]
+        [InlineData(MaxInt - 1)]
+        [InlineData(MaxInt)]
+        [InlineData(MaxInt + 1)]
+        [InlineData(MaxInt + 2)]
         [OuterLoop]
         public static void LongInputString(int length)
         {

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
@@ -367,16 +367,16 @@ namespace System.Text.Json.Serialization.Tests
 
         private const long ArrayPoolMaxSizeBeforeUsingNormalAlloc = 1024 * 1024;
         private const int MaxExpansionFactorWhileTranscoding = 3;
-        private const long Theshold = ArrayPoolMaxSizeBeforeUsingNormalAlloc / MaxExpansionFactorWhileTranscoding;
+        private const long Threshold = ArrayPoolMaxSizeBeforeUsingNormalAlloc / MaxExpansionFactorWhileTranscoding;
 
         [Theory]
-        [InlineData(Theshold - 3)]
-        [InlineData(Theshold - 2)]
-        [InlineData(Theshold - 1)]
-        [InlineData(Theshold)]
-        [InlineData(Theshold + 1)]
-        [InlineData(Theshold + 2)]
-        [InlineData(Theshold + 3)]
+        [InlineData(Threshold - 3)]
+        [InlineData(Threshold - 2)]
+        [InlineData(Threshold - 1)]
+        [InlineData(Threshold)]
+        [InlineData(Threshold + 1)]
+        [InlineData(Threshold + 2)]
+        [InlineData(Threshold + 3)]
         public static void LongInputString(int length)
         {
             // Verify boundary conditions in Deserialize() that inspect the size to determine allocation strategy.


### PR DESCRIPTION
Address late feedback from previous perf PR #41098 and other misc perf-related deserialization changes.

Results in deserialization perf increase of ~1% - ~2% for simple object.