### PR TITLE
Prevent ImplicitTransform of index getter method (#41418)

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
@@ -711,7 +711,9 @@ namespace System.Diagnostics
                 TypeInfo curTypeInfo = type.GetTypeInfo();
                 foreach (PropertyInfo property in curTypeInfo.DeclaredProperties)
                 {
-                    Type propertyType = property.PropertyType;
+                    // prevent TransformSpec from attempting to implicitly transform index properties
+                    if (property.GetMethod == null || property.GetMethod!.GetParameters().Length > 0)
+                        continue;
                     newSerializableArgs = new TransformSpec(property.Name, 0, property.Name.Length, newSerializableArgs);
                 }
                 return Reverse(newSerializableArgs);

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
@@ -712,7 +712,8 @@ namespace System.Diagnostics
                 foreach (PropertyInfo property in curTypeInfo.DeclaredProperties)
                 {
                     // prevent TransformSpec from attempting to implicitly transform index properties
-                    if (property.GetMethod == null || property.GetMethod!.GetParameters().Length > 0)
+                    MethodInfo getterMethodInfo = property.GetMethod;
+                    if (getterMethodInfo == null || getterMethodInfo!.GetParameters().Length > 0)
                         continue;
                     newSerializableArgs = new TransformSpec(property.Name, 0, property.Name.Length, newSerializableArgs);
                 }

--- a/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceEventSourceBridgeTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceEventSourceBridgeTests.cs
@@ -734,6 +734,43 @@ namespace System.Diagnostics.Tests
                 }
             }).Dispose();
         }
+
+        [Fact]
+        public void IndexGetters_DontThrow()
+        {
+            RemoteExecutor.Invoke(() =>
+            {
+                using (var eventListener = new TestDiagnosticSourceEventListener())
+                using (var diagnosticListener = new DiagnosticListener("MySource"))
+                {
+                    eventListener.Enable(
+                        "MySource/MyEvent"
+                    );
+                    // The type MyEvent only declares 3 Properties, but actually
+                    // has 4 due to the implicit Item property from having the index
+                    // operator implemented. The Getter for this Item property
+                    // is unusual for Property getters because it takes
+                    // an int32 as an input. This test ensures that this
+                    // implicit Property isn't implicitly serialized by
+                    // DiagnosticSourceEventSource.
+                    diagnosticListener.Write(
+                        "MyEvent",
+                        new MyEvent
+                        {
+                            Number = 1,
+                            OtherNumber = 2
+                        }
+                    );
+                    Assert.Equal(1, eventListener.EventCount);
+                    Assert.Equal("MySource", eventListener.LastEvent.SourceName);
+                    Assert.Equal("MyEvent", eventListener.LastEvent.EventName);
+                    Assert.True(eventListener.LastEvent.Arguments.Count <= 3);
+                    Assert.Equal("1", eventListener.LastEvent.Arguments["Number"]);
+                    Assert.Equal("2", eventListener.LastEvent.Arguments["OtherNumber"]);
+                    Assert.Equal("2", eventListener.LastEvent.Arguments["Count"]);
+                }
+            }).Dispose();
+        }
     }
 
     /****************************************************************************/
@@ -755,6 +792,22 @@ namespace System.Diagnostics.Tests
     {
         public int X { get; set; }
         public int Y { get; set; }
+    }
+
+    /// <summary>
+    /// classes for test data
+    /// </summary>
+    internal class MyEvent
+    {
+        public int Number { get; set; }
+        public int OtherNumber { get; set; }
+        public int Count => 2;
+        public KeyValuePair<string, object> this[int index] => index switch
+        {
+            0 => new KeyValuePair<string, object>(nameof(Number), Number),
+            1 => new KeyValuePair<string, object>(nameof(OtherNumber), OtherNumber),
+            _ => throw new IndexOutOfRangeException()
+        };
     }
 
     /****************************************************************************/


### PR DESCRIPTION
## Description

Cherry-pick of #41418 to release/3.1

Fix for the exception thrown in dotnet/coreclr#26890 that is a fallout of the issue being fixed in `DiagnosticSourceEventSource` in conjunction with aspnet/AspNetCore#11730.

<details>
    <summary>small repro (click to expand)</summary>

---
Attach `dotnet trace` to this app and turn on the `Microsoft-Diagnostics-DiagnosticSource` provider.

```csharp
    class Program
    {
        static void Main(string[] args)
        {
            Console.WriteLine($"PID: {System.Diagnostics.Process.GetCurrentProcess().Id}");
            var diagnosticListener = new DiagnosticListener("MySource");
            while (true)
            {
                Console.Write(">");
                var input = Console.ReadLine();
                if (input == "exit")
                    break;

                diagnosticListener.Write("MyEvent", new List<int> { 1, 2, 3 });
            }
        }
    }
```
---
</details>

### Root Cause of Exception:
The getter for the implicit `Item` property for the index operator takes an argument, and `DiagnosticSourceEventSource` makes the assumption that property getters don't take arguments.  It tries to bind the resulting delegate of type `[retval] get_Item(int32 index)` to the type `Func<TObject, TProperty>` so the binding fails and we get the exception you see in dotnet/coreclr#26890.

This change prevents `DiagnosticSourceEventSource` from attempting to serialize the implicit `Item` property by blocking index getters.

## Customer Impact

ASP.NET Core has used `DiagnosticSourceEventSource` for their eventing.  Since they changed their event types to inherit from `IReadOnlyCollection` in 3.0, they will all hit the exception in dotnet/coreclr#26890 when turned on causing a bad diagnostic experience if you do not explicitly specify a transform.

## Regression

I don't believe this is a regression as the code existed in the 2.0 time frame as well, but it was rarely encountered.  The difference now being that after aspnet/AspNetCore#11730, the behavior is being hit routinely by ASP.NET Core when diagnosing an MVC app.

## Risk

Minimal.  This code prevents an exception from being thrown and prevents bad behavior without changing expected behavior.

## Tests

A test were added to validate that this change prevents the implicit index getter from being serialized.

CC - @tommcdon @noahfalk 