### PR TITLE
Httpstress: add max execution time argument

### DIFF
--- a/src/System.Net.Http/tests/StressTests/HttpStress/ChecksumHelpers.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/ChecksumHelpers.cs
@@ -57,7 +57,7 @@ namespace HttpStress
             return c;
         }
 
-        public static ulong update_crc(ulong crc, string text, Encoding encoding = null)
+        public static ulong update_crc(ulong crc, string text, Encoding? encoding = null)
         {
             encoding = encoding ?? Encoding.ASCII;
             byte[] bytes = encoding.GetBytes(text);
@@ -65,9 +65,9 @@ namespace HttpStress
         }
 
         public static ulong CalculateCRC(byte[] buf) => update_crc(InitialCrc, buf, buf.Length) ^ InitialCrc;
-        public static ulong CalculateCRC(string text, Encoding encoding = null) => update_crc(InitialCrc, text, encoding) ^ InitialCrc;
+        public static ulong CalculateCRC(string text, Encoding? encoding = null) => update_crc(InitialCrc, text, encoding) ^ InitialCrc;
 
-        public static ulong CalculateHeaderCrc<T>(IEnumerable<(string name, T)> headers, Encoding encoding = null) where T : IEnumerable<string>
+        public static ulong CalculateHeaderCrc<T>(IEnumerable<(string name, T)> headers, Encoding? encoding = null) where T : IEnumerable<string>
         {
             ulong checksum = InitialCrc;
 

--- a/src/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
@@ -300,14 +300,14 @@ namespace HttpStress
                                 return;
                             }
 
-                            string name = e.InnerException?.GetType().Name;
+                            string? name = e.InnerException?.GetType().Name;
                             switch (name)
                             {
                                 case "Http2ProtocolException":
                                 case "Http2ConnectionException":
                                 case "Http2StreamException":
-                                    if (e.InnerException.Message.Contains("INTERNAL_ERROR") || // UseKestrel (https://github.com/aspnet/AspNetCore/issues/12256)
-                                        e.InnerException.Message.Contains("CANCEL")) // UseHttpSys
+                                    if ((e.InnerException?.Message?.Contains("INTERNAL_ERROR") ?? false) || // UseKestrel (https://github.com/aspnet/AspNetCore/issues/12256)
+                                        (e.InnerException?.Message?.Contains("CANCEL") ?? false)) // UseHttpSys
                                     {
                                         return;
                                     }
@@ -482,7 +482,7 @@ namespace HttpStress
             }
         }
 
-        private static void ValidateContent(string expectedContent, string actualContent, string details = null)
+        private static void ValidateContent(string expectedContent, string actualContent, string? details = null)
         {
             if (actualContent != expectedContent)
             {

--- a/src/System.Net.Http/tests/StressTests/HttpStress/Configuration.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/Configuration.cs
@@ -40,6 +40,7 @@ namespace HttpStress
         public TimeSpan DisplayInterval { get; set; }
         public TimeSpan DefaultTimeout { get; set; }
         public TimeSpan? ConnectionLifetime { get; set; }
+        public TimeSpan? MaximumExecutionTime { get; set; }
         public double CancellationProbability { get; set; }
 
         public bool UseHttpSys { get; set; }

--- a/src/System.Net.Http/tests/StressTests/HttpStress/Configuration.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/Configuration.cs
@@ -22,11 +22,11 @@ namespace HttpStress
 
     public class Configuration
     {
-        public Uri ServerUri { get; set; } = new Uri("https://localhost:5001");
+        public Uri ServerUri { get; set; } = new Uri("http://placeholder");
         public RunMode RunMode { get; set; }
         public bool ListOperations { get; set; }
 
-        public Version HttpVersion { get; set; } = new Version(2, 0);
+        public Version HttpVersion { get; set; } = new Version();
         public bool UseWinHttpHandler { get; set; }
         public int ConcurrentRequests { get; set; }
         public int RandomSeed { get; set; }

--- a/src/System.Net.Http/tests/StressTests/HttpStress/Configuration.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/Configuration.cs
@@ -22,11 +22,11 @@ namespace HttpStress
 
     public class Configuration
     {
-        public Uri ServerUri { get; set; }
+        public Uri ServerUri { get; set; } = new Uri("https://localhost:5001");
         public RunMode RunMode { get; set; }
         public bool ListOperations { get; set; }
 
-        public Version HttpVersion { get; set; }
+        public Version HttpVersion { get; set; } = new Version(2, 0);
         public bool UseWinHttpHandler { get; set; }
         public int ConcurrentRequests { get; set; }
         public int RandomSeed { get; set; }
@@ -35,8 +35,8 @@ namespace HttpStress
         public int MaxRequestHeaderCount { get; set; }
         public int MaxRequestHeaderTotalSize { get; set; }
         public int MaxParameters { get; set; }
-        public int[] OpIndices { get; set; }
-        public int[] ExcludedOpIndices { get; set; }
+        public int[]? OpIndices { get; set; }
+        public int[]? ExcludedOpIndices { get; set; }
         public TimeSpan DisplayInterval { get; set; }
         public TimeSpan DefaultTimeout { get; set; }
         public TimeSpan? ConnectionLifetime { get; set; }
@@ -44,7 +44,7 @@ namespace HttpStress
         public double CancellationProbability { get; set; }
 
         public bool UseHttpSys { get; set; }
-        public string LogPath { get; set; }
+        public string? LogPath { get; set; }
         public bool LogAspNet { get; set; }
         public int? ServerMaxConcurrentStreams { get; set; }
         public int? ServerMaxFrameSize { get; set; }

--- a/src/System.Net.Http/tests/StressTests/HttpStress/HttpStress.csproj
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/HttpStress.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>preview</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Net.Http/tests/StressTests/HttpStress/Program.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/Program.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.CommandLine;
 using System.IO;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Net;
@@ -20,7 +21,7 @@ public static class Program
 
     public static async Task<int> Main(string[] args)
     {
-        if (!TryParseCli(args, out Configuration config))
+        if (!TryParseCli(args, out Configuration? config))
         {
             return 2;
         }
@@ -28,7 +29,7 @@ public static class Program
         return await Run(config);
     }
 
-    private static bool TryParseCli(string[] args, out Configuration config)
+    private static bool TryParseCli(string[] args, [NotNullWhen(true)] out Configuration? config)
     {
         var cmd = new RootCommand();
         cmd.AddOption(new Option("-n", "Max number of requests to make concurrently.") { Argument = new Argument<int>("numWorkers", Environment.ProcessorCount) });
@@ -41,8 +42,8 @@ public static class Program
         cmd.AddOption(new Option("-maxRequestHeaderTotalSize", "Max request header total size.") { Argument = new Argument<int>("numBytes", 1000) });
         cmd.AddOption(new Option("-http", "HTTP version (1.1 or 2.0)") { Argument = new Argument<Version>("version", HttpVersion.Version20) });
         cmd.AddOption(new Option("-connectionLifetime", "Max connection lifetime length (milliseconds).") { Argument = new Argument<int?>("connectionLifetime", null) });
-        cmd.AddOption(new Option("-ops", "Indices of the operations to use") { Argument = new Argument<int[]>("space-delimited indices", null) });
-        cmd.AddOption(new Option("-xops", "Indices of the operations to exclude") { Argument = new Argument<int[]>("space-delimited indices", null) });
+        cmd.AddOption(new Option("-ops", "Indices of the operations to use") { Argument = new Argument<int[]?>("space-delimited indices", null) });
+        cmd.AddOption(new Option("-xops", "Indices of the operations to exclude") { Argument = new Argument<int[]?>("space-delimited indices", null) });
         cmd.AddOption(new Option("-trace", "Enable Microsoft-System-Net-Http tracing.") { Argument = new Argument<string>("\"console\" or path") });
         cmd.AddOption(new Option("-aspnetlog", "Enable ASP.NET warning and error logging.") { Argument = new Argument<bool>("enable", false) });
         cmd.AddOption(new Option("-listOps", "List available options.") { Argument = new Argument<bool>("enable", false) });
@@ -167,7 +168,7 @@ public static class Program
         Console.WriteLine();
 
 
-        StressServer server = null;
+        StressServer? server = null;
         if (config.RunMode.HasFlag(RunMode.server))
         {
             // Start the Kestrel web server in-proc.
@@ -176,7 +177,7 @@ public static class Program
             Console.WriteLine($"Server started at {server.ServerUri}");
         }
 
-        StressClient client = null;
+        StressClient? client = null;
         if (config.RunMode.HasFlag(RunMode.client))
         {
             // Start the client.

--- a/src/System.Net.Http/tests/StressTests/HttpStress/Program.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/Program.cs
@@ -19,7 +19,7 @@ using HttpStress;
 public static class Program
 {
 
-    public enum ExitCode { Success = 0, CliError = 2, StressError = 3 };
+    public enum ExitCode { Success = 0, StressError = 1, CliError = 2 };
 
     public static async Task<int> Main(string[] args)
     {

--- a/src/System.Net.Http/tests/StressTests/HttpStress/Program.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/Program.cs
@@ -135,7 +135,7 @@ public static class Program
             {
                 Console.WriteLine(clientOperations[i].name);
             }
-            return 0;
+            return ExitCode.Success;
         }
 
         // derive client operations based on arguments

--- a/src/System.Net.Http/tests/StressTests/HttpStress/StressClient.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/StressClient.cs
@@ -27,6 +27,8 @@ namespace HttpStress
         private readonly CancellationTokenSource _cts = new CancellationTokenSource();
         private Task _clientTask;
 
+        public long TotalErrorCount => _aggregator.TotalErrorCount;
+
         public StressClient((string name, Func<RequestContext, Task> operation)[] clientOperations, Configuration configuration)
         {
             _clientOperations = clientOperations;
@@ -190,6 +192,8 @@ namespace HttpStress
 
             private readonly ConcurrentDictionary<(Type exception, string message, string callSite)[], StressFailureType> _failureTypes;
             private readonly ConcurrentBag<double> _latencies = new ConcurrentBag<double>();
+
+            public long TotalErrorCount => _failures.Sum();
 
             public StressResultAggregator((string name, Func<RequestContext, Task>)[] operations)
             {

--- a/src/System.Net.Http/tests/StressTests/HttpStress/StressClient.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/StressClient.cs
@@ -25,7 +25,7 @@ namespace HttpStress
         private readonly StressResultAggregator _aggregator;
         private readonly Stopwatch _stopwatch = new Stopwatch();
         private readonly CancellationTokenSource _cts = new CancellationTokenSource();
-        private Task _clientTask;
+        private Task? _clientTask;
 
         public long TotalErrorCount => _aggregator.TotalErrorCount;
 
@@ -241,9 +241,7 @@ namespace HttpStress
 
                     lock (failureType)
                     {
-                        List<DateTime> timestamps;
-
-                        if(!failureType.Failures.TryGetValue(operationIndex, out timestamps))
+                        if(!failureType.Failures.TryGetValue(operationIndex, out List<DateTime>? timestamps))
                         {
                             timestamps = new List<DateTime>();
                             failureType.Failures.Add(operationIndex, timestamps);
@@ -256,10 +254,10 @@ namespace HttpStress
                     {
                         var acc = new List<(Type exception, string message, string callSite)>();
 
-                        while (exn != null)
+                        for (Exception? e = exn; e != null; )
                         {
-                            acc.Add((exn.GetType(), exn.Message ?? "", new StackTrace(exn, true).GetFrame(0)?.ToString() ?? ""));
-                            exn = exn.InnerException;
+                            acc.Add((e.GetType(), e.Message ?? "", new StackTrace(e, true).GetFrame(0)?.ToString() ?? ""));
+                            e = e.InnerException;
                         }
 
                         return acc.ToArray();

--- a/src/System.Net.Http/tests/StressTests/HttpStress/StressServer.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/StressServer.cs
@@ -34,7 +34,7 @@ namespace HttpStress
         // Header indicating expected response content length to be returned by the server
         public const string ExpectedResponseContentLength = "Expected-Response-Content-Length";
 
-        private EventListener _eventListener;
+        private EventListener? _eventListener;
         private readonly IWebHost _webHost;
 
         public Uri ServerUri { get; }
@@ -312,9 +312,9 @@ namespace HttpStress
         /// <summary>EventListener that dumps HTTP events out to either the console or a stream writer.</summary>
         private sealed class HttpEventListener : EventListener
         {
-            private readonly StreamWriter _writer;
+            private readonly StreamWriter? _writer;
 
-            public HttpEventListener(StreamWriter writer = null) => _writer = writer;
+            public HttpEventListener(StreamWriter? writer = null) => _writer = writer;
 
             protected override void OnEventSourceCreated(EventSource eventSource)
             {
@@ -329,11 +329,11 @@ namespace HttpStress
                     if (_writer != null)
                     {
                         var sb = new StringBuilder().Append($"[{eventData.EventName}] ");
-                        for (int i = 0; i < eventData.Payload.Count; i++)
+                        for (int i = 0; i < eventData.Payload?.Count; i++)
                         {
                             if (i > 0)
                                 sb.Append(", ");
-                            sb.Append(eventData.PayloadNames[i]).Append(": ").Append(eventData.Payload[i]);
+                            sb.Append(eventData.PayloadNames?[i]).Append(": ").Append(eventData.Payload[i]);
                         }
                         _writer.WriteLine(sb);
                     }
@@ -342,12 +342,12 @@ namespace HttpStress
                         Console.ForegroundColor = ConsoleColor.DarkYellow;
                         Console.Write($"[{eventData.EventName}] ");
                         Console.ResetColor();
-                        for (int i = 0; i < eventData.Payload.Count; i++)
+                        for (int i = 0; i < eventData.Payload?.Count; i++)
                         {
                             if (i > 0)
                                 Console.Write(", ");
                             Console.ForegroundColor = ConsoleColor.DarkGray;
-                            Console.Write(eventData.PayloadNames[i] + ": ");
+                            Console.Write(eventData.PayloadNames?[i] + ": ");
                             Console.ResetColor();
                             Console.Write(eventData.Payload[i]);
                         }


### PR DESCRIPTION
Makes the following changes to the stress suite app:

* Adds a `-maxExecutionTime` argument. Need this to enable running the stress suite for a predetermined amount of time on Azure pipelines.
* Return nonzero exit code if there are errors.
* Also adds nullable reference type annotations.