### PR TITLE
Update coding-style.md

### DIFF
--- a/Documentation/coding-guidelines/coding-style.md
+++ b/Documentation/coding-guidelines/coding-style.md
@@ -20,7 +20,7 @@ The general rule we follow is "use Visual Studio defaults".
    blank lines between members of a type.
 8. Avoid spurious free spaces.
    For example avoid `if (someVar == 0)...`, where the dots mark the spurious free spaces.
-   Consider enabling "View White Space (Ctrl+R, Ctrl+W)" if using Visual Studio to aid detection.
+   Consider enabling "View White Space (Ctrl+R, Ctrl+W)" or "Edit -> Advanced -> View White Space" if using Visual Studio to aid detection.
 9. If a file happens to differ in style from these guidelines (e.g. private members are named `m_member`
    rather than `_member`), the existing style in that file takes precedence.
 10. We only use `var` when it's obvious what the variable type is (e.g. `var stream = new FileStream(...)` not `var stream = OpenStandardInput()`).

--- a/Documentation/coding-guidelines/coding-style.md
+++ b/Documentation/coding-guidelines/coding-style.md
@@ -20,7 +20,7 @@ The general rule we follow is "use Visual Studio defaults".
    blank lines between members of a type.
 8. Avoid spurious free spaces.
    For example avoid `if (someVar == 0)...`, where the dots mark the spurious free spaces.
-   Consider enabling "View White Space (Ctrl+E, S)" if using Visual Studio to aid detection.
+   Consider enabling "View White Space (Ctrl+R, Ctrl+W)" if using Visual Studio to aid detection.
 9. If a file happens to differ in style from these guidelines (e.g. private members are named `m_member`
    rather than `_member`), the existing style in that file takes precedence.
 10. We only use `var` when it's obvious what the variable type is (e.g. `var stream = new FileStream(...)` not `var stream = OpenStandardInput()`).


### PR DESCRIPTION
Changed Keyboard shortcut to show white space. There was a wrong shortcut of View White Space (Ctrl+E, S) and correct one is (Ctrl+R, Ctrl+W). I don't know is it allows us to contribute/change in guidelines or not. It's my first PR. I hope it will be accepted.