### PR TITLE
Support For Getting base-64 String as Byte Array

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+// testing issue labeler
 using System.Collections.Generic;
 using System.Diagnostics;
 

--- a/src/System.Text.Json/src/System/Text/Json/Node/JsonString.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Node/JsonString.cs
@@ -4,6 +4,7 @@
 
 using System.Globalization;
 
+// testing issue labeler
 namespace System.Text.Json
 {
     /// <summary>

--- a/src/System.Text.Json/tests/JsonElementWithNodeParentTests.cs
+++ b/src/System.Text.Json/tests/JsonElementWithNodeParentTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+// testing issue labeler
 using System.Globalization;
 using System.IO;
 using Xunit;


### PR DESCRIPTION
Reimplementation to solve problems from #41464. Only added one test where the method returns false as suggested:

> This needs a lot more tests... whitespace-containing, two trailing =, zero trailing =, something that returns false (including zero, one, and two trailing = in the false-returning inputs)

but the rest of these cases should with this reimplementation be covered by [Convert.FromBase64.cs](https://github.com/dotnet/corefx/blob/master/src/System.Runtime.Extensions/tests/System/Convert.FromBase64.cs).

Solves #41132. Implemented support for getting JsonString encoded in base-64 as an equivalent byte array.