### PR TITLE
Disable Save_SimpleSettings_Ok test in all platforms

### DIFF
--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/ApplicationSettingsBaseTests.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/ApplicationSettingsBaseTests.cs
@@ -102,7 +102,7 @@ namespace System.ConfigurationTests
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer)),
             InlineData(true),
             InlineData(false)]
-        [ActiveIssue("https://github.com/dotnet/corefx/issues/35668", TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/corefx/issues/35668")]
         public void Save_SimpleSettings_Ok(bool isSynchronized)
         {
             PersistedSimpleSettings settings = isSynchronized


### PR DESCRIPTION
It's been failing on windows for the past few weeks, disabling while issue is open to have a cleaner CI.

cc: @stephentoub @ViktorHofer 