### PR TITLE
Replace PrintF with Console.WriteLine and cleanups

### DIFF
--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeX509Handles.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeX509Handles.Unix.cs
@@ -21,9 +21,7 @@ namespace Microsoft.Win32.SafeHandles
         {
             if (s_captureTrace)
             {
-                Console.WriteLine(
-                    "{0}\n\n",
-                    $"0x{handle.ToInt64():x} {_stacktrace?.ToString() ?? "no stacktrace..."}");
+                Console.WriteLine($"0x{handle.ToInt64():x} {_stacktrace?.ToString() ?? "no stacktrace..."}");
             }
         }
 #endif

--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeX509Handles.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeX509Handles.Unix.cs
@@ -21,8 +21,8 @@ namespace Microsoft.Win32.SafeHandles
         {
             if (s_captureTrace)
             {
-                Interop.Sys.PrintF(
-                    "%s\n\n",
+                Console.WriteLine(
+                    "{0}\n\n",
                     $"0x{handle.ToInt64():x} {_stacktrace?.ToString() ?? "no stacktrace..."}");
             }
         }

--- a/src/Native/Unix/System.Native/pal_string.c
+++ b/src/Native/Unix/System.Native/pal_string.c
@@ -2,14 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#include "pal_config.h"
 #include "pal_string.h"
 #include "pal_utilities.h"
 
 #include <assert.h>
 #include <stdarg.h>
 #include <stdio.h>
-#include <string.h>
 
 int32_t SystemNative_SNPrintF(char* string, int32_t size, const char* format, ...)
 {
@@ -23,15 +21,6 @@ int32_t SystemNative_SNPrintF(char* string, int32_t size, const char* format, ..
     va_list arguments;
     va_start(arguments, format);
     int result = vsnprintf(string, Int32ToSizeT(size), format, arguments);
-    va_end(arguments);
-    return result;
-}
-
-int32_t SystemNative_PrintF(const char* format, ...)
-{
-    va_list arguments;
-    va_start(arguments, format);
-    int result = vprintf(format, arguments);
     va_end(arguments);
     return result;
 }

--- a/src/Native/Unix/System.Native/pal_string.h
+++ b/src/Native/Unix/System.Native/pal_string.h
@@ -16,12 +16,3 @@
  * On failure, returns a negative value.
  */
 DLLEXPORT int32_t SystemNative_SNPrintF(char* string, int32_t size, const char* format, ...);
-
-/**
- * printf is difficult to represent in C# due to the argument list, so the C# PInvoke
- * layer will have multiple overloads pointing to this function.
- *
- * Returns the number of characters written to the output stream on success; otherwise, returns
- * a negative number and errno and ferror are both set.
- */
-DLLEXPORT int32_t SystemNative_PrintF(const char* format, ...);

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -485,9 +485,6 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Poll.cs">
       <Link>Common\Interop\Unix\libc\Interop.Poll.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.PrintF.cs">
-      <Link>Common\Interop\Unix\libc\Interop.PrintF.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\CoreLib\Interop\Unix\System.Native\Interop.Read.cs">
       <Link>Common\Interop\Unix\libc\Interop.Read.cs</Link>
     </Compile>
@@ -693,6 +690,7 @@
     <Reference Include="System.IO.Compression.Brotli" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
+    <Reference Include="System.Console" Condition="'$(ConfigurationGroup)' == 'Debug'" />
     <Reference Include="System.Diagnostics.StackTrace" />
     <Reference Include="System.IO.FileSystem" />
     <Reference Include="System.Security.Cryptography.Algorithms" />

--- a/src/System.Net.Security/src/System.Net.Security.csproj
+++ b/src/System.Net.Security/src/System.Net.Security.csproj
@@ -266,9 +266,6 @@
     <Compile Include="$(CommonPath)\CoreLib\Interop\Unix\Interop.Errors.cs">
       <Link>Common\CoreLib\Interop\Unix\Interop.Errors.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.PrintF.cs">
-      <Link>Common\Interop\Unix\System.Native\Interop.PrintF.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.Initialization.cs">
       <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.Initialization.cs</Link>
     </Compile>
@@ -469,6 +466,7 @@
     <Reference Include="System.Threading.ThreadPool" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
+    <Reference Include="System.Console" Condition="'$(ConfigurationGroup)' == 'Debug'" />
     <Reference Include="System.Diagnostics.StackTrace" />
     <Reference Include="System.Security.Cryptography.Algorithms" />
     <Reference Include="System.Security.Cryptography.OpenSsl" />

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -300,9 +300,6 @@
     <Compile Include="Microsoft\Win32\SafeHandles\SafePasswordHandle.Unix.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' AND '$(TargetsOSX)' != 'true' ">
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.PrintF.cs">
-      <Link>Common\Interop\Unix\System.Native\Interop.PrintF.cs</Link>
-    </Compile>
     <AsnXml Include="System\Security\Cryptography\X509Certificates\Asn1\DistributionPointAsn.xml" />
     <Compile Include="System\Security\Cryptography\X509Certificates\Asn1\DistributionPointAsn.xml.cs">
       <DependentUpon>System\Security\Cryptography\X509Certificates\Asn1\DistributionPointAsn.xml</DependentUpon>
@@ -711,6 +708,9 @@
   <ItemGroup Condition="'$(TargetsUnix)' == 'true' AND '$(TargetsOSX)' != 'true'">
     <Reference Include="System.Diagnostics.StackTrace" />
     <Reference Include="System.Security.Cryptography.OpenSsl" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
+    <Reference Include="System.Console" Condition="'$(ConfigurationGroup)' == 'Debug'" />
   </ItemGroup>
   <ItemGroup>
     <None Include="@(AsnXml)" /> 


### PR DESCRIPTION
The three usages of these vararg wrapper functions are using fixed number of arguments (1).