### PR TITLE
Ignore ERROR_NOT_FOUND in File.Encrypt test

### DIFF
--- a/src/Common/src/Interop/Windows/Advapi32/Interop.EncryptDecrypt.cs
+++ b/src/Common/src/Interop/Windows/Advapi32/Interop.EncryptDecrypt.cs
@@ -7,12 +7,12 @@ using System.Runtime.InteropServices;
 
 internal partial class Interop
 {
-    internal partial class Kernel32
+    internal partial class Advapi32
     {
         /// <summary>
         /// WARNING: This method does not implicitly handle long paths. Use EncryptFile.
         /// </summary>
-        [DllImport(Libraries.Advapi32, EntryPoint = "EncryptFileW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
+        [DllImport(Libraries.Advapi32, EntryPoint = "EncryptFileW", SetLastError = true, CharSet = CharSet.Unicode)]
         private static extern bool EncryptFilePrivate(string lpFileName);
 
         internal static bool EncryptFile(string path)
@@ -24,7 +24,7 @@ internal partial class Interop
         /// <summary>
         /// WARNING: This method does not implicitly handle long paths. Use DecryptFile.
         /// </summary>
-        [DllImport(Libraries.Advapi32, EntryPoint = "DecryptFileW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
+        [DllImport(Libraries.Advapi32, EntryPoint = "DecryptFileW", SetLastError = true, CharSet = CharSet.Unicode)]
         private static extern bool DecryptFileFilePrivate(string lpFileName, int dwReserved);
 
         internal static bool DecryptFile(string path)

--- a/src/Microsoft.IO.Redist/src/Microsoft.IO.Redist.csproj
+++ b/src/Microsoft.IO.Redist/src/Microsoft.IO.Redist.csproj
@@ -159,7 +159,7 @@
     <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GenericOperations.cs">
       <Link>Common\Interop\Windows\Interop.GenericOperations.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.EncryptDecrypt.cs">
+    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.EncryptDecrypt.cs">
       <Link>Common\Interop\Windows\Interop.EncryptDecrypt.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetVolumeInformation.cs">

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -184,7 +184,7 @@
     <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.CreateFile.cs">
       <Link>Common\Interop\Windows\Interop.CreateFile.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.EncryptDecrypt.cs">
+    <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.EncryptDecrypt.cs">
       <Link>Common\Interop\Windows\Interop.EncryptDecrypt.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.UNICODE_STRING.cs">

--- a/src/System.IO.FileSystem/src/System/IO/FileSystem.Win32.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileSystem.Win32.cs
@@ -19,7 +19,7 @@ namespace System.IO
         {
             string fullPath = Path.GetFullPath(path);
 
-            if (!Interop.Kernel32.EncryptFile(fullPath))
+            if (!Interop.Advapi32.EncryptFile(fullPath))
             {
                 ThrowExceptionEncryptDecryptFail(fullPath);
             }
@@ -29,7 +29,7 @@ namespace System.IO
         {
             string fullPath = Path.GetFullPath(path);
 
-            if (!Interop.Kernel32.DecryptFile(fullPath))
+            if (!Interop.Advapi32.DecryptFile(fullPath))
             {
                 ThrowExceptionEncryptDecryptFail(fullPath);
             }

--- a/src/System.IO.FileSystem/tests/File/EncryptDecrypt.cs
+++ b/src/System.IO.FileSystem/tests/File/EncryptDecrypt.cs
@@ -41,7 +41,16 @@ namespace System.IO.Tests
                 string fileContentRead = File.ReadAllText(tmpFileName);
                 Assert.Equal(textContentToEncrypt, fileContentRead);
 
-                File.Encrypt(tmpFileName);
+                try
+                {
+                    File.Encrypt(tmpFileName);
+                }
+                catch (IOException e) when (e.HResult == unchecked((int)0x80070490))
+                {
+                    // Ignore ERROR_NOT_FOUND 1168 (0x490). It is reported when EFS is disabled by domain policy.
+                    return;
+                }
+
                 Assert.Equal(fileContentRead, File.ReadAllText(tmpFileName));
                 Assert.Equal(FileAttributes.Encrypted, (FileAttributes.Encrypted & File.GetAttributes(tmpFileName)));
 


### PR DESCRIPTION
Makes the test pass when EFS (Encrypted File System) is not available.

I have also fixed the interop definition for Encrypt/DecryptFile P/Invokes while I was on it.

Fixes #39211