### PR TITLE
[release/3.1] Update experimental IsShipping and block stable properties (#41513)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -395,9 +395,11 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- When IsShipping property is set, other IsShipping* properties take its value if they are not set.
-    This is why IsShippingPackage is only set for Private packages, as Experimental are covered with IsShipping -->
-    <IsShipping Condition="$(MSBuildProjectName.Contains('Experimental'))">false</IsShipping>
+    <!-- Experimental packages should not be stable -->
+    <SuppressFinalPackageVersion Condition="'$(SuppressFinalPackageVersion)' == '' and $(MSBuildProjectName.Contains('Experimental'))">true</SuppressFinalPackageVersion>
+    <IsShippingAssembly Condition="$(MSBuildProjectName.Contains('Experimental'))">false</IsShippingAssembly>
+
+    <!-- We don't want Private packages to be shipped to NuGet.org -->
     <IsShippingPackage Condition="$(MSBuildProjectName.Contains('Private')) and '$(MSBuildProjectExtension)' == '.pkgproj'">false</IsShippingPackage>
   </PropertyGroup>
 </Project>

--- a/eng/Packaging.targets
+++ b/eng/Packaging.targets
@@ -35,7 +35,7 @@
                       '%(Dependency.Identity)' != '_._'" />
   </Target>
 
-  <Target Name="BlockStable" Condition="'$(BlockStable)' == 'true'" AfterTargets="CalculatePackageVersion">
+  <Target Name="BlockStable" Condition="'$(SuppressFinalPackageVersion)' == 'true'" AfterTargets="CalculatePackageVersion">
     <!-- DO NOT ship this packages as stable -->
     <Error Condition="!$(PackageVersion.Contains('-'))" Text="Package $(Id) should not be built stable" />
   </Target>
@@ -46,7 +46,7 @@
     <ItemGroup>
       <_PackageIdentityWithoutPrerelease Include="$(Id)">
         <Version>$(PackageVersion)</Version>
-        <BlockStable>$(BlockStable)</BlockStable>
+        <SuppressFinalPackageVersion>$(SuppressFinalPackageVersion)</SuppressFinalPackageVersion>
       </_PackageIdentityWithoutPrerelease>
     </ItemGroup>
   </Target>

--- a/pkg/Directory.Build.props
+++ b/pkg/Directory.Build.props
@@ -57,8 +57,8 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <!-- BlockStable on private packages by default -->
-    <BlockStable Condition="'$(BlockStable)' == '' and $(MSBuildProjectName.Contains('Private'))">true</BlockStable>
+    <!-- SuppressFinalPackageVersion on private packages by default -->
+    <SuppressFinalPackageVersion Condition="'$(SuppressFinalPackageVersion)' == '' and $(MSBuildProjectName.Contains('Private'))">true</SuppressFinalPackageVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/System.Numerics.Tensors/Directory.Build.props
+++ b/src/System.Numerics.Tensors/Directory.Build.props
@@ -5,6 +5,7 @@
     <PackageVersion>0.3.0</PackageVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <!-- This is a preview package. Do not mark as stable. -->
-    <BlockStable>true</BlockStable>
+    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
+    <IsShippingAssembly>false</IsShippingAssembly>
   </PropertyGroup>
 </Project>

--- a/src/System.Numerics.Tensors/pkg/System.Numerics.Tensors.pkgproj
+++ b/src/System.Numerics.Tensors/pkg/System.Numerics.Tensors.pkgproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <!-- we need to be supported on pre-nuget-3 platforms (Dev12, Dev11, etc) -->
     <MinClientVersion>2.8.6</MinClientVersion>
-    <IsShipping>false</IsShipping>
   </PropertyGroup>
   <ItemGroup>
     <!-- We don't include the reference project for two reasons:

--- a/src/System.Runtime.Intrinsics.Experimental/Directory.Build.props
+++ b/src/System.Runtime.Intrinsics.Experimental/Directory.Build.props
@@ -2,8 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.1.0</AssemblyVersion>
-    <!-- DO NOT ship this as stable. It contains preview-only APIs that will be stable in a future version. -->
-    <BlockStable>true</BlockStable>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>
 </Project>

--- a/src/System.Utf8String.Experimental/Directory.Build.props
+++ b/src/System.Utf8String.Experimental/Directory.Build.props
@@ -5,7 +5,5 @@
     <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <!-- System.Memory uses the Open key, so we will also. -->
     <StrongNameKeyId>Open</StrongNameKeyId>
-    <!-- This is a preview package. Do not ship as stable. -->
-    <BlockStable>true</BlockStable>
   </PropertyGroup>
 </Project>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -62,7 +62,7 @@
     <UpdatePackageIndex
       PackageIndexFile="$(PackageIndexFile)"
       StablePackages="@(_StablePackages)"
-      Condition="'%(_StablePackages.BlockStable)' != 'true'" />
+      Condition="'%(_StablePackages.SuppressFinalPackageVersion)' != 'true'" />
 
   </Target>
 


### PR DESCRIPTION
When I moved to use the arcade `IsShipping` convention, I disabled publishing to NuGet.org for experimental packages. The reasoning of that, is because anything mark as non-shipping, will not make it to NuGet.org.

So we need to mark them only as `IsShippingAssembly=false` so that the `AssemblyInformationalVersion` in metadata isn't stable whenever we ship stable. Also, mark them as `SuppressFinalPackageVersion` so that it doesn't produce a stable version of the package whenever we build those. `SuppressFinalPackageVersion` is the new `BlockStable` property: https://github.com/dotnet/arcade/issues/1213

cc: @danmosemsft 