### PR TITLE
Remove System.Linq dependency from System.Security.Cryptography.X509Certificates

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -687,7 +687,6 @@
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.Diagnostics.Tools" />
     <Reference Include="System.IO.FileSystem" />
-    <Reference Include="System.Linq" />
     <Reference Include="System.Memory" />
     <Reference Include="System.Net.Primitives" />
     <Reference Include="System.Resources.ResourceManager" />

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/Pkcs10CertificationRequestInfo.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/Pkcs10CertificationRequestInfo.cs
@@ -5,7 +5,6 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
-using System.Linq;
 using System.Security.Cryptography.Asn1;
 using System.Security.Cryptography.X509Certificates.Asn1;
 using Internal.Cryptography;
@@ -58,12 +57,18 @@ namespace System.Security.Cryptography.X509Certificates
             spki.Algorithm = new AlgorithmIdentifierAsn { Algorithm = PublicKey.Oid, Parameters = PublicKey.EncodedParameters.RawData };
             spki.SubjectPublicKey = PublicKey.EncodedKeyValue.RawData;
 
+            var attributes = new AttributeAsn[Attributes.Count];
+            for (int i = 0; i < attributes.Length; i++)
+            {
+                attributes[i] = new AttributeAsn(Attributes[i]);
+            }
+
             CertificationRequestInfoAsn requestInfo = new CertificationRequestInfoAsn
             {
                 Version = 0,
                 Subject = this.Subject.RawData,
                 SubjectPublicKeyInfo = spki,
-                Attributes = Attributes.Select(a => new AttributeAsn(a)).ToArray(),
+                Attributes = attributes
             };
 
             using (AsnWriter writer = new AsnWriter(AsnEncodingRules.DER))


### PR DESCRIPTION
System.Linq was only being used in two places:
- In Pkcs10CertificateRequestInfo, it was using Collection<>.Select(...).ToArray().  We can replace it with a simple for loop, which is both faster (e.g. fewer delegate invocations) and fewer generic instantiations (no one else is going to have an instantiation with AttributeAsn).
- In LoadMachineStores on Linux, it was using Prepend.  We can avoid the need for Prepend (and the associated allocations) entirely by slightly reorganizing the method and using a local function.