### PR TITLE
Added a test scenario to verify that  Nullable<T> is not assignable from T

### DIFF
--- a/src/System.Reflection/tests/TypeInfoTests.cs
+++ b/src/System.Reflection/tests/TypeInfoTests.cs
@@ -574,6 +574,33 @@ namespace System.Reflection.Tests
             Assert.Equal(expected, type.GetTypeInfo().IsAssignableFrom(c?.GetTypeInfo()));
         }
 
+        [Fact]
+        public void IsAssignableFromNullable()
+        {
+            var nubInt = typeof(Nullable<int>);
+            var intType = typeof(int);
+            var objType = typeof(object);
+            var valTypeType = typeof(ValueType);
+
+            // sanity checks
+            // Nullable<T>  is assignable from  int
+            Assert.True(nubInt.IsAssignableFrom(intType));
+            Assert.False(intType.IsAssignableFrom(nubInt));
+
+            var nubOfT = nubInt.GetGenericTypeDefinition();
+            var T = nubOfT.GetTypeInfo().GenericTypeParameters[0];
+
+            // should be true
+            Assert.True(T.IsAssignableFrom(T));
+            Assert.True(objType.IsAssignableFrom(T));
+            Assert.True(valTypeType.IsAssignableFrom(T));
+
+            // should be false
+            // Nullable<T> is not assignable from T
+            Assert.False(nubOfT.IsAssignableFrom(T));
+            Assert.False(T.IsAssignableFrom(nubOfT));
+        }
+
         public static IEnumerable<object[]> IsEquivilentTo_TestData()
         {
             yield return new object[] { typeof(string), typeof(string), true };

--- a/src/System.Reflection/tests/TypeInfoTests.cs
+++ b/src/System.Reflection/tests/TypeInfoTests.cs
@@ -577,18 +577,18 @@ namespace System.Reflection.Tests
         [Fact]
         public void IsAssignableFromNullable()
         {
-            var nubInt = typeof(Nullable<int>);
-            var intType = typeof(int);
-            var objType = typeof(object);
-            var valTypeType = typeof(ValueType);
+            Type nubInt = typeof(Nullable<int>);
+            Type intType = typeof(int);
+            Type objType = typeof(object);
+            Type valTypeType = typeof(ValueType);
 
             // sanity checks
             // Nullable<T>  is assignable from  int
             Assert.True(nubInt.IsAssignableFrom(intType));
             Assert.False(intType.IsAssignableFrom(nubInt));
 
-            var nubOfT = nubInt.GetGenericTypeDefinition();
-            var T = nubOfT.GetTypeInfo().GenericTypeParameters[0];
+            Type nubOfT = nubInt.GetGenericTypeDefinition();
+            Type T = nubOfT.GetTypeInfo().GenericTypeParameters[0];
 
             // should be true
             Assert.True(T.IsAssignableFrom(T));


### PR DESCRIPTION
For any substitution of `T`, like for example `int` there is assignability.
For example  `Nullable<int>` is assignable from `int`  because boxed forms have the same representation.

However generically `Nullable<T>` is not assignable from `T`.

This is subtle and easy to regress when touching castability. (as I found in https://github.com/dotnet/coreclr/pull/23548).

Looks like we have no tests for this. So adding a scenario.