### PR TITLE
Update the hex value for DarkSeaGreen color

### DIFF
--- a/src/Common/src/System/Drawing/KnownColorTable.cs
+++ b/src/Common/src/System/Drawing/KnownColorTable.cs
@@ -45,7 +45,7 @@ namespace System.Drawing
             0xFF9932CC,     // DarkOrchid
             0xFF8B0000,     // DarkRed
             0xFFE9967A,     // DarkSalmon
-            0xFF8FBC8B,     // DarkSeaGreen
+            0xFF8FBC8F,     // DarkSeaGreen
             0xFF483D8B,     // DarkSlateBlue
             0xFF2F4F4F,     // DarkSlateGray
             0xFF00CED1,     // DarkTurquoise

--- a/src/System.Drawing.Primitives/tests/ColorTests.cs
+++ b/src/System.Drawing.Primitives/tests/ColorTests.cs
@@ -51,7 +51,7 @@ namespace System.Drawing.Primitives.Tests
                 new object[] {"DarkOrchid", 255, 153, 50, 204},
                 new object[] {"DarkRed", 255, 139, 0, 0},
                 new object[] {"DarkSalmon", 255, 233, 150, 122},
-                new object[] {"DarkSeaGreen", 255, 143, 188, 139},
+                new object[] {"DarkSeaGreen", 255, 143, 188, 143},
                 new object[] {"DarkSlateBlue", 255, 72, 61, 139},
                 new object[] {"DarkSlateGray", 255, 47, 79, 79},
                 new object[] {"DarkTurquoise", 255, 0, 206, 209},


### PR DESCRIPTION
Update the hex value for DarkSeaGreen color to 0xFF8FBC8F.

Based on W3 definition, the hex value for DarkSeaGreen color needs to be fixed:
https://www.w3.org/wiki/CSS/Properties/color/keywords

No issues were created for this problem but one comment has been made previously:
https://github.com/dotnet/corefx/commit/97c736e09f2e119d6ec3d3ebebb7234dee48145d#r35239355
