### PR TITLE
Stop using vfork with musl libc and credentials

### DIFF
--- a/src/Native/Unix/System.Native/pal_process.c
+++ b/src/Native/Unix/System.Native/pal_process.c
@@ -339,7 +339,21 @@ int32_t SystemNative_ForkAndExecProcess(const char* filename,
     // on another thread while a vfork() child is still pending, bad things are possible; however we
     // do not do that.
 
+#if defined (__GLIBC__)
     if ((processId = vfork()) == 0) // processId == 0 if this is child process
+#else
+    // musl libc has an undocumented failure mode around setuid(); we must exclude it.
+    if (setCredentials)
+    {
+        processId = fork();
+    }
+    else
+    {
+        processId = vfork();
+    }
+    if (processId == 0)
+#endif
+
 #else
     if ((processId = fork()) == 0) // processId == 0 if this is child process
 #endif


### PR DESCRIPTION
Port https://github.com/dotnet/corefx/pull/41457 to master.  We should have started with this master; we can later refine it if desired.
#41432