### PR TITLE
Fix serialization of elements with an empty-string child text node

### DIFF
--- a/src/System.Private.Xml/src/System/Xml/Core/XmlTextWriter.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlTextWriter.cs
@@ -851,7 +851,7 @@ namespace System.Xml
         {
             try
             {
-                if (null != text && text.Length != 0)
+                if (null != text)
                 {
                     AutoComplete(Token.Content);
                     _xmlEncoder.Write(text);


### PR DESCRIPTION
Related to #41574

Output after change
```
<root>
  <Elem></Elem>
</root>
```

Can we skip the length check?

Please review.
Thank you in advance