### PR TITLE
Make ResolveEventArgs.Name not nullable

### DIFF
--- a/src/Common/src/CoreLib/System/ResolveEventArgs.cs
+++ b/src/Common/src/CoreLib/System/ResolveEventArgs.cs
@@ -8,18 +8,18 @@ namespace System
 {
     public class ResolveEventArgs : EventArgs
     {
-        public ResolveEventArgs(string? name)
+        public ResolveEventArgs(string name)
         {
             Name = name;
         }
 
-        public ResolveEventArgs(string? name, Assembly? requestingAssembly)
+        public ResolveEventArgs(string name, Assembly? requestingAssembly)
         {
             Name = name;
             RequestingAssembly = requestingAssembly;
         }
 
-        public string? Name { get; }
+        public string Name { get; }
         public Assembly? RequestingAssembly { get; }
     }
 }

--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -2074,9 +2074,9 @@ namespace System
     }
     public partial class ResolveEventArgs : System.EventArgs
     {
-        public ResolveEventArgs(string? name) { }
-        public ResolveEventArgs(string? name, System.Reflection.Assembly? requestingAssembly) { }
-        public string? Name { get { throw null; } }
+        public ResolveEventArgs(string name) { }
+        public ResolveEventArgs(string name, System.Reflection.Assembly? requestingAssembly) { }
+        public string Name { get { throw null; } }
         public System.Reflection.Assembly? RequestingAssembly { get { throw null; } }
     }
     public ref partial struct RuntimeArgumentHandle


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/41404

cc: @jnm2 @stephentoub @jkotas 