### PR TITLE
[release/3.1] Improve JsonSerializer support for derived types (#40654)

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.Helpers.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.Helpers.cs
@@ -138,7 +138,6 @@ namespace System.Text.Json
 
             if (!(typeof(IEnumerable).IsAssignableFrom(queryType)) ||
                 queryType == typeof(string) ||
-                queryType.IsAbstract ||
                 queryType.IsInterface ||
                 queryType.IsArray ||
                 IsNativelySupportedCollection(queryType))
@@ -191,18 +190,7 @@ namespace System.Text.Json
                 }
             }
 
-            // Try non-generic interfaces without add methods
-            if (typeof(IEnumerable).IsAssignableFrom(queryType))
-            {
-                return typeof(IEnumerable);
-            }
-            else if (typeof(ICollection).IsAssignableFrom(queryType))
-            {
-                return typeof(ICollection);
-            }
-
-            // No natively supported collection that we support as derived types was detected.
-            return queryType;
+            return typeof(IEnumerable);
         }
 
         public static bool IsDeserializedByAssigningFromList(Type type)

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
@@ -178,9 +178,9 @@ namespace System.Text.Json
                         }
                         else if (ClassType == ClassType.Enumerable)
                         {
-                            // Else if it's an implementing type that is not assignable from IList.
+                            // Else if it's an implementing type whose runtime type is not assignable to IList.
                             if (DeclaredPropertyType != ImplementedPropertyType &&
-                                (!typeof(IList).IsAssignableFrom(DeclaredPropertyType) ||
+                                (!typeof(IList).IsAssignableFrom(RuntimePropertyType) ||
                                 ImplementedPropertyType == typeof(ArrayList) ||
                                 ImplementedPropertyType == typeof(IList)))
                             {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoCommon.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoCommon.cs
@@ -118,6 +118,15 @@ namespace System.Text.Json
 
         public override IEnumerable CreateDerivedEnumerableInstance(JsonPropertyInfo collectionPropertyInfo, IList sourceList, string jsonPath, JsonSerializerOptions options)
         {
+            // Implementing types that don't have default constructors are not supported for deserialization.
+            if (collectionPropertyInfo.DeclaredTypeClassInfo.CreateObject == null)
+            {
+                throw ThrowHelper.GetNotSupportedException_SerializationNotSupportedCollection(
+                    collectionPropertyInfo.DeclaredPropertyType,
+                    collectionPropertyInfo.ParentClassType,
+                    collectionPropertyInfo.PropertyInfo);
+            }
+
             object instance = collectionPropertyInfo.DeclaredTypeClassInfo.CreateObject();
 
             if (instance is IList instanceOfIList && !instanceOfIList.IsReadOnly)
@@ -157,7 +166,8 @@ namespace System.Text.Json
                 return instanceOfQueue;
             }
 
-            // TODO: Use reflection to support types implementing Stack or Queue.
+            // TODO (https://github.com/dotnet/corefx/issues/40479):
+            // Use reflection to support types implementing Stack or Queue.
             throw ThrowHelper.GetNotSupportedException_SerializationNotSupportedCollection(
                 collectionPropertyInfo.DeclaredPropertyType,
                 collectionPropertyInfo.ParentClassType,
@@ -166,6 +176,15 @@ namespace System.Text.Json
 
         public override object CreateDerivedDictionaryInstance(JsonPropertyInfo collectionPropertyInfo, IDictionary sourceDictionary, string jsonPath, JsonSerializerOptions options)
         {
+            // Implementing types that don't have default constructors are not supported for deserialization.
+            if (collectionPropertyInfo.DeclaredTypeClassInfo.CreateObject == null)
+            {
+                throw ThrowHelper.GetNotSupportedException_SerializationNotSupportedCollection(
+                    collectionPropertyInfo.DeclaredPropertyType,
+                    collectionPropertyInfo.ParentClassType,
+                    collectionPropertyInfo.PropertyInfo);
+            }
+
             object instance = collectionPropertyInfo.DeclaredTypeClassInfo.CreateObject();
 
             if (instance is IDictionary instanceOfIDictionary && !instanceOfIDictionary.IsReadOnly)
@@ -187,7 +206,8 @@ namespace System.Text.Json
                 return instanceOfGenericIDictionary;
             }
 
-            // TODO: Use reflection to support types implementing SortedList and maybe immutable dictionaries.
+            // TODO (https://github.com/dotnet/corefx/issues/40479):
+            // Use reflection to support types implementing SortedList and maybe immutable dictionaries.
 
             // Types implementing SortedList and immutable dictionaries will fail here.
             throw ThrowHelper.GetNotSupportedException_SerializationNotSupportedCollection(

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.ObjectModelCollections.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.ObjectModelCollections.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.ObjectModel;
+using Xunit;
+
+namespace System.Text.Json.Serialization.Tests
+{
+    public static partial class ValueTests
+    {
+        [Fact]
+        public static void Read_ObjectModelCollection()
+        {
+            Collection<bool> c = JsonSerializer.Deserialize<Collection<bool>>("[true,false]");
+            Assert.Equal(2, c.Count);
+            Assert.True(c[0]);
+            Assert.False(c[1]);
+
+            // Regression test for https://github.com/dotnet/corefx/issues/40597.
+            ObservableCollection<bool> oc = JsonSerializer.Deserialize<ObservableCollection<bool>>("[true,false]");
+            Assert.Equal(2, oc.Count);
+            Assert.True(oc[0]);
+            Assert.False(oc[1]);
+
+            SimpleKeyedCollection kc = JsonSerializer.Deserialize<SimpleKeyedCollection>("[true]");
+            Assert.Equal(1, kc.Count);
+            Assert.True(kc[0]);
+        }
+
+        [Fact]
+        public static void Read_ObjectModelCollection_Throws()
+        {
+            // No default constructor.
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ReadOnlyCollection<bool>>("[true,false]"));
+            // No default constructor.
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ReadOnlyObservableCollection<bool>>("[true,false]"));
+            // No default constructor.
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ReadOnlyDictionary<string, bool>>(@"{""true"":false}"));
+
+            // Abstract types can't be instantiated. This means there's no default constructor, so the type is not supported for deserialization.
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<KeyedCollection<string, bool>>("[true]"));
+        }
+
+        public class SimpleKeyedCollection : KeyedCollection<string, bool>
+        {
+            protected override string GetKeyForItem(bool item)
+            {
+                return item.ToString();
+            }
+        }
+    }
+}

--- a/src/System.Text.Json/tests/Serialization/Value.WriteTests.ObjectModelCollections.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.WriteTests.ObjectModelCollections.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Xunit;
+
+namespace System.Text.Json.Serialization.Tests
+{
+    public static partial class ValueTests
+    {
+        [Fact]
+        public static void Write_ObjectModelCollection()
+        {
+            Collection<bool> c = new Collection<bool>() { true, false };
+            Assert.Equal("[true,false]", JsonSerializer.Serialize(c));
+
+            ObservableCollection<bool> oc = new ObservableCollection<bool>() { true, false };
+            Assert.Equal("[true,false]", JsonSerializer.Serialize(oc));
+
+            SimpleKeyedCollection kc = new SimpleKeyedCollection() { true, false };
+            Assert.Equal("[true,false]", JsonSerializer.Serialize(kc));
+            Assert.Equal("[true,false]", JsonSerializer.Serialize<KeyedCollection<string, bool>>(kc));
+
+            ReadOnlyCollection<bool> roc = new ReadOnlyCollection<bool>(new List<bool> { true, false });
+            Assert.Equal("[true,false]", JsonSerializer.Serialize(oc));
+
+            ReadOnlyObservableCollection<bool> rooc = new ReadOnlyObservableCollection<bool>(oc);
+            Assert.Equal("[true,false]", JsonSerializer.Serialize(rooc));
+
+            ReadOnlyDictionary<string, bool> rod = new ReadOnlyDictionary<string, bool>(new Dictionary<string, bool> { ["true"] = false } );
+            Assert.Equal(@"{""true"":false}", JsonSerializer.Serialize(rod));
+        }
+    }
+}

--- a/src/System.Text.Json/tests/System.Text.Json.Tests.csproj
+++ b/src/System.Text.Json/tests/System.Text.Json.Tests.csproj
@@ -90,10 +90,12 @@
     <Compile Include="Serialization\Value.ReadTests.GenericCollections.cs" />
     <Compile Include="Serialization\Value.ReadTests.ImmutableCollections.cs" />
     <Compile Include="Serialization\Value.ReadTests.NonGenericCollections.cs" />
+    <Compile Include="Serialization\Value.ReadTests.ObjectModelCollections.cs" />
     <Compile Include="Serialization\Value.WriteTests.cs" />
     <Compile Include="Serialization\Value.WriteTests.GenericCollections.cs" />
     <Compile Include="Serialization\Value.WriteTests.ImmutableCollections.cs" />
     <Compile Include="Serialization\Value.WriteTests.NonGenericCollections.cs" />
+    <Compile Include="Serialization\Value.WriteTests.ObjectModelCollections.cs" />
     <Compile Include="Serialization\WriteValueTests.cs" />
     <Compile Include="TestCaseType.cs" />
     <Compile Include="TestClasses.ClassWithComplexObjects.cs" />


### PR DESCRIPTION
Ports https://github.com/dotnet/corefx/pull/40654 to 3.1

## Description
- When determining whether to handle a derived type as `IList` (i.e populating directly, without using a converter), check whether the runtime type is assignable to `IList`, not the declared type.
This fixes https://github.com/dotnet/corefx/issues/40597.
- Preemptively throw `NotSupportedException` on deserialization of implementing types that don't have default constructors. This prevents a `NullReferenceException` when we try to create the instance.
- Detect and use the implemented type of abstract implementing types for (de)serialization. This allows us to correctly throw `NotSupportedException` on deserialization (because abstract types have no default constructor).
- Document expectations of (de)serializing collections in `System.Collections.ObjectModel` in tests.

## Customer Impact

- Prevents `NullReferenceException` when trying to deserialize a derived type without a parameterless ctor (https://github.com/dotnet/corefx/issues/41242).
- Enables support for System.Collections.ObjectModel collections where applicable, throws `NotSupportedException` otherwise
(https://github.com/dotnet/corefx/issues/40597).

## Regression?

No.

## Risk

Low. This PR does not modify already existing features, so the possibility of breaking functionality or introducing regressions is limited. Extensive test cases were added to ensure that the new changes work as expected.