### PR TITLE
Support For Getting base-64 String as Byte Array

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
@@ -495,9 +495,9 @@ namespace System.Text.Json
 
             var jsonNode = (JsonNode)_parent;
 
-            if (jsonNode is JsonString)
+            if (jsonNode is JsonString jsonString)
             {
-                throw new NotSupportedException();
+                return jsonString.TryGetBytesFromBase64(out value);
             }
 
             throw ThrowHelper.GetJsonElementWrongTypeException(JsonValueKind.String, jsonNode.ValueKind);

--- a/src/System.Text.Json/src/System/Text/Json/Node/JsonString.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Node/JsonString.cs
@@ -230,7 +230,7 @@ namespace System.Text.Json
             }
 
             // we decode string -> byte, so the resulting length will
-            // be /4 * 3 - padding. To be on the safe side, keep padding in slice later
+            // be /4 * 3 - padding. To be on the safe side, keep padding and slice later
             int bufferSize = _value.Length / 4 * 3;
 
             byte[] arrayToReturnToPool = null;

--- a/src/System.Text.Json/src/System/Text/Json/Node/JsonString.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Node/JsonString.cs
@@ -223,7 +223,7 @@ namespace System.Text.Json
         /// </returns>
         internal bool TryGetBytesFromBase64(out byte[] value)
         {
-            if (_value.Length < 1)
+            if (_value.Length < 4)
             {
                 value = default;
                 return false;

--- a/src/System.Text.Json/src/System/Text/Json/Node/JsonString.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Node/JsonString.cs
@@ -208,5 +208,30 @@ namespace System.Text.Json
         ///   Returns <see cref="JsonValueKind.String"/>
         /// </summary>
         public override JsonValueKind ValueKind { get => JsonValueKind.String; }
+
+        /// <summary>
+        ///   Converts the text value of this instance, which should encode binary data as base-64 digits, to an equivalent 8-bit unsigned <see cref="byte"/> array.
+        ///   The return value indicates wether the conversion succeeded.
+        /// </summary>
+        /// <param name="value">
+        ///   When this method returns, contains the <see cref="byte"/> array equivalent of the text contained in this instance,
+        ///   if the conversion succeeded.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if text was converted successfully; othwerwise returns <see langword="false"/>.
+        /// </returns>
+        internal bool TryGetBytesFromBase64(out byte[] value)
+        {
+            try
+            {
+                value = Convert.FromBase64String(_value);
+                return true;
+            }
+            catch
+            {
+                value = null;
+                return false;
+            }
+        }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Node/JsonString.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Node/JsonString.cs
@@ -240,7 +240,7 @@ namespace System.Text.Json
 
             byte[] arrayToReturnToPool = null;
             Span<byte> buffer = bufferSize <= JsonConstants.StackallocThreshold
-                ? stackalloc byte[bufferSize]
+                ? stackalloc byte[JsonConstants.StackallocThreshold]
                 : arrayToReturnToPool = ArrayPool<byte>.Shared.Rent(bufferSize);
             try
             {

--- a/src/System.Text.Json/src/System/Text/Json/Node/JsonString.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Node/JsonString.cs
@@ -239,7 +239,7 @@ namespace System.Text.Json
             int bufferSize = _value.Length / 4 * 3;
 
             byte[] arrayToReturnToPool = null;
-            Span<byte> buffer = bufferSize <= 256
+            Span<byte> buffer = bufferSize <= JsonConstants.StackallocThreshold
                 ? stackalloc byte[bufferSize]
                 : arrayToReturnToPool = ArrayPool<byte>.Shared.Rent(bufferSize);
             try

--- a/src/System.Text.Json/tests/JsonElementWithNodeParentTests.cs
+++ b/src/System.Text.Json/tests/JsonElementWithNodeParentTests.cs
@@ -122,7 +122,8 @@ namespace System.Text.Json.Tests
         [Fact]
         public static void TestBytesFromBase64()
         {
-            Assert.Throws<NotSupportedException>(() => new JsonString().AsJsonElement().GetBytesFromBase64());
+            Assert.Equal(Encoding.UTF8.GetBytes("value"), new JsonString("dmFsdWU=").AsJsonElement().GetBytesFromBase64());
+            Assert.Throws<FormatException>(() => new JsonString("Not base-64").AsJsonElement().GetBytesFromBase64());
             Assert.Throws<InvalidOperationException>(() => new JsonBoolean().AsJsonElement().GetBytesFromBase64());
         }
 

--- a/src/System.Text.Json/tests/JsonElementWithNodeParentTests.cs
+++ b/src/System.Text.Json/tests/JsonElementWithNodeParentTests.cs
@@ -123,10 +123,17 @@ namespace System.Text.Json.Tests
         public static void TestBytesFromBase64()
         {
             Assert.Equal(Encoding.UTF8.GetBytes("value"), new JsonString("dmFsdWU=").AsJsonElement().GetBytesFromBase64());
+            Assert.Equal(Encoding.UTF8.GetBytes(SR.LoremIpsum40Words), new JsonString(SR.LoremIpsum40WordsBase64).AsJsonElement().GetBytesFromBase64());
+
             Assert.Throws<FormatException>(() => new JsonString("Not base-64").AsJsonElement().GetBytesFromBase64());
+            Assert.Throws<FormatException>(() => new JsonString("abc").AsJsonElement().GetBytesFromBase64());
             Assert.Throws<FormatException>(() => new JsonString("").AsJsonElement().GetBytesFromBase64());
             Assert.Throws<FormatException>(() => new JsonString().AsJsonElement().GetBytesFromBase64());
+
             Assert.Throws<InvalidOperationException>(() => new JsonBoolean().AsJsonElement().GetBytesFromBase64());
+
+            Assert.True(new JsonString("dmFsdWU=").AsJsonElement().TryGetBytesFromBase64(out _));
+            Assert.False(new JsonString().AsJsonElement().TryGetBytesFromBase64(out _));
         }
 
         [Fact]

--- a/src/System.Text.Json/tests/JsonElementWithNodeParentTests.cs
+++ b/src/System.Text.Json/tests/JsonElementWithNodeParentTests.cs
@@ -124,6 +124,8 @@ namespace System.Text.Json.Tests
         {
             Assert.Equal(Encoding.UTF8.GetBytes("value"), new JsonString("dmFsdWU=").AsJsonElement().GetBytesFromBase64());
             Assert.Throws<FormatException>(() => new JsonString("Not base-64").AsJsonElement().GetBytesFromBase64());
+            Assert.Throws<FormatException>(() => new JsonString("").AsJsonElement().GetBytesFromBase64());
+            Assert.Throws<FormatException>(() => new JsonString().AsJsonElement().GetBytesFromBase64());
             Assert.Throws<InvalidOperationException>(() => new JsonBoolean().AsJsonElement().GetBytesFromBase64());
         }
 

--- a/src/System.Text.Json/tests/JsonElementWithNodeParentTests.cs
+++ b/src/System.Text.Json/tests/JsonElementWithNodeParentTests.cs
@@ -122,7 +122,10 @@ namespace System.Text.Json.Tests
         [Fact]
         public static void TestBytesFromBase64()
         {
-            Assert.Equal(Encoding.UTF8.GetBytes("value"), new JsonString("dmFsdWU=").AsJsonElement().GetBytesFromBase64());
+            string valueString = "value";
+            string valueBase64String = "dmFsdWU=";
+
+            Assert.Equal(Encoding.UTF8.GetBytes(valueString), new JsonString(valueBase64String).AsJsonElement().GetBytesFromBase64());
             Assert.Equal(Encoding.UTF8.GetBytes(SR.LoremIpsum40Words), new JsonString(SR.LoremIpsum40WordsBase64).AsJsonElement().GetBytesFromBase64());
 
             Assert.Throws<FormatException>(() => new JsonString("Not base-64").AsJsonElement().GetBytesFromBase64());
@@ -132,7 +135,8 @@ namespace System.Text.Json.Tests
 
             Assert.Throws<InvalidOperationException>(() => new JsonBoolean().AsJsonElement().GetBytesFromBase64());
 
-            Assert.True(new JsonString("dmFsdWU=").AsJsonElement().TryGetBytesFromBase64(out _));
+            Assert.True(new JsonString(valueBase64String).AsJsonElement().TryGetBytesFromBase64(out byte[] buffer));
+            Assert.Equal(Encoding.UTF8.GetBytes(valueString), buffer);
             Assert.False(new JsonString().AsJsonElement().TryGetBytesFromBase64(out _));
         }
 

--- a/src/System.Text.Json/tests/Resources/Strings.resx
+++ b/src/System.Text.Json/tests/Resources/Strings.resx
@@ -1,4 +1,5 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
   <!-- 
     Microsoft ResX Schema 
     
@@ -20270,5 +20271,11 @@ tiline\"another\" String\\"],"str":"\"\""}</value>
   </data>
   <data name="BufferWriterAdvancedTooFar" xml:space="preserve">
     <value>Cannot advance past the end of the buffer, which has a size of {0}.</value>
+  </data>
+  <data name="LoremIpsum40Words" xml:space="preserve">
+    <value>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur viverra neque at erat laoreet, at sagittis arcu efficitur. Ut pulvinar eros nec odio cursus eleifend. Maecenas viverra elementum porttitor. Nullam mi velit, malesuada commodo tristique eu, mollis a velit. Morbi.</value>
+  </data>
+  <data name="LoremIpsum40WordsBase64" xml:space="preserve">
+    <value>TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gQ3VyYWJpdHVyIHZpdmVycmEgbmVxdWUgYXQgZXJhdCBsYW9yZWV0LCBhdCBzYWdpdHRpcyBhcmN1IGVmZmljaXR1ci4gVXQgcHVsdmluYXIgZXJvcyBuZWMgb2RpbyBjdXJzdXMgZWxlaWZlbmQuIE1hZWNlbmFzIHZpdmVycmEgZWxlbWVudHVtIHBvcnR0aXRvci4gTnVsbGFtIG1pIHZlbGl0LCBtYWxlc3VhZGEgY29tbW9kbyB0cmlzdGlxdWUgZXUsIG1vbGxpcyBhIHZlbGl0LiBNb3JiaS4=</value>
   </data>
 </root>


### PR DESCRIPTION
Reimplementation to solve problems from #41464. Only added one test where the method returns false as suggested:

> This needs a lot more tests... whitespace-containing, two trailing =, zero trailing =, something that returns false (including zero, one, and two trailing = in the false-returning inputs)

but the rest of these cases should with this reimplementation be covered by [Convert.FromBase64.cs](https://github.com/dotnet/corefx/blob/master/src/System.Runtime.Extensions/tests/System/Convert.FromBase64.cs).

Solves #41132. Implemented support for getting JsonString encoded in base-64 as an equivalent byte array.