### PR TITLE
[release/3.1] Add Fedora 32, and CentOS 8 runtime ids

### DIFF
--- a/pkg/Microsoft.NETCore.Platforms/runtime.compatibility.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.compatibility.json
@@ -319,6 +319,32 @@
     "any",
     "base"
   ],
+  "centos.8": [
+    "centos.8",
+    "centos",
+    "rhel.8",
+    "rhel",
+    "linux",
+    "unix",
+    "any",
+    "base"
+  ],
+  "centos.8-x64": [
+    "centos.8-x64",
+    "centos.8",
+    "centos-x64",
+    "rhel.8-x64",
+    "centos",
+    "rhel.8",
+    "rhel-x64",
+    "rhel",
+    "linux-x64",
+    "linux",
+    "unix-x64",
+    "unix",
+    "any",
+    "base"
+  ],
   "debian": [
     "debian",
     "linux",
@@ -886,6 +912,38 @@
   "fedora.31-x64": [
     "fedora.31-x64",
     "fedora.31",
+    "fedora-x64",
+    "fedora",
+    "linux-x64",
+    "linux",
+    "unix-x64",
+    "unix",
+    "any",
+    "base"
+  ],
+  "fedora.32": [
+    "fedora.32",
+    "fedora",
+    "linux",
+    "unix",
+    "any",
+    "base"
+  ],
+  "fedora.32-arm64": [
+    "fedora.32-arm64",
+    "fedora.32",
+    "fedora-arm64",
+    "fedora",
+    "linux-arm64",
+    "linux",
+    "unix-arm64",
+    "unix",
+    "any",
+    "base"
+  ],
+  "fedora.32-x64": [
+    "fedora.32-x64",
+    "fedora.32",
     "fedora-x64",
     "fedora",
     "linux-x64",

--- a/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -148,6 +148,19 @@
         "rhel.7-x64"
       ]
     },
+    "centos.8": {
+      "#import": [
+        "centos",
+        "rhel.8"
+      ]
+    },
+    "centos.8-x64": {
+      "#import": [
+        "centos.8",
+        "centos-x64",
+        "rhel.8-x64"
+      ]
+    },
     "debian": {
       "#import": [
         "linux"
@@ -455,6 +468,23 @@
     "fedora.31-x64": {
       "#import": [
         "fedora.31",
+        "fedora-x64"
+      ]
+    },
+    "fedora.32": {
+      "#import": [
+        "fedora"
+      ]
+    },
+    "fedora.32-arm64": {
+      "#import": [
+        "fedora.32",
+        "fedora-arm64"
+      ]
+    },
+    "fedora.32-x64": {
+      "#import": [
+        "fedora.32",
         "fedora-x64"
       ]
     },

--- a/pkg/Microsoft.NETCore.Platforms/runtimeGroups.props
+++ b/pkg/Microsoft.NETCore.Platforms/runtimeGroups.props
@@ -28,8 +28,9 @@
     <RuntimeGroup Include="centos">
       <Parent>rhel</Parent>
       <Architectures>x64</Architectures>
-      <Versions>7</Versions>
+      <Versions>7;8</Versions>
       <ApplyVersionsToParent>true</ApplyVersionsToParent>
+      <TreatVersionsAsCompatible>false</TreatVersionsAsCompatible>
     </RuntimeGroup>
 
     <RuntimeGroup Include="debian">
@@ -42,7 +43,7 @@
     <RuntimeGroup Include="fedora">
       <Parent>linux</Parent>
       <Architectures>x64;arm64</Architectures>
-      <Versions>23;24;25;26;27;28;29;30;31</Versions>
+      <Versions>23;24;25;26;27;28;29;30;31;32</Versions>
       <TreatVersionsAsCompatible>false</TreatVersionsAsCompatible>
     </RuntimeGroup>
 


### PR DESCRIPTION
This is combined backport of:

- PR #41397: commit 6f82bd59a05ea9556397596ae9e59f39b904b222
- PR #40786: commit 86fc9e751c424278a9c4e163e0a71a9d7e30c8e7

This hasn't been releaesd yet; do I need to update project/build files like in https://github.com/dotnet/corefx/pull/35297 ?