### PR TITLE
[release/3.0] Handle "too small" success from CNG and clear out decryption residuals.

### DIFF
--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAKeyExchangeFormatter.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAKeyExchangeFormatter.cs
@@ -23,7 +23,6 @@ namespace System.Security.Cryptography.Rsa.Tests
             }
         }
 
-        [ActiveIssue(40434, TestPlatforms.Windows)]
         [Fact]
         public static void VerifyDecryptKeyExchangePkcs1()
         {
@@ -54,7 +53,6 @@ namespace System.Security.Cryptography.Rsa.Tests
             }
         }
 
-        [ActiveIssue(40434, TestPlatforms.Windows)]
         [Fact]
         public static void TestKnownValuePkcs1()
         {

--- a/src/System.Security.Cryptography.Xml/tests/Samples/EncryptingDecryptingAsymmetric.cs
+++ b/src/System.Security.Cryptography.Xml/tests/Samples/EncryptingDecryptingAsymmetric.cs
@@ -78,16 +78,10 @@ namespace System.Security.Cryptography.Xml.Tests
             encrypted.DecryptDocument();
         }
 
-        [Fact]
-        public void AsymmetricEncryptionRoundtripUseOAEP() =>
-            AsymmetricEncryptionRoundtrip(useOAEP: true); // OAEP is recommended
-
-        [ActiveIssue(40759, TestPlatforms.Windows)]
-        [Fact]
-        public void AsymmetricEncryptionRoundtrip() =>
-            AsymmetricEncryptionRoundtrip(useOAEP: false);
-
-        private void AsymmetricEncryptionRoundtrip(bool useOAEP)
+        [Theory]
+        [InlineData(true)] // OAEP is recommended
+        [InlineData(false)]
+        public void AsymmetricEncryptionRoundtrip(bool useOAEP)
         {
             const string testString = "some text node";
             const string exampleXmlRootElement = "example";


### PR DESCRIPTION
* When NCryptEncrypt or NCryptDecrypt reports success with a cbResult value that doesn't make sense, normalize the error to NTE_BUFFER_TOO_SMALL.
* When resizing arrays for the array-returning implementation, clear out the temporary arrays to reduce the amount of time they're sitting in memory before the GC clears the memory for reissuance.

Port of #41331 to release/3.0.
Undoes #41360 (because it fixed the tests).