### PR TITLE
Fix HtmlEncode handling of surrogate pairs

### DIFF
--- a/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
@@ -639,17 +639,17 @@ namespace System.Net
         private static int GetNextUnicodeScalarValueFromUtf16Surrogate(ReadOnlySpan<char> input, ref int index)
         {
             // invariants
-            Debug.Assert(input.Length >= 1);
-            Debug.Assert(char.IsSurrogate(input[0]));
+            Debug.Assert(input.Length - index >= 1);
+            Debug.Assert(char.IsSurrogate(input[index]));
 
-            if (input.Length <= 1)
+            if (input.Length - index <= 1)
             {
                 // not enough characters remaining to resurrect the original scalar value
                 return UnicodeReplacementChar;
             }
 
-            char leadingSurrogate = input[0];
-            char trailingSurrogate = input[1];
+            char leadingSurrogate = input[index];
+            char trailingSurrogate = input[index + 1];
 
             if (!char.IsSurrogatePair(leadingSurrogate, trailingSurrogate))
             {

--- a/src/System.Runtime.Extensions/tests/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/tests/System/Net/WebUtility.cs
@@ -83,6 +83,8 @@ namespace System.Net.Tests
             yield return new object[] { char.ConvertFromUtf32(144308), "&#144308;" };
             yield return new object[] { "\uD800\uDC00", "&#65536;" };
             yield return new object[] { "a\uD800\uDC00b", "a&#65536;b" };
+            yield return new object[] { "\uD83D\uDE01\uD83D\uDE02\uD83D\uDE03", "&#128513;&#128514;&#128515;" };
+            yield return new object[] { "a\uD83D\uDE01\uD83D\uDE02\uD83D\uDE03b", "a&#128513;&#128514;&#128515;b" };
 
             // High BMP non-chars
             yield return new object[] { "\uFFFD", "\uFFFD" };


### PR DESCRIPTION
Due to a regression that came as part of changing the code from using pointers to using spans, when the surrogate pair isn't at the beginning of the the input, it's incorrectly encoded.

Fixes https://github.com/dotnet/corefx/issues/41570
cc: @ViktorHofer, @GrabYourPitchforks 