### PR TITLE
Several improvements to SocketsHttpHandler perf

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
@@ -58,6 +58,8 @@ namespace System.Net.Http.Headers
             _treatAsCustomHeaderTypes = treatAsCustomHeaderTypes;
         }
 
+        internal Dictionary<HeaderDescriptor, HeaderStoreItemInfo> HeaderStore => _headerStore;
+
         public void Add(string name, string value)
         {
             Add(GetHeaderDescriptor(name), value);
@@ -353,32 +355,6 @@ namespace System.Net.Http.Headers
                     string[] values = GetValuesAsStrings(descriptor, info);
                     yield return new KeyValuePair<string, IEnumerable<string>>(descriptor.Name, values);
                 }
-            }
-        }
-
-        // The following is the same general code as the above GetEnumerator, but returning the
-        // HeaderDescriptor and values string[], rather than the key name and a values enumerable.
-        // It also doesn't force validate any raw headers.
-
-        internal IEnumerable<KeyValuePair<HeaderDescriptor, string[]>> GetHeaderDescriptorsAndValuesWithoutParsing()
-        {
-            return _headerStore != null && _headerStore.Count > 0 ?
-                GetHeaderDescriptorsAndValuesWithoutParsingCore() :
-                Array.Empty<KeyValuePair<HeaderDescriptor, string[]>>();
-        }
-
-        private IEnumerable<KeyValuePair<HeaderDescriptor, string[]>> GetHeaderDescriptorsAndValuesWithoutParsingCore()
-        {
-            foreach (KeyValuePair<HeaderDescriptor, HeaderStoreItemInfo> header in _headerStore)
-            {
-                HeaderDescriptor descriptor = header.Key;
-                HeaderStoreItemInfo info = header.Value;
-
-                // Do not parse raw values.  Any raw values added via TryAddWithoutValidation are passed through,
-                // per the "without validation" part of the API.  If the value added is actually a list of values,
-                // it'll be output as a single value, again per the "without validation" request.
-                string[] values = GetValuesAsStrings(descriptor, info);
-                yield return new KeyValuePair<HeaderDescriptor, string[]>(descriptor, values);
             }
         }
 
@@ -1187,9 +1163,7 @@ namespace System.Net.Http.Headers
                 // The values array may not be full because some values were excluded
                 if (currentIndex < length)
                 {
-                    string[] trimmedValues = new string[currentIndex];
-                    Array.Copy(values, 0, trimmedValues, 0, currentIndex);
-                    values = trimmedValues;
+                    values = values.AsSpan(0, currentIndex).ToArray();
                 }
             }
             else
@@ -1201,34 +1175,41 @@ namespace System.Net.Http.Headers
             return values;
         }
 
+        internal static int GetValuesAsStrings(HeaderDescriptor descriptor, HeaderStoreItemInfo info, ref string[] values)
+        {
+            Debug.Assert(values != null);
+            int length = GetValueCount(info);
+
+            if (length > 0)
+            {
+                if (values.Length < length)
+                {
+                    values = new string[length];
+                }
+
+                int currentIndex = 0;
+                ReadStoreValues<string>(values, info.RawValue, null, null, ref currentIndex);
+                ReadStoreValues<object>(values, info.ParsedValue, descriptor.Parser, null, ref currentIndex);
+                ReadStoreValues<string>(values, info.InvalidValue, null, null, ref currentIndex);
+                Debug.Assert(currentIndex == length);
+            }
+
+            return length;
+        }
+
         private static int GetValueCount(HeaderStoreItemInfo info)
         {
             Debug.Assert(info != null);
 
-            int valueCount = 0;
-            UpdateValueCount<string>(info.RawValue, ref valueCount);
-            UpdateValueCount<string>(info.InvalidValue, ref valueCount);
-            UpdateValueCount<object>(info.ParsedValue, ref valueCount);
-
+            int valueCount = Count<string>(info.RawValue);
+            valueCount += Count<string>(info.InvalidValue);
+            valueCount += Count<object>(info.ParsedValue);
             return valueCount;
-        }
 
-        private static void UpdateValueCount<T>(object valueStore, ref int valueCount)
-        {
-            if (valueStore == null)
-            {
-                return;
-            }
-
-            List<T> values = valueStore as List<T>;
-            if (values != null)
-            {
-                valueCount += values.Count;
-            }
-            else
-            {
-                valueCount++;
-            }
+            static int Count<T>(object valueStore) =>
+                valueStore is null ? 0 :
+                valueStore is List<T> list ? list.Count :
+                1;
         }
 
         private static void ReadStoreValues<T>(string[] values, object storeValue, HttpHeaderParser parser,
@@ -1294,34 +1275,17 @@ namespace System.Net.Http.Headers
 
 #region Private Classes
 
-        private class HeaderStoreItemInfo
+        internal class HeaderStoreItemInfo
         {
-            private object _rawValue;
-            private object _invalidValue;
-            private object _parsedValue;
+            internal HeaderStoreItemInfo() { }
 
-            internal object RawValue
-            {
-                get { return _rawValue; }
-                set { _rawValue = value; }
-            }
-
-            internal object InvalidValue
-            {
-                get { return _invalidValue; }
-                set { _invalidValue = value; }
-            }
-
-            internal object ParsedValue
-            {
-                get { return _parsedValue; }
-                set { _parsedValue = value; }
-            }
+            internal object RawValue { get; set; }
+            internal object InvalidValue { get; set; }
+            internal object ParsedValue { get; set; }
 
             internal bool CanAddValue(HttpHeaderParser parser)
             {
-                Debug.Assert(parser != null,
-                    "There should be no reason to call CanAddValue if there is no parser for the current header.");
+                Debug.Assert(parser != null, "There should be no reason to call CanAddValue if there is no parser for the current header.");
 
                 // If the header only supports one value, and we have already a value set, then we can't add
                 // another value. E.g. the 'Date' header only supports one value. We can't add multiple timestamps
@@ -1332,17 +1296,10 @@ namespace System.Net.Http.Headers
                 // supporting 1 value. When the first value gets parsed, CanAddValue returns true and we add the
                 // parsed value to ParsedValue. When the second value is parsed, CanAddValue returns false, because
                 // we have already a parsed value.
-                return ((parser.SupportsMultipleValues) || ((_invalidValue == null) && (_parsedValue == null)));
+                return parser.SupportsMultipleValues || ((InvalidValue == null) && (ParsedValue == null));
             }
 
-            internal bool IsEmpty
-            {
-                get { return ((_rawValue == null) && (_invalidValue == null) && (_parsedValue == null)); }
-            }
-
-            internal HeaderStoreItemInfo()
-            {
-            }
+            internal bool IsEmpty => (RawValue == null) && (InvalidValue == null) && (ParsedValue == null);
         }
 #endregion
     }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackEncoder.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackEncoder.cs
@@ -262,7 +262,7 @@ namespace System.Net.Http.HPack
         }
 
         /// <summary>Encodes a "Literal Header Field without Indexing - New Name".</summary>
-        public static bool EncodeLiteralHeaderFieldWithoutIndexingNewName(string name, string[] values, string separator, Span<byte> destination, out int bytesWritten)
+        public static bool EncodeLiteralHeaderFieldWithoutIndexingNewName(string name, ReadOnlySpan<string> values, string separator, Span<byte> destination, out int bytesWritten)
         {
             // From https://tools.ietf.org/html/rfc7541#section-6.2.2
             // ------------------------------------------------------
@@ -422,7 +422,7 @@ namespace System.Net.Http.HPack
             return false;
         }
 
-        public static bool EncodeStringLiterals(string[] values, string separator, Span<byte> destination, out int bytesWritten)
+        public static bool EncodeStringLiterals(ReadOnlySpan<string> values, string separator, Span<byte> destination, out int bytesWritten)
         {
             bytesWritten = 0;
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -949,7 +949,7 @@ namespace System.Net.Http
         {
             if (NetEventSource.IsEnabled) Trace("");
 
-            foreach (KeyValuePair<HeaderDescriptor, string[]> header in headers.GetHeaderDescriptorsAndValues())
+            foreach (KeyValuePair<HeaderDescriptor, string[]> header in headers.GetHeaderDescriptorsAndValuesWithoutParsing())
             {
                 Debug.Assert(header.Value.Length > 0, "No values for header??");
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -26,6 +26,9 @@ namespace System.Net.Http
         private ArrayBuffer _outgoingBuffer;
         private ArrayBuffer _headerBuffer;
 
+        /// <summary>Reusable array used to get the values for each header being written to the wire.</summary>
+        private string[] _headerValues = Array.Empty<string>();
+
         private int _currentWriteSize;      // as passed to StartWriteAsync
 
         private readonly HPackDecoder _hpackDecoder;
@@ -893,9 +896,9 @@ namespace System.Net.Http
             _headerBuffer.Commit(bytesWritten);
         }
 
-        private void WriteLiteralHeader(string name, string[] values)
+        private void WriteLiteralHeader(string name, ReadOnlySpan<string> values)
         {
-            if (NetEventSource.IsEnabled) Trace($"{nameof(name)}={name}, {nameof(values)}={string.Join(", ", values)}");
+            if (NetEventSource.IsEnabled) Trace($"{nameof(name)}={name}, {nameof(values)}={string.Join(", ", values.ToArray())}");
 
             int bytesWritten;
             while (!HPackEncoder.EncodeLiteralHeaderFieldWithoutIndexingNewName(name, values, HttpHeaderParser.DefaultSeparator, _headerBuffer.AvailableSpan, out bytesWritten))
@@ -906,9 +909,9 @@ namespace System.Net.Http
             _headerBuffer.Commit(bytesWritten);
         }
 
-        private void WriteLiteralHeaderValues(string[] values, string separator)
+        private void WriteLiteralHeaderValues(ReadOnlySpan<string> values, string separator)
         {
-            if (NetEventSource.IsEnabled) Trace($"{nameof(values)}={string.Join(separator, values)}");
+            if (NetEventSource.IsEnabled) Trace($"{nameof(values)}={string.Join(separator, values.ToArray())}");
 
             int bytesWritten;
             while (!HPackEncoder.EncodeStringLiterals(values, separator, _headerBuffer.AvailableSpan, out bytesWritten))
@@ -949,9 +952,16 @@ namespace System.Net.Http
         {
             if (NetEventSource.IsEnabled) Trace("");
 
-            foreach (KeyValuePair<HeaderDescriptor, string[]> header in headers.GetHeaderDescriptorsAndValuesWithoutParsing())
+            if (headers.HeaderStore is null)
             {
-                Debug.Assert(header.Value.Length > 0, "No values for header??");
+                return;
+            }
+
+            foreach (KeyValuePair<HeaderDescriptor, HttpHeaders.HeaderStoreItemInfo> header in headers.HeaderStore)
+            {
+                int headerValuesCount = HttpHeaders.GetValuesAsStrings(header.Key, header.Value, ref _headerValues);
+                Debug.Assert(headerValuesCount > 0, "No values for header??");
+                ReadOnlySpan<string> headerValues = _headerValues.AsSpan(0, headerValuesCount);
 
                 KnownHeader knownHeader = header.Key.KnownHeader;
                 if (knownHeader != null)
@@ -964,7 +974,7 @@ namespace System.Net.Http
                         if (header.Key.KnownHeader == KnownHeaders.TE)
                         {
                             // HTTP/2 allows only 'trailers' TE header. rfc7540 8.1.2.2
-                            foreach (string value in header.Value)
+                            foreach (string value in headerValues)
                             {
                                 if (string.Equals(value, "trailers", StringComparison.OrdinalIgnoreCase))
                                 {
@@ -979,7 +989,7 @@ namespace System.Net.Http
                         // For all other known headers, send them via their pre-encoded name and the associated value.
                         WriteBytes(knownHeader.Http2EncodedName);
                         string separator = null;
-                        if (header.Value.Length > 1)
+                        if (headerValues.Length > 1)
                         {
                             HttpHeaderParser parser = header.Key.Parser;
                             if (parser != null && parser.SupportsMultipleValues)
@@ -992,13 +1002,13 @@ namespace System.Net.Http
                             }
                         }
 
-                        WriteLiteralHeaderValues(header.Value, separator);
+                        WriteLiteralHeaderValues(headerValues, separator);
                     }
                 }
                 else
                 {
                     // The header is not known: fall back to just encoding the header name and value(s).
-                    WriteLiteralHeader(header.Key.Name, header.Value);
+                    WriteLiteralHeader(header.Key.Name, headerValues);
                 }
             }
         }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -78,6 +78,8 @@ namespace System.Net.Http
         private readonly byte[] _writeBuffer;
         private int _writeOffset;
         private int _allowedReadLineBytes;
+        /// <summary>Reusable array used to get the values for each header being written to the wire.</summary>
+        private string[] _headerValues = Array.Empty<string>();
 
         private ValueTask<int>? _readAheadTask;
         private int _readAheadTaskLock = 0; // 0 == free, 1 == held
@@ -217,50 +219,54 @@ namespace System.Net.Http
 
         private async Task WriteHeadersAsync(HttpHeaders headers, string cookiesFromContainer)
         {
-            foreach (KeyValuePair<HeaderDescriptor, string[]> header in headers.GetHeaderDescriptorsAndValuesWithoutParsing())
+            if (headers.HeaderStore != null)
             {
-                if (header.Key.KnownHeader != null)
+                foreach (KeyValuePair<HeaderDescriptor, HttpHeaders.HeaderStoreItemInfo> header in headers.HeaderStore)
                 {
-                    await WriteBytesAsync(header.Key.KnownHeader.AsciiBytesWithColonSpace).ConfigureAwait(false);
-                }
-                else
-                {
-                    await WriteAsciiStringAsync(header.Key.Name).ConfigureAwait(false);
-                    await WriteTwoBytesAsync((byte)':', (byte)' ').ConfigureAwait(false);
-                }
-
-                Debug.Assert(header.Value.Length > 0, "No values for header??");
-                if (header.Value.Length > 0)
-                {
-                    await WriteStringAsync(header.Value[0]).ConfigureAwait(false);
-
-                    if (cookiesFromContainer != null && header.Key.KnownHeader == KnownHeaders.Cookie)
+                    if (header.Key.KnownHeader != null)
                     {
-                        await WriteTwoBytesAsync((byte)';', (byte)' ').ConfigureAwait(false);
-                        await WriteStringAsync(cookiesFromContainer).ConfigureAwait(false);
-
-                        cookiesFromContainer = null;
+                        await WriteBytesAsync(header.Key.KnownHeader.AsciiBytesWithColonSpace).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        await WriteAsciiStringAsync(header.Key.Name).ConfigureAwait(false);
+                        await WriteTwoBytesAsync((byte)':', (byte)' ').ConfigureAwait(false);
                     }
 
-                    // Some headers such as User-Agent and Server use space as a separator (see: ProductInfoHeaderParser)
-                    if (header.Value.Length > 1)
+                    int headerValuesCount = HttpHeaders.GetValuesAsStrings(header.Key, header.Value, ref _headerValues);
+                    Debug.Assert(headerValuesCount > 0, "No values for header??");
+                    if (headerValuesCount > 0)
                     {
-                        HttpHeaderParser parser = header.Key.Parser;
-                        string separator = HttpHeaderParser.DefaultSeparator;
-                        if (parser != null && parser.SupportsMultipleValues)
+                        await WriteStringAsync(_headerValues[0]).ConfigureAwait(false);
+
+                        if (cookiesFromContainer != null && header.Key.KnownHeader == KnownHeaders.Cookie)
                         {
-                            separator = parser.Separator;
+                            await WriteTwoBytesAsync((byte)';', (byte)' ').ConfigureAwait(false);
+                            await WriteStringAsync(cookiesFromContainer).ConfigureAwait(false);
+
+                            cookiesFromContainer = null;
                         }
 
-                        for (int i = 1; i < header.Value.Length; i++)
+                        // Some headers such as User-Agent and Server use space as a separator (see: ProductInfoHeaderParser)
+                        if (headerValuesCount > 1)
                         {
-                            await WriteAsciiStringAsync(separator).ConfigureAwait(false);
-                            await WriteStringAsync(header.Value[i]).ConfigureAwait(false);
+                            HttpHeaderParser parser = header.Key.Parser;
+                            string separator = HttpHeaderParser.DefaultSeparator;
+                            if (parser != null && parser.SupportsMultipleValues)
+                            {
+                                separator = parser.Separator;
+                            }
+
+                            for (int i = 1; i < headerValuesCount; i++)
+                            {
+                                await WriteAsciiStringAsync(separator).ConfigureAwait(false);
+                                await WriteStringAsync(_headerValues[i]).ConfigureAwait(false);
+                            }
                         }
                     }
-                }
 
-                await WriteTwoBytesAsync((byte)'\r', (byte)'\n').ConfigureAwait(false);
+                    await WriteTwoBytesAsync((byte)'\r', (byte)'\n').ConfigureAwait(false);
+                }
             }
 
             if (cookiesFromContainer != null)

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -217,7 +217,7 @@ namespace System.Net.Http
 
         private async Task WriteHeadersAsync(HttpHeaders headers, string cookiesFromContainer)
         {
-            foreach (KeyValuePair<HeaderDescriptor, string[]> header in headers.GetHeaderDescriptorsAndValues())
+            foreach (KeyValuePair<HeaderDescriptor, string[]> header in headers.GetHeaderDescriptorsAndValuesWithoutParsing())
             {
                 if (header.Key.KnownHeader != null)
                 {

--- a/src/System.Net.Http/tests/UnitTests/HPack/HPackRoundtripTests.cs
+++ b/src/System.Net.Http/tests/UnitTests/HPack/HPackRoundtripTests.cs
@@ -50,7 +50,7 @@ namespace System.Net.Http.Unit.Tests.HPack
             var buffer = new ArrayBuffer(4);
             FillAvailableSpaceWithOnes(buffer);
 
-            foreach (KeyValuePair<HeaderDescriptor, string[]> header in headers.GetHeaderDescriptorsAndValues())
+            foreach (KeyValuePair<HeaderDescriptor, string[]> header in headers.GetHeaderDescriptorsAndValuesWithoutParsing())
             {
                 KnownHeader knownHeader = header.Key.KnownHeader;
                 if (knownHeader != null)

--- a/src/System.Net.Http/tests/UnitTests/HPack/HPackRoundtripTests.cs
+++ b/src/System.Net.Http/tests/UnitTests/HPack/HPackRoundtripTests.cs
@@ -49,16 +49,21 @@ namespace System.Net.Http.Unit.Tests.HPack
         {
             var buffer = new ArrayBuffer(4);
             FillAvailableSpaceWithOnes(buffer);
+            string[] headerValues = Array.Empty<string>();
 
-            foreach (KeyValuePair<HeaderDescriptor, string[]> header in headers.GetHeaderDescriptorsAndValuesWithoutParsing())
+            foreach (KeyValuePair<HeaderDescriptor, HttpHeaders.HeaderStoreItemInfo> header in headers.HeaderStore)
             {
+                int headerValuesCount = HttpHeaders.GetValuesAsStrings(header.Key, header.Value, ref headerValues);
+                Assert.InRange(headerValuesCount, 0, int.MaxValue);
+                ReadOnlySpan<string> headerValuesSpan = headerValues.AsSpan(0, headerValuesCount);
+
                 KnownHeader knownHeader = header.Key.KnownHeader;
                 if (knownHeader != null)
                 {
                     // For all other known headers, send them via their pre-encoded name and the associated value.
                     WriteBytes(knownHeader.Http2EncodedName);
                     string separator = null;
-                    if (header.Value.Length > 1)
+                    if (headerValuesSpan.Length > 1)
                     {
                         HttpHeaderParser parser = header.Key.Parser;
                         if (parser != null && parser.SupportsMultipleValues)
@@ -71,12 +76,12 @@ namespace System.Net.Http.Unit.Tests.HPack
                         }
                     }
 
-                    WriteLiteralHeaderValues(header.Value, separator);
+                    WriteLiteralHeaderValues(headerValuesSpan, separator);
                 }
                 else
                 {
                     // The header is not known: fall back to just encoding the header name and value(s).
-                    WriteLiteralHeader(header.Key.Name, header.Value);
+                    WriteLiteralHeader(header.Key.Name, headerValuesSpan);
                 }
             }
 
@@ -94,7 +99,7 @@ namespace System.Net.Http.Unit.Tests.HPack
                 buffer.Commit(bytes.Length);
             }
 
-            void WriteLiteralHeaderValues(string[] values, string separator)
+            void WriteLiteralHeaderValues(ReadOnlySpan<string> values, string separator)
             {
                 int bytesWritten;
                 while (!HPackEncoder.EncodeStringLiterals(values, separator, buffer.AvailableSpan, out bytesWritten))
@@ -106,7 +111,7 @@ namespace System.Net.Http.Unit.Tests.HPack
                 buffer.Commit(bytesWritten);
             }
 
-            void WriteLiteralHeader(string name, string[] values)
+            void WriteLiteralHeader(string name, ReadOnlySpan<string> values)
             {
                 int bytesWritten;
                 while (!HPackEncoder.EncodeLiteralHeaderFieldWithoutIndexingNewName(name, values, HttpHeaderParser.DefaultSeparator, buffer.AvailableSpan, out bytesWritten))


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/39835

Commit 1:
Per https://github.com/dotnet/corefx/issues/39835#issuecomment-538755366, the intent of HttpHeaders.TryAddWithoutValidation was that we wouldn't validate the headers.  But while we're currently not validating them as part of that API call itself, we're currently validating them as part of enumerating the headers to write the out to the wire, for both HTTP/1.1 and HTTP/2.0.  Stop doing that.  This does mean that we could end up writing out something that would render the HTTP request invalid, but that's the nature of "WithoutValidation" and what the developer asked for.

Commit 2:
Several releases ago, when we weren't paying attention to ExpectContinue, we optimized away the backing field for it into a lazily-initialized collection; that made it cheaper when not accessed but more expensive when accessed, which was fine, as we wouldn't access it from the implementation and developers would rarely set it.  But now SocketsHttpHandler checks it on every request, which means we're paying for the more expensive thing always. So, revert the optimization for this field.

Commit 3:
When we enumerate the headers to write them out, we currently allocate a string[] for each.  We can instead just fill the same array over and over and over.

Benchmark:

|  Method |        Toolchain |     Mean |    Error |   StdDev | Ratio |  Gen 0 | Allocated |
|-------- |----------------- |---------:|---------:|---------:|------:|-------:|----------:|
| HttpGet | \old\corerun.exe | 66.44 us | 0.886 us | 0.828 us |  1.00 | 0.8545 |   5.58 KB |
| HttpGet | \new\corerun.exe | 61.88 us | 0.935 us | 0.780 us |  0.93 | 0.4883 |   3.15 KB |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Diagnosers;
using BenchmarkDotNet.Running;
using System;
using System.Net;
using System.Net.Http;
using System.Net.Sockets;
using System.Text;
using System.Threading.Tasks;

[MemoryDiagnoser]
public class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromTypes(new[] { typeof(Program) }).Run(args);

    private static Socket s_listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
    private static HttpClient s_client = new HttpClient(new HttpClientHandler() { ServerCertificateCustomValidationCallback = delegate { return true; } });
    private static Uri s_uri;

    [Benchmark]
    public async Task HttpGet()
    {
        var m = new HttpRequestMessage(HttpMethod.Get, s_uri);
        m.Headers.TryAddWithoutValidation("Authorization", "ANYTHING SOMEKEY");
        m.Headers.TryAddWithoutValidation("Referer", "http://someuri.com");
        m.Headers.TryAddWithoutValidation("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36");
        m.Headers.TryAddWithoutValidation("Host", "www.somehost.com");
        (await s_client.SendAsync(m, default)).Dispose();
    }

    [GlobalSetup]
    public void CreateSocketServer()
    {
        s_listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
        s_listener.Listen(int.MaxValue);
        var ep = (IPEndPoint)s_listener.LocalEndPoint;
        s_uri = new Uri($"http://{ep.Address}:{ep.Port}/");
        byte[] response = Encoding.UTF8.GetBytes("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
        byte[] endSequence = new byte[] { (byte)'\r', (byte)'\n', (byte)'\r', (byte)'\n' };

        Task.Run(async () =>
        {
            while (true)
            {
                Socket s = await s_listener.AcceptAsync();
                _ = Task.Run(() =>
                {
                    using (var ns = new NetworkStream(s, true))
                    {
                        byte[] buffer = new byte[1024];
                        int totalRead = 0;
                        while (true)
                        {
                            totalRead += ns.Read(buffer.AsSpan(totalRead));
                            if (buffer.AsSpan(0, totalRead).IndexOf(endSequence) == -1)
                            {
                                if (totalRead == buffer.Length) Array.Resize(ref buffer, buffer.Length * 2);
                                continue;
                            }

                            ns.Write(response);

                            totalRead = 0;
                        }
                    }
                });
            }
        });
    }
}
```