### PR TITLE
Remove System.Linq dependency from System.Security.Cryptography.Algorithms

### DIFF
--- a/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -710,7 +710,6 @@
     <Reference Include="System.Collections.Concurrent" />
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.Diagnostics.Tools" />
-    <Reference Include="System.Linq" />
     <Reference Include="System.Memory" />
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/AesCcm.Unix.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/AesCcm.Unix.cs
@@ -2,14 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
-using Internal.Cryptography;
 using Microsoft.Win32.SafeHandles;
 
 namespace System.Security.Cryptography

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/AesCcm.Windows.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/AesCcm.Windows.cs
@@ -2,14 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Internal.Cryptography;
 using Internal.NativeCrypto;
-using static Interop.BCrypt;
 
 namespace System.Security.Cryptography
 {

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/AesGcm.Unix.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/AesGcm.Unix.cs
@@ -2,14 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
-using Internal.Cryptography;
 using Microsoft.Win32.SafeHandles;
 
 namespace System.Security.Cryptography

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/AesGcm.Windows.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/AesGcm.Windows.cs
@@ -2,14 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Internal.Cryptography;
 using Internal.NativeCrypto;
-using static Interop.BCrypt;
 
 namespace System.Security.Cryptography
 {


### PR DESCRIPTION
It's not being used.  Remove it.