### PR TITLE
[release/3.0] Fix HtmlEncode handling of surrogate pairs (#41576)

### DIFF
--- a/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
@@ -639,17 +639,17 @@ namespace System.Net
         private static int GetNextUnicodeScalarValueFromUtf16Surrogate(ReadOnlySpan<char> input, ref int index)
         {
             // invariants
-            Debug.Assert(input.Length >= 1);
-            Debug.Assert(char.IsSurrogate(input[0]));
+            Debug.Assert(input.Length - index >= 1);
+            Debug.Assert(char.IsSurrogate(input[index]));
 
-            if (input.Length <= 1)
+            if (input.Length - index <= 1)
             {
                 // not enough characters remaining to resurrect the original scalar value
                 return UnicodeReplacementChar;
             }
 
-            char leadingSurrogate = input[0];
-            char trailingSurrogate = input[1];
+            char leadingSurrogate = input[index];
+            char trailingSurrogate = input[index + 1];
 
             if (!char.IsSurrogatePair(leadingSurrogate, trailingSurrogate))
             {

--- a/src/System.Runtime.Extensions/tests/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/tests/System/Net/WebUtility.cs
@@ -83,6 +83,8 @@ namespace System.Net.Tests
             yield return new object[] { char.ConvertFromUtf32(144308), "&#144308;" };
             yield return new object[] { "\uD800\uDC00", "&#65536;" };
             yield return new object[] { "a\uD800\uDC00b", "a&#65536;b" };
+            yield return new object[] { "\uD83D\uDE01\uD83D\uDE02\uD83D\uDE03", "&#128513;&#128514;&#128515;" };
+            yield return new object[] { "a\uD83D\uDE01\uD83D\uDE02\uD83D\uDE03b", "a&#128513;&#128514;&#128515;b" };
 
             // High BMP non-chars
             yield return new object[] { "\uFFFD", "\uFFFD" };


### PR DESCRIPTION
Port #41576 to release/3.0.
Fixes https://github.com/dotnet/corefx/issues/41570

## Description

WebUtility.HtmlEncode (which is also the implementation for HttpUtility.HtmlEncode) was changed in 3.0 from using pointers to using span.  In doing so, a regression was introduced where as it iterates through all of the characters, when it finds a surrogate, rather than looking at the current two characters in the string, it instead looks at the first two characters in the string, thus making the wrong replacement.

## Customer Impact

Surrogate pairs that appear anywhere other than at the beginning of the string being encoded are encoded incorrectly.

## Regression?

Yes, from .NET Core 2.2 and .NET Framework.

## Testing

New tests were added.  Previously tests were only validating when the surrogate pair was at the beginning.

## Risk

Low.  It's changing some indexing to be based off of the current position rather than off of 0, all accesses are bounds-checked, if the index was 0 it's obvious from a code inspection that there's no change in behavior, and if the index isn't 0 it was already wrong.