### PR TITLE
Disable flaky member descriptor test

### DIFF
--- a/src/System.ComponentModel.TypeConverter/tests/MemberDescriptorTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/MemberDescriptorTests.cs
@@ -308,6 +308,7 @@ namespace System.ComponentModel.Tests
         }
 
         [Fact]
+        [ActiveIssue(40948)]
         public void AttributeArray_SetGetAttributesAndModify_DoesCopy()
         {
             var attribute1 = new MockAttribute1();


### PR DESCRIPTION
Failed multiple times in CI: https://github.com/dotnet/corefx/issues/40948

The issue itself could be a product bug and @stephentoub set the milestone and label to track it accordingly. This should not hinder us disabling the test in CI.