### PR TITLE
[release/3.0] Stop using vfork with musl libc and credentials

### DIFF
--- a/src/Native/Unix/System.Native/pal_process.c
+++ b/src/Native/Unix/System.Native/pal_process.c
@@ -343,7 +343,6 @@ int32_t SystemNative_ForkAndExecProcess(const char* filename,
     if ((processId = vfork()) == 0) // processId == 0 if this is child process
 #else
     // musl libc has an undocumented failure mode around setuid(); we must exclude it.
-    // Don't pack this expression down. setjmp rules apply. See K&R C 2.0 Appendix B.8
     if (setCredentials)
     {
         processId = fork();


### PR DESCRIPTION
Edited by @stephentoub...

Fixes #41432.  Works around an issue in musl libc.

## Description

In .NET Core 3.0 we changed Process.Start on Unix to use `vfork` rather than `fork`, as a perf optimization (in particularly around memory usage).  However, there's an issue when running on musl libc (e.g. on Alpine) where the call to `vfork` ends up hanging when also setting process credentials.

## Customer Impact

Process.Start on Alpine hangs when starting the process with credentials.

## Regression?

Yes, from .NET Core 2.2.

## Risk

Low; this is just reverting back to using `fork` in some cases (we used to always use `fork`).  The biggest risk here IMHO isn't the changes in this PR; it's that we might find additional cases we want to revert as well.