### PR TITLE
Prevent ImplicitTransform of index getter method

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
@@ -710,7 +710,7 @@ namespace System.Diagnostics
                 foreach (PropertyInfo property in curTypeInfo.DeclaredProperties)
                 {
                     // prevent TransformSpec from attempting to implicitly transform index properties
-                    if (property.GetMethod.GetParameters().Length > 0)
+                    if (property.GetMethod == null || property.GetMethod!.GetParameters().Length > 0)
                         continue;
                     newSerializableArgs = new TransformSpec(property.Name, 0, property.Name.Length, newSerializableArgs);
                 }

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
@@ -709,6 +709,9 @@ namespace System.Diagnostics
                 TypeInfo curTypeInfo = type.GetTypeInfo();
                 foreach (PropertyInfo property in curTypeInfo.DeclaredProperties)
                 {
+                    // prevent TransformSpec from attempting to implicitly transform index properties
+                    if (property.GetGetMethod().GetParameters().Length > 0)
+                        continue;
                     newSerializableArgs = new TransformSpec(property.Name, 0, property.Name.Length, newSerializableArgs);
                 }
                 return Reverse(newSerializableArgs);

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
@@ -710,7 +710,7 @@ namespace System.Diagnostics
                 foreach (PropertyInfo property in curTypeInfo.DeclaredProperties)
                 {
                     // prevent TransformSpec from attempting to implicitly transform index properties
-                    if (property.GetGetMethod().GetParameters().Length > 0)
+                    if (property.GetMethod.GetParameters().Length > 0)
                         continue;
                     newSerializableArgs = new TransformSpec(property.Name, 0, property.Name.Length, newSerializableArgs);
                 }

--- a/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceEventSourceBridgeTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceEventSourceBridgeTests.cs
@@ -734,6 +734,35 @@ namespace System.Diagnostics.Tests
                 }
             }).Dispose();
         }
+
+        [Fact]
+        public void IndexGetters_DontThrow()
+        {
+            RemoteExecutor.Invoke(() =>
+            {
+                using (var eventListener = new TestDiagnosticSourceEventListener())
+                using (var diagnosticListener = new DiagnosticListener("MySource"))
+                {
+                    eventListener.Enable(
+                        "MySource/MyEvent"
+                    );
+                    diagnosticListener.Write(
+                        "MyEvent",
+                        new MyEvent
+                        {
+                            Number = 1,
+                            OtherNumber = 2
+                        }
+                    );
+                    Assert.Equal(1, eventListener.EventCount);
+                    Assert.Equal("MySource", eventListener.LastEvent.SourceName);
+                    Assert.Equal("MyEvent", eventListener.LastEvent.EventName);
+                    Assert.True(2 <= eventListener.LastEvent.Arguments.Count);
+                    Assert.Equal("1", eventListener.LastEvent.Arguments["Number"]);
+                    Assert.Equal("2", eventListener.LastEvent.Arguments["OtherNumber"]);
+                }
+            }).Dispose();
+        }
     }
 
     /****************************************************************************/
@@ -755,6 +784,22 @@ namespace System.Diagnostics.Tests
     {
         public int X { get; set; }
         public int Y { get; set; }
+    }
+
+    /// <summary>
+    /// classes for test data
+    /// </summary>
+    internal class MyEvent
+    {
+        public int Number { get; set; }
+        public int OtherNumber { get; set; }
+        public int Count => 2;
+        public KeyValuePair<string, object> this[int index] => index switch
+        {
+            0 => new KeyValuePair<string, object>(nameof(Number), Number),
+            1 => new KeyValuePair<string, object>(nameof(OtherNumber), OtherNumber),
+            _ => throw new IndexOutOfRangeException()
+        };
     }
 
     /****************************************************************************/

--- a/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceEventSourceBridgeTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceEventSourceBridgeTests.cs
@@ -746,6 +746,13 @@ namespace System.Diagnostics.Tests
                     eventListener.Enable(
                         "MySource/MyEvent"
                     );
+                    // The type MyEvent only declares 3 Properties, but actually
+                    // has 4 due to the implicit Item property from having the index
+                    // operator implemented. The Getter for this Item property
+                    // is unusual for Property getters because it takes
+                    // an int32 as an input. This test ensures that this
+                    // implicit Property isn't implicitly serialized by
+                    // DiagnosticSourceEventSource.
                     diagnosticListener.Write(
                         "MyEvent",
                         new MyEvent
@@ -757,9 +764,10 @@ namespace System.Diagnostics.Tests
                     Assert.Equal(1, eventListener.EventCount);
                     Assert.Equal("MySource", eventListener.LastEvent.SourceName);
                     Assert.Equal("MyEvent", eventListener.LastEvent.EventName);
-                    Assert.True(2 <= eventListener.LastEvent.Arguments.Count);
+                    Assert.True(eventListener.LastEvent.Arguments.Count <= 3);
                     Assert.Equal("1", eventListener.LastEvent.Arguments["Number"]);
                     Assert.Equal("2", eventListener.LastEvent.Arguments["OtherNumber"]);
+                    Assert.Equal("2", eventListener.LastEvent.Arguments["Count"]);
                 }
             }).Dispose();
         }

--- a/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceTests.cs
@@ -685,33 +685,6 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        
-        [Fact]
-        public void IndexGetters_DontThrow()
-        {
-            using (var eventListener = new TestDiagnosticSourceEventListener())
-            using (var diagnosticListener = new DiagnosticListener("MySource"))
-            {
-                eventListener.Enable(
-                    "MySource/MyEvent"
-                );
-                diagnosticListener.Write(
-                    "MyEvent",
-                    new MyEvent
-                    {
-                        Number = 1,
-                        OtherNumber = 2
-                    }
-                );
-                Assert.Equal(1, eventListener.EventCount);
-                Assert.Equal("MySource", eventListener.LastEvent.SourceName);
-                Assert.Equal("MyEvent", eventListener.LastEvent.EventName);
-                Assert.True(2 <= eventListener.LastEvent.Arguments.Count);
-                Assert.Equal("1", eventListener.LastEvent.Arguments["Number"]);
-                Assert.Equal("2", eventListener.LastEvent.Arguments["OtherNumber"]);
-            }
-        }
-
         #region Helpers
         /// <summary>
         /// Returns the list of active diagnostic listeners.
@@ -811,21 +784,5 @@ namespace System.Diagnostics.Tests
     {
         public string Name { get; set; }
         public int Id { get; set; }
-    }
-
-    /// <summary>
-    /// classes for test data
-    /// </summary>
-    internal class MyEvent
-    {
-        public int Number { get; set; }
-        public int OtherNumber { get; set; }
-        public int Count => 2;
-        public KeyValuePair<string, object> this[int index] => index switch
-        {
-            0 => new KeyValuePair<string, object>(nameof(Number), Number),
-            1 => new KeyValuePair<string, object>(nameof(OtherNumber), OtherNumber),
-            _ => throw new IndexOutOfRangeException()
-        };
     }
 }

--- a/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceTests.cs
@@ -685,6 +685,33 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        
+        [Fact]
+        public void IndexGetters_DontThrow()
+        {
+            using (var eventListener = new TestDiagnosticSourceEventListener())
+            using (var diagnosticListener = new DiagnosticListener("MySource"))
+            {
+                eventListener.Enable(
+                    "MySource/MyEvent"
+                );
+                diagnosticListener.Write(
+                    "MyEvent",
+                    new MyEvent
+                    {
+                        Number = 1,
+                        OtherNumber = 2
+                    }
+                );
+                Assert.Equal(1, eventListener.EventCount);
+                Assert.Equal("MySource", eventListener.LastEvent.SourceName);
+                Assert.Equal("MyEvent", eventListener.LastEvent.EventName);
+                Assert.True(2 <= eventListener.LastEvent.Arguments.Count);
+                Assert.Equal("1", eventListener.LastEvent.Arguments["Number"]);
+                Assert.Equal("2", eventListener.LastEvent.Arguments["OtherNumber"]);
+            }
+        }
+
         #region Helpers
         /// <summary>
         /// Returns the list of active diagnostic listeners.
@@ -784,5 +811,21 @@ namespace System.Diagnostics.Tests
     {
         public string Name { get; set; }
         public int Id { get; set; }
+    }
+
+    /// <summary>
+    /// classes for test data
+    /// </summary>
+    internal class MyEvent
+    {
+        public int Number { get; set; }
+        public int OtherNumber { get; set; }
+        public int Count => 2;
+        public KeyValuePair<string, object> this[int index] => index switch
+        {
+            0 => new KeyValuePair<string, object>(nameof(Number), Number),
+            1 => new KeyValuePair<string, object>(nameof(OtherNumber), OtherNumber),
+            _ => throw new IndexOutOfRangeException()
+        };
     }
 }


### PR DESCRIPTION
partially resolves dotnet/coreclr#26890

<details>
    <summary>small repro (click to expand)</summary>

---
Attach `dotnet trace` to this app and turn on the `Microsoft-Diagnostics-DiagnosticSource` provider.

```csharp
    class Program
    {
        static void Main(string[] args)
        {
            Console.WriteLine($"PID: {System.Diagnostics.Process.GetCurrentProcess().Id}");
            var diagnosticListener = new DiagnosticListener("MySource");
            while (true)
            {
                Console.Write(">");
                var input = Console.ReadLine();
                if (input == "exit")
                    break;

                diagnosticListener.Write("MyEvent", new List<int> { 1, 2, 3 });
            }
        }
    }
```
---
</details>

### Root Cause of Exception:
The getter for the implicit `Item` property for the index operator takes an argument, and `DiagnosticSourceEventSource` makes the assumption that property getters don't take arguments.  It tries to bind the resulting delegate of type `[retval] get_Item(int32 index)` to the type `Func<TObject, TProperty>` so the binding fails and we get the exception you see in dotnet/coreclr#26890.

offending code:
https://github.com/dotnet/corefx/blob/ac99a1b7168bd32046a954c3f06012c0fa909bed/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs#L890-L901

This change should prevent `DiagnosticSourceEventSource` from attempting to serialize the implicit `Item` property by blocking index getters.

I am intending for this change to be back ported to 3.1 and hopefully 3.0, since ASP.NET Core has used `DiagnosticSourceEventSource` for their eventing.  Since they changed their event types to inherit from `IReadOnlyCollection`, they will all hit the exception in dotnet/coreclr#26890 causing a bad diagnostic experience if you do not explicitly specify a transform.