### PR TITLE
TCPListener doesn't create a new socket on Stop

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
@@ -66,6 +66,7 @@ namespace System.Net.Sockets
         {
             get
             {
+                CreateNewSocketIfNeeded();
                 return _serverSocket;
             }
         }
@@ -142,12 +143,7 @@ namespace System.Net.Sockets
                 return;
             }
 
-            _serverSocket ??= new Socket(_serverSocketEP.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-
-            if (_exclusiveAddressUse)
-            {
-                _serverSocket.ExclusiveAddressUse = true;
-            }
+            CreateNewSocketIfNeeded();
 
             _serverSocket.Bind(_serverSocketEP);
             try
@@ -337,6 +333,16 @@ namespace System.Net.Sockets
             if (NetEventSource.IsEnabled) NetEventSource.Exit(null, port);
 
             return listener;
+        }
+
+        private void CreateNewSocketIfNeeded()
+        {
+            _serverSocket ??= new Socket(_serverSocketEP.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+
+            if (_exclusiveAddressUse)
+            {
+                _serverSocket.ExclusiveAddressUse = true;
+            }
         }
     }
 }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
@@ -93,7 +93,7 @@ namespace System.Net.Sockets
         {
             get
             {
-                return _serverSocket.ExclusiveAddressUse;
+                return _serverSocket != null ? _serverSocket.ExclusiveAddressUse : _exclusiveAddressUse;
             }
             set
             {
@@ -102,7 +102,10 @@ namespace System.Net.Sockets
                     throw new InvalidOperationException(SR.net_tcplistener_mustbestopped);
                 }
 
-                _serverSocket.ExclusiveAddressUse = value;
+                if (_serverSocket != null)
+                {
+                    _serverSocket.ExclusiveAddressUse = value;
+                }
                 _exclusiveAddressUse = value;
             }
         }
@@ -139,6 +142,12 @@ namespace System.Net.Sockets
                 return;
             }
 
+            _serverSocket = new Socket(_serverSocketEP.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+            if (_exclusiveAddressUse)
+            {
+                _serverSocket.ExclusiveAddressUse = true;
+            }
+
             _serverSocket.Bind(_serverSocketEP);
             try
             {
@@ -160,14 +169,9 @@ namespace System.Net.Sockets
         {
             if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
 
-            _serverSocket.Dispose();
+            _serverSocket?.Dispose();
             _active = false;
-            _serverSocket = new Socket(_serverSocketEP.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-
-            if (_exclusiveAddressUse)
-            {
-                _serverSocket.ExclusiveAddressUse = true;
-            }
+            _serverSocket = null;
 
             if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
         }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
@@ -142,10 +142,7 @@ namespace System.Net.Sockets
                 return;
             }
 
-            if (_serverSocket == null)
-            {
-                _serverSocket = new Socket(_serverSocketEP.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-            }
+            _serverSocket ??= new Socket(_serverSocketEP.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 
             if (_exclusiveAddressUse)
             {

--- a/src/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
@@ -142,7 +142,11 @@ namespace System.Net.Sockets
                 return;
             }
 
-            _serverSocket = new Socket(_serverSocketEP.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+            if (_serverSocket == null)
+            {
+                _serverSocket = new Socket(_serverSocketEP.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+            }
+
             if (_exclusiveAddressUse)
             {
                 _serverSocket.ExclusiveAddressUse = true;

--- a/src/System.Net.Sockets/tests/FunctionalTests/TcpListenerTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/TcpListenerTest.cs
@@ -150,7 +150,7 @@ namespace System.Net.Sockets.Tests
             await VerifyAccept(listener);
             listener.Stop();
 
-            Assert.Null(listener.Server);
+            Assert.NotNull(listener.Server);
 
             listener.Start();
             Assert.NotNull(listener.Server);

--- a/src/System.Net.Sockets/tests/FunctionalTests/TcpListenerTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/TcpListenerTest.cs
@@ -172,9 +172,10 @@ namespace System.Net.Sockets.Tests
         {
             var listener = new TcpListener(IPAddress.Loopback, 0);
 
-            Assert.False(listener.ExclusiveAddressUse);
             listener.ExclusiveAddressUse = true;
             Assert.True(listener.ExclusiveAddressUse);
+            listener.ExclusiveAddressUse = false;
+            Assert.False(listener.ExclusiveAddressUse);
         }
 
         [Fact]

--- a/src/System.Net.Sockets/tests/FunctionalTests/TcpListenerTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/TcpListenerTest.cs
@@ -156,6 +156,15 @@ namespace System.Net.Sockets.Tests
             Assert.NotNull(listener.Server);
             await VerifyAccept(listener);
             listener.Stop();
+
+            async Task VerifyAccept(TcpListener listener)
+            {
+                using var client = new TcpClient();
+                Task connectTask = client.ConnectAsync(IPAddress.Loopback, ((IPEndPoint)listener.LocalEndpoint).Port);
+                using Socket s = await listener.AcceptSocketAsync();
+                Assert.False(listener.Pending());
+                await connectTask;
+            }
         }
 
         [Fact]
@@ -198,19 +207,6 @@ namespace System.Net.Sockets.Tests
             listener.Stop();
 
             Assert.True(listener.ExclusiveAddressUse);
-        }
-
-        private static async Task VerifyAccept(TcpListener listener)
-        {
-            using (var client = new TcpClient())
-            {
-                Task connectTask = client.ConnectAsync(IPAddress.Loopback, ((IPEndPoint)listener.LocalEndpoint).Port);
-                using (Socket s = listener.AcceptSocket())
-                {
-                    Assert.False(listener.Pending());
-                }
-                await connectTask;
-            }
         }
 
         private sealed class DerivedTcpListener : TcpListener


### PR DESCRIPTION
TCPListener.Stop disposes the socket and resets the reference. New socket is created only on the next Start call.
Fixes #26170 