### PR TITLE
Remove unused usings from System.Security.Cryptography.Xml

### DIFF
--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/AncestralNamespaceContextManager.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/AncestralNamespaceContextManager.cs
@@ -2,10 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Xml;
-using System.IO;
-using System.Text;
 using System.Collections;
 
 namespace System.Security.Cryptography.Xml

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/AttributeSortOrder.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/AttributeSortOrder.cs
@@ -2,10 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Xml;
-using System.IO;
-using System.Text;
 using System.Collections;
 
 namespace System.Security.Cryptography.Xml

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/C14NAncestralNamespaceContextManager.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/C14NAncestralNamespaceContextManager.cs
@@ -3,8 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Xml;
-using System.IO;
-using System.Text;
 using System.Collections;
 
 namespace System.Security.Cryptography.Xml

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXml.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXml.cs
@@ -5,9 +5,6 @@
 using System.Xml;
 using System.IO;
 using System.Text;
-using System.Collections;
-using System.Security.Cryptography;
-using System;
 
 namespace System.Security.Cryptography.Xml
 {

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlAttribute.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlAttribute.cs
@@ -2,12 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Xml;
-using System.IO;
 using System.Text;
-using System.Collections;
-using System.Security.Cryptography;
 
 namespace System.Security.Cryptography.Xml
 {

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlCDataSection.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlCDataSection.cs
@@ -2,12 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Xml;
-using System.IO;
 using System.Text;
-using System.Collections;
-using System.Security.Cryptography;
 
 namespace System.Security.Cryptography.Xml
 {

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlComment.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlComment.cs
@@ -2,12 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Xml;
-using System.IO;
 using System.Text;
-using System.Collections;
-using System.Security.Cryptography;
 
 namespace System.Security.Cryptography.Xml
 {

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlDocument.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlDocument.cs
@@ -2,12 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Xml;
-using System.IO;
 using System.Text;
-using System.Collections;
-using System.Security.Cryptography;
 
 namespace System.Security.Cryptography.Xml
 {

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlElement.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlElement.cs
@@ -2,12 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Xml;
-using System.IO;
 using System.Text;
 using System.Collections;
-using System.Security.Cryptography;
 
 namespace System.Security.Cryptography.Xml
 {

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlEntityReference.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlEntityReference.cs
@@ -2,12 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Xml;
-using System.IO;
 using System.Text;
-using System.Collections;
-using System.Security.Cryptography;
 
 namespace System.Security.Cryptography.Xml
 {

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlNodeList.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlNodeList.cs
@@ -2,10 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Xml;
-using System.IO;
-using System.Text;
 using System.Collections;
 
 namespace System.Security.Cryptography.Xml

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlProcessingInstruction.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlProcessingInstruction.cs
@@ -2,12 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Xml;
-using System.IO;
 using System.Text;
-using System.Collections;
-using System.Security.Cryptography;
 
 namespace System.Security.Cryptography.Xml
 {

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlSignificantWhitespace.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlSignificantWhitespace.cs
@@ -2,12 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Xml;
-using System.IO;
 using System.Text;
-using System.Collections;
-using System.Security.Cryptography;
 
 namespace System.Security.Cryptography.Xml
 {

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlText.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlText.cs
@@ -2,12 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Xml;
-using System.IO;
 using System.Text;
-using System.Collections;
-using System.Security.Cryptography;
 
 namespace System.Security.Cryptography.Xml
 {

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlWhitespace.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalXmlWhitespace.cs
@@ -2,12 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Xml;
-using System.IO;
 using System.Text;
-using System.Collections;
-using System.Security.Cryptography;
 
 namespace System.Security.Cryptography.Xml
 {

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalizationDispatcher.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CanonicalizationDispatcher.cs
@@ -2,12 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Xml;
-using System.IO;
 using System.Text;
-using System.Collections;
-using System.Security.Cryptography;
 
 namespace System.Security.Cryptography.Xml
 {

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CertUsageType.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CertUsageType.cs
@@ -2,17 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Win32;
-using System;
-using System.Collections;
-using System.Diagnostics;
-using System.Globalization;
-using System.IO;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
-using System.Threading;
-using System.Xml;
-
 namespace System.Security.Cryptography.Xml
 {
     internal enum CertUsageType

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CipherData.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CipherData.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections;
 using System.Xml;
 
 namespace System.Security.Cryptography.Xml

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CipherReference.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CipherReference.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections;
 using System.Xml;
 
 namespace System.Security.Cryptography.Xml

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CryptoHelpers.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CryptoHelpers.cs
@@ -2,12 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace System.Security.Cryptography.Xml
 {
     internal static class CryptoHelpers

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/DSAKeyValue.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/DSAKeyValue.cs
@@ -2,12 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections;
-using System.Runtime.InteropServices;
-using System.Security.Cryptography;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
 using System.Xml;
 
 namespace System.Security.Cryptography.Xml

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/DataObject.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/DataObject.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.IO;
 using System.Xml;
 
 namespace System.Security.Cryptography.Xml

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/DataReference.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/DataReference.cs
@@ -2,10 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections;
-using System.Xml;
-
 namespace System.Security.Cryptography.Xml
 {
     public sealed class DataReference : EncryptedReference

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/DocPosition.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/DocPosition.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-
 namespace System.Security.Cryptography.Xml
 {
     // the current rendering position in document

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/EncryptedData.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/EncryptedData.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections;
 using System.Xml;
 
 namespace System.Security.Cryptography.Xml

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/EncryptedKey.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/EncryptedKey.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections;
 using System.Xml;
 
 namespace System.Security.Cryptography.Xml

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/EncryptedReference.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/EncryptedReference.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections;
 using System.Xml;
 
 namespace System.Security.Cryptography.Xml

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/EncryptedType.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/EncryptedType.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections;
 using System.Xml;
 
 namespace System.Security.Cryptography.Xml

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/EncryptedXml.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/EncryptedXml.cs
@@ -4,7 +4,6 @@
 
 using System.Collections;
 using System.IO;
-using System.Net;
 using System.Security.Cryptography.X509Certificates;
 using System.Security.Policy;
 using System.Text;

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/EncryptionMethod.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/EncryptionMethod.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections;
 using System.Xml;
 
 namespace System.Security.Cryptography.Xml

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/EncryptionProperty.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/EncryptionProperty.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections;
 using System.Xml;
 
 namespace System.Security.Cryptography.Xml

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/EncryptionPropertyCollection.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/EncryptionPropertyCollection.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections;
-using System.Xml;
 
 namespace System.Security.Cryptography.Xml
 {

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/ExcAncestralNamespaceContextManager.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/ExcAncestralNamespaceContextManager.cs
@@ -3,8 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Xml;
-using System.IO;
-using System.Text;
 using System.Collections;
 
 namespace System.Security.Cryptography.Xml

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/ExcCanonicalXml.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/ExcCanonicalXml.cs
@@ -5,9 +5,6 @@
 using System.Xml;
 using System.IO;
 using System.Text;
-using System.Collections;
-using System.Security.Cryptography;
-using System;
 
 namespace System.Security.Cryptography.Xml
 {

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/ICanonicalizableNode.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/ICanonicalizableNode.cs
@@ -2,12 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Xml;
-using System.IO;
 using System.Text;
-using System.Collections;
-using System.Security.Cryptography;
 
 namespace System.Security.Cryptography.Xml
 {

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/KeyInfo.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/KeyInfo.cs
@@ -2,12 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections;
-using System.Runtime.InteropServices;
-using System.Security.Cryptography;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
 using System.Xml;
 
 namespace System.Security.Cryptography.Xml

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/KeyInfoEncryptedKey.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/KeyInfoEncryptedKey.cs
@@ -2,12 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections;
-using System.Runtime.InteropServices;
-using System.Security.Cryptography;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
 using System.Xml;
 
 namespace System.Security.Cryptography.Xml

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/KeyInfoName.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/KeyInfoName.cs
@@ -2,12 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections;
-using System.Runtime.InteropServices;
-using System.Security.Cryptography;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
 using System.Xml;
 
 namespace System.Security.Cryptography.Xml

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/KeyInfoNode.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/KeyInfoNode.cs
@@ -2,12 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections;
-using System.Runtime.InteropServices;
-using System.Security.Cryptography;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
 using System.Xml;
 
 namespace System.Security.Cryptography.Xml

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/KeyInfoRetrievalMethod.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/KeyInfoRetrievalMethod.cs
@@ -2,12 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections;
-using System.Runtime.InteropServices;
-using System.Security.Cryptography;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
 using System.Xml;
 
 namespace System.Security.Cryptography.Xml

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/KeyInfoX509Data.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/KeyInfoX509Data.cs
@@ -2,14 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections;
 using System.Globalization;
 using System.Numerics;
-using System.Runtime.InteropServices;
-using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
-using System.Text;
 using System.Xml;
 
 namespace System.Security.Cryptography.Xml

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/KeyReference.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/KeyReference.cs
@@ -2,10 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections;
-using System.Xml;
-
 namespace System.Security.Cryptography.Xml
 {
     public sealed class KeyReference : EncryptedReference

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/MyXmlDocument.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/MyXmlDocument.cs
@@ -2,14 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Win32;
-using System.Collections;
-using System.Diagnostics;
-using System.Globalization;
-using System.IO;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
-using System.Threading;
 using System.Xml;
 
 namespace System.Security.Cryptography.Xml

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/NamespaceFrame.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/NamespaceFrame.cs
@@ -2,10 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Xml;
-using System.IO;
-using System.Text;
 using System.Collections;
 
 namespace System.Security.Cryptography.Xml

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/NamespaceSortOrder.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/NamespaceSortOrder.cs
@@ -2,10 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Xml;
-using System.IO;
-using System.Text;
 using System.Collections;
 
 namespace System.Security.Cryptography.Xml

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/RSAKeyValue.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/RSAKeyValue.cs
@@ -2,12 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections;
-using System.Runtime.InteropServices;
-using System.Security.Cryptography;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
 using System.Xml;
 
 namespace System.Security.Cryptography.Xml

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/Reference.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/Reference.cs
@@ -2,14 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.IO;
 using System.Net;
-using System.Runtime.InteropServices;
-using System.Security.Cryptography;
 using System.Xml;
-using System.Globalization;
-using System.Runtime.Versioning;
 
 namespace System.Security.Cryptography.Xml
 {

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/ReferenceList.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/ReferenceList.cs
@@ -2,11 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace System.Security.Cryptography.Xml
 {

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/ReferenceTargetType.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/ReferenceTargetType.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-
 namespace System.Security.Cryptography.Xml
 {
     internal enum ReferenceTargetType

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/Signature.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/Signature.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections;
 using System.Xml;
 

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/SignedInfo.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/SignedInfo.cs
@@ -2,11 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections;
-using System.Runtime.InteropServices;
 using System.Xml;
-using System.Globalization;
 
 namespace System.Security.Cryptography.Xml
 {

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/SignedXml.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/SignedXml.cs
@@ -2,18 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Globalization;
-using System.IO;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Xml;
-using Microsoft.Win32;
 
 namespace System.Security.Cryptography.Xml
 {

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/SignedXmlDebugLog.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/SignedXmlDebugLog.cs
@@ -2,13 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
-using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Xml;

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/SymmetricKeyWrap.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/SymmetricKeyWrap.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Security.Cryptography;
 
 namespace System.Security.Cryptography.Xml
 {

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/Transform.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/Transform.cs
@@ -14,15 +14,9 @@
 // Once the Transform chain is constructed, call TransformToOctetStream to convert some sort of input type to an octet
 // stream. (We only bother implementing that much now since every use of transform chains in XmlDsig ultimately yields something to hash).
 
-using System;
 using System.Collections;
 using System.IO;
-using System.Runtime.InteropServices;
-using System.Security;
-using System.Text;
 using System.Xml;
-using System.Xml.XPath;
-using System.Xml.Xsl;
 
 namespace System.Security.Cryptography.Xml
 {

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/TransformChain.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/TransformChain.cs
@@ -14,15 +14,9 @@
 // Once the Transform chain is constructed, call TransformToOctetStream to convert some sort of input type to an octet
 // stream. (We only bother implementing that much now since every use of transform chains in XmlDsig ultimately yields something to hash).
 
-using System;
 using System.Collections;
 using System.IO;
-using System.Runtime.InteropServices;
-using System.Security;
-using System.Text;
 using System.Xml;
-using System.Xml.XPath;
-using System.Xml.Xsl;
 
 namespace System.Security.Cryptography.Xml
 {

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/Utils.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/Utils.cs
@@ -2,17 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Win32;
-using System;
 using System.Collections;
 using System.Diagnostics;
-using System.Globalization;
 using System.IO;
-using System.Security;
-using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
-using System.Threading;
 using System.Xml;
 
 namespace System.Security.Cryptography.Xml

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlDecryptionTransform.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlDecryptionTransform.cs
@@ -2,15 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections;
 using System.IO;
-using System.Runtime.InteropServices;
-using System.Security;
-using System.Text;
 using System.Xml;
-using System.Xml.XPath;
-using System.Xml.Xsl;
 
 namespace System.Security.Cryptography.Xml
 {

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlDsigBase64Transform.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlDsigBase64Transform.cs
@@ -2,15 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections;
 using System.IO;
-using System.Runtime.InteropServices;
-using System.Security;
 using System.Text;
 using System.Xml;
-using System.Xml.XPath;
-using System.Xml.Xsl;
 
 namespace System.Security.Cryptography.Xml
 {

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlDsigC14NTransform.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlDsigC14NTransform.cs
@@ -2,15 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections;
 using System.IO;
-using System.Runtime.InteropServices;
-using System.Security;
-using System.Text;
 using System.Xml;
-using System.Xml.XPath;
-using System.Xml.Xsl;
 
 namespace System.Security.Cryptography.Xml
 {

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlDsigC14NWithCommentsTransform.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlDsigC14NWithCommentsTransform.cs
@@ -2,16 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections;
-using System.IO;
-using System.Runtime.InteropServices;
-using System.Security;
-using System.Text;
-using System.Xml;
-using System.Xml.XPath;
-using System.Xml.Xsl;
-
 namespace System.Security.Cryptography.Xml
 {
     public class XmlDsigC14NWithCommentsTransform : XmlDsigC14NTransform

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlDsigEnvelopedSignatureTransform.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlDsigEnvelopedSignatureTransform.cs
@@ -2,15 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections;
 using System.IO;
-using System.Runtime.InteropServices;
-using System.Security;
-using System.Text;
 using System.Xml;
-using System.Xml.XPath;
-using System.Xml.Xsl;
 
 namespace System.Security.Cryptography.Xml
 {

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlDsigExcC14NTransform.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlDsigExcC14NTransform.cs
@@ -2,15 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections;
 using System.IO;
-using System.Runtime.InteropServices;
-using System.Security;
-using System.Text;
 using System.Xml;
-using System.Xml.XPath;
-using System.Xml.Xsl;
 
 namespace System.Security.Cryptography.Xml
 {

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlDsigExcC14NWithCommentsTransform.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlDsigExcC14NWithCommentsTransform.cs
@@ -2,16 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections;
-using System.IO;
-using System.Runtime.InteropServices;
-using System.Security;
-using System.Text;
-using System.Xml;
-using System.Xml.XPath;
-using System.Xml.Xsl;
-
 namespace System.Security.Cryptography.Xml
 {
     // <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlDsigXPathTransform.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlDsigXPathTransform.cs
@@ -2,15 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections;
 using System.IO;
-using System.Runtime.InteropServices;
-using System.Security;
-using System.Text;
 using System.Xml;
 using System.Xml.XPath;
-using System.Xml.Xsl;
 
 namespace System.Security.Cryptography.Xml
 {

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlDsigXsltTransform.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlDsigXsltTransform.cs
@@ -2,12 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections;
 using System.IO;
-using System.Runtime.InteropServices;
-using System.Security;
-using System.Text;
 using System.Xml;
 using System.Xml.XPath;
 using System.Xml.Xsl;

--- a/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlLicenseTransform.cs
+++ b/src/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlLicenseTransform.cs
@@ -2,15 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections;
 using System.IO;
-using System.Runtime.InteropServices;
-using System.Security;
-using System.Text;
 using System.Xml;
-using System.Xml.XPath;
-using System.Xml.Xsl;
 
 namespace System.Security.Cryptography.Xml
 {


### PR DESCRIPTION
I was looking for uses of "using System.Linq;".  One file had it, but it turned out to be unused/unnecessary, so as long as I was removing it, I ran VS' "remove unused usings" on the project.