### PR TITLE
Remove unnecessary System.Linq usage from Microsoft.CSharp

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/RuntimeBinder.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Dynamic;
-using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.CSharp.RuntimeBinder.Errors;
 using Microsoft.CSharp.RuntimeBinder.Semantics;
@@ -1295,7 +1294,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             LocalVariableSymbol[] locals)
         {
             Debug.Assert(arguments.Length >= 2);
-            Debug.Assert(arguments.All(a => a.Type != null));
+            Debug.Assert(Array.TrueForAll(arguments, a => a.Type != null));
 
             string name = payload.Name;
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Binding/Better.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Binding/Better.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using Microsoft.CSharp.RuntimeBinder.Syntax;
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
@@ -484,9 +483,8 @@ LAgain:
             out CandidateFunctionMember methAmbig1,
             out CandidateFunctionMember methAmbig2)
         {
-            Debug.Assert(list.Any());
-            Debug.Assert(list.First().mpwi != null);
-            Debug.Assert(list.Count > 0);
+            Debug.Assert(list.Count != 0);
+            Debug.Assert(list[0].mpwi != null);
 
             // select the best method:
             /*
@@ -501,8 +499,8 @@ LAgain:
                 goto phase 2
             Phase 2: compare all items before candidate to candidate
                 If candidate always better, return it, otherwise return null
+            */
 
-        */
             // Record two method that are ambiguous for error reporting.
             CandidateFunctionMember ambig1 = null;
             CandidateFunctionMember ambig2 = null;
@@ -584,8 +582,8 @@ LAgain:
             {
                 // For some reason, we have an ambiguity but never had a tie.
                 // This can easily happen in a circular graph of candidate methods.
-                methAmbig1 = list.First();
-                methAmbig2 = list.Skip(1).First();
+                methAmbig1 = list[0];
+                methAmbig2 = list[1];
             }
 
             return null;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/ExpressionBinder.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using Microsoft.CSharp.RuntimeBinder.Errors;
 using Microsoft.CSharp.RuntimeBinder.Syntax;
 
@@ -1106,7 +1105,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             int iDst = 0;
             int argCount = ExpressionIterator.Count(argsPtr);
 
-            Debug.Assert(!@params.Items.Any(p => p is ArgumentListType)); // We should never have picked a varargs method to bind to.
+            Debug.Assert(!Array.Exists(@params.Items, p => p is ArgumentListType)); // We should never have picked a varargs method to bind to.
 
             bool bDontFixParamArray = false;
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookup.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/MemberLookup.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using Microsoft.CSharp.RuntimeBinder.Errors;
 using Microsoft.CSharp.RuntimeBinder.Syntax;
 
@@ -317,7 +316,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 {
                     return false;
                 }
-                var o = field.AssociatedFieldInfo.GetCustomAttributes(typeof(System.Runtime.CompilerServices.DynamicAttribute), false).ToArray();
+                var o = field.AssociatedFieldInfo.GetCustomAttributes(typeof(System.Runtime.CompilerServices.DynamicAttribute), false);
                 if (o.Length == 1)
                 {
                     da = o[0] as System.Runtime.CompilerServices.DynamicAttribute;
@@ -331,7 +330,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 {
                     return false;
                 }
-                var o = prop.AssociatedPropertyInfo.GetCustomAttributes(typeof(System.Runtime.CompilerServices.DynamicAttribute), false).ToArray();
+                var o = prop.AssociatedPropertyInfo.GetCustomAttributes(typeof(System.Runtime.CompilerServices.DynamicAttribute), false);
                 if (o.Length == 1)
                 {
                     da = o[0] as System.Runtime.CompilerServices.DynamicAttribute;

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeArray.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeArray.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 
 namespace Microsoft.CSharp.RuntimeBinder.Semantics
 {
@@ -101,7 +100,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public void AssertValid()
         {
             Debug.Assert(Count >= 0);
-            Debug.Assert(Items.All(item => item != null));
+            Debug.Assert(Array.TrueForAll(Items, item => item != null));
         }
 
         public void CopyItems(int i, int c, CType[] dest) => Array.Copy(Items, i, dest, 0, c);

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Syntax/NameTable.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Syntax/NameTable.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Diagnostics;
-using System.Linq;
 
 namespace Microsoft.CSharp.RuntimeBinder.Syntax
 {
@@ -65,7 +65,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Syntax
         {
             int hashCode = ComputeHashCode(name.Text);
             // make sure it doesn't already exist
-            Debug.Assert(_entries.All(e => e?.Name.Text != name.Text));
+            Debug.Assert(Array.TrueForAll(_entries, e => e?.Name.Text != name.Text));
 
             AddEntry(name, hashCode);
         }


### PR DESCRIPTION
Most of the usage was just as easily (if not more easily) done without LINQ.  In some cases the use was entirely superfluous (e.g. MethodReturningNewArray().ToArray()).