### PR TITLE
[System.Drawing.Common] Relax IconTests.CorrectColorDepthExtracted test

### DIFF
--- a/src/System.Drawing.Common/tests/IconTests.cs
+++ b/src/System.Drawing.Common/tests/IconTests.cs
@@ -861,15 +861,23 @@ namespace System.Drawing.Tests
                         switch (expectedBitDepth)
                         {
                             case 32:
-                                // libgdiplus on Unix doesn't natively support ARGB32 format. It
-                                // uses the Cairo library which represents the bitmaps as PARGB32
-                                // with individual channels premultiplied with the alpha channel.
-                                // When converting back and forth it results in slight loss of
-                                // precision so allow both original and rounded values here.
-                                uint color = (uint)bitmap.GetPixel(0, 0).ToArgb();
-                                Assert.True(color == 0x879EE532u || color == 0x879EE431u, color.ToString("x"));
-                                color = (uint)bitmap.GetPixel(0, 31).ToArgb();
-                                Assert.True(color == 0x661CD8B7u || color == 0x661BD7B6u, color.ToString("x"));
+                                if (!PlatformDetection.IsWindows)
+                                {
+                                    // libgdiplus on Unix doesn't natively support ARGB32 format. It
+                                    // uses the Cairo library which represents the bitmaps as PARGB32
+                                    // with individual channels premultiplied with the alpha channel.
+                                    // When converting back and forth it results in slight loss of
+                                    // precision so allow both original and rounded values here.
+                                    uint color = (uint)bitmap.GetPixel(0, 0).ToArgb();
+                                    Assert.True(color == 0x879EE532u || color == 0x879EE431u, color.ToString("x"));
+                                    color = (uint)bitmap.GetPixel(0, 31).ToArgb();
+                                    Assert.True(color == 0x661CD8B7u || color == 0x661BD7B6u, color.ToString("x"));
+                                }
+                                else
+                                {
+                                    Assert.Equal(0x879EE532u, (uint)bitmap.GetPixel(0, 0).ToArgb());
+                                    Assert.Equal(0x661CD8B7u, (uint)bitmap.GetPixel(0, 31).ToArgb());
+                                }
                                 break;
                             case 16:
                             case 8:

--- a/src/System.Drawing.Common/tests/IconTests.cs
+++ b/src/System.Drawing.Common/tests/IconTests.cs
@@ -861,8 +861,15 @@ namespace System.Drawing.Tests
                         switch (expectedBitDepth)
                         {
                             case 32:
-                                Assert.Equal(0x879EE532u, (uint)bitmap.GetPixel(0, 0).ToArgb());
-                                Assert.Equal(0x661CD8B7u, (uint)bitmap.GetPixel(0, 31).ToArgb());
+                                // libgdiplus on Unix doesn't natively support ARGB32 format. It
+                                // uses the Cairo library which represents the bitmaps as PARGB32
+                                // with individual channels premultiplied with the alpha channel.
+                                // When converting back and forth it results in slight loss of
+                                // precision so allow both original and rounded values here.
+                                uint color = (uint)bitmap.GetPixel(0, 0).ToArgb();
+                                Assert.True(color == 0x879EE532u || color == 0x879EE431u, color.ToString("x"));
+                                color = (uint)bitmap.GetPixel(0, 31).ToArgb();
+                                Assert.True(color == 0x661CD8B7u || color == 0x661BD7B6u, color.ToString("x"));
                                 break;
                             case 16:
                             case 8:


### PR DESCRIPTION
…to work on newer libgdiplus on Unix.

Related: https://github.com/mono/libgdiplus/pull/599

libgdiplus on Unix uses Cairo as the backend library for manipulating the bitmaps. Unfortunately Cairo has very limited support for different pixel formats. Thus the ARGB32 format has to be emulated using the PARGB32 format (individual channels are premultiplied with the alpha value). This may result in slight loss of precision and rounding errors when converting between the formats back and forth. Adjust the tests to be more forgiving for this scenario.

Note that it worked on older libgdiplus only because there was couple of bugs that were canceling itself out. Cairo surfaces were often created with the non-premultiplied ARGB32 data and drawing operations performed on them resulted in the alpha channel not being applied correctly.