### PR TITLE
(WIP of #41002) Add support for Reference Handling on Deserialization.

### DIFF
--- a/src/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/System.Text.Json/ref/System.Text.Json.cs
@@ -84,6 +84,13 @@ namespace System.Text.Json
         Skip = (byte)1,
         Allow = (byte)2,
     }
+
+    public enum ReferenceHandlingOnDeserialize
+    {
+        IgnoreMetadata,
+        PreserveDuplicates,
+    }
+
     public sealed partial class JsonDocument : System.IDisposable
     {
         internal JsonDocument() { }
@@ -460,6 +467,7 @@ namespace System.Text.Json
         public System.Text.Json.JsonCommentHandling ReadCommentHandling { get { throw null; } set { } }
         public bool WriteIndented { get { throw null; } set { } }
         public System.Text.Json.Serialization.JsonConverter GetConverter(System.Type typeToConvert) { throw null; }
+        public System.Text.Json.ReferenceHandlingOnDeserialize ReadReferenceHandling { get { throw null; } set { } }
     }
     public sealed partial class JsonString : System.Text.Json.JsonNode, System.IEquatable<System.Text.Json.JsonString>
     {

--- a/src/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/System.Text.Json/src/System.Text.Json.csproj
@@ -22,6 +22,8 @@
     <Compile Include="System\Text\Json\JsonHelpers.cs" />
     <Compile Include="System\Text\Json\JsonHelpers.Date.cs" />
     <Compile Include="System\Text\Json\JsonTokenType.cs" />
+    <Compile Include="System\Text\Json\Serialization\JsonSerializer.Read.HandleReference.cs" />
+    <Compile Include="System\Text\Json\Serialization\ReferenceHandlingOnDeserialize.cs" />
     <Compile Include="System\Text\Json\ThrowHelper.cs" />
     <Compile Include="System\Text\Json\ThrowHelper.Serialization.cs" />
     <Compile Include="System\Text\Json\Document\JsonDocument.cs" />

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
@@ -72,13 +72,9 @@ namespace System.Text.Json
                     // Primitive arrays being returned without object
                     state.Current.SetReturnValue(value);
                 }
-
-                if (state.Current.EnumerableMetadataId != null)
-                {
-                    // Save the reference to this array.
-                    state.SetReference(state.Current.EnumerableMetadataId, value);
-                }
             }
+
+            SetArrayReference(ref state, value);
         }
 
         private static bool HandleEndArray(
@@ -279,6 +275,22 @@ namespace System.Text.Json
                 Debug.Assert(state.Current.JsonPropertyInfo != null);
                 state.Current.JsonPropertyInfo.SetValueAsObject(state.Current.ReturnValue, value);
             }
+        }
+
+        private static void SetArrayReference(ref ReadStack state, object value)
+        {
+            if (state.DelayedMetadataId == null)
+            {
+                return;
+            }
+
+            if (state.Current.TempEnumerableValues != null)
+            {
+                throw new JsonException("Immutable enumerable types are not supported.");
+            }
+
+            Debug.Assert(value != null);
+            state.SetReference(state.DelayedMetadataId, value);
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
@@ -72,6 +72,12 @@ namespace System.Text.Json
                     // Primitive arrays being returned without object
                     state.Current.SetReturnValue(value);
                 }
+
+                if (state.Current.EnumerableMetadataId != null)
+                {
+                    // Save the reference to this array.
+                    state.SetReference(state.Current.EnumerableMetadataId, value);
+                }
             }
         }
 

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleObject.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleObject.cs
@@ -50,6 +50,8 @@ namespace System.Text.Json
             {
                 state.Current.ReturnValue = classInfo.CreateObject();
             }
+
+            SetObjectReference(ref state, state.Current.ReturnValue);
         }
 
         private static void HandleEndObject(ref ReadStack state)
@@ -77,6 +79,22 @@ namespace System.Text.Json
                 state.Pop();
                 ApplyObjectToEnumerable(value, ref state);
             }
+        }
+
+        private static void SetObjectReference(ref ReadStack state, object value)
+        {
+            if (state.DelayedMetadataId == null)
+            {
+                return;
+            }
+
+            if (state.Current.IsProcessingIDictionaryConstructible())
+            {
+                throw new JsonException("Immutable dictionary types are not supported.");
+            }
+
+            Debug.Assert(value != null);
+            state.SetReference(state.DelayedMetadataId, value);
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleReference.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleReference.cs
@@ -1,0 +1,162 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace System.Text.Json
+{
+    /// <summary>
+    /// Provides functionality to serialize objects or value types to JSON and
+    /// deserialize JSON into objects or value types.
+    /// </summary>
+    public static partial class JsonSerializer
+    {
+        private static void HandleMetadataProperty(JsonSerializerOptions options, ref Utf8JsonReader reader, ref ReadStack state)
+        {
+            if (state.Current.Drain) //Verify if this is the right condition. Why should I use this over state.Current.SkipProperty?
+            {
+                return;
+            }
+
+            MetadataPropertyName meta = GetMetadataPropertyName(reader.HasValueSequence ? reader.ValueSequence.ToArray() : reader.ValueSpan);
+            MetadataPropertyName previous = state.Current.LastMetaProperty;
+
+            if (meta == MetadataPropertyName.Unknown)
+            {
+                if (previous == MetadataPropertyName.Ref)
+                {
+                    throw new JsonException("Properties other than $ref are not allowed in reference objects.");
+                }
+            }
+
+            else if (meta == MetadataPropertyName.Id)
+            {
+                //TODO: Validate that multiple ids are not found in the same object, however, this is not validated by Json.Net.
+            }
+
+            else if (meta == MetadataPropertyName.Values)
+            {
+                if (previous != MetadataPropertyName.Id)
+                {
+                    throw new JsonException("Cannot have a preserved enumerable without specifying one id");
+                }
+                // remove misconcepted object.
+                InitTask task = state.RemoveInitTask(state.PendingTasksCount - 1);
+                state.Current.EnumerableMetadataId = task.MetadataId;
+            }
+
+            else if (meta == MetadataPropertyName.Ref)
+            {
+                // since pending objects are initialized when a non-metadata property is found, having zero pending tasks means that $ref is not the first property in the object.
+                if (state.PendingTasksCount == 0)
+                {
+                    throw new JsonException("Properties other than $ref are not allowed in reference objects.");
+                }
+
+                //Remove the misconcepted object from the queue.
+                state.RemoveInitTask(state.PendingTasksCount - 1);
+                //Create dummy frame in order to isolate its LastMetaProperty.
+                state.Push();
+            }
+
+            state.Current.LastMetaProperty = meta;
+            return;
+        }
+
+        //true if last property was metadata; false otherwise.
+        private static bool HandleMetadataValue(JsonTokenType tokenType, ref Utf8JsonReader reader, ref ReadStack state)
+        {
+            MetadataPropertyName previous = state.Current.LastMetaProperty;
+
+            if (previous == MetadataPropertyName.Unknown)
+            {
+                return false;
+            }
+
+            if (tokenType != JsonTokenType.String)
+            {
+                throw new JsonException("metadata property value must be of type string");
+            }
+
+            if (previous == MetadataPropertyName.Id)
+            {
+                //Add the $id associated to the reference object to use it when it gets initialized.
+                state.UpdateInitTask(state.PendingTasksCount - 1, metadataID: reader.GetString());
+            }
+            else if (previous == MetadataPropertyName.Ref)
+            {
+                state.Current.MetadataId = reader.GetString();
+            }
+
+            return true;
+        }
+
+        private static MetadataPropertyName GetMetadataPropertyName(ReadOnlySpan<byte> propertyName)
+        {
+            if (propertyName[0] == '$')
+            {
+                switch (propertyName.Length)
+                {
+                    case 3:
+                        if (propertyName[1] == 'i' &&
+                            propertyName[2] == 'd')
+                        {
+                            return MetadataPropertyName.Id;
+                        }
+                        break;
+
+                    case 4:
+                        if (propertyName[1] == 'r' &&
+                            propertyName[2] == 'e' &&
+                            propertyName[3] == 'f')
+                        {
+                            return MetadataPropertyName.Ref;
+                        }
+                        break;
+
+                    case 7:
+                        if (propertyName[1] == 'v' &&
+                            propertyName[2] == 'a' &&
+                            propertyName[3] == 'l' &&
+                            propertyName[4] == 'u' &&
+                            propertyName[5] == 'e' &&
+                            propertyName[6] == 's')
+                        {
+                            return MetadataPropertyName.Values;
+                        }
+                        break;
+                }
+            }
+
+            return MetadataPropertyName.Unknown;
+        }
+
+
+    }
+
+    // Preserve Reference Handling
+    internal enum MetadataPropertyName
+    {
+        Unknown, //it may be called invalid as well
+        Id,
+        Ref,
+        Values,
+    }
+
+    internal enum InitTaskType
+    {
+        None,
+        Dictionary,
+        Object
+    }
+
+    internal class InitTask
+    {
+        public InitTaskType Type { get; set; }
+        public string MetadataId { get; set; }
+        public MetadataPropertyName LastMetaProperty { get; set; }
+    }
+}

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -26,6 +26,7 @@ namespace System.Text.Json
         private JsonNamingPolicy _dictionayKeyPolicy;
         private JsonNamingPolicy _jsonPropertyNamingPolicy;
         private JsonCommentHandling _readCommentHandling;
+        private ReferenceHandlingOnDeserialize _referenceHandlingOnDeserialize;
         private JavaScriptEncoder _encoder;
         private int _defaultBufferSize = BufferSizeDefault;
         private int _maxDepth;
@@ -393,6 +394,23 @@ namespace System.Text.Json
             if (_haveTypesBeenCreated)
             {
                 ThrowHelper.ThrowInvalidOperationException_SerializerOptionsImmutable();
+            }
+        }
+
+        /// <summary>
+        /// Defines how metadata properties used to handle duplicate references are treated when reading the JSON payload.
+        /// </summary>
+        public ReferenceHandlingOnDeserialize ReadReferenceHandling
+        {
+            get => _referenceHandlingOnDeserialize;
+            set
+            {
+                if (!JsonHelpers.IsInRangeInclusive((int) value, (uint)ReferenceHandlingOnDeserialize.IgnoreMetadata, (uint) ReferenceHandlingOnDeserialize.PreserveDuplicates))
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+
+                _referenceHandlingOnDeserialize = value;
             }
         }
     }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
@@ -11,6 +11,11 @@ namespace System.Text.Json
     [DebuggerDisplay("Path:{JsonPath()} Current: ClassType.{Current.JsonClassInfo.ClassType}, {Current.JsonClassInfo.Type.Name}")]
     internal struct ReadStack
     {
+        public MetadataPropertyName LastMetadata;
+        public InitTaskType DelayedHandle;
+        public string DelayedMetadataId;
+        public bool ReadMetadataValue;
+
         internal static readonly char[] SpecialCharacters = { '.', ' ', '\'', '/', '"', '[', ']', '(', ')', '\t', '\n', '\r', '\f', '\b', '\\', '\u0085', '\u2028', '\u2029' };
 
         // A field is used instead of a property to avoid value semantics.
@@ -19,51 +24,6 @@ namespace System.Text.Json
         private List<ReadStackFrame> _previous;
         public int _index;
         private Dictionary<string, object> _preservedReferences;
-
-        public int PendingTasksCount { get => (_pendingInitializations?.Count).GetValueOrDefault(); }
-        private List<InitTask> _pendingInitializations;
-
-        public void EnqueueInitTask(InitTaskType taskType, string metadataId = null)
-        {
-            if (_pendingInitializations == null)
-            {
-                _pendingInitializations = new List<InitTask>();
-            }
-
-            _pendingInitializations.Add(new InitTask { Type = taskType, MetadataId = metadataId });
-            //PendingInitializationIndex++;
-        }
-
-        public InitTask DequeueInitTask()
-        {
-            InitTask task = _pendingInitializations[0];
-            _pendingInitializations.RemoveAt(0);
-
-            return task;
-        }
-
-        public InitTask RemoveInitTask(int index)
-        {
-            InitTask task = _pendingInitializations[index];
-            _pendingInitializations.RemoveAt(index);
-
-            return task;
-        }
-
-        public void UpdateInitTask(int index, string metadataID = null, MetadataPropertyName? lastMetaProperty = null)
-        {
-            InitTask task = _pendingInitializations[index];
-
-            if (metadataID != null)
-            {
-                task.MetadataId = metadataID;
-            }
-
-            if (lastMetaProperty != null)
-            {
-                task.LastMetaProperty = lastMetaProperty.Value;
-            }
-        }
 
         public void SetReference(string key, object value)
         {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
@@ -18,6 +18,74 @@ namespace System.Text.Json
 
         private List<ReadStackFrame> _previous;
         public int _index;
+        private Dictionary<string, object> _preservedReferences;
+
+        public int PendingTasksCount { get => (_pendingInitializations?.Count).GetValueOrDefault(); }
+        private List<InitTask> _pendingInitializations;
+
+        public void EnqueueInitTask(InitTaskType taskType, string metadataId = null)
+        {
+            if (_pendingInitializations == null)
+            {
+                _pendingInitializations = new List<InitTask>();
+            }
+
+            _pendingInitializations.Add(new InitTask { Type = taskType, MetadataId = metadataId });
+            //PendingInitializationIndex++;
+        }
+
+        public InitTask DequeueInitTask()
+        {
+            InitTask task = _pendingInitializations[0];
+            _pendingInitializations.RemoveAt(0);
+
+            return task;
+        }
+
+        public InitTask RemoveInitTask(int index)
+        {
+            InitTask task = _pendingInitializations[index];
+            _pendingInitializations.RemoveAt(index);
+
+            return task;
+        }
+
+        public void UpdateInitTask(int index, string metadataID = null, MetadataPropertyName? lastMetaProperty = null)
+        {
+            InitTask task = _pendingInitializations[index];
+
+            if (metadataID != null)
+            {
+                task.MetadataId = metadataID;
+            }
+
+            if (lastMetaProperty != null)
+            {
+                task.LastMetaProperty = lastMetaProperty.Value;
+            }
+        }
+
+        public void SetReference(string key, object value)
+        {
+            if (_preservedReferences == null)
+            {
+                _preservedReferences = new Dictionary<string, object>();
+            }
+
+            _preservedReferences[key] = value;
+        }
+
+        public object GetReference(string key)
+        {
+            if (_preservedReferences == null)
+            {
+                return null;
+            }
+
+            _preservedReferences.TryGetValue(key, out object value);
+
+            return value;
+        }
 
         public void Push()
         {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
@@ -14,10 +14,8 @@ namespace System.Text.Json
     internal struct ReadStackFrame
     {
         //Metadata properties
-        public MetadataPropertyName LastMetaProperty;
-        public string EnumerableMetadataId;
-        public string MetadataId;
-        public bool HandleWrappingBrace;
+        public bool HandleArrayEndWrappingBrace;
+        public bool HandleRefEndBrace;
 
         // The object (POCO or IEnumerable) that is being populated
         public object ReturnValue;
@@ -181,11 +179,10 @@ namespace System.Text.Json
         public void Reset()
         {
             Drain = false;
+            HandleArrayEndWrappingBrace = false;
             JsonClassInfo = null;
             PropertyRefCache = null;
             ReturnValue = null;
-            MetadataId = null;
-            LastMetaProperty = default;
             EndObject();
         }
 
@@ -212,13 +209,6 @@ namespace System.Text.Json
             // If the property has an EnumerableConverter, then we use tempEnumerableValues.
             if (jsonPropertyInfo.EnumerableConverter != null)
             {
-                if (state.Current.LastMetaProperty == MetadataPropertyName.Values)
-                {
-                    //An immutable collection is trying to be preserved which is unsupported.
-                    //NOTE: Aside from Immutables, is there other reason why Enumerables would use a converter?
-                    throw new JsonException("Cannot preserve references for types that are immutable.");
-                }
-
                 IList converterList;
                 if (jsonPropertyInfo.ElementClassInfo.ClassType == ClassType.Value)
                 {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/ReferenceHandlingOnDeserialize.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/ReferenceHandlingOnDeserialize.cs
@@ -5,7 +5,7 @@ using System.Text;
 namespace System.Text.Json
 {
     /// <summary>
-    /// This enum defines the various ways the <see cref="Utf8JsonReader"/> can deal with comments.
+    /// Defines how to hanlde metadata properties on deserialization when used for referencing duplicate objects in the JSON payload.
     /// </summary>
     public enum ReferenceHandlingOnDeserialize
     {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/ReferenceHandlingOnDeserialize.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/ReferenceHandlingOnDeserialize.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace System.Text.Json
+{
+    /// <summary>
+    /// This enum defines the various ways the <see cref="Utf8JsonReader"/> can deal with comments.
+    /// </summary>
+    public enum ReferenceHandlingOnDeserialize
+    {
+        /// <summary>
+        /// Indicates to the deserialier to ignore metadata properties in the payload.
+        /// </summary>
+        IgnoreMetadata,
+        /// <summary>
+        /// Indicates to the deserializer to use metadata properties in the payload in order to handle duplicate references.
+        /// </summary>
+        PreserveDuplicates,
+    }
+}

--- a/src/System.Text.Json/tests/ReferenceHandlingTests.Deserialize.cs
+++ b/src/System.Text.Json/tests/ReferenceHandlingTests.Deserialize.cs
@@ -493,7 +493,7 @@ namespace System.Text.Json.Tests
             }";
 
             Exception ex = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Employee>(json, _deserializeOptions));
-            Assert.Equal("Properties other than $ref are not allowed in reference objects.", ex.Message);
+            Assert.Equal("Properties other than '$ref' are not allowed in reference objects.", ex.Message);
         }
 
         [Fact] 
@@ -510,7 +510,7 @@ namespace System.Text.Json.Tests
             }";
 
             Exception ex = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Employee>(json, _deserializeOptions));
-            Assert.Equal("Properties other than $ref are not allowed in reference objects.", ex.Message);
+            Assert.Equal("Properties other than '$ref' are not allowed in reference objects.", ex.Message);
         }
 
         //Immutables
@@ -524,7 +524,7 @@ namespace System.Text.Json.Tests
             }";
 
             Exception ex = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ImmutableList<Employee>>(json, _deserializeOptions));
-            Assert.Equal("Cannot preserve references for types that are immutable.", ex.Message);
+            Assert.Equal("Immutable enumerable types are not supported.", ex.Message);
         }
 
         [Fact] 
@@ -537,7 +537,7 @@ namespace System.Text.Json.Tests
             }";
 
             Exception ex = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ImmutableDictionary<string, Employee>>(json, _deserializeOptions));
-            Assert.Equal("Cannot preserve references for types that are immutable.", ex.Message);
+            Assert.Equal("Immutable dictionary types are not supported.", ex.Message);
         }
 
         private class EmployeeWithImmutables
@@ -562,7 +562,7 @@ namespace System.Text.Json.Tests
             }";
 
             Exception ex = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<EmployeeWithImmutables>(json, _deserializeOptions));
-            Assert.Equal("Cannot preserve references for types that are immutable.", ex.Message);
+            Assert.Equal("Immutable enumerable types are not supported.", ex.Message);
         }
 
         [Fact]
@@ -578,7 +578,7 @@ namespace System.Text.Json.Tests
             }";
 
             Exception ex = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<EmployeeWithImmutables>(json, _deserializeOptions));
-            Assert.Equal("Cannot preserve references for types that are immutable.", ex.Message);
+            Assert.Equal("Immutable dictionary types are not supported.", ex.Message);
         }
         #endregion
     }

--- a/src/System.Text.Json/tests/ReferenceHandlingTests.Deserialize.cs
+++ b/src/System.Text.Json/tests/ReferenceHandlingTests.Deserialize.cs
@@ -1,0 +1,585 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Xunit;
+
+namespace System.Text.Json.Tests
+{
+    public static partial class ReferenceHandlingTests
+    {
+        private static JsonSerializerOptions _deserializeOptions = new JsonSerializerOptions { ReadReferenceHandling = ReferenceHandlingOnDeserialize.PreserveDuplicates };
+
+        private class EmployeeWithContacts
+        {
+            public string Name { get; set; }
+            public EmployeeWithContacts Manager { get; set; }
+            public List<EmployeeWithContacts> Subordinates { get; set; }
+            public Dictionary<string, EmployeeWithContacts> Contacts { get; set; }
+        }
+
+        private class Employee
+        {
+            public string Name { get; set; }
+            public Employee Manager { get; set; }
+            public List<Employee> Subordinates { get; set; }
+        }
+
+        #region Root Object
+        [Fact] //Employee list as a property and then use reference to itself on nested Employee.
+        public static void ObjectReferenceLoop()
+        {
+            string json =
+            @"{
+                ""$id"": ""1"",
+                ""Name"": ""Angela"",
+                ""Manager"": {
+                    ""$ref"": ""1""
+                }
+            }";
+
+            Employee angela = JsonSerializer.Deserialize<Employee>(json, _deserializeOptions);
+            Assert.Same(angela, angela.Manager);
+        }
+
+        [Fact] // Employee whose subordinates is a preserved list. EmployeeListEmployee
+        public static void ObjectReferenceLoopInList()
+        {
+            string json =
+            @"{
+                ""$id"": ""1"",
+                ""Subordinates"": {
+                    ""$id"": ""2"",
+                    ""$values"": [
+                        {
+                            ""$ref"": ""1""
+                        }
+                    ]
+                }
+            }";
+
+            Employee employee = JsonSerializer.Deserialize<Employee>(json, _deserializeOptions);
+            Assert.Equal(1, employee.Subordinates.Count);
+            Assert.Same(employee, employee.Subordinates[0]);
+        }
+
+        [Fact] // Employee whose subordinates is a preserved list. EmployeeListEmployee
+        public static void ObjectReferenceLoopInDictionary()
+        {
+            string json =
+            @"{
+                ""$id"": ""1"",
+                ""Contacts"":{
+                    ""$id"": ""2"",
+                    ""Angela"":{
+                        ""$ref"": ""1""
+                    }
+                }
+            }";
+
+            EmployeeWithContacts employee = JsonSerializer.Deserialize<EmployeeWithContacts>(json, _deserializeOptions);
+            Assert.Same(employee, employee.Contacts["Angela"]);
+        }
+
+        [Fact] //Employee list as a property and then use reference to itself on nested Employee.
+        public static void ObjectWithArrayReferencedDeeper()
+        {
+            string json =
+            @"{
+                ""$id"": ""1"",
+                ""Subordinates"": {
+                    ""$id"": ""2"",
+                    ""$values"": [
+                        {
+                            ""$id"": ""3"",
+                            ""Name"": ""Angela"",
+                            ""Subordinates"":{
+                                ""$ref"": ""2""
+                            }
+                        }
+                    ]
+                }
+            }";
+
+            Employee employee = JsonSerializer.Deserialize<Employee>(json, _deserializeOptions);
+            Assert.Same(employee.Subordinates, employee.Subordinates[0].Subordinates);
+        }
+
+        [Fact] //Employee Dictionary as a property and then use reference to itself on nested Employee.
+        public static void ObjectWithDictionaryReferenceDeeper()
+        {
+            string json =
+            @"{
+                ""$id"": ""1"",
+                ""Contacts"": {
+                    ""$id"": ""2"",
+                    ""Angela"": {
+                        ""$id"": ""3"",
+                        ""Name"": ""Angela"",
+                        ""Contacts"": {
+                            ""$ref"": ""2""
+                        }
+                    }
+                }
+            }";
+
+            EmployeeWithContacts employee = JsonSerializer.Deserialize<EmployeeWithContacts>(json, _deserializeOptions);
+            Assert.Same(employee.Contacts, employee.Contacts["Angela"].Contacts);
+        }
+        #endregion
+
+        #region Root Dictionary
+        [Fact] //Employee list as a property and then use reference to itself on nested Employee.
+        public static void DictionaryReferenceLoop()
+        {
+            string json =
+            @"{
+                ""$id"": ""1"",
+                ""Angela"": {
+                    ""$id"": ""2"",
+                    ""Name"": ""Angela"",
+                    ""Contacts"": {
+                        ""$ref"": ""1""
+                    }
+                }
+            }";
+
+            Dictionary<string, EmployeeWithContacts> dictionary = JsonSerializer.Deserialize<Dictionary<string, EmployeeWithContacts>>(json, _deserializeOptions);
+
+            Assert.Same(dictionary, dictionary["Angela"].Contacts);
+        }
+
+        [Fact]
+        public static void DictionaryReferenceLoopInList()
+        {
+            string json =
+            @"{
+                ""$id"": ""1"",
+                ""Angela"": {
+                    ""$id"": ""2"",
+                    ""Name"": ""Angela"",
+                    ""Subordinates"": {
+                        ""$id"": ""3"",
+                        ""$values"": [
+                            {
+                                ""$id"": ""4"",
+                                ""Name"": ""Bob"",
+                                ""Contacts"": {
+                                    ""$ref"": ""1""
+                                }
+                            }
+                        ]
+                    }
+                }
+            }";
+
+            Dictionary<string, EmployeeWithContacts> dictionary = JsonSerializer.Deserialize<Dictionary<string, EmployeeWithContacts>>(json, _deserializeOptions);
+            Assert.Same(dictionary, dictionary["Angela"].Subordinates[0].Contacts);
+        }
+
+        [Fact]
+        public static void DicitionaryDuplicatedObject()
+        {
+            string json =
+            @"{
+              ""555"": { ""$id"": ""1"", ""Name"": ""Angela"" },
+              ""556"": { ""Name"": ""Bob"" },
+              ""557"": { ""$ref"": ""1"" }
+            }";
+
+            Dictionary<string, Employee> directory = JsonSerializer.Deserialize<Dictionary<string, Employee>>(json, _deserializeOptions);
+            Assert.Same(directory["555"], directory["557"]);
+        }
+
+        [Fact] //This should not throw, since the references are in nested objects, not in the immutable dictionary itself.
+        public static void ImmutableDictionaryPreserveNestedObjects()
+        {
+            string json =
+            @"{
+                ""Angela"": {
+                    ""$id"": ""1"",
+                    ""Name"": ""Angela"",
+                    ""Subordinates"": {
+                        ""$id"": ""2"",
+                        ""$values"": [
+                            {
+                                ""$id"": ""3"",
+                                ""Name"": ""Carlos"",
+                                ""Manager"": {
+                                    ""$ref"": ""1""
+                                }
+                            }
+                        ]
+                    }
+                },
+                ""Bob"": {
+                    ""$id"": ""4"",
+                    ""Name"": ""Bob""
+                },
+                ""Carlos"": {
+                    ""$ref"": ""3""
+                }
+            }";
+
+            ImmutableDictionary<string, Employee> dictionary = JsonSerializer.Deserialize<ImmutableDictionary<string, Employee>>(json, _deserializeOptions);
+            Assert.Same(dictionary["Angela"], dictionary["Angela"].Subordinates[0].Manager);
+            Assert.Same(dictionary["Carlos"], dictionary["Angela"].Subordinates[0]);
+        }
+        #endregion
+
+        #region Root Array
+        [Fact] // Preserved list that contains an employee whose subordinates is a reference to the root list.
+        public static void ArrayNestedArray()
+        {
+            string json =
+            @"{
+                ""$id"": ""1"",
+                ""$values"":[
+                    {
+                        ""$id"":""2"",
+                        ""Name"": ""Angela"",
+                        ""Subordinates"": {
+                            ""$ref"": ""1""
+                        }
+                    }
+                ]
+            }";
+
+            List<Employee> employees = JsonSerializer.Deserialize<List<Employee>>(json, _deserializeOptions);
+
+            Assert.Same(employees, employees[0].Subordinates);
+        }
+
+
+        [Fact]
+        public static void EmptyArray() //Make sure the serializer can understand lists that were wrapped in braces.
+        {
+            string json =
+            @"{
+              ""$id"": ""1"",
+              ""Subordinates"": {
+                ""$id"": ""2"",
+                ""$values"": []
+              },
+              ""Name"": ""Angela""
+            }";
+
+            Employee angela = JsonSerializer.Deserialize<Employee>(json, _deserializeOptions);
+
+            Assert.NotNull(angela);
+            Assert.NotNull(angela.Subordinates);
+            Assert.Equal(0, angela.Subordinates.Count);
+
+        }
+
+        [Fact]
+        public static void ArrayWithDuplicates() //Make sure the serializer can understand lists that were wrapped in braces.
+        {
+            string json =
+            @"{
+                ""$id"": ""1"",
+                ""$values"":[
+                    {
+                        ""$id"": ""2"",
+                        ""Name"": ""Angela""
+                    },
+                    {
+                        ""$id"": ""3"",
+                        ""Name"": ""Bob""
+                    },
+                    {
+                        ""$ref"": ""2""
+                    },
+                    {
+                        ""$ref"": ""3""
+                    },
+                    {
+                        ""$id"": ""4""
+                    },
+                    {
+                        ""$ref"": ""4""
+                    }
+                ]
+            }";
+
+            List<Employee> employees = JsonSerializer.Deserialize<List<Employee>>(json, _deserializeOptions);
+            Assert.Equal(6, employees.Count);
+            Assert.Same(employees[0], employees[2]);
+            Assert.Same(employees[1], employees[3]);
+            Assert.Same(employees[4], employees[5]);
+
+        }
+
+        [Fact]
+        public static void ArrayNotPreservedWithDuplicates() //Make sure the serializer can understand lists that were wrapped in braces.
+        {
+            string json =
+            @"[
+                {
+                    ""$id"": ""2"",
+                    ""Name"": ""Angela""
+                },
+                {
+                    ""$id"": ""3"",
+                    ""Name"": ""Bob""
+                },
+                {
+                    ""$ref"": ""2""
+                },
+                {
+                    ""$ref"": ""3""
+                },
+                {
+                    ""$id"": ""4""
+                },
+                {
+                    ""$ref"": ""4""
+                }
+            ]";
+
+            Employee[] employees = JsonSerializer.Deserialize<Employee[]>(json, _deserializeOptions);
+            Assert.Equal(6, employees.Length);
+            Assert.Same(employees[0], employees[2]);
+            Assert.Same(employees[1], employees[3]);
+            Assert.Same(employees[4], employees[5]);
+        }
+        #endregion
+
+        #region Converter
+        [Fact] //This only demonstrates that behavior with converters remain the same.
+        public static void DeserializeWithListConverter()
+        {
+            string json =
+            @"{
+                ""$id"": ""1"",
+                ""Subordinates"": {
+                    ""$id"": ""2"",
+                    ""$values"": [
+                        {
+                            ""$ref"": ""1""
+                        }
+                    ]
+                },
+                ""Name"": ""Angela"",
+                ""Manager"": {
+                    ""Subordinates"": {
+                        ""$ref"": ""2""
+                    }
+                }
+            }";
+
+            var options = new JsonSerializerOptions();
+            options.ReadReferenceHandling = ReferenceHandlingOnDeserialize.PreserveDuplicates;
+            options.Converters.Add(new MyConverter());
+
+            Employee angela = JsonSerializer.Deserialize<Employee>(json, options);
+        }
+
+        //NOTE: If you implement a converter, you are on your own when handling metadata properties and therefore references.Newtonsoft does the same.
+        //However; is there a way to recall preserved references previously found in the payload and to store new ones found in the converter's payload? that would be a cool enhancement.
+        private class MyConverter : Serialization.JsonConverter<List<Employee>>
+        {
+            public override List<Employee> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                int startObjectCount = 0;
+                int endObjectCount = 0;
+
+                while (true)
+                {
+                    switch (reader.TokenType)
+                    {
+                        case JsonTokenType.StartObject:
+                            startObjectCount++; break;
+                        case JsonTokenType.EndObject:
+                            endObjectCount++; break;
+                    }
+
+                    if (startObjectCount == endObjectCount)
+                    {
+                        break;
+                    }
+
+                    reader.Read();
+                }
+
+                return new List<Employee>();
+            }
+
+            public override void Write(Utf8JsonWriter writer, List<Employee> value, JsonSerializerOptions options)
+            {
+                throw new NotImplementedException();
+            }
+        }
+        #endregion
+
+        #region Null/non-existent reference
+        [Fact]
+        public static void ObjectNull() //Make sure the serializer can understand lists that were wrapped in braces.
+        {
+            string json =
+            @"{
+                ""$ref"": ""1""
+            }";
+
+            Employee employee = JsonSerializer.Deserialize<Employee>(json, _deserializeOptions);
+            Assert.Null(employee);
+        }
+
+        [Fact]
+        public static void ArrayNull() //Make sure the serializer can understand lists that were wrapped in braces.
+        {
+            string json =
+            @"{
+                ""$ref"": ""1""
+            }";
+
+            Employee[] array = JsonSerializer.Deserialize<Employee[]>(json, _deserializeOptions);
+            Assert.Null(array);
+        }
+
+        [Fact]
+        public static void DictionaryNull() //Make sure the serializer can understand lists that were wrapped in braces.
+        {
+            string json =
+            @"{
+                ""$ref"": ""1""
+            }";
+
+            Dictionary<string, Employee> dictionary = JsonSerializer.Deserialize<Dictionary<string, Employee>>(json, _deserializeOptions);
+            Assert.Null(dictionary);
+        }
+
+        [Fact]
+        public static void ArrayPropertyNull() //Make sure the serializer can understand lists that were wrapped in braces.
+        {
+            string json =
+            @"{
+                ""$id"": ""1"",
+                ""Name"": ""Angela"",
+                ""Manager"": {
+                    ""$ref"": ""1""
+                },
+                ""Subordinates"": {
+                    ""$ref"": ""2""
+                }
+            }";
+
+            Employee angela = JsonSerializer.Deserialize<Employee>(json, _deserializeOptions);
+            Assert.Null(angela.Subordinates);
+        }
+
+        // TODO: Add struct case where reference would evaluate as null; also, what does Json.Net does for that?
+        #endregion
+
+        #region Throw cases
+        [Fact]
+        public static void VerifyReferenceHandlingInJsonSerializerOptions()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new JsonSerializerOptions { ReadReferenceHandling = (ReferenceHandlingOnDeserialize) (-1) });
+        }
+
+        [Fact]
+        public static void PropertyAfterRef()
+        {
+            string json =
+            @"{
+              ""$id"": ""1"",
+              ""Name"": ""Angela"",
+              ""Manager"": {
+                    ""$ref"": ""1"",
+                    ""Name"": ""Bob""
+                }
+            }";
+
+            Exception ex = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Employee>(json, _deserializeOptions));
+            Assert.Equal("Properties other than $ref are not allowed in reference objects.", ex.Message);
+        }
+
+        [Fact] 
+        public static void PropertyBeforeRef()
+        {
+            string json =
+            @"{
+              ""$id"": ""1"",
+              ""Name"": ""Angela"",
+              ""Manager"": {
+                    ""Name"": ""Bob"",
+                    ""$ref"": ""1""
+                }
+            }";
+
+            Exception ex = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Employee>(json, _deserializeOptions));
+            Assert.Equal("Properties other than $ref are not allowed in reference objects.", ex.Message);
+        }
+
+        //Immutables
+        [Fact] 
+        public static void ImmutableListTryPreserve()
+        {
+            string json =
+            @"{
+                ""$id"": ""1"",
+                ""$values"": []
+            }";
+
+            Exception ex = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ImmutableList<Employee>>(json, _deserializeOptions));
+            Assert.Equal("Cannot preserve references for types that are immutable.", ex.Message);
+        }
+
+        [Fact] 
+        public static void ImmutableDictionaryTryPreserve()
+        {
+            string json =
+            @"{
+                ""$id"": ""1"",
+                ""Angela"": {}
+            }";
+
+            Exception ex = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ImmutableDictionary<string, Employee>>(json, _deserializeOptions));
+            Assert.Equal("Cannot preserve references for types that are immutable.", ex.Message);
+        }
+
+        private class EmployeeWithImmutables
+        {
+            public string Name { get; set; }
+            public EmployeeWithImmutables Manager { get; set; }
+            public ImmutableList<EmployeeWithImmutables> Subordinates { get; set; }
+            public ImmutableDictionary<string, EmployeeWithImmutables> Contacts { get; set; }
+        }
+
+        [Fact]
+        public static void ImmutableListAsPropertyTryPreserve()
+        {
+            string json =
+            @"{
+                ""$id"": ""1"",
+                ""Name"": ""Angela"",
+                ""Subordinates"": {
+                    ""$id"": ""2"",
+                    ""$values"": []
+                }
+            }";
+
+            Exception ex = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<EmployeeWithImmutables>(json, _deserializeOptions));
+            Assert.Equal("Cannot preserve references for types that are immutable.", ex.Message);
+        }
+
+        [Fact]
+        public static void ImmutableDictionaryAsPropertyTryPreserve()
+        {
+            string json =
+            @"{
+                ""$id"": ""1"",
+                ""Name"": ""Angela"",
+                ""Contacts"": {
+                    ""$id"": ""2""
+                }
+            }";
+
+            Exception ex = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<EmployeeWithImmutables>(json, _deserializeOptions));
+            Assert.Equal("Cannot preserve references for types that are immutable.", ex.Message);
+        }
+        #endregion
+    }
+}

--- a/src/System.Text.Json/tests/System.Text.Json.Tests.csproj
+++ b/src/System.Text.Json/tests/System.Text.Json.Tests.csproj
@@ -31,6 +31,7 @@
     <Compile Include="NewtonsoftTests\EnumConverterTests.cs" />
     <Compile Include="NewtonsoftTests\ImmutableCollectionsTests.cs" />
     <Compile Include="NewtonsoftTests\JsonSerializerTests.cs" />
+    <Compile Include="ReferenceHandlingTests.Deserialize.cs" />
     <Compile Include="Serialization\Array.ReadTests.cs" />
     <Compile Include="Serialization\Array.WriteTests.cs" />
     <Compile Include="Serialization\CacheTests.cs" />


### PR DESCRIPTION
Add support for metadata properties ($id, $ref and $values) used for reference handling on Deserialization.

This is a work in progress and as such, some things in the implementation are still missing, like correctly handling exception messages, property names, etc.

The main purpose of this PR for me is to validate with the area owners if I am on the right path on the prototype/implementation.

This PR only covers the Read or Deserializaiton part, I will address Write/Serialization in a separate PR.
