### PR TITLE
Remove System.Linq dependency from System.Net.NetworkInformation

### DIFF
--- a/src/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
+++ b/src/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
@@ -301,7 +301,6 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
     <Reference Include="System.IO.FileSystem" />
-    <Reference Include="System.Linq" />
     <Reference Include="System.Threading.Thread" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsLinux)' == 'true'">

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdIPGlobalProperties.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdIPGlobalProperties.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Linq;
-using System.Threading.Tasks;
-
 namespace System.Net.NetworkInformation
 {
     internal class BsdIPGlobalProperties : UnixIPGlobalProperties
@@ -73,7 +70,12 @@ namespace System.Net.NetworkInformation
         public override IPEndPoint[] GetActiveTcpListeners()
         {
             TcpConnectionInformation[] allConnections = GetTcpConnections(listeners:true);
-            return allConnections.Select(tci => tci.LocalEndPoint).ToArray();
+            var endPoints = new IPEndPoint[allConnections.Length];
+            for (int i = 0; i < allConnections.Length; i++)
+            {
+                endPoints[i] = allConnections[i].LocalEndPoint;
+            }
+            return endPoints;
         }
 
         public unsafe override IPEndPoint[] GetActiveUdpListeners()

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdIPv4GlobalStatistics.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdIPv4GlobalStatistics.cs
@@ -3,8 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 
 namespace System.Net.NetworkInformation
 {

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdIpInterfaceProperties.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdIpInterfaceProperties.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Linq;
 
 namespace System.Net.NetworkInformation
 {

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdNetworkInterface.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdNetworkInterface.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Linq;
 
 namespace System.Net.NetworkInformation
 {
@@ -102,7 +101,13 @@ namespace System.Net.NetworkInformation
                 }
                 else if (result == 0)
                 {
-                    return interfacesByName.Values.ToArray();
+                    var results = new BsdNetworkInterface[interfacesByName.Count];
+                    int i = 0;
+                    foreach (KeyValuePair<string, BsdNetworkInterface> item in interfacesByName)
+                    {
+                        results[i++] = item.Value;
+                    }
+                    return results;
                 }
                 else
                 {

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxIPGlobalProperties.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxIPGlobalProperties.cs
@@ -2,12 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
-
 namespace System.Net.NetworkInformation
 {
     internal class LinuxIPGlobalProperties : UnixIPGlobalProperties

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxNetworkInterface.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxNetworkInterface.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 
 namespace System.Net.NetworkInformation
 {
@@ -93,7 +92,13 @@ namespace System.Net.NetworkInformation
                 }
                 else if (result == 0)
                 {
-                    return interfacesByName.Values.ToArray();
+                    var results = new LinuxNetworkInterface[interfacesByName.Count];
+                    int i = 0;
+                    foreach (KeyValuePair<string, LinuxNetworkInterface> item in interfacesByName)
+                    {
+                        results[i++] = item.Value;
+                    }
+                    return results;
                 }
                 else
                 {

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixIPInterfaceProperties.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixIPInterfaceProperties.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net.Sockets;
 
 namespace System.Net.NetworkInformation
@@ -82,12 +81,15 @@ namespace System.Net.NetworkInformation
         private static UnicastIPAddressInformationCollection GetUnicastAddresses(UnixNetworkInterface uni)
         {
             var collection = new UnicastIPAddressInformationCollection();
-            foreach (IPAddress address in uni.Addresses.Where((addr) => !IPAddressUtil.IsMulticast(addr)))
+            foreach (IPAddress address in uni.Addresses)
             {
-                IPAddress netMask = (address.AddressFamily == AddressFamily.InterNetwork)
-                                    ? uni.GetNetMaskForIPv4Address(address)
-                                    : IPAddress.Any; // Windows compatibility
-                collection.InternalAdd(new UnixUnicastIPAddressInformation(address, netMask));
+                if (!IPAddressUtil.IsMulticast(address))
+                {
+                    IPAddress netMask = (address.AddressFamily == AddressFamily.InterNetwork)
+                                        ? uni.GetNetMaskForIPv4Address(address)
+                                        : IPAddress.Any; // Windows compatibility
+                    collection.InternalAdd(new UnixUnicastIPAddressInformation(address, netMask));
+                }
             }
 
             return collection;
@@ -96,9 +98,12 @@ namespace System.Net.NetworkInformation
         private static MulticastIPAddressInformationCollection GetMulticastAddresses(UnixNetworkInterface uni)
         {
             var collection = new MulticastIPAddressInformationCollection();
-            foreach (IPAddress address in uni.Addresses.Where(IPAddressUtil.IsMulticast))
+            foreach (IPAddress address in uni.Addresses)
             {
-                collection.InternalAdd(new UnixMulticastIPAddressInformation(address));
+                if (IPAddressUtil.IsMulticast(address))
+                {
+                    collection.InternalAdd(new UnixMulticastIPAddressInformation(address));
+                }
             }
 
             return collection;

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixNetworkInterface.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixNetworkInterface.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 
 namespace System.Net.NetworkInformation
 {
@@ -36,12 +35,19 @@ namespace System.Net.NetworkInformation
 
         public override bool Supports(NetworkInterfaceComponent networkInterfaceComponent)
         {
-            Sockets.AddressFamily family =
-                (networkInterfaceComponent == NetworkInterfaceComponent.IPv4)
-                ? Sockets.AddressFamily.InterNetwork
-                : Sockets.AddressFamily.InterNetworkV6;
+            Sockets.AddressFamily family = (networkInterfaceComponent == NetworkInterfaceComponent.IPv4) ?
+                Sockets.AddressFamily.InterNetwork :
+                Sockets.AddressFamily.InterNetworkV6;
 
-            return _addresses.Any(addr => addr.AddressFamily == family);
+            foreach (IPAddress addr in _addresses)
+            {
+                if (addr.AddressFamily == family)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
It was only being used on Unix, and the uses are all easily replaced with more efficient implementations.