### PR TITLE
HttpWebRequest caches HttpClient in simple cases

### DIFF
--- a/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -75,7 +75,7 @@ namespace System.Net
 
         private static readonly object s_syncRoot = new object();
         private static volatile HttpClient s_cachedHttpClient;
-        private static volatile HttpClientParameters s_cachedHttpClientParameters;
+        private static HttpClientParameters s_cachedHttpClientParameters;
 
         //these should be safe.
         [Flags]

--- a/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -73,9 +73,9 @@ namespace System.Net
         private bool _preAuthenticate;
         private DecompressionMethods _automaticDecompression = HttpHandlerDefaults.DefaultAutomaticDecompression;
 
-        private static readonly object _syncRoot = new object();
-        private static HttpClient _cachedHttpClient;
-        private static HttpClientParameters _cachedHttpClientParameters;
+        private static readonly object s_syncRoot = new object();
+        private static HttpClient s_cachedHttpClient;
+        private static HttpClientParameters s_cachedHttpClientParameters;
 
         //these should be safe.
         [Flags]
@@ -1495,22 +1495,22 @@ namespace System.Net
             }
 
             disposeRequired = false;
-            if (_cachedHttpClient == null)
+            if (s_cachedHttpClient == null)
             {
-                lock (_syncRoot)
+                lock (s_syncRoot)
                 {
-                    if (_cachedHttpClient == null)
+                    if (s_cachedHttpClient == null)
                     {
-                        _cachedHttpClientParameters = new HttpClientParameters(this);
-                        _cachedHttpClient = CreateHttpClient();
-                        return _cachedHttpClient;
+                        s_cachedHttpClientParameters = new HttpClientParameters(this);
+                        s_cachedHttpClient = CreateHttpClient();
+                        return s_cachedHttpClient;
                     }
                 }
             }
 
-            if (_cachedHttpClientParameters.Matches(this))
+            if (s_cachedHttpClientParameters.Matches(this))
             {
-                return _cachedHttpClient;
+                return s_cachedHttpClient;
             }
 
             disposeRequired = true;

--- a/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -1589,13 +1589,14 @@ namespace System.Net
                 }
 
                 // Set relevant properties from ServicePointManager
-                handler.SslProtocols = (SslProtocols)ServicePointManager.SecurityProtocol;
-                handler.CheckCertificateRevocationList = ServicePointManager.CheckCertificateRevocationList;
+                handler.SslProtocols = (SslProtocols)parameters.SslProtocols;
+                handler.CheckCertificateRevocationList = parameters.CheckCertificateRevocationList;
                 RemoteCertificateValidationCallback rcvc = parameters.ServerCertificateValidationCallback;
                 if (rcvc != null)
                 {
                     RemoteCertificateValidationCallback localRcvc = rcvc;
-                    handler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => localRcvc(request, cert, chain, errors);
+                    HttpWebRequest localRequest = request;
+                    handler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => localRcvc(localRequest, cert, chain, errors);
                 }
 
                 return client;

--- a/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -99,19 +99,12 @@ namespace System.Net
         private class HttpClientParameters
         {
             public readonly DecompressionMethods AutomaticDecompression;
-
             public readonly bool AllowAutoRedirect;
-
             public readonly int MaximumAutomaticRedirections;
-
             public readonly int MaximumResponseHeadersLength;
-
             public readonly bool PreAuthenticate;
-
             public readonly int Timeout;
-
-            public readonly SslProtocols SslProtocols;
-
+            public readonly SecurityProtocolType SslProtocols;
             public readonly bool CheckCertificateRevocationList;
 
             public HttpClientParameters(HttpWebRequest webRequest)
@@ -122,7 +115,7 @@ namespace System.Net
                 MaximumResponseHeadersLength = webRequest.MaximumResponseHeadersLength;
                 PreAuthenticate = webRequest.PreAuthenticate;
                 Timeout = webRequest.Timeout;
-                SslProtocols = (SslProtocols)ServicePointManager.SecurityProtocol;
+                SslProtocols = ServicePointManager.SecurityProtocol;
                 CheckCertificateRevocationList = ServicePointManager.CheckCertificateRevocationList;
             }
 
@@ -131,7 +124,7 @@ namespace System.Net
                 return AutomaticDecompression == webRequest.AutomaticDecompression && AllowAutoRedirect == webRequest.AllowAutoRedirect
                     && MaximumAutomaticRedirections == webRequest.MaximumAutomaticRedirections
                     && MaximumResponseHeadersLength == webRequest.MaximumResponseHeadersLength && PreAuthenticate == webRequest.PreAuthenticate
-                    && Timeout == webRequest.Timeout && SslProtocols == (SslProtocols)ServicePointManager.SecurityProtocol
+                    && Timeout == webRequest.Timeout && SslProtocols == ServicePointManager.SecurityProtocol
                     && CheckCertificateRevocationList == ServicePointManager.CheckCertificateRevocationList;
             }
 

--- a/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -74,8 +74,8 @@ namespace System.Net
         private DecompressionMethods _automaticDecompression = HttpHandlerDefaults.DefaultAutomaticDecompression;
 
         private static readonly object s_syncRoot = new object();
-        private static HttpClient s_cachedHttpClient;
-        private static HttpClientParameters s_cachedHttpClientParameters;
+        private static volatile HttpClient s_cachedHttpClient;
+        private static volatile HttpClientParameters s_cachedHttpClientParameters;
 
         //these should be safe.
         [Flags]

--- a/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -1162,7 +1162,7 @@ namespace System.Net
 
             var request = new HttpRequestMessage(new HttpMethod(_originVerb), _requestUri);
 
-            bool disposeRequired = true;
+            bool disposeRequired = false;
             HttpClient client = null;
             try
             {

--- a/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -121,17 +121,22 @@ namespace System.Net
 
             public bool Matches(HttpWebRequest webRequest)
             {
-                return AutomaticDecompression == webRequest.AutomaticDecompression && AllowAutoRedirect == webRequest.AllowAutoRedirect
+                return AutomaticDecompression == webRequest.AutomaticDecompression
+                    && AllowAutoRedirect == webRequest.AllowAutoRedirect
                     && MaximumAutomaticRedirections == webRequest.MaximumAutomaticRedirections
-                    && MaximumResponseHeadersLength == webRequest.MaximumResponseHeadersLength && PreAuthenticate == webRequest.PreAuthenticate
-                    && Timeout == webRequest.Timeout && SslProtocols == ServicePointManager.SecurityProtocol
+                    && MaximumResponseHeadersLength == webRequest.MaximumResponseHeadersLength
+                    && PreAuthenticate == webRequest.PreAuthenticate
+                    && Timeout == webRequest.Timeout
+                    && SslProtocols == ServicePointManager.SecurityProtocol
                     && CheckCertificateRevocationList == ServicePointManager.CheckCertificateRevocationList;
             }
 
             public static bool AreParametersAcceptableForCaching(HttpWebRequest webRequest)
             {
-                return webRequest._credentials == null && ReferenceEquals(webRequest._proxy, DefaultWebProxy)
-                    && webRequest.ServerCertificateValidationCallback == null && ServicePointManager.ServerCertificateValidationCallback == null
+                return webRequest._credentials == null
+                    && ReferenceEquals(webRequest._proxy, DefaultWebProxy)
+                    && webRequest.ServerCertificateValidationCallback == null
+                    && ServicePointManager.ServerCertificateValidationCallback == null
                     && (webRequest._clientCertificates == null || webRequest._clientCertificates.Count == 0)
                     && webRequest._cookieContainer == null;
             }

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -1668,62 +1668,67 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        public async Task GetResponseAsync_ParametersAreCachableButDifferent_CreateNewClient()
+        public void GetResponseAsync_ParametersAreCachableButDifferent_CreateNewClient()
         {
-            using (var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            var handle = RemoteExecutor.Invoke(async () =>
             {
-                listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
-                listener.Listen(1);
-                var ep = (IPEndPoint)listener.LocalEndPoint;
-                var uri = new Uri($"http://{ep.Address}:{ep.Port}/");
-
-                var referenceParameters = new HttpWebRequestParameters
+                using (var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
                 {
-                    AllowAutoRedirect = true,
-                    AutomaticDecompression = DecompressionMethods.GZip,
-                    MaximumAutomaticRedirections = 2,
-                    MaximumResponseHeadersLength = 100,
-                    PreAuthenticate = true,
-                    SslProtocols = SecurityProtocolType.Tls12,
-                    Timeout = 100000
-                };
-                HttpWebRequest firstRequest = WebRequest.CreateHttp(uri);
-                referenceParameters.Configure(firstRequest);
-                firstRequest.Method = HttpMethod.Get.Method;
+                    listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                    listener.Listen(1);
+                    var ep = (IPEndPoint)listener.LocalEndPoint;
+                    var uri = new Uri($"http://{ep.Address}:{ep.Port}/");
 
-                string responseContent = "Test response.";
-
-                Task<WebResponse> firstResponseTask = firstRequest.GetResponseAsync();
-                using (Socket server = await listener.AcceptAsync())
-                using (var serverStream = new NetworkStream(server, ownsSocket: false))
-                using (var serverReader = new StreamReader(serverStream))
-                {
-                    await ReplyToClient(responseContent, server, serverReader);
-                    await VerifyResponse(responseContent, firstResponseTask);
-
-                    foreach (var caseRow in CachableWebRequestParameters())
+                    var referenceParameters = new HttpWebRequestParameters
                     {
-                        var currentParameters = (HttpWebRequestParameters)caseRow[0];
-                        var connectionReused = (bool)caseRow[1];
-                        Task<Socket> secondAccept = listener.AcceptAsync();
+                        AllowAutoRedirect = true,
+                        AutomaticDecompression = DecompressionMethods.GZip,
+                        MaximumAutomaticRedirections = 2,
+                        MaximumResponseHeadersLength = 100,
+                        PreAuthenticate = true,
+                        SslProtocols = SecurityProtocolType.Tls12,
+                        Timeout = 100000
+                    };
+                    HttpWebRequest firstRequest = WebRequest.CreateHttp(uri);
+                    referenceParameters.Configure(firstRequest);
+                    firstRequest.Method = HttpMethod.Get.Method;
 
-                        var currentRequest = WebRequest.CreateHttp(uri);
-                        currentParameters.Configure(currentRequest);
+                    string responseContent = "Test response.";
 
-                        Task<WebResponse> currentResponseTask = currentRequest.GetResponseAsync();
-                        if (connectionReused)
+                    Task<WebResponse> firstResponseTask = firstRequest.GetResponseAsync();
+                    using (Socket server = await listener.AcceptAsync())
+                    using (var serverStream = new NetworkStream(server, ownsSocket: false))
+                    using (var serverReader = new StreamReader(serverStream))
+                    {
+                        await ReplyToClient(responseContent, server, serverReader);
+                        await VerifyResponse(responseContent, firstResponseTask);
+
+                        foreach (var caseRow in CachableWebRequestParameters())
                         {
-                            await ReplyToClient(responseContent, server, serverReader);
-                            Assert.False(secondAccept.IsCompleted);
-                            await VerifyResponse(responseContent, currentResponseTask);
-                        }
-                        else
-                        {
-                            await VerifyNewConnection(responseContent, secondAccept, currentResponseTask);
+                            var currentParameters = (HttpWebRequestParameters)caseRow[0];
+                            var connectionReused = (bool)caseRow[1];
+                            Task<Socket> secondAccept = listener.AcceptAsync();
+
+                            var currentRequest = WebRequest.CreateHttp(uri);
+                            currentParameters.Configure(currentRequest);
+
+                            Task<WebResponse> currentResponseTask = currentRequest.GetResponseAsync();
+                            if (connectionReused)
+                            {
+                                await ReplyToClient(responseContent, server, serverReader);
+                                Assert.False(secondAccept.IsCompleted);
+                                await VerifyResponse(responseContent, currentResponseTask);
+                            }
+                            else
+                            {
+                                await VerifyNewConnection(responseContent, secondAccept, currentResponseTask);
+                            }
                         }
                     }
                 }
-            }
+                return RemoteExecutor.SuccessExitCode;
+            });
+            Assert.Equal(RemoteExecutor.SuccessExitCode, handle.ExitCode);
         }
 
         [Fact]

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -40,7 +40,7 @@ namespace System.Net.Tests
 
             public int Timeout { get; set; }
 
-            public SslProtocols SslProtocols { get; set; }
+            public SecurityProtocolType SslProtocols { get; set; }
 
             public bool CheckCertificateRevocationList { get; set; }
 
@@ -59,31 +59,29 @@ namespace System.Net.Tests
         private readonly byte[] _requestBodyBytes = Encoding.UTF8.GetBytes(RequestBody);
         private readonly NetworkCredential _explicitCredential = new NetworkCredential("user", "password", "domain");
         private readonly ITestOutputHelper _output;
-        private AutoResetEvent _dataRead = new AutoResetEvent(false);
-        private AutoResetEvent _dataSent = new AutoResetEvent(false);
 
         public static readonly object[][] EchoServers = Configuration.Http.EchoServers;
 
         public static IEnumerable<object[]> CachableWebRequestParameters()
         {
             yield return new object[] {new HttpWebRequestParameters { AllowAutoRedirect = true, AutomaticDecompression = DecompressionMethods.GZip,
-                MaximumAutomaticRedirections = 2, MaximumResponseHeadersLength = 100, PreAuthenticate = true, SslProtocols = SslProtocols.Tls12, Timeout = 100000}};
+                MaximumAutomaticRedirections = 2, MaximumResponseHeadersLength = 100, PreAuthenticate = true, SslProtocols = SecurityProtocolType.Tls12, Timeout = 100000}};
             yield return new object[] {new HttpWebRequestParameters { AllowAutoRedirect = false, AutomaticDecompression = DecompressionMethods.GZip,
-                MaximumAutomaticRedirections = 2, MaximumResponseHeadersLength = 100, PreAuthenticate = true, SslProtocols = SslProtocols.Tls12, Timeout = 10000}};
+                MaximumAutomaticRedirections = 2, MaximumResponseHeadersLength = 100, PreAuthenticate = true, SslProtocols = SecurityProtocolType.Tls12, Timeout = 10000}};
             yield return new object[] {new HttpWebRequestParameters { AllowAutoRedirect = true, AutomaticDecompression = DecompressionMethods.Deflate,
-                MaximumAutomaticRedirections = 2, MaximumResponseHeadersLength = 100, PreAuthenticate = true, SslProtocols = SslProtocols.Tls12, Timeout = 10000}};
+                MaximumAutomaticRedirections = 2, MaximumResponseHeadersLength = 100, PreAuthenticate = true, SslProtocols = SecurityProtocolType.Tls12, Timeout = 10000}};
             yield return new object[] {new HttpWebRequestParameters { AllowAutoRedirect = true, AutomaticDecompression = DecompressionMethods.GZip,
-                MaximumAutomaticRedirections = 3, MaximumResponseHeadersLength = 100, PreAuthenticate = true, SslProtocols = SslProtocols.Tls12, Timeout = 10000}};
+                MaximumAutomaticRedirections = 3, MaximumResponseHeadersLength = 100, PreAuthenticate = true, SslProtocols = SecurityProtocolType.Tls12, Timeout = 10000}};
             yield return new object[] {new HttpWebRequestParameters { AllowAutoRedirect = true, AutomaticDecompression = DecompressionMethods.GZip,
-                MaximumAutomaticRedirections = 2, MaximumResponseHeadersLength = 110, PreAuthenticate = true, SslProtocols = SslProtocols.Tls12, Timeout = 10000}};
+                MaximumAutomaticRedirections = 2, MaximumResponseHeadersLength = 110, PreAuthenticate = true, SslProtocols = SecurityProtocolType.Tls12, Timeout = 10000}};
             yield return new object[] {new HttpWebRequestParameters { AllowAutoRedirect = true, AutomaticDecompression = DecompressionMethods.GZip,
-                MaximumAutomaticRedirections = 2, MaximumResponseHeadersLength = 100, PreAuthenticate = false, SslProtocols = SslProtocols.Tls12, Timeout = 10000}};
+                MaximumAutomaticRedirections = 2, MaximumResponseHeadersLength = 100, PreAuthenticate = false, SslProtocols = SecurityProtocolType.Tls12, Timeout = 10000}};
             yield return new object[] {new HttpWebRequestParameters { AllowAutoRedirect = true, AutomaticDecompression = DecompressionMethods.GZip,
-                MaximumAutomaticRedirections = 2, MaximumResponseHeadersLength = 100, PreAuthenticate = true, SslProtocols = SslProtocols.Tls11, Timeout = 10000}};
+                MaximumAutomaticRedirections = 2, MaximumResponseHeadersLength = 100, PreAuthenticate = true, SslProtocols = SecurityProtocolType.Tls11, Timeout = 10000}};
             yield return new object[] {new HttpWebRequestParameters { AllowAutoRedirect = true, AutomaticDecompression = DecompressionMethods.GZip,
-                MaximumAutomaticRedirections = 2, MaximumResponseHeadersLength = 100, PreAuthenticate = true, SslProtocols = SslProtocols.Tls11, Timeout = 10250}};
+                MaximumAutomaticRedirections = 2, MaximumResponseHeadersLength = 100, PreAuthenticate = true, SslProtocols = SecurityProtocolType.Tls11, Timeout = 10250}};
             yield return new object[] {new HttpWebRequestParameters { AllowAutoRedirect = true, AutomaticDecompression = DecompressionMethods.GZip,
-                MaximumAutomaticRedirections = 2, MaximumResponseHeadersLength = 100, PreAuthenticate = true, SslProtocols = SslProtocols.Tls11, Timeout = 10000}};
+                MaximumAutomaticRedirections = 2, MaximumResponseHeadersLength = 100, PreAuthenticate = true, SslProtocols = SecurityProtocolType.Tls11, Timeout = 10000}};
         }
 
         public static IEnumerable<object[]> Dates_ReadValue_Data()
@@ -1591,8 +1589,7 @@ namespace System.Net.Tests
             RemoteExecutor.Invoke(async (serializedParameters) =>
             {
                 var parameters = JsonSerializer.Deserialize<HttpWebRequestParameters>(serializedParameters);
-                var options = new LoopbackServer.Options { UseSsl = false };
-                ServicePointManager.SecurityProtocol = (SecurityProtocolType)parameters.SslProtocols;
+                ServicePointManager.SecurityProtocol = parameters.SslProtocols;
                 ServicePointManager.CheckCertificateRevocationList = parameters.CheckCertificateRevocationList;
 
                 await LoopbackServer.CreateClientAndServerAsync(async uri =>
@@ -1626,7 +1623,7 @@ namespace System.Net.Tests
                     } while (count > 0 && sb.ToString().Substring(sb.Length - 4, 4) != "\r\n\r\n");
 
                     Assert.StartsWith("GET / HTTP/1.1", sb.ToString());
-                }), options);
+                }), new LoopbackServer.Options());
                 return RemoteExecutor.SuccessExitCode;
             }, JsonSerializer.Serialize(requestParameters));
         }
@@ -1637,8 +1634,7 @@ namespace System.Net.Tests
             RemoteExecutor.Invoke(async (serializedParameters) =>
             {
                 var parameters = JsonSerializer.Deserialize<HttpWebRequestParameters>(serializedParameters);
-                var options = new LoopbackServer.Options { UseSsl = false };
-                ServicePointManager.SecurityProtocol = (SecurityProtocolType)parameters.SslProtocols;
+                ServicePointManager.SecurityProtocol = parameters.SslProtocols;
                 ServicePointManager.CheckCertificateRevocationList = parameters.CheckCertificateRevocationList;
                 ServicePointManager.ServerCertificateValidationCallback = delegate { return true; }; // this prevents HttpClient from being cached
 
@@ -1673,7 +1669,7 @@ namespace System.Net.Tests
                     } while (count > 0 && sb.ToString().Substring(sb.Length - 4, 4) != "\r\n\r\n");
 
                     Assert.StartsWith("GET / HTTP/1.1", sb.ToString());
-                }), options);
+                }), new LoopbackServer.Options());
             }, JsonSerializer.Serialize(requestParameters));
         }
 

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -1869,7 +1869,7 @@ namespace System.Net.Tests
 
         private static async Task VerifyNewConnection(string responseContent, Task<Socket> secondAccept, Task<WebResponse> currentResponseTask)
         {
-            var secondServer = await secondAccept;
+            Socket secondServer = await secondAccept;
             Assert.True(secondAccept.IsCompleted);
             using (var secondStream = new NetworkStream(secondServer, ownsSocket: false))
             using (var secondReader = new StreamReader(secondStream))

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -1701,13 +1701,13 @@ namespace System.Net.Tests
                          await ReplyToClient(responseContent, server, serverReader);
                          await VerifyResponse(responseContent, firstResponseTask);
 
-                         foreach (var caseRow in CachableWebRequestParameters())
+                         foreach (object[] caseRow in CachableWebRequestParameters())
                          {
                              var currentParameters = (HttpWebRequestParameters)caseRow[0];
-                             var connectionReused = (bool)caseRow[1];
+                             bool connectionReused = (bool)caseRow[1];
                              Task<Socket> secondAccept = listener.AcceptAsync();
 
-                             var currentRequest = WebRequest.CreateHttp(uri);
+                             HttpWebRequest currentRequest = WebRequest.CreateHttp(uri);
                              currentParameters.Configure(currentRequest);
 
                              Task<WebResponse> currentResponseTask = currentRequest.GetResponseAsync();
@@ -1892,11 +1892,11 @@ namespace System.Net.Tests
 
         private static async Task VerifyResponse(string expectedResponse, Task<WebResponse> responseTask)
         {
-            var firstRequest = await responseTask;
-            using (var firstResponseStream = firstRequest.GetResponseStream())
+            WebResponse firstRequest = await responseTask;
+            using (Stream firstResponseStream = firstRequest.GetResponseStream())
             using (var reader = new StreamReader(firstResponseStream))
             {
-                var response = reader.ReadToEnd();
+                string response = reader.ReadToEnd();
                 Assert.Equal(expectedResponse, response);
             }
         }

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -1616,6 +1616,7 @@ namespace System.Net.Tests
         }
 
         [Theory, MemberData(nameof(MixedWebRequestParameters))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)]
         public void GetResponseAsync_ParametersAreNotCachable_CreateNewClient(HttpWebRequestParameters requestParameters, bool connectionReusedParameter)
         {
             RemoteExecutor.Invoke(async (serializedParameters, connectionReusedString) =>
@@ -1666,6 +1667,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)]
         public void GetResponseAsync_ParametersAreCachableButDifferent_CreateNewClient()
         {
             RemoteExecutor.Invoke(async () =>

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -13,10 +13,10 @@ using System.Net.Test.Common;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Security.Authentication;
 using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.RemoteExecutor;
-using Newtonsoft.Json;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -54,7 +54,7 @@ namespace System.Net.Tests
                 webRequest.Timeout = Timeout;
             }
         }
-        
+
         private const string RequestBody = "This is data to POST.";
         private readonly byte[] _requestBodyBytes = Encoding.UTF8.GetBytes(RequestBody);
         private readonly NetworkCredential _explicitCredential = new NetworkCredential("user", "password", "domain");
@@ -1469,7 +1469,7 @@ namespace System.Net.Tests
                     WebRequest.DefaultWebProxy.Credentials = new NetworkCredential(user, pw);
                     HttpWebRequest request = HttpWebRequest.CreateHttp(Configuration.Http.RemoteEchoServer);
 
-                    using (var response = (HttpWebResponse) await request.GetResponseAsync())
+                    using (var response = (HttpWebResponse)await request.GetResponseAsync())
                     {
                         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                     }
@@ -1590,7 +1590,7 @@ namespace System.Net.Tests
         {
             RemoteExecutor.Invoke(async (serializedParameters) =>
             {
-                var parameters = JsonConvert.DeserializeObject<HttpWebRequestParameters>(serializedParameters);
+                var parameters = JsonSerializer.Deserialize<HttpWebRequestParameters>(serializedParameters);
                 var options = new LoopbackServer.Options { UseSsl = false };
                 ServicePointManager.SecurityProtocol = (SecurityProtocolType)parameters.SslProtocols;
                 ServicePointManager.CheckCertificateRevocationList = parameters.CheckCertificateRevocationList;
@@ -1628,7 +1628,7 @@ namespace System.Net.Tests
                     Assert.StartsWith("GET / HTTP/1.1", sb.ToString());
                 }), options);
                 return RemoteExecutor.SuccessExitCode;
-            }, JsonConvert.SerializeObject(requestParameters));
+            }, JsonSerializer.Serialize(requestParameters));
         }
 
         [Theory, MemberData(nameof(CachableWebRequestParameters))]
@@ -1636,7 +1636,7 @@ namespace System.Net.Tests
         {
             RemoteExecutor.Invoke(async (serializedParameters) =>
             {
-                var parameters = JsonConvert.DeserializeObject<HttpWebRequestParameters>(serializedParameters);
+                var parameters = JsonSerializer.Deserialize<HttpWebRequestParameters>(serializedParameters);
                 var options = new LoopbackServer.Options { UseSsl = false };
                 ServicePointManager.SecurityProtocol = (SecurityProtocolType)parameters.SslProtocols;
                 ServicePointManager.CheckCertificateRevocationList = parameters.CheckCertificateRevocationList;
@@ -1674,7 +1674,7 @@ namespace System.Net.Tests
 
                     Assert.StartsWith("GET / HTTP/1.1", sb.ToString());
                 }), options);
-            }, JsonConvert.SerializeObject(requestParameters));
+            }, JsonSerializer.Serialize(requestParameters));
         }
 
         [Fact]


### PR DESCRIPTION
HttpWebRequest caches and tries to reuse a single static HttpClient instance when it's safe to share the same instance among concurrent requests with the given parameters.
Fixes #15460