### PR TITLE
Support For Getting base-64 String as Byte Array

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
@@ -495,9 +495,9 @@ namespace System.Text.Json
 
             var jsonNode = (JsonNode)_parent;
 
-            if (jsonNode is JsonString)
+            if (jsonNode is JsonString jsonString)
             {
-                throw new NotSupportedException();
+                return jsonString.TryGetBytesFromBase64(out value);
             }
 
             throw ThrowHelper.GetJsonElementWrongTypeException(JsonValueKind.String, jsonNode.ValueKind);

--- a/src/System.Text.Json/src/System/Text/Json/Node/JsonString.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Node/JsonString.cs
@@ -208,5 +208,26 @@ namespace System.Text.Json
         ///   Returns <see cref="JsonValueKind.String"/>
         /// </summary>
         public override JsonValueKind ValueKind { get => JsonValueKind.String; }
+
+        /// <summary>
+        ///   Converts the text value of this instance, which should encode binary data as base-64 digits, to an equivalent 8-bit unsigned <see cref="byte"/> array.
+        ///   The return value indicates wether the conversion succeeded.
+        /// </summary>
+        /// <param name="value">
+        ///   When this method returns, contains the <see cref="byte"/> array equivalent of the text contained in this instance,
+        ///   if the conversion succeeded.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if text was converted successfully; othwerwise returns <see langword="false"/>.
+        /// </returns>
+        internal bool TryGetBytesFromBase64(out byte[] value)
+        {
+            value = new byte[((_value.Length * 3) + 3) / 4 -
+                (_value.Length > 0 && _value[_value.Length - 1] == '=' ?
+                    _value.Length > 1 && _value[_value.Length - 2] == '=' ?
+                        2 : 1 : 0)];
+
+            return Convert.TryFromBase64String(_value, value, out int bytesWritten);
+        }
     }
 }

--- a/src/System.Text.Json/tests/JsonElementWithNodeParentTests.cs
+++ b/src/System.Text.Json/tests/JsonElementWithNodeParentTests.cs
@@ -122,7 +122,7 @@ namespace System.Text.Json.Tests
         [Fact]
         public static void TestBytesFromBase64()
         {
-            Assert.Throws<NotSupportedException>(() => new JsonString().AsJsonElement().GetBytesFromBase64());
+            Assert.Equal(Encoding.UTF8.GetBytes("value"), new JsonString("dmFsdWU=").AsJsonElement().GetBytesFromBase64());
             Assert.Throws<InvalidOperationException>(() => new JsonBoolean().AsJsonElement().GetBytesFromBase64());
         }
 


### PR DESCRIPTION
Solves #41132. Implemented support for getting `JsonString`  encoded in base-64 as an equivalent byte array.