### PR TITLE
Remove unnecessary length restriction on Uri.Escape{Data/Uri}String

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/FormUrlEncodedContentTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/FormUrlEncodedContentTest.cs
@@ -42,7 +42,7 @@ namespace System.Net.Http.Functional.Tests
         public async Task Ctor_LongSource_Succeed(char c, int length)
         {
             const string Key = "test";
-            string value = new string(c, length);
+            var value = new string(c, length);
             var content = new FormUrlEncodedContent(new Dictionary<string, string> { { Key, value } });
             Assert.Equal($"{Key}={Uri.EscapeDataString(value)}", await content.ReadAsStringAsync());
         }

--- a/src/System.Net.Http/tests/FunctionalTests/FormUrlEncodedContentTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/FormUrlEncodedContentTest.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
@@ -35,6 +34,17 @@ namespace System.Net.Http.Functional.Tests
             var content = new FormUrlEncodedContent(new Dictionary<string, string>());
             Stream stream = await content.ReadAsStreamAsync();
             Assert.Equal(0, stream.Length);
+        }
+
+        [Theory]
+        [InlineData('F', ushort.MaxValue + 10)]
+        [InlineData('/', ushort.MaxValue + 10)]
+        public async Task Ctor_LongSource_Succeed(char c, int length)
+        {
+            const string Key = "test";
+            string value = new string(c, length);
+            var content = new FormUrlEncodedContent(new Dictionary<string, string> { { Key, value } });
+            Assert.Equal($"{Key}={Uri.EscapeDataString(value)}", await content.ReadAsStringAsync());
         }
 
         [Fact]

--- a/src/System.Private.Uri/src/System/UriHelper.cs
+++ b/src/System.Private.Uri/src/System/UriHelper.cs
@@ -134,9 +134,6 @@ namespace System
         internal static unsafe char[]? EscapeString(string input, int start, int end, char[]? dest, ref int destPos,
             bool isUriString, char force1, char force2, char rsvd)
         {
-            if (end - start >= Uri.c_MaxUriBufferSize)
-                throw new UriFormatException(SR.net_uri_SizeLimit);
-
             int i = start;
             int prevInputPos = start;
             byte* bytes = stackalloc byte[c_MaxUnicodeCharsReallocate * c_MaxUTF_8BytesPerUnicodeChar];   // 40*4=160

--- a/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
@@ -495,36 +495,24 @@ namespace System.PrivateUri.Tests
             { }
         }
 
-        [Fact]
-        public void Iri_ValidateVeryLongInputString_EscapeDataString()
+        [Theory]
+        [InlineData(maxUriLength)]
+        [InlineData(maxUriLength + 1)]
+        [InlineData(10 + ushort.MaxValue)]
+        public void Iri_ValidateVeryLongInputString_EscapeDataString(int length)
         {
-            string bigString1 = GetUnicodeString(0, maxUriLength, 1);
-            Assert.True(Uri.EscapeDataString(bigString1).Length > bigString1.Length);
-
-            try
-            {
-                string bigString2 = GetUnicodeString(0, maxUriLength + 1, 1);
-                Uri.EscapeDataString(bigString2);
-                Assert.False(true, "Expected UriFormatException: Uri too large");
-            }
-            catch (FormatException)
-            { }
+            string s = GetUnicodeString(0, length, 1);
+            Assert.InRange(Uri.EscapeDataString(s).Length, s.Length + 1, int.MaxValue);
         }
 
-        [Fact]
-        public void Iri_ValidateVeryLongInputString_EscapeUriString()
+        [Theory]
+        [InlineData(maxUriLength)]
+        [InlineData(maxUriLength + 1)]
+        [InlineData(10 + ushort.MaxValue)]
+        public void Iri_ValidateVeryLongInputString_EscapeUriString(int length)
         {
-            string bigString1 = GetUnicodeString(0, maxUriLength, 1);
-            Assert.True(Uri.EscapeUriString(bigString1).Length > bigString1.Length);
-
-            try
-            {
-                string bigString2 = GetUnicodeString(0, maxUriLength + 1, 1);
-                Uri.EscapeUriString(bigString2);
-                Assert.False(true, "Expected UriFormatException: Uri too large");
-            }
-            catch (FormatException)
-            { }
+            string s = GetUnicodeString(0, length, 1);
+            Assert.InRange(Uri.EscapeUriString(s).Length, s.Length + 1, int.MaxValue);
         }
 
         [Theory]

--- a/src/System.Runtime/tests/System/Uri.MethodsTests.cs
+++ b/src/System.Runtime/tests/System/Uri.MethodsTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.InteropServices;
 using Xunit;
 
@@ -421,10 +422,22 @@ namespace System.Tests
         }
 
         [Fact]
+        public void EscapeDataString_Long_Success()
+        {
+            string s;
+            const int LongCount = 65520 + 1;
+
+            s = new string('a', LongCount);
+            Assert.Equal(s, Uri.EscapeDataString(s));
+
+            s = new string('/', LongCount);
+            Assert.Equal(string.Concat(Enumerable.Repeat("%2F", LongCount)), Uri.EscapeDataString(s));
+        }
+
+        [Fact]
         public void EscapeDataString_Invalid()
         {
             AssertExtensions.Throws<ArgumentNullException>("stringToEscape", () => Uri.EscapeDataString(null)); // StringToEscape is null
-            Assert.Throws<UriFormatException>(() => Uri.EscapeDataString(UriCreateStringTests.s_longString)); // StringToEscape is too long
 
             Assert.Throws<UriFormatException>(() => Uri.EscapeDataString("\uD800")); // Incomplete surrogate pair provided
             Assert.Throws<UriFormatException>(() => Uri.EscapeDataString("abc\uD800")); // Incomplete surrogate pair provided
@@ -463,10 +476,22 @@ namespace System.Tests
         }
 
         [Fact]
+        public void EscapeUriString_Long_Success()
+        {
+            string s;
+            const int LongCount = 65520 + 1;
+
+            s = new string('a', LongCount);
+            Assert.Equal(s, Uri.EscapeUriString(s));
+
+            s = new string('<', LongCount);
+            Assert.Equal(string.Concat(Enumerable.Repeat("%3C", LongCount)), Uri.EscapeUriString(s));
+        }
+
+        [Fact]
         public void EscapeUriString_Invalid()
         {
             AssertExtensions.Throws<ArgumentNullException>("stringToEscape", () => Uri.EscapeUriString(null)); // StringToEscape is null
-            Assert.Throws<UriFormatException>(() => Uri.EscapeUriString(UriCreateStringTests.s_longString)); // StringToEscape is too long
 
             Assert.Throws<UriFormatException>(() => Uri.EscapeUriString("\uD800")); // Incomplete surrogate pair provided
             Assert.Throws<UriFormatException>(() => Uri.EscapeUriString("abc\uD800")); // Incomplete surrogate pair provided


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/1936