### PR TITLE
Find zip file end of central directory backwards up to max possible size (resubmit due to build break)

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -63,7 +63,7 @@
     <NewtonsoftJsonPackageVersion>12.0.1</NewtonsoftJsonPackageVersion>
     <MicrosoftDotNetPlatformAbstractionsPackageVersion>3.0.0-preview6-27804-01</MicrosoftDotNetPlatformAbstractionsPackageVersion>
     <!-- Test data -->
-    <SystemIOCompressionTestDataPackageVersion>1.0.14</SystemIOCompressionTestDataPackageVersion>
+    <SystemIOCompressionTestDataPackageVersion>1.0.15</SystemIOCompressionTestDataPackageVersion>
     <SystemIOPackagingTestDataPackageVersion>1.0.4</SystemIOPackagingTestDataPackageVersion>
     <SystemSecurityCryptographyX509CertificatesTestDataPackageVersion>1.0.7</SystemSecurityCryptographyX509CertificatesTestDataPackageVersion>
     <SystemNetTestDataPackageVersion>1.0.6</SystemNetTestDataPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -63,7 +63,7 @@
     <NewtonsoftJsonPackageVersion>12.0.1</NewtonsoftJsonPackageVersion>
     <MicrosoftDotNetPlatformAbstractionsPackageVersion>3.0.0-preview6-27804-01</MicrosoftDotNetPlatformAbstractionsPackageVersion>
     <!-- Test data -->
-    <SystemIOCompressionTestDataPackageVersion>1.0.15</SystemIOCompressionTestDataPackageVersion>
+    <SystemIOCompressionTestDataPackageVersion>1.0.16</SystemIOCompressionTestDataPackageVersion>
     <SystemIOPackagingTestDataPackageVersion>1.0.4</SystemIOPackagingTestDataPackageVersion>
     <SystemSecurityCryptographyX509CertificatesTestDataPackageVersion>1.0.7</SystemSecurityCryptographyX509CertificatesTestDataPackageVersion>
     <SystemNetTestDataPackageVersion>1.0.6</SystemNetTestDataPackageVersion>

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
@@ -525,9 +525,15 @@ namespace System.IO.Compression
         {
             try
             {
-                // this seeks to the start of the end of central directory record
+                // This seeks backwards almost to the beginning of the EOCD, one byte after where the signature would be
+                // located if the EOCD had the minimum possible size (no file zip comment)
                 _archiveStream.Seek(-ZipEndOfCentralDirectoryBlock.SizeOfBlockWithoutSignature, SeekOrigin.End);
-                if (!ZipHelper.SeekBackwardsToSignature(_archiveStream, ZipEndOfCentralDirectoryBlock.SignatureConstant))
+
+                // If the EOCD has the minimum possible size (no zip file comment), then exactly the previous 4 bytes will contain the signature
+                // But if the EOCD has max possible size, the signature should be found somewhere in the previous 64K + 4 bytes
+                if (!ZipHelper.SeekBackwardsToSignature(_archiveStream,
+                        ZipEndOfCentralDirectoryBlock.SignatureConstant,
+                        ZipEndOfCentralDirectoryBlock.ZipFileCommentMaxLength + ZipEndOfCentralDirectoryBlock.SignatureSize))
                     throw new InvalidDataException(SR.EOCDNotFound);
 
                 long eocdStart = _archiveStream.Position;
@@ -543,56 +549,17 @@ namespace System.IO.Compression
 
                 _numberOfThisDisk = eocd.NumberOfThisDisk;
                 _centralDirectoryStart = eocd.OffsetOfStartOfCentralDirectoryWithRespectToTheStartingDiskNumber;
+
                 if (eocd.NumberOfEntriesInTheCentralDirectory != eocd.NumberOfEntriesInTheCentralDirectoryOnThisDisk)
                     throw new InvalidDataException(SR.SplitSpanned);
+
                 _expectedNumberOfEntries = eocd.NumberOfEntriesInTheCentralDirectory;
 
                 // only bother saving the comment if we are in update mode
                 if (_mode == ZipArchiveMode.Update)
                     _archiveComment = eocd.ArchiveComment;
 
-                // only bother looking for zip64 EOCD stuff if we suspect it is needed because some value is FFFFFFFFF
-                // because these are the only two values we need, we only worry about these
-                // if we don't find the zip64 EOCD, we just give up and try to use the original values
-                if (eocd.NumberOfThisDisk == ZipHelper.Mask16Bit ||
-                    eocd.OffsetOfStartOfCentralDirectoryWithRespectToTheStartingDiskNumber == ZipHelper.Mask32Bit ||
-                    eocd.NumberOfEntriesInTheCentralDirectory == ZipHelper.Mask16Bit)
-                {
-                    // we need to look for zip 64 EOCD stuff
-                    // seek to the zip 64 EOCD locator
-                    _archiveStream.Seek(eocdStart - Zip64EndOfCentralDirectoryLocator.SizeOfBlockWithoutSignature, SeekOrigin.Begin);
-                    // if we don't find it, assume it doesn't exist and use data from normal eocd
-                    if (ZipHelper.SeekBackwardsToSignature(_archiveStream, Zip64EndOfCentralDirectoryLocator.SignatureConstant))
-                    {
-                        // use locator to get to Zip64EOCD
-                        Zip64EndOfCentralDirectoryLocator locator;
-                        bool zip64eocdLocatorProper = Zip64EndOfCentralDirectoryLocator.TryReadBlock(_archiveReader, out locator);
-                        Debug.Assert(zip64eocdLocatorProper); // we just found this using the signature finder, so it should be okay
-
-                        if (locator.OffsetOfZip64EOCD > long.MaxValue)
-                            throw new InvalidDataException(SR.FieldTooBigOffsetToZip64EOCD);
-                        long zip64EOCDOffset = (long)locator.OffsetOfZip64EOCD;
-
-                        _archiveStream.Seek(zip64EOCDOffset, SeekOrigin.Begin);
-
-                        // read Zip64EOCD
-                        Zip64EndOfCentralDirectoryRecord record;
-                        if (!Zip64EndOfCentralDirectoryRecord.TryReadBlock(_archiveReader, out record))
-                            throw new InvalidDataException(SR.Zip64EOCDNotWhereExpected);
-
-                        _numberOfThisDisk = record.NumberOfThisDisk;
-
-                        if (record.NumberOfEntriesTotal > long.MaxValue)
-                            throw new InvalidDataException(SR.FieldTooBigNumEntries);
-                        if (record.OffsetOfCentralDirectory > long.MaxValue)
-                            throw new InvalidDataException(SR.FieldTooBigOffsetToCD);
-                        if (record.NumberOfEntriesTotal != record.NumberOfEntriesOnThisDisk)
-                            throw new InvalidDataException(SR.SplitSpanned);
-
-                        _expectedNumberOfEntries = (long)record.NumberOfEntriesTotal;
-                        _centralDirectoryStart = (long)record.OffsetOfCentralDirectory;
-                    }
-                }
+                TryReadZip64EndOfCentralDirectory(eocd, eocdStart);
 
                 if (_centralDirectoryStart > _archiveStream.Length)
                 {
@@ -606,6 +573,63 @@ namespace System.IO.Compression
             catch (IOException ex)
             {
                 throw new InvalidDataException(SR.CDCorrupt, ex);
+            }
+        }
+
+        // Tries to find the Zip64 End of Central Directory Locator, then the Zip64 End of Central Directory, assuming the
+        // End of Central Directory block has already been found, as well as the location in the stream where the EOCD starts.
+        private void TryReadZip64EndOfCentralDirectory(ZipEndOfCentralDirectoryBlock eocd, long eocdStart)
+        {
+            // Only bother looking for the Zip64-EOCD stuff if we suspect it is needed because some value is FFFFFFFFF
+            // because these are the only two values we need, we only worry about these
+            // if we don't find the Zip64-EOCD, we just give up and try to use the original values
+            if (eocd.NumberOfThisDisk == ZipHelper.Mask16Bit ||
+                eocd.OffsetOfStartOfCentralDirectoryWithRespectToTheStartingDiskNumber == ZipHelper.Mask32Bit ||
+                eocd.NumberOfEntriesInTheCentralDirectory == ZipHelper.Mask16Bit)
+            {
+                // Read Zip64 End of Central Directory Locator
+
+                // This seeks forwards almost to the beginning of the Zip64-EOCDL, one byte after where the signature would be located
+                _archiveStream.Seek(eocdStart - Zip64EndOfCentralDirectoryLocator.SizeOfBlockWithoutSignature, SeekOrigin.Begin);
+
+                // Exactly the previous 4 bytes should contain the Zip64-EOCDL signature
+                // if we don't find it, assume it doesn't exist and use data from normal EOCD
+                if (ZipHelper.SeekBackwardsToSignature(_archiveStream,
+                        Zip64EndOfCentralDirectoryLocator.SignatureConstant,
+                        Zip64EndOfCentralDirectoryLocator.SignatureSize))
+                {
+                    // use locator to get to Zip64-EOCD
+                    Zip64EndOfCentralDirectoryLocator locator;
+                    bool zip64eocdLocatorProper = Zip64EndOfCentralDirectoryLocator.TryReadBlock(_archiveReader, out locator);
+                    Debug.Assert(zip64eocdLocatorProper); // we just found this using the signature finder, so it should be okay
+
+                    if (locator.OffsetOfZip64EOCD > long.MaxValue)
+                        throw new InvalidDataException(SR.FieldTooBigOffsetToZip64EOCD);
+
+                    long zip64EOCDOffset = (long)locator.OffsetOfZip64EOCD;
+
+                    _archiveStream.Seek(zip64EOCDOffset, SeekOrigin.Begin);
+
+                    // Read Zip64 End of Central Directory Record
+
+                    Zip64EndOfCentralDirectoryRecord record;
+                    if (!Zip64EndOfCentralDirectoryRecord.TryReadBlock(_archiveReader, out record))
+                        throw new InvalidDataException(SR.Zip64EOCDNotWhereExpected);
+
+                    _numberOfThisDisk = record.NumberOfThisDisk;
+
+                    if (record.NumberOfEntriesTotal > long.MaxValue)
+                        throw new InvalidDataException(SR.FieldTooBigNumEntries);
+
+                    if (record.OffsetOfCentralDirectory > long.MaxValue)
+                        throw new InvalidDataException(SR.FieldTooBigOffsetToCD);
+
+                    if (record.NumberOfEntriesTotal != record.NumberOfEntriesOnThisDisk)
+                        throw new InvalidDataException(SR.SplitSpanned);
+
+                    _expectedNumberOfEntries = (long)record.NumberOfEntriesTotal;
+                    _centralDirectoryStart = (long)record.OffsetOfCentralDirectory;
+                }
             }
         }
 

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
@@ -598,6 +598,8 @@ namespace System.IO.Compression
                         Zip64EndOfCentralDirectoryLocator.SignatureConstant,
                         Zip64EndOfCentralDirectoryLocator.SignatureSize))
                 {
+                    Debug.Assert(_archiveReader != null);
+
                     // use locator to get to Zip64-EOCD
                     Zip64EndOfCentralDirectoryLocator locator;
                     bool zip64eocdLocatorProper = Zip64EndOfCentralDirectoryLocator.TryReadBlock(_archiveReader, out locator);

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
@@ -651,7 +651,9 @@ namespace System.IO.Compression
         public const int SizeOfBlockWithoutSignature = 18;
 
         // The end of central directory can have a variable size zip file comment at the end, but its max length can be 64K
-        public const int ZipFileCommentMaxLength = 65536;
+        // The Zip File Format Specification does not explicitly mention a max size for this field, but we are assuming this
+        // max size because that is the maximum value an ushort can hold.
+        public const int ZipFileCommentMaxLength = ushort.MaxValue;
 
         public uint Signature;
         public ushort NumberOfThisDisk;

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
@@ -289,6 +289,8 @@ namespace System.IO.Compression
     internal struct Zip64EndOfCentralDirectoryLocator
     {
         public const uint SignatureConstant = 0x07064B50;
+        public const int SignatureSize = sizeof(uint);
+
         public const int SizeOfBlockWithoutSignature = 16;
 
         public uint NumberOfDiskWithZip64EOCD;
@@ -643,7 +645,14 @@ namespace System.IO.Compression
     internal struct ZipEndOfCentralDirectoryBlock
     {
         public const uint SignatureConstant = 0x06054B50;
+        public const int SignatureSize = sizeof(uint);
+
+        // This is the minimum possible size, assuming the zip file comments variable section is empty
         public const int SizeOfBlockWithoutSignature = 18;
+
+        // The end of central directory can have a variable size zip file comment at the end, but its max length can be 64K
+        public const int ZipFileCommentMaxLength = 65536;
+
         public uint Signature;
         public ushort NumberOfThisDisk;
         public ushort NumberOfTheDiskWithTheStartOfTheCentralDirectory;

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
@@ -684,7 +684,7 @@ namespace System.IO.Compression
             writer.Write(startOfCentralDirectoryTruncated);
 
             // Should be valid because of how we read archiveComment in TryReadBlock:
-            Debug.Assert((archiveComment == null) || (archiveComment.Length < ushort.MaxValue));
+            Debug.Assert((archiveComment == null) || (archiveComment.Length <= ZipFileCommentMaxLength));
 
             writer.Write(archiveComment != null ? (ushort)archiveComment.Length : (ushort)0); // zip file comment length
             if (archiveComment != null)

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipHelper.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipHelper.cs
@@ -102,11 +102,15 @@ namespace System.IO.Compression
             return (uint)ret;
         }
 
-        // assumes all bytes of signatureToFind are non zero, looks backwards from current position in stream,
+        // Assumes all bytes of signatureToFind are non zero, looks backwards from current position in stream,
+        // assumes maxBytesToRead is positive, ensures to not read beyond the provided max number of bytes,
         // if the signature is found then returns true and positions stream at first byte of signature
         // if the signature is not found, returns false
-        internal static bool SeekBackwardsToSignature(Stream stream, uint signatureToFind)
+        internal static bool SeekBackwardsToSignature(Stream stream, uint signatureToFind, int maxBytesToRead)
         {
+            Debug.Assert(signatureToFind != 0);
+            Debug.Assert(maxBytesToRead > 0);
+
             int bufferPointer = 0;
             uint currentSignature = 0;
             byte[] buffer = new byte[BackwardsSeekingBufferSize];
@@ -114,7 +118,8 @@ namespace System.IO.Compression
             bool outOfBytes = false;
             bool signatureFound = false;
 
-            while (!signatureFound && !outOfBytes)
+            int bytesRead = 0;
+            while (!signatureFound && !outOfBytes && bytesRead <= maxBytesToRead)
             {
                 outOfBytes = SeekBackwardsAndRead(stream, buffer, out bufferPointer);
 
@@ -132,6 +137,8 @@ namespace System.IO.Compression
                         bufferPointer--;
                     }
                 }
+
+                bytesRead += buffer.Length;
             }
 
             if (!signatureFound)

--- a/src/System.IO.Compression/tests/ZipArchive/zip_ReadTests.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_ReadTests.cs
@@ -20,6 +20,67 @@ namespace System.IO.Compression.Tests
         //}
 
         [Theory]
+        [InlineData("NewZip.exe", "NewZip")]
+        //[InlineData("levels.zip", "levelszip")]
+        //[InlineData("levels32KBytes.zip", "levels32KByteszip")]
+        //[InlineData("levels65KChars.zip", "levels65KCharszip")]
+        //[InlineData("levels65535.zip", "levels65535zip")]
+        //[InlineData("large.cab", "largecab")]
+        //[InlineData("large.zip", "largezip")]
+        public static void Test(string zipFile, string zipFolder)
+        {
+            string zipFilePath = @"C:\Users\calope\Desktop\" + zipFile;
+            string destinationDirectoryPath = @"C:\Users\calope\Desktop\" + zipFolder;
+
+            if (!Directory.Exists(destinationDirectoryPath))
+            {
+                Console.WriteLine($"Destination directory does not exist. Creating: {destinationDirectoryPath}");
+                Directory.CreateDirectory(destinationDirectoryPath);
+            }
+            else
+            {
+                Console.WriteLine($"Destination directory exists. Deleting it...");
+                Directory.Delete(destinationDirectoryPath, recursive: true);
+            }
+
+            Console.WriteLine($"Opening zip file: {zipFile}");
+            using (FileStream fs = new FileStream(zipFilePath, FileMode.Open, FileAccess.Read))
+            {
+                using (ZipArchive archive = new ZipArchive(fs, ZipArchiveMode.Read))
+                {
+                    Console.WriteLine($"Zip file opened!");
+                    foreach (var entry in archive.Entries)
+                    {
+                        string destinationPath = Path.Join(destinationDirectoryPath, entry.FullName);
+                        Console.WriteLine($"  Entry: {destinationPath}");
+                        if (destinationPath.EndsWith("/") || destinationPath.EndsWith(@"\"))
+                        {
+                            Console.WriteLine($"    It is a directory!");
+                            if (!Directory.Exists(destinationPath))
+                            {
+                                Console.WriteLine($"      Directory does not exist. Creating...");
+                                Directory.CreateDirectory(destinationPath);
+                            }
+                        }
+                        else
+                        {
+                            Console.WriteLine($"    It is a file!");
+                            if (!File.Exists(destinationPath))
+                            {
+                                Console.WriteLine($"      Extracting file...");
+                                entry.ExtractToFile(destinationPath);
+                            }
+                            else
+                            {
+                                Console.WriteLine($"      File already exists. skipping it.");
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        [Theory]
         [InlineData("normal.zip", "normal")]
         [InlineData("fake64.zip", "small")]
         [InlineData("empty.zip", "empty")]

--- a/src/System.IO.Compression/tests/ZipArchive/zip_ReadTests.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_ReadTests.cs
@@ -9,6 +9,22 @@ namespace System.IO.Compression.Tests
 {
     public class zip_ReadTests : ZipFileTestBase
     {
+        //[Fact]
+        //public static void ReadHugeFileWithoutEOCD()
+        //{
+        //    Diagnostics.Stopwatch sw = new Diagnostics.Stopwatch();
+
+        //    sw.Start();
+
+        //    Assert.Throws<InvalidDataException>(() =>
+        //    {
+        //        using FileStream fs = File.OpenRead(@"large.cab"); // 549 MB
+        //        using ZipArchive z = new ZipArchive(fs, ZipArchiveMode.Read);
+        //    });
+
+        //    Console.WriteLine($"Elapsed time (s): {sw.Elapsed.TotalSeconds}"); // 0.0104 seconds
+        //}
+
         [Theory]
         [InlineData("normal.zip", "normal")]
         [InlineData("fake64.zip", "small")]

--- a/src/System.IO.Compression/tests/ZipArchive/zip_ReadTests.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_ReadTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
-using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -148,7 +146,6 @@ namespace System.IO.Compression.Tests
                 ArraysEqual<byte>(e1readnormal, e1selfInterleaved2, e1readnormal.Length);
             }
         }
-
         [Fact]
         public static async Task ReadModeInvalidOpsTest()
         {

--- a/src/System.IO.Compression/tests/ZipArchive/zip_ReadTests.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_ReadTests.cs
@@ -12,17 +12,11 @@ namespace System.IO.Compression.Tests
         //[Fact]
         //public static void ReadHugeFileWithoutEOCD()
         //{
-        //    Diagnostics.Stopwatch sw = new Diagnostics.Stopwatch();
-
-        //    sw.Start();
-
         //    Assert.Throws<InvalidDataException>(() =>
         //    {
         //        using FileStream fs = File.OpenRead(@"large.cab"); // 549 MB
         //        using ZipArchive z = new ZipArchive(fs, ZipArchiveMode.Read);
         //    });
-
-        //    Console.WriteLine($"Elapsed time (s): {sw.Elapsed.TotalSeconds}"); // 0.0104 seconds
         //}
 
         [Theory]

--- a/src/System.IO.Compression/tests/ZipArchive/zip_ReadTests.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_ReadTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -9,77 +11,6 @@ namespace System.IO.Compression.Tests
 {
     public class zip_ReadTests : ZipFileTestBase
     {
-        //[Fact]
-        //public static void ReadHugeFileWithoutEOCD()
-        //{
-        //    Assert.Throws<InvalidDataException>(() =>
-        //    {
-        //        using FileStream fs = File.OpenRead(@"large.cab"); // 549 MB
-        //        using ZipArchive z = new ZipArchive(fs, ZipArchiveMode.Read);
-        //    });
-        //}
-
-        [Theory]
-        [InlineData("NewZip.exe", "NewZip")]
-        //[InlineData("levels.zip", "levelszip")]
-        //[InlineData("levels32KBytes.zip", "levels32KByteszip")]
-        //[InlineData("levels65KChars.zip", "levels65KCharszip")]
-        //[InlineData("levels65535.zip", "levels65535zip")]
-        //[InlineData("large.cab", "largecab")]
-        //[InlineData("large.zip", "largezip")]
-        public static void Test(string zipFile, string zipFolder)
-        {
-            string zipFilePath = @"C:\Users\calope\Desktop\" + zipFile;
-            string destinationDirectoryPath = @"C:\Users\calope\Desktop\" + zipFolder;
-
-            if (!Directory.Exists(destinationDirectoryPath))
-            {
-                Console.WriteLine($"Destination directory does not exist. Creating: {destinationDirectoryPath}");
-                Directory.CreateDirectory(destinationDirectoryPath);
-            }
-            else
-            {
-                Console.WriteLine($"Destination directory exists. Deleting it...");
-                Directory.Delete(destinationDirectoryPath, recursive: true);
-            }
-
-            Console.WriteLine($"Opening zip file: {zipFile}");
-            using (FileStream fs = new FileStream(zipFilePath, FileMode.Open, FileAccess.Read))
-            {
-                using (ZipArchive archive = new ZipArchive(fs, ZipArchiveMode.Read))
-                {
-                    Console.WriteLine($"Zip file opened!");
-                    foreach (var entry in archive.Entries)
-                    {
-                        string destinationPath = Path.Join(destinationDirectoryPath, entry.FullName);
-                        Console.WriteLine($"  Entry: {destinationPath}");
-                        if (destinationPath.EndsWith("/") || destinationPath.EndsWith(@"\"))
-                        {
-                            Console.WriteLine($"    It is a directory!");
-                            if (!Directory.Exists(destinationPath))
-                            {
-                                Console.WriteLine($"      Directory does not exist. Creating...");
-                                Directory.CreateDirectory(destinationPath);
-                            }
-                        }
-                        else
-                        {
-                            Console.WriteLine($"    It is a file!");
-                            if (!File.Exists(destinationPath))
-                            {
-                                Console.WriteLine($"      Extracting file...");
-                                entry.ExtractToFile(destinationPath);
-                            }
-                            else
-                            {
-                                Console.WriteLine($"      File already exists. skipping it.");
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
         [Theory]
         [InlineData("normal.zip", "normal")]
         [InlineData("fake64.zip", "small")]
@@ -217,6 +148,7 @@ namespace System.IO.Compression.Tests
                 ArraysEqual<byte>(e1readnormal, e1selfInterleaved2, e1readnormal.Length);
             }
         }
+
         [Fact]
         public static async Task ReadModeInvalidOpsTest()
         {


### PR DESCRIPTION
Original PR https://github.com/dotnet/corefx/pull/41007
There was a conflict with a recent Compression change that added nullable checks. The CI passed in my PR, but it ran before the nullable fix was merged.

