### PR TITLE
Set IsShipping only for experimental and IsShippingPackages only for private packages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -393,6 +393,9 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <IsShipping Condition="$(MSBuildProjectName.Contains('Private')) or $(MSBuildProjectName.Contains('Experimental'))">false</IsShipping>
+    <!-- When IsShipping property is set, other IsShipping* properties take its value if they are not set.
+    This is why IsShippingPackage is only set for Private packages, as Experimental are covered with IsShipping -->
+    <IsShipping Condition="$(MSBuildProjectName.Contains('Experimental'))">false</IsShipping>
+    <IsShippingPackage Condition="$(MSBuildProjectName.Contains('Private')) and '$(MSBuildProjectExtension)' == '.pkgproj'">false</IsShippingPackage>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
### Description
Fixes: https://github.com/dotnet/corefx/issues/41315

.NET Core App product assemblies that contain `Private` in their name, like `System.Private.Xml` contain wrong `AssemblyInformationalVersion` in its metadata.

### Customer Impact:

For people that read that to know what release the assembly is coming from, it would lead to the wrong release because it would always include a prerelease suffix on the version (depending on the build date). This also affected the display in http://bing.com/version

### Regression? 

Yes, infrastructure regression when adopting `IsShipping` and `NonShipping` conventions from arcade to adopt stages.

### Risk

Low, it just changes metadata information.

### Tests run / added

Manual testing:
![image](https://user-images.githubusercontent.com/22899328/65660774-9c571100-dfe4-11e9-9a79-62beea3de501.png)

![image](https://user-images.githubusercontent.com/22899328/65660801-ada01d80-dfe4-11e9-9431-4de9654c03bf.png)

![image](https://user-images.githubusercontent.com/22899328/65660810-b85ab280-dfe4-11e9-8c2c-fc1551d1bf88.png)

![image](https://user-images.githubusercontent.com/22899328/65660838-ca3c5580-dfe4-11e9-857d-ed46bfe60a46.png)

cc: @danmosemsft 
