### PR TITLE
Unit tests to verify DirectoryInfo.Parent.ToString (CoreFX/Framework)

### DIFF
--- a/src/System.IO.FileSystem/tests/DirectoryInfo/ToString.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/ToString.cs
@@ -45,5 +45,34 @@ namespace System.IO.Tests
             var info = new DirectoryInfo(path);
             Assert.Equal(path, info.ToString());
         }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsFullFramework))]
+        public void ParentToString_Framework()
+        {
+            ParentToString(false);
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNetCore))]
+        public void ParentToString_Core()
+        {
+            ParentToString(true);
+        }
+
+        private void ParentToString(bool compareFullName)
+        {
+            string filePath = GetTestFilePath();
+
+            string dirPath = Path.GetDirectoryName(filePath);
+            DirectoryInfo dirInfo = new DirectoryInfo(dirPath);
+
+            string parentDirPath = Path.GetDirectoryName(dirPath);
+            DirectoryInfo parentDirInfo = new DirectoryInfo(parentDirPath);
+
+            string dirInfoParentString = compareFullName ? dirInfo.Parent.FullName : dirInfo.Parent.Name;
+            string parentDirInfoString = compareFullName ? parentDirInfo.FullName : parentDirInfo.Name;
+
+            Assert.Equal(dirInfo.Parent.ToString(), dirInfoParentString);
+            Assert.Equal(dirInfo.Parent.ToString(), parentDirInfoString);
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/38215
The `DirectoryInfo.Parent.ToString()` method returns a different value in Core and in Framework. I already documented it in Docs, now we need to make sure it has unit tests.