### PR TITLE
Backup wiki information before documentation consolidation

### DIFF
--- a/Documentation/wiki/ApiCompat.md
+++ b/Documentation/wiki/ApiCompat.md
@@ -1,0 +1,1276 @@
+### List of behavioral changes/compat breaks and deprecated/legacy APIs
+
+**Consider adding deprecations entries directly into https://github.com/dotnet/platform-compat/pull/24**
+
+When editing this file, please do not delete pre-existing content. If you don't like it, make a comment, but do NOT DELETE it.
+It is honor system. There are no PRs, anyone on GitHub can edit our wiki docs.
+
+The content will serve as database for platform-compat tool
+
+#### FAQ
+
+Q: Why not use **Obsolete** instead?
+
+A: Obsolete attributes causes warnings. Warnings are often treated as Errors. Errors in compiler/framework update are viewed as breaking changes by large number of our customers. Roslyn team tried that in the past and fell back to do "warning waves" you have to opt-into.
+Tooling on the side has 2 pros:
+1. We can be agile and change/add things as we find them with fast shipping cycle.
+2. We can annotate already-shipped versions (.NET Framework 4.6.x/4.7/older, .NET Core 1.0/1.1)
+
+# Behavioral changes across platforms (compat breaks)
+
+### System
+
+- Secondary AppDomains are not supported on .NET Core. API such as AppDomain.CreateDomain will throw PNSE. Consider alternative isolation mechanisms such as separate processes. For controlling assembly load, consider AssemblyLoadContext.
+- Remoting is not supported on .NET Core. Consider alternative IPC mechanisms such as memory mapped files, or pipes.
+- Code Access Security and SecurityTransparency are not supported on .NET Core.
+
+There is some more information at https://docs.microsoft.com/en-us/dotnet/core/porting/libraries
+
+---
+
+### System.Diagnostics.Process
+
+- ```Process.Start``` with identity is not supported on Unix platforms.
+- ```Process.UseShellExecute``` may not work on all Windows versions. Unlike Desktop, it defaults to false.
+- Remote processes are not supported on Unix platforms.
+
+#### Unsupported members in .NET Core
+
+Key:
+
+- PNSE : PlatformNotSupportedException
+- Nop : No operation
+
+| Member | Platform | Action |
+| ------ | -------------------- | ------------- |
+| Process.set_MaxWorkingSet() | Linux | PNSE |
+| Process.set_MinWorkingSet() | Linux | PNSE |
+| Process.get_MaxWorkingSet() | OSX | PNSE for other processes |
+| Process.set_MaxWorkingSet() | OSX | PNSE for other processes; for current process value cannot be decreased |
+| Process.get_ProcessorAffinity() | OSX | PNSE |
+| Process.set_ProcessorAffinity() | OSX | PNSE |
+| Process.get_MainWindowHandle() | Unix | PNSE |
+| ProcessStartInfo.get_UserName() | Unix | PNSE |
+| ProcessStartInfo.set_UserName() | Unix | PNSE |
+| ProcessStartInfo.get_PasswordInClearText() | Unix | PNSE |
+| ProcessStartInfo.set_PasswordInClearText() | Unix | PNSE |
+| ProcessStartInfo.get_Domain() | Unix | PNSE |
+| ProcessStartInfo.set_Domain() | Unix | PNSE |
+| ProcessStartInfo.get_LoadUserProfile() | Unix | PNSE |
+| ProcessStartInfo.set_LoadUserProfile() | Unix | PNSE |
+| ProcessThread.get_BasePriority() | OSX | PNSE |
+| ProcessThread.set_BasePriority() | Unix | PNSE |
+| ProcessThread.set_ProcessorAffinity() | Unix | PNSE |
+| ProcessThread.set_IdealProcessor() | Unix | Nop |
+| ProcessThread.ResetIdealProcessor() | Unix | Nop |
+| ProcessThread.get_PriorityBoostEnabled() | Unix | false |
+| ProcessThread.set_PriorityBoostEnabled() | Unix | Nop |
+
+---
+
+### System.Diagnostics.EventSource
+
+Channel support APIs (e.g. EventData.Channel) are present (they will compile on .NET Core and .NET Native)
+however they do not do anything on a non-windows system.  Channel support on windows has not been tested
+on .NET Core or .NET Native platforms.  
+
+---
+
+### System.Codedom
+
+- Compilation support not enabled in Codedom, throws ```PlatformNotSupportedException``` in .NET Core. See [#12180](https://github.com/dotnet/corefx/issues/12180)
+
+---
+
+### System.Collections.Concurrent
+
+#### ConcurrentDictionary<T>
+
+##### ctor(...)
+* Affected platforms: Desktop
+* Description: APIs on Desktop throw `NullReferenceException` - TODO better details = see [#18441](https://github.com/dotnet/corefx/pull/18441#issuecomment-294672821)
+
+### System.Collections.NonGeneric
+##### Modified Exceptions
+| Member | netcore2.0 | netfx | Details |
+| ------ | --------- | --------- | ---- |
+| SortedList.GetValueList.CopyTo | ANE("destinationArray") | ANE("dest") | Array is null |
+| SortedList.GetValueList.CopyTo | AE("array") | AE(null) | Array is multidimensional |
+| SortedList.GetValueList.CopyTo | AOoRE("destinationIndex") | AOoRE("dstIndex") | negative index |
+| SortedList.GetValueList.CopyTo | AE("destinationArray") | AE("") | Index + list.Count > array.Count |
+| SortedList.GetKeyList.CopyTo | ANE("destinationArray") | ANE("dest") | Array is null |
+| SortedList.GetKeyList.CopyTo | AE("array") | AE(null) | Array is multidimensional |
+| SortedList.GetKeyList.CopyTo | AOoRE("destinationIndex") | AOoRE("dstIndex") | negative index |
+| SortedList.GetKeyList.CopyTo | AE("destinationArray") | AE("") | Index + list.Count > array.Count |
+| CollectionBase.CopyTo | AOoRE("destinationIndex") | AOoRE("dstIndex") | Index < 0 |
+| CollectionBase.CopyTo | AE("destinationArray") | AE("") | Index + array.Length > collection.Count |
+| ReadOnlyCollectionBase.CopyTo | ANE("destinationArray") | ANE("dest") | Array is null |
+| ReadOnlyCollectionBase.CopyTo | AOoRE("destinationIndex") | AOoRE("dstIndex") | Index < 0 |
+| ReadOnlyCollectionBase.CopyTo | AE("destinationArray") | AE("") | Index + array.Length > collection.Count |
+
+---
+
+### System.Collections.Immutable
+##### Modified Exceptions
+| Member | netcore2.0 | netfx | Details |
+| ------ | --------- | --------- | ---- |
+| ImmutableArray.CopyTo | ANE("destinationArray") | ANE("dest") | destinationArray is null |
+| ImmutableArray.CopyTo | AOoRE("sourceIndex") | AOoRE("srcIndex") | negative sourceIndex |
+| ImmutableArray.CopyTo | AOoRE("destinationIndex") | AOoRE("dstIndex") | negative destinationIndex |
+| ImmutableArray.CopyTo | AE("sourceArray") | AE("") | Index + list.Count > sourceArray.Count |
+| ImmutableArray.CopyTo | AE("destinationArray") | AE("") | Index + list.Count > destinationArray.Count |
+
+---
+
+### System.Collections.Generic
+##### Modified Exceptions
+| Member | netcore2.0 | netfx | Details |
+| ------ | --------- | --------- | ---- |
+| SortedSet<T>.GetViewBetween | AE("lowerValue") | AE(null) | lowerValue > upperValue |
+| SortedSet<T>.IntersectWith | No Exception | throws IOE | Collection was modified after the Enumerator was instantiated |
+
+---
+
+### System.Console
+##### Unsupported Members
+| Member | Platform | Action |
+| ------ | -------------------- | ------------- |
+MoveBufferArea | AnyUnix | throws PNSE
+set_BufferHeight | AnyUnix | throws PNSE
+set_BufferWidth | AnyUnix | throws PNSE
+set_WindowWidth | AnyUnix | throws PNSE
+set_WindowHeight | AnyUnix | throws PNSE
+set_WindowLeft | AnyUnix | throws PNSE
+set_WindowTop | AnyUnix | throws PNSE
+get_CursorVisible| AnyUnix | throws PNSE
+get_Title| AnyUnix | throws PNSE
+Beep| AnyUnix | throws PNSE
+set_CursorSize | AnyUnix | throws PNSE
+SetWindowPosition | AnyUnix | throws PNSE
+SetWindowSize | AnyUnix | throws PNSE
+
+---
+
+### System.Globalization
+
+#### RegionInfo
+
+##### Name
+* Affected platforms: .Net Core
+* Description: When creating a RegionInfo object using a culture name (e.g. "en-US") and then requesting the region name using RegionInfo.Name, on the Desktop the returned name will be the culture name (e.g. "en-US") while on .Net Core the returned name will be the region name only (e.g. "US")
+
+#### CultureInfo
+
+##### GetCultures(CultureTypes types)
+* Affected platforms: .Net Core on Linux and OSX
+* Description: When enumerating the cultures on Linux/OSX using CultureInfo.GetCultures and passing the CultureTypes enums, only the values CultureTypes.NeutralCultures and CultureTypes.SpecificCultures will be honored and any other value will be ignored. The reason is the other CultureTypes values are Windows specific and not applicable to Linux systems.
+
+---
+
+### System.ServiceProcess.ServiceController
+
+- ```System.ServiceProcess.TimeoutException``` is not a ```Serializable``` type in .NET Core. Using ```TimeoutException(SerializationInfo, StreamingContext)``` ctor() will result in ```PlatformNotSupportedException```.
+
+---
+
+### System.Text
+
+#### Encoding
+
+##### GetEncoding(int codepage), GetEncoding(String name)
+* Affected platforms: .Net Core
+* Description: .Net Core by default doesn't support all encodings which is supported on the Desktop. It only supports a limited set of the following encodings: Unicode, UTF8, UTF32, UTF7, ASCII, and ISO-8859-1. For the applications which need to use other encodings, the app will need to opt-in registering CodePagesEncodingProvider or other custom encoding provider which support the desired encoding.
+The Remarks section in the page https://msdn.microsoft.com/en-us/library/system.text.encodingprovider(v=vs.110).aspx has more information how this can be done.
+
+#### Encoding
+
+##### Default
+* Affected platforms: .Net Core
+* Description: On the Desktop when requesting the default encoding using Encoding.Default, we read the value of the active code page on the system and then we return the matching encoding object. On .Net Core we always return UTF8 as the default encoding. The reason is, UTF8 should be the default encoding because it covers all possible code points. Also .Net Core doesn't support all encodings by default so returning encoding matches the active code page on the system will not be possible. The apps can do the following to get the same value we used to get from Encoding.Default on the desktop:
+- Register the CodePagesEncodingProvider. Look at the Remarks section in the page https://msdn.microsoft.com/en-us/library/system.text.encodingprovider(v=vs.110).aspx to know how to do that.
+- Issue the call Encoding.GetEncoding(0)
+
+Note, on Linux systems we always return UTF8 even if registered the encoding provider.
+
+---
+
+### System.IO.Pipes
+
+#### Unsupported Members
+| Member | Unsupported on |
+| ------ | -------------------- |
+| System.IO.Pipes.PipeAccessRights | non-Windows |
+| System.IO.Pipes.PipeAccessRule | non-Windows |
+| System.IO.Pipes.PipeAuditRule | non-Windows |
+| System.IO.Pipes.PipesAclExtensions | non-Windows |
+| System.IO.Pipes.PipeSecurity | non-Windows |
+
+#### Platform Differences
+There are a large number of differences in behavior between Pipes on Windows and on Unix. Where possible we matched behavior but due to functional differences inherent in the platforms, some differences had to remain. Some of these manifest in the form of PNSEs while others result in functional differences. See https://github.com/dotnet/corefx/pull/1056 for details.
+
+### System.IO
+
+#### System.IO.UnmanagedMemoryStream.set_Position
+- NetFX allows a negative Position following some PositionPointer overflowing inputs. See dotnet/coreclr#11376.On Netcoreapp we throw an AOoRE.
+#### System.IO.MemoryMappedFile.CreateView/CreateFromFile
+- ##### Unix/Windows differences
+   - On Unix, permission errors come from CreateView*
+   - On Windows, permission errors come from CreateFromFile
+   - On Unix, map names are not supported
+   - FileShare is limited on Unix, with None == exclusive, everything else == concurrent
+   - Unix model for executable MemoryMappedFileAccess differs from Windows
+- ##### Netfx/Netcoreapp differences
+   - On netfx, the MMF.CreateFromFile default FileShare is None. We intentionally changed it in netcoreapp in #6092.
+   - CreateFromFile in desktop uses FileStream's ctor that takes a FileSystemRights in order to specify execute privileges. This means that it can use MemoryMappedFileAccess.*Execute, whereas netcoreapp throws UnauthorizedAccessExceptions.
+#### System.IO.RenamedEventArgs
+- On netfx, creating a RenamedEventArgs with a given OldName or OldFullPath leads to a demand for FileIOPermissions and validity checking for that path. On netcoreapp we allow any path and do not check it or assert permissions against it.
+#### System.IO.FileSystemWatcher.EnableRaisingEvents
+- Desktop FSW disallows modification of the watched folder. On netcoreapp it is allowed and events against it will be properly caught
+- There are a number of differences in the thrown events between Windows and Unix. This is mostly due to large differences in how the Linux, OSX, and Windows filesystem watchers interact. For example, Unix often throws a paired Created+Deleted event instead of a Renamed event. 
+#### System.IO.BinaryReader.Read
+- Difference in behavior that added extra checks to BinaryReader/Writer buffers on .Net Core.
+#### System.IO.StreamWriter.WriteLineAsync 
+- On netfx, calling WriteLineAsync with an empty string would throw a NullReferenceException. On netcoreapp we changed it to instead write a new line.
+#### System.IO.IsolatedStorage
+- Enumerating `IsolatedStorageFile`'s (via `IsolatedStorageFile.GetEnumerator(IsolatedStorageScope)`) does not yield any results. See #10936.
+- `IsolatedStorageFile.GetUserStoreForSite()` throws `NotSupportedException` as NetFX does as it applies only to Silverlight.
+- `IsolatedStorageFile.GetStore()` methods throw `PlatformNotSupportedException` when specifying identity or evidence types. `GetUserStore*` and `GetMachineStore*` methods should be used.
+- Machine wide scope is not supported on UAP.
+#### Modified Exceptions
+| Member | netcore2.0 | netfx | Details |
+| ------ | --------- | --------- | ---- |
+| System.IO.MemoryMappedFile.CreateFromFile | AE("mode") | ANE(null) | FileMode.Truncate disallowed |
+| System.IO.FileSystemWatcher.ctor | AE("path") | null | empty or invalid path |
+#### Unsupported Members
+| Member | Unsupported on |
+| ------ | -------------------- |
+| System.IO.FileSystemAclExtensions | non-Windows |
+| System.Security.AccessControl.DirectoryObjectSecurity | non-Windows |
+| System.Security.AccessControl.DirectorySecurity | non-Windows |
+| System.Security.AccessControl.FileSecurity | non-Windows |
+| System.Security.AccessControl.FileSystemAccessRule | non-Windows |
+| System.Security.AccessControl.FileSystemAuditRule | non-Windows |
+| System.Security.AccessControl.FileSystemSecurity | non-Windows |
+| System.IO.IsolatedStorage.IsolatedStorage.GetPermission(System.Security.PermissionSet) | all |
+| System.IO.IsolatedStorage.IsolatedStorageFile.GetPermission(System.Security.PermissionSet) | all |
+| System.IO.IsolatedStorage.IsolatedStorageFile.GetStore(System.IO.IsolatedStorage.IsolatedStorageScope, System.Security.Policy.Evidence, System.Type, System.Security.Policy.Evidence, System.Type) | all |
+
+---
+
+### System.Net
+
+#### HttpWebRequest
+
+##### Sending a POST request
+* Affected platforms: UWP
+* Description: HttpWebRequest has historically allowed any request header to be sent. However, in CoreFx and the UWP platform, it is built on top of System.Net.Http. And System.Net.Http has a stricter object model where it requires headers to be added only to specific collections, either regular request headers or entity-body (content) related headers (such as 'Content-Type', 'Content-Length'). Prior releases of the UWP platform prevented content-related request headers from being added to a request if the request (i.e. POST) had no actual request body. This was a different behavior than .NET Framework. The current release of the UWP platform fixes that matching the .NET Framework behavior. This means that any content-related request header can be sent even if there is no actual request body content.
+
+Details: [issue #5565](https://github.com/dotnet/corefx/issues/5565)
+
+---
+
+### System.Net.Http
+
+#### HttpClientHandler
+
+##### AllowAutoRedirects
+* Affected platforms: All
+* Description: When AllowAutoRedirects is true, the implementation on the desktop will automatically follow redirects, even when redirecting from an https URI to an http URI.  For security reasons, the implementation in .NET Core does not follow such redirects, instead either failing the request or simply not following the redirection as if AllowAutoRedirects was false.
+
+Details: [issue #19098](https://github.com/dotnet/corefx/issues/19098)
+
+##### MaxAutomaticRedirections
+* Affected platforms: .NET Core (Windows, Linux)
+* Description: On .NET Framework and UWP platforms, sending a request that exceeds the maximum automatic redirections setting will result in a final 3xx HTTP response status code.  On .NET Core (Windows, Linux), exceeding the maximum will result in an HttpRequestException being thrown.
+
+Details: [Issue #8947](https://github.com/dotnet/corefx/issues/8947)
+
+##### MaxRequestContentBufferSize
+* Affected platforms: .NET Core including UWP
+* Description: This property is not supported. In the .NET Framework it was only used when the handler needed to automatically buffer the request content. That only happened if neither 'Content-Length' nor 'Transfer-Encoding: chunked' request headers were specified. So, the handler thus needed to buffer in the request content to determine its length and then would choose 'Content-Length' semantics when POST'ing. In .NET Core and UWP platforms, the handler will resolve the ambiguity by always choosing 'Transfer-Encoding: chunked'. The handler will never automatically buffer in the request content. The property will always return a value of zero in the getter. The setter is ignored.
+
+Details: [PR #22201](https://github.com/dotnet/corefx/pull/22201)
+
+##### MaxResponseHeadersLength
+* Affected platforms: UWP
+* Description: On the UWP platform, the default value for MaxResponseHeadersLength is -1. This setting means that there is no limit. Setting the property to any other value is ignored. On UWP, HttpClientHandler is built on the WinRT APIs which use a hard-code value (default value of WinInet) for MaxResponseHeadersLength.
+
+Details: [PR #21511](https://github.com/dotnet/corefx/pull/21511)
+
+##### PreAuthenticate
+
+* Affected platforms: UWP
+* Description: When PreAuthenticate is true, the HTTP stack will try to reuse any cached HTTP credentials (Authorization request header) for subsequent requests. The default is false. On the UWP platform, however, the default for this property is true. Setting the property to false is ignored. On UWP, HttpClientHandler is built on the WinRT
+APIs which in turn are built on WinInet. And WinInet always uses authentication caching internally.
+
+Details: [PR #21403](https://github.com/dotnet/corefx/pull/21403)
+
+##### SendAsync (using the 'TRACE' HttpMethod)
+
+* Affected platforms: UWP
+* Description: Sending an HttpRequestMessage with the 'TRACE' method is not supported on UWP platform. Doing so will return an HttpRequestException. Please see related article: https://www.rapid7.com/db/vulnerabilities/http-trace-method-enabled
+
+Details: [Issue #22161](https://github.com/dotnet/corefx/issues/22161)
+
+##### UseDefaultCredentials
+
+* Affected platforms: UWP
+* Description: This property will default to false (same as .NET Framework). However, it cannot be
+set to true. The setter is a no-op. The UWP platform implementation of System.Net.Http uses a different set of rules for sending default credentials. It is based on whether the app has Enterprise Authentication capability as well as if the
+endpoint is specified in an intranet zone. This design is part of the base native WinInet and WinHTTP stacks. It was a design choice to provide optimum security as well as convenience for developers writing apps for enterprise scenarios.
+
+Details: [PR #21672](https://github.com/dotnet/corefx/pull/21672)
+
+---
+
+### System.Net.HttpListener
+
+#### HttpListener
+
+* Affected platforms: UWP, Linux
+* Description: HTTPS connection support for HttpListener on the UWP or Linux platforms is not currently supported. Implementing this will require new APIs/behavior to configure TLS/SSL certificates in a cross-platform manner. This
+work be scheduled for a future release.
+
+Details: [issue #14691](https://github.com/dotnet/corefx/issues/14691)
+
+---
+
+### System.Net.NetworkInformation
+
+#### Ping
+
+##### Send/SendAsync/SendPingAsync
+* Affected platforms: UWP
+* Description: The UWP implementation of Ping.Send* APIs throws `PlatformNotSupportedException` due to missing Windows OS support for ICMP from AppContainer processes.
+
+Details: [issue #19583](https://github.com/dotnet/corefx/issues/19583)
+
+---
+
+### System.Net.Sockets
+
+#### Socket
+
+##### IOControlCode.OobDataRead
+* Affected platforms: All
+* OobDataRead wraps the operating system implementation of the IO control code SIOCATMARK, which varies significantly between Windows, Linux, and OSX. The specifics of each system are beyond the scope of this document, but are investigated in the issue linked below.
+
+Details: [issue #25639](https://github.com/dotnet/corefx/issues/25639)
+
+---
+
+### System.Net.WebSockets.Client
+
+#### ClientWebSocket
+
+##### SendAsync
+* Affected platforms: UWP
+* Description: The UWP implementation of ClientWebSocket buffers the entire message before it can pass it to the underlying WinRT MessageWebSocket. This is due to missing support for sending partial messages in WinRT. This is a behavior difference from .NET Framework and .NET Core.
+
+Details: [issue #22053](https://github.com/dotnet/corefx/issues/22053)
+
+#### ClientWebSocketOptions
+
+|Platform|.Net Core|Member|Supported|
+|---|---|---|---|
+|Windows|2.0|ClientCertificates|NO|
+|Windows|2.0|Proxy|NO|
+|UWP|2.0|ClientCertificates|YES|
+|UWP|2.0|Proxy|NO (Default proxy always used)|
+|Linux/OSX|1.1|ClientCertificates|YES|
+|Linux/OSX|2.0|Proxy|NO|
+
+Details: [issue #5120](https://github.com/dotnet/corefx/issues/5120)
+
+---
+
+### System.Numerics
+
+#### Complex
+
+##### Sqrt
+
+* A new algorithm has been adopted for Complex.Sqrt, and several other related Complex functions. The new algorithm is more efficient, more accurate, and has better handling for numerical edge cases. This will affect the return value of these functions. In all cases, the result will be at least as accurate as the old algorithm.
+  * Affected functions: Sqrt, Abs, Asin
+  * Most notably, Complex.Sqrt(-1) now correctly returns Complex.ImaginaryOne, as expected.
+  * In many other cases, operations previously returning NaN or Infinity will now return valid, accurate, and finite results.
+
+Details: [PR #15338](https://github.com/dotnet/corefx/pull/15338)
+
+##### Sin, Cos, Tan
+
+* A new algorithm has been adopted for the Complex trigonometric functions, Sin, Cos, and Tan. The new algorithm has different behavior for numerical edge cases, but is at least as accurate as before. This change will primarily result in different return values for trig functions with extremely large input values.
+
+Details: [PR #15835](https://github.com/dotnet/corefx/pull/15835)
+
+---
+
+### System.Security
+#### Unsupported Members
+| Member | Unsupported on |
+| ------ | -------------------- |
+| System.Security.AccessControl.**** | non-Windows |
+| System.Security.Principal.IdentityNotMappedException | non-Windows |
+| System.Security.Principal.IdentityReference | non-Windows |
+| System.Security.Principal.IdentityReferenceCollection | non-Windows |
+| System.Security.Principal.NTAccount | non-Windows |
+| System.Security.Principal.SecurityIdentifier | non-Windows |
+| System.Security.Principal.TokenAccessLevels | non-Windows |
+| System.Security.Principal.WellKnownSidType | non-Windows |
+| System.Security.Principal.WindowsBuiltInRole | non-Windows |
+| System.Security.Principal.WindowsIdentity | non-Windows |
+| System.Security.Principal.WindowsPrincipal | non-Windows |
+| Microsoft.Win32.SafeHandles.SafeAccessTokenHandle | non-Windows |
+
+---
+
+### System.Security.Cryptography
+
+#### HMAC
+
+The HMAC base class in .NET Core does not provide the HMAC algorithm to derived types, as all HMAC operations in .NET Core are performed by system libraries.  Initialize, HashCore, and HashFinal all throw PlatformNotSupportedException.
+
+HMAC.HashName can only be set to the current value in .NET Core, otherwise a PlatformNotSupportedException is thrown.
+
+#### SignedXml is missing constants defining SHA2 related algorithms
+* Affected platforms: all except Desktop >= 4.6.2 and nuget packages released before mentioned change.
+* Workaround: Use hard-coded specification strings
+* Motivation: Members were removed in order to make System.Security.Cryptography.Xml work on netstandard. Constants must be backported on Desktop in order to add them back.
+* Related changes: https://github.com/dotnet/corefx/pull/19189
+
+#### SignedXml will not be able to find public key for DSA certificates
+* Affected platforms: all except Desktop
+* Workaround: Find key for DSA certificate manually and use key directly
+* Motivation: Members were removed in order to make System.Security.Crytography.Xml work on netstandard.
+* Affected APIs:
+    - `bool SignedXml.CheckSignature(X509Certificate2 certificate, bool verifySignatureOnly)`
+    - (protected) `virtual SignedXml.AsymmetricAlgorithm GetPublicKey()`
+    - `bool SignedXml.CheckSignatureReturningKey(out AsymmetricAlgorithm signingKey)`
+* Related changes: https://github.com/dotnet/corefx/pull/19189
+
+#### `ProtectedData`
+* Affected platforms: Non-Windows
+* Description: Throws `PlatformNotSupportedException` if not on Windows (https://github.com/dotnet/corefx/issues/6746)
+
+#### `X509Certificates` on macOS
+* In .NET Core 1.x certificates were backed by OpenSSL, now they are backed by Security.framework
+  * X509Certificate2.Handle is now a SecIdentityRef or SecCertificateRef value, as appropriate.
+  * new X509Certificate2(IntPtr) will only work for a SecIdentityRef or SecCertificateRef value, not an OpenSSL X509\*.
+* X509Store is now driven by Keychain services
+  * Data previously added to an X509Store will not be discovered X509Store any longer.
+  * Custom stores can not be created, because Keychain creation requires data not available in the API surface.
+* X509Certificate2.PrivateKey
+  * On .NET Framework this returns instances of RSACryptoServiceProvider or DSACryptoServiceProvider, and no other types.
+  * On .NET Core this returns the value of cert.GetRSAPrivateKey() or cert.GetDSAPrivateKey(), which are not tightly constrained in their specific return type.
+
+#### `AsymmetricAlgorithm.FromXmlString` (or `ToXmlString`)
+* In .NET Core these methods are not implemented due to a cycle in dependencies between XML, HTTP, and cryptography.
+
+#### `[Algorithm].Create()`
+* In .NET Framework the `Create()` factories for cryptographic algorithms (`Aes.Create()`, `RSA.Create()`, et cetera) produce instances of public types (e.g. `RSACryptoServiceProvider`), and the returned type can be controlled via CryptoConfig.
+* In .NET Core the factory methods produce instances of private types, and the returned type cannot be controlled.
+
+#### `[Algorithm].Create(string)`
+* `AsymmetricAlgorithm`, `HashAlgorithm`, `HMAC`, `KeyedHashAlgorithm`, `SymmetricAlgorithm` all have Create(string) methods that throw `PlatformNotSupportedException`s on netcoreapp.
+* To work around the PNSEs, replace `[Algorithm].Create(string)` with `([Algorithm])CryptoConfig.CreateFromName(string)`
+* See https://github.com/dotnet/corefx/issues/22626
+
+#### Cryptographic algorithm instances with "Managed" in their name
+* Types such as SHA1Managed are written in managed code in .NET Framework. In .NET Core the types exist only for API compatibility, and they use the same system library that the `[Algorithm].Create()` instance would use.
+  * Since SHA1Managed (et al) wraps an instance of `SHA1.Create()` (et al) it is marginally slower than using the factory.
+  * Performance characteristics may differ between .NET Framework and .NET Core.
+
+#### Cryptographic algorithm instances with "CryptoServiceProvider" in their name
+* The "CryptoServiceProvider" suffix indicates types that are backed by the legacy Windows Cryptographic API (CAPI).
+* On Windows these types behave as their .NET Framework equivalent types behave.
+* On non-Windows OSes the types exist for compatibility, but as wrappers for (e.g.) `RSA.Create()`.
+  * Members which are specific to Windows CAPI, such as `ICspSymmetricAlgorithm.get_CspKeyContainerInfo()`, will throw a `PlatformNotSupportedException`.
+
+#### `Oid.FromFriendlyName(string)`, `new Oid(string).FriendlyName`, `Oid.FromValue(string).FriendlyName`
+* "Friendly Name" values for OIDs are provided by the system cryptographic libraries, with the exception of a small set of hard-coded lookups within .NET Core.
+  * In general FriendlyName should only be used to display data, and never as a programmatic decision.
+  * .NET Core on Windows will behave as .NET Framework behaved.
+    * Caution: Many OID Friendly Name values are localized on Windows.
+  * .NET Core on Linux uses the OpenSSL "long name" string for a given object ID.
+  * .NET Core on macOS only has the hard-coded lookup table, resulting in significantly more exceptions from `Oid.FromFriendlyName(string)`.
+
+#### `System.Security.Cryptography.Rijndael`, `System.Security.Cryptography.RijndaelManaged`
+* In .NET Framework the `Rijndael` class represents the Rijndael algorithm, which permits `BlockSize` values other than 128-bit.
+* In .NET Core the `Rijndael` class exists only for compatibility. The `RijndaelManaged` class uses the subset of the Rijndael algorithm which is standardized as AES.
+
+#### `System.Security.Cryptography.RSAOAEPKeyExchangeFormatter`, `System.Security.Cryptography.RSAOAEPKeyExchangeDeformatter`
+* The .NET Framework version of these classes has a legacy fallback which may present pre-padded data to the `RSA.EncryptValue(byte[])` method, permitting interoperability to custom RSA types implemented before .NET 4.6 added the `RSA.Encrypt(byte[], RSAEncryptionPadding)` method.
+* .NET Core only uses the `RSA.Encrypt(byte[], RSAEncryptionPadding)` method.
+
+---
+
+### System.Threading
+
+#### Unsupported members
+
+| Member | Runtimes | Platforms |
+| - | - | - |
+| Thread.Abort() | .NET Core | All |
+| Thread.Abort(object) | .NET Core | All |
+| Thread.ResetAbort() | .NET Core | All |
+| Thread.Resume | .NET Core | All |
+| Thread.Suspend | .NET Core | All |
+
+#### ExecutionContext
+
+##### .NET Framework -> .NET Core
+
+###### `SynchronizationContext` is not captured or applied
+* `SynchronizationContext` is no longer part of the `ExecutionContext`. `Run` does not apply the synchronization context that was current at the point of the corresponding `ExecutionContext.Capture`.
+* See https://blogs.msdn.microsoft.com/pfxteam/2012/06/15/executioncontext-vs-synchronizationcontext/ under the section titled "Isn’t SynchronizationContext part of ExecutionContext?" for some more information and some of the reasoning behind this change.
+
+###### Changing an `AsyncLocal` instance's value changes the current `ExecutionContext`
+* .NET Framework keeps `ExecutionContext` instances mutable, and generally tries to create a new instance on Capture, such that captured instances don’t change. .NET Core on the other hand, keeps EC instances immutable and does not need to copy on Capture. So as a result, multiple Captures may share the same EC instance.
+* This transfers the negative performance impact from allocation from the frequent operations `Capture` and `Run`, to less frequent operations, including changing an `AsyncLocal`'s value among
+
+###### `Run` does not throw in some cases based on the execution context
+* .NET Framework does not allow `Run` for an execution context acquired from `Thread.CurrentThread.ExecutionContext`. It is recommended to use an instance provided by `ExecutionContext.Capture` instead.
+
+###### `Run` can be called multiple times with the same execution context
+* .NET Framework only allows one call to `Run` for an instance of `ExecutionContext` obtained from `ExecutionContext.Capture`. .NET Core allows multiple calls.
+
+###### `CreateCopy` does not throw in some cases based on the execution context
+* .NET Framework does not allow `CreateCopy` on an execution context that has been passed into `Run`, or for an execution context obtained from `Thread.CurrentThread.ExecutionContext`. .NET Core allows these.
+
+###### `AsyncFlowControl.Undo` allows restoring flow on a different `ExecutionContext` instance
+* `AsyncFlowControl.Undo` allows restoring flow on a different `ExecutionContext` instance than the one that was current at the time of the corresponding `ExecutionContext.SuppressFlow`. `AsyncFlowControl` is disposable and may be used with a `using` block in C#.
+
+###### `AsyncFlowControl` equality does not behave equivalently in all scenarios
+* The contents of `AsyncFlowControl` have changed, and two instances may not compare equal similarly to how they compared before. `AsyncFlowControl` is a struct for performance reasons and its contents are implementation-defined.
+
+#### `ReaderWriterLock`
+
+##### .NET Framework -> .NET Core
+
+###### `Int32` timeout parameter values cannot be less than `-1`
+* .NET Framework treats the `Int32` timeout parameter values as unsigned, where `-1` is considered an infinite timeout. .NET Core throws `ArgumentOutOfRangeException` for values less than `-1`.
+
+#### `CancellationTokenSource`
+
+##### .NET Framework -> .NET Core
+
+###### The `AppContext` switch "Switch.System.Threading.ThrowExceptionIfDisposedCancellationTokenSource" has no effect
+* .NET Core behaves as though that switch is set to false, and there is no way to override this behavior. As one example, `CancellationToken.Register` does not throw after the token source is disposed.
+
+#### `Thread`
+
+##### .NET Framework -> .NET Core
+
+###### `CurrentCulture`, `CurrentUICulture` sometimes throw `InvalidOperationException`
+* .NET Core requires that these properties are accessed from the thread corresponding to the thread instance. If a thread tries to read or write these properties on a thread instance corresponding to a different thread, `InvalidOperationException` is thrown. Consider using `CultureInfo.CurrentCulture` and `CultureInfo.CurrentUICulture` instead where appropriate.
+
+###### `Interrupt` may interrupt a wait in a `finally` block
+* .NET Framework does not interrupt a thread while it is inside a `finally` block, .NET Core does.
+
+---
+
+### System.Transactions
+
+#### Distributed transactions are not supported in .NET Core
+* Affected platforms: .NET Core
+* Description: Only local transaction is supported on .NET Core for now.
+Details: issue #16755
+
+---
+
+### System.Xml
+
+#### XmlAttributeCollection
+
+##### InsertAfter
+* Affected platforms: .Net Core
+* Description: When the reference node is the last in the collection and it's a duplicate of the new node, InsertAfter is unable to handle the case on Desktop and throws `System.ArgumentOutOfRangeException` further in List<T>.Insert() due to an incorrectly calculated insert position. To be consistent with what InsertBefore does, the duplicate node (attribute) needed to be removed before inserting. This change was made in Core.
+
+##### SetNamedItem
+* Affected platforms: .Net Core
+* Description: Desktop does not check for null argument and throws `System.NullReferenceException`. Core returns null instead.
+
+#### XmlNamedNodeMap
+
+##### SetNamedItem
+* Affected platforms: .Net Core
+* Description: Desktop does not check for null argument and throws `System.NullReferenceException`. Core returns null instead.
+
+---
+
+### System.Xml.Schema
+
+#### XmlSchemaSet
+
+##### Add
+* Affected platforms: .NET Core
+* Description: If the schema being added imports another schema through external URI, Core does not allow resolving that URI by default while Desktop does. To allow the resolution on Core, the following needs to be called before adding the schema:
+`AppContext.SetSwitch("Switch.System.Xml.AllowDefaultResolver", true);`
+
+---
+
+### System.Xml.Xsl
+
+#### XslCompiledTransform
+
+##### Load
+* Affected platforms: .Net Core
+* Description: Due to unavailability of some System.CodeDom APIs XslCompiledTransform.Load throws `PlatformNotSupportedException` if `msxsl:script` is used in the stylesheet on .NET Core.
+
+#### XslTransform
+
+##### Load
+* Affected platforms: .Net Core
+* Description: Due to unavailability of some System.CodeDom APIs XslTransform.Load throws `PlatformNotSupportedException` if `msxsl:script` is used in the stylesheet on .NET Core.
+
+# Obsolete/Deprecated APIs
+
+Want to add something new? Please copy and paste this section, or follow steps in https://github.com/dotnet/platform-compat/pull/24:
+
+```Markdown
+### <Description of the API>
+
+#### Motivation
+
+*Placeholder: Why should the API be deprecated?*
+
+#### Replacement
+
+*Placeholder: What are the placements?*
+```
+
+### System.Xml.Serialization
+
+#### Issue with Soap Encoded Message Serialization (https://github.com/dotnet/corefx/issues/18964)
+
+If an application is built on .Net Standard2.0 and uses Soap encoded serialization, the application needs to be built against .Net Framework before it can run on .Net Framework because of https://github.com/dotnet/corefx/issues/18964.
+
+### System.Runtime.Serialization
+
+#### DataContractSerializer/DataContractJsonSerializer serializes Exceptions differently between .Net Core 1.1 and .Net Core 2.0
+
+Exception types implements ISerializable interface on .Net Framework. As ISerializable was not available in .Net Core 1.1, DataContractSerializer dealt with Exception types specially to support Exception serialization. ISerializable is now available in .Net Core 2.0. As a result, DataContractSerializer serializes Exceptions as normal ISerializable types. The serialization payloads of Exceptions are different between .Net Core 1.1 and .Net Core 2.0.
+
+### System.Net.WebSockets - RegisterPrefixes and CreateClientWebSocket
+
+#### Motivation
+
+The APIs are documented already on MSDN as internal, not for external/direct consumption -- [`WebSocket.RegisterPrefixes`](https://msdn.microsoft.com/en-us/library/system.net.websockets.websocket.registerprefixes(v=vs.110).aspx) and [`WebSocket.CreateClientWebSocket`](https://msdn.microsoft.com/en-us/library/system.net.websockets.websocket.createclientwebsocket(v=vs.110).aspx).
+
+Details: [issue #18905](https://github.com/dotnet/corefx/issues/18905)
+
+#### Replacement
+
+N/A
+
+### `System.Security.Cryptography.AsymmetricAlgorithm.Create()`
+
+#### Motivation
+
+Callers may expect this method to provide them with a good choice of asymmetric algorithm, but it always returns a default-keysize `RSA` object.  While RSA can be used for both asymmetric encryption and asymmetric digital signature, it cannot be used for asymmetric key agreement (no supported algorithm supports all three).  The resulting `AsymmetricAlgorithm` object would have to be cast to a specific algorithm type before being used.
+
+#### Replacement
+
+Choose an algorithm based upon your needs, and call that algorithm-specific `Create()` method:
+
+* Encryption: `System.Security.Cryptography.RSA.Create()`
+* Digital Signature: `System.Security.Cryptography.RSA.Create()`, `System.Security.Cryptography.ECDsa.Create()`, or `System.Security.Cryptography.DSA.Create()`
+* Key Agreement: `System.Security.Cryptography.ECDiffieHellman.Create()` (.NET Framework only)
+
+### `System.Security.Cryptography.AsymmetricAlgorithm.Create(string)`
+
+#### Motivation
+
+The AsymmetricAlgorithm class does not provide sufficient members to perform any asymmetric operations, so callers must always cast the return type anyways.
+
+On .NET Core this method throws `PlatformNotSupportedException`.
+
+#### Replacement
+
+The most direct replacement is `(AsymmetricAlgorithm)CryptoConfig.CreateFromName(algName)`, but that has the same problems.
+
+The recommended replacement is to identify what algorithm you are expecting and make use of the type-specific methods:
+
+* RSA: `System.Security.Cryptography.RSA.Create()` or `System.Security.Cryptography.RSA.Create(string)`
+* ECDSA: `System.Security.Cryptography.ECDsa.Create()`, or `System.Security.Cryptography.ECDsa.Create(string)`
+* DSA: `System.Security.Cryptography.DSA.Create()` or `System.Security.Cryptography.DSA.Create(string)`
+* EC Diffie-Hellman: `System.Security.Cryptography.ECDiffieHellman.Create()` (.NET Framework only) or `System.Security.Cryptography.ECDiffieHellman.Create(string)` (.NET Framework only)
+
+### `System.Security.Cryptography.AsymmetricAlgorithm.KeyExchangeAlgorithm`
+
+#### Motivation
+
+This `string` value has inconsistent behavior across the algorithm implementations.
+
+#### Replacement
+
+* `KeyExchangeAlgorithm` only makes sense for RSA, so one easy replacement is the [pattern matching expression](https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-7#pattern-matching) `if (key is RSA rsa)`.
+* For an RSA algorithm instance the KeyExchangeAlgorithm was a coarse proxy for testing if the key had encryption enabled. The correct replacement is a `try { encrypt/decrypt } catch (CryptographicException) { }` statement.
+
+### `System.Security.Cryptography.AsymmetricAlgorithm.SignatureAlgorithm`
+
+#### Motivation
+
+This `string` value has inconsistent behavior across the algorithm implementations.
+
+#### Replacement
+
+A type check (`is`, `as`, or pattern-is-assignment).
+
+### `System.Security.Cryptography.HashAlgorithm.Create()`
+
+#### Motivation
+
+Callers may expect this method to provide them with a good choice of hash/digest algorithm, but it always returns SHA-1 (for compatibility reasons).
+
+This method throws `PlatformNotSupportedException` in .NET Core.
+
+#### Replacement
+
+Choose an algorithm based upon your needs, and call that algorithm-specific `Create()` method. For example, `System.Security.Cryptography.SHA256.Create()`.
+
+### `System.Security.Cryptography.HashAlgorithm.Create(string)`
+
+#### Motivation
+
+The algorithm chosen may require options to be set using members not available on the `KeyedHashAlgorithm` class, making it possible that casting would be required before safe utilization of the cryptographic object.  For example, `KeyedHashAlgorithm` derives from `HashAlgorithm`, so all HMAC types can be returned from this method.
+
+This method throws `PlatformNotSupportedException` in .NET Core.
+
+#### Replacement
+
+Choose an algorithm based upon your needs, and instantiate the algorithm appropriately.  For example, `System.Security.Cryptography.SHA256.Create()`.
+
+### `System.Security.Cryptography.KeyedHashAlgorithm.Create()`
+
+#### Motivation
+
+Callers may expect this method to provide them with a good choice of a keyed hash/digest algorithm, but it always returns HMAC-SHA-1 (for compatibility reasons).  Even if that were not the case, the specific chosen algorithm could have options not available at the base class level, making it possible that casting would be required before safe utilization of the cryptographic object.
+
+This method throws `PlatformNotSupportedException` in .NET Core.
+
+#### Replacement
+
+Choose an algorithm based upon your needs, and instantiate the algorithm appropriately.  For example, `new System.Security.Cryptography.HMACSHA256()` or `new System.Security.Cryptography.HMACSHA256(byte[])`.
+
+### `System.Security.Cryptography.KeyedHashAlgorithm.Create(string)`
+
+#### Motivation
+
+The algorithm chosen may require options to be set using members not available on the `KeyedHashAlgorithm` class, making it possible that casting would be required before safe utilization of the cryptographic object.
+
+This method throws `PlatformNotSupportedException` in .NET Core.
+
+#### Replacement
+
+Choose an algorithm based upon your needs, and instantiate the algorithm appropriately.  For example, `new System.Security.Cryptography.HMACSHA256()` or `new System.Security.Cryptography.HMACSHA256(byte[])`.
+
+### `System.Security.Cryptography.HMAC.Create()`
+
+#### Motivation
+
+Callers may expect this method to provide them with a good choice of a HMAC algorithm, but it always returns HMAC-SHA-1 (for compatibility reasons).
+
+This method throws `PlatformNotSupportedException` in .NET Core.
+
+#### Replacement
+
+Choose an algorithm based upon your needs, and instantiate the algorithm appropriately.  For example, `new System.Security.Cryptography.HMACSHA256()` or `new System.Security.Cryptography.HMACSHA256(byte[])`.
+
+### `System.Security.Cryptography.HMAC.Create(string)`
+
+#### Motivation
+
+This method throws `PlatformNotSupportedException` in .NET Core.
+
+#### Replacement
+
+Choose an algorithm based upon your needs, and instantiate the algorithm appropriately.  For example, `new System.Security.Cryptography.HMACSHA256()` or `new System.Security.Cryptography.HMACSHA256(byte[])`.
+
+### `System.Security.Cryptography.SymmetricAlgorithm.Create()`
+
+#### Motivation
+
+Callers may expect this method to provide them with a good choice of a keyed hash/digest algorithm, but it always returns Rijndael (for compatibility reasons).  Even if that were not the case, the specific chosen algorithm could have options not available at the base class level, making it possible that casting would be required before safe utilization of the cryptographic object.
+
+This method throws `PlatformNotSupportedException` in .NET Core.
+
+#### Replacement
+
+Choose an algorithm based upon your needs, and instantiate the algorithm appropriately.  For example, `System.Security.Cryptography.Aes.Create()`.
+
+### `System.Security.Cryptography.SymmetricAlgorithm.Create(string)`
+
+#### Motivation
+
+The algorithm chosen may require options to be set using members not available on the `SymmetricAlgorithm` class, making it possible that casting would be required before safe utilization of the cryptographic object.
+
+This method throws `PlatformNotSupportedException` in .NET Core.
+
+#### Replacement
+
+Choose an algorithm based upon your needs, and instantiate the algorithm appropriately.  For example, `System.Security.Cryptography.Aes.Create()`.
+
+### `System.Security.Cryptography.AesManaged`
+
+#### Motivation
+
+* The AesManaged implementation on .NET Core is not implemented in managed code, it defers to Aes.Create().
+* On .NET Framework the AesManaged class cannot be instantiated on computers with FIPS policy enforcement enabled.
+
+#### Replacement
+
+`Aes.Create()`
+
+### System.Security.Cryptography.DES
+
+#### Motivation
+
+DES (Data Encryption Standard) is a weak algorithm due to its small keyspace (56 bits) and small block size (64 bits). DES should not be used for directly encrypting data, but may be appropriate in specialized circumstances:
+
+* Decrypting data already encrypted with DES.
+* Used where required as part of a specification
+* Used as a primitive in the construction of a larger algorithm, such as DES-EDE, aka 3DES, aka TripleDES.
+
+#### Replacement
+
+System.Security.Cryptography.Aes is a representation of the AES (Advanced Encryption Standard) algorithm, the replacement recommended by [NIST SP 800-57, Part 1, Revision 4](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-57pt1r4.pdf).
+
+### `System.Security.Cryptography.RC2`
+
+#### Motivation
+
+RC2 is an old algorithm which should not be used for encrypting new data.
+
+#### Replacement
+
+System.Security.Cryptography.Aes is a representation of the AES (Advanced Encryption Standard) algorithm, the replacement recommended by [NIST SP 800-57, Part 1, Revision 4](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-57pt1r4.pdf).
+
+### `System.Security.Cryptography.Rijndael`
+
+#### Motivation
+
+The AES algorithm is the Rijndael algorithm with a BlockSize value fixed at 128-bit. Few platforms support Rijndael, but most support AES.
+
+The .NET Core implementation of Rijndael is functionally limited to the functionality of AES.
+
+#### Replacement
+
+`System.Security.Cryptography.Aes`
+
+### `System.Security.Cryptography.RijndaelManaged`
+
+#### Motivation
+
+* The RijndaelManaged implementation on .NET Core is not implemented in managed code, it defers to Rijndael.Create().
+* The RijndaelManaged implementation on .NET Core is functionally limited to the AES behaviors.
+* On .NET Framework the RijndaelManaged class cannot be instantiated on computers with FIPS policy enforcement enabled.
+
+#### Replacement
+
+`System.Security.Cryptography.Aes.Create()`.  (On .NET Framework, if non-AES Rijndael is required, `System.Security.Cryptography.Rijndael.Create()`)
+
+### `System.Security.Cryptography.Rfc2898DeriveBytes..ctor(byte[], byte[], int)`
+
+#### Motivation
+
+This constructor overload chooses SHA-1 as the basis for the HMAC, hiding the algorithm choice.
+
+#### Replacement
+
+.NET Core users should change to `System.Security.Cryptography.Rfc2898DeriveBytes..ctor(byte[], byte[], int, HashAlgorithmName)`, using HashAlgorithmName.SHA1 when needed for compatibility.
+
+The new overload is not available in .NET Framework at this time.
+
+### `System.Security.Cryptography.Rfc2898DeriveBytes..ctor(string, byte[])`
+
+#### Motivation
+
+This constructor overload chooses SHA-1 as the basis for the HMAC, hiding the algorithm choice; it also chooses an iteration count of 1000, which is considered too low by modern standards.
+
+#### Replacement
+
+.NET Core users should change to `System.Security.Cryptography.Rfc2898DeriveBytes..ctor(string, byte[], int, HashAlgorithmName)`, using HashAlgorithmName.SHA1 and 1000 iterations when needed for compatibility.
+
+While the HashAlgorithmName overload is not available to current .NET Framework versions, the `System.Security.Cryptography.Rfc2898DeriveBytes..ctor(string, byte[], int)` overload should be preferred.
+
+### `System.Security.Cryptography.Rfc2898DeriveBytes..ctor(string, int)`
+
+#### Motivation
+
+This constructor overload chooses SHA-1 as the basis for the HMAC, hiding the algorithm choice.  It also chooses 1000 for the iteration count, a value considered too low by modern standards.
+
+#### Replacement
+
+.NET Core users should change to `System.Security.Cryptography.Rfc2898DeriveBytes..ctor(string, int, int, HashAlgorithmName)`, using HashAlgorithmName.SHA1 and 1000 iterations when needed for compatibility.
+
+While the HashAlgorithmName overload is not available to current .NET Framework versions, the `System.Security.Cryptography.Rfc2898DeriveBytes..ctor(string, int, int)` overload should be preferred.
+
+### `System.Security.Cryptography.Rfc2898DeriveBytes..ctor(string, int, int)`
+
+#### Motivation
+
+This constructor overload chooses SHA-1 as the basis for the HMAC, hiding the algorithm choice.
+
+#### Replacement
+
+.NET Core users should change to `System.Security.Cryptography.Rfc2898DeriveBytes..ctor(string, int, int, HashAlgorithmName)`, using HashAlgorithmName.SHA1 when needed for compatibility.
+
+The new overload is not available in .NET Framework at this time.
+
+### `System.Security.Cryptography.RSA.DecryptValue(byte[])`
+
+#### Motivation
+
+This method has never been implemented by a subclass of RSA which was part of .NET Core or the .NET Framework, and it has no officially defined behavior.
+
+#### Replacement
+
+`System.Security.Cryptography.RSA.Decrypt(byte[], RSAEncryptionPadding)`
+
+### `System.Security.Cryptography.RSA.EncryptValue(byte[])`
+
+#### Motivation
+
+This method has never been implemented by a subclass of RSA which was part of .NET Core or the .NET Framework, and it has no officially defined behavior.
+
+#### Replacement
+
+`System.Security.Cryptography.RSA.Encrypt(byte[], RSAEncryptionPadding)`
+
+### `System.Security.Cryptography.SHA1Managed`
+
+#### Motivation
+
+* The SHA1Managed implementation on .NET Core is not implemented in managed code, it defers to SHA1.Create().
+* On .NET Framework the SHA1Managed class cannot be instantiated on computers with FIPS policy enforcement enabled.
+
+#### Replacement
+
+`System.Security.Cryptography.SHA1.Create()`
+
+### `System.Security.Cryptography.SHA256Managed`
+
+#### Motivation
+
+* The SHA256Managed implementation on .NET Core is not implemented in managed code, it defers to SHA256.Create().
+* On .NET Framework the SHA256Managed class cannot be instantiated on computers with FIPS policy enforcement enabled.
+
+#### Replacement
+
+`System.Security.Cryptography.SHA256.Create()`
+
+### `System.Security.Cryptography.SHA384Managed`
+
+#### Motivation
+
+* The SHA384Managed implementation on .NET Core is not implemented in managed code, it defers to SHA384.Create().
+* On .NET Framework the SHA384Managed class cannot be instantiated on computers with FIPS policy enforcement enabled.
+
+#### Replacement
+
+`System.Security.Cryptography.SHA384.Create()`
+
+### `System.Security.Cryptography.SHA512Managed`
+
+#### Motivation
+
+* The SHA512Managed implementation on .NET Core is not implemented in managed code, it defers to SHA512.Create().
+* On .NET Framework the SHA512Managed class cannot be instantiated on computers with FIPS policy enforcement enabled.
+
+#### Replacement
+
+`System.Security.Cryptography.SHA512.Create()`
+
+### `System.Security.Cryptography.AesCryptoServiceProvider`
+
+#### Motivation
+
+* On .NET Framework AesCryptoServiceProvider uses the legacy Windows Cryptographic API (API). In Windows 8.1 and newer the CAPI implementation calls the CNG implementation, making this type automatically marginally slower than AesCng.
+* On .NET Core AesCryptoServiceProvider is written as a wrapper over Aes.Create(), making this type marginally slower than calling Aes.Create() directly.
+
+#### Replacement
+
+`System.Security.Cryptography.Aes.Create()`
+
+### `System.Security.Cryptography.DESCryptoServiceProvider`
+
+#### Motivation
+
+* DES (Data Encryption Standard) is a weak algorithm.
+* On .NET Core DESCryptoServiceProvider is written as a wrapper over DES.Create(), making this type marginally slower than calling DES.Create() directly.
+
+#### Replacement
+
+When DES is required, `System.Security.Cryptography.DES.Create()`.
+
+Otherwise, `System.Security.Cryptography.Aes` is a representation of the AES (Advanced Encryption Standard) algorithm, the replacement recommended by [NIST SP 800-57, Part 1, Revision 4](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-57pt1r4.pdf). 
+
+### `System.Security.Cryptography.DSACryptoServiceProvider`
+
+#### Motivation
+
+* DSACryptoServiceProvider only supports FIPS 186-2 DSA, which has a keysize limitation of 1024-bit and SHA-1 as the only choice for digest algorithm.
+* On .NET Core on non-Windows systems DSACryptoServiceProvider is written as a wrapper over DSA.Create(), making this type marginally slower than calling DSA.Create() directly, and CAPI-specific members will throw exceptions.
+
+#### Replacement
+
+* If direct interop is required to Windows CAPI, no replacement exists.
+* If DSA is required, use `System.Security.Cryptography.DSA.Create()`.
+* If the algorithm choice is flexible, consider changing to RSA (`System.Security.Cryptography.RSA.Create()`) or Elliptic-Curve DSA (ECDSA) (`System.Security.Cryptography.ECDsa.Create()`).
+
+### `System.Security.Cryptography.MD5CryptoServiceProvider`
+
+#### Motivation
+
+On .NET Core MD5CryptoServiceProvider is written as a wrapper over MD5.Create(), making this type marginally slower than calling MD5.Create() directly.
+
+#### Replacement
+
+`System.Security.Cryptography.MD5.Create()`
+
+### `System.Security.Cryptography.RC2CryptoServiceProvider`
+
+#### Motivation
+
+On .NET Core RC2CryptoServiceProvider is written as a wrapper over RC2.Create(), making this type marginally slower than calling RC2.Create() directly.
+
+#### Replacement
+
+`System.Security.Cryptography.RC2.Create()`
+
+### `System.Security.Cryptography.RNGCryptoServiceProvider`
+
+#### Motivation
+
+* On .NET Framework RNGCryptoServiceProvider is the implementation returned by RandomNumberGenerator.Create()
+* On .NET Core RNGCryptoServiceProvider is written as a wrapper over RandomNumberGenerator.Create(), making this type marginally slower than calling RandomNumberGenerator.Create() directly.
+
+#### Replacement
+
+`System.Security.Cryptography.RandomNumberGenerator.Create()`
+
+### `System.Security.Cryptography.RSACryptoServiceProvider`
+
+#### Motivation
+
+* RSACryptoServiceProvider does not have support for OAEP encryption or decryption with SHA-2 (SHA256, SHA384, SHA512) as the choice of hash algorithm.
+* RSACryptoServiceProvider does not have support for RSA-PSS signature generation or validation.
+* On .NET Core on non-Windows systems RSACryptoServiceProvider is written as a wrapper over RSA.Create(), making this type marginally slower than calling RSA.Create() directly, and CAPI-specific members will throw exceptions.
+
+#### Replacement
+
+* If direct interop is required to Windows CAPI, no replacement exists.
+* Otherwise, `System.Security.Cryptography.RSA.Create()`
+  * On .NET Framework `RSA.Create()` returns an instance of RSACryptoServiceProvider. This behavior can be changed via CryptoConfig, or callers may need to cross-compile and instantiate `System.Security.Cryptography.RSACng` directly.
+
+### `System.Security.Cryptography.SHA1CryptoServiceProvider`
+
+#### Motivation
+
+* On .NET Framework SHA1CryptoServiceProvider uses the legacy Windows Cryptographic API (API). In Windows 8.1 and newer the CAPI implementation calls the CNG implementation, making this type automatically marginally slower than SHA1Cng.
+* On .NET Core SHA1CryptoServiceProvider is written as a wrapper over SHA1.Create(), making this type marginally slower than calling SHA1.Create() directly.
+
+#### Replacement
+
+`System.Security.Cryptography.SHA1.Create()`
+
+### `System.Security.Cryptography.SHA256CryptoServiceProvider`
+
+#### Motivation
+
+* On .NET Framework SHA256CryptoServiceProvider uses the legacy Windows Cryptographic API (API). In Windows 8.1 and newer the CAPI implementation calls the CNG implementation, making this type automatically marginally slower than SHA256Cng.
+* On .NET Core SHA256CryptoServiceProvider is written as a wrapper over SHA256.Create(), making this type marginally slower than calling SHA256.Create() directly.
+
+#### Replacement
+
+`System.Security.Cryptography.SHA256.Create()` (as of .NET Framework 4.6.2, SHA256.Create() no longer throws when FIPS policy enforcement is enabled)
+
+### `System.Security.Cryptography.SHA384CryptoServiceProvider`
+
+#### Motivation
+
+* On .NET Framework SHA384CryptoServiceProvider uses the legacy Windows Cryptographic API (API). In Windows 8.1 and newer the CAPI implementation calls the CNG implementation, making this type automatically marginally slower than SHA384Cng.
+* On .NET Core SHA384CryptoServiceProvider is written as a wrapper over SHA384.Create(), making this type marginally slower than calling SHA384.Create() directly.
+
+#### Replacement
+
+`System.Security.Cryptography.SHA384.Create()`  (as of .NET Framework 4.6.2, SHA384.Create() no longer throws when FIPS policy enforcement is enabled)
+
+### `System.Security.Cryptography.SHA512CryptoServiceProvider`
+
+#### Motivation
+
+* On .NET Framework SHA512CryptoServiceProvider uses the legacy Windows Cryptographic API (API). In Windows 8.1 and newer the CAPI implementation calls the CNG implementation, making this type automatically marginally slower than SHA512Cng.
+* On .NET Core SHA512CryptoServiceProvider is written as a wrapper over SHA512.Create(), making this type marginally slower than calling SHA512.Create() directly.
+
+#### Replacement
+
+`System.Security.Cryptography.SHA512.Create()`  (as of .NET Framework 4.6.2, SHA512.Create() no longer throws when FIPS policy enforcement is enabled)
+
+### `System.Security.Cryptography.TripleDESCryptoServiceProvider`
+
+#### Motivation
+
+* On .NET Framework TripleDESCryptoServiceProvider uses the legacy Windows Cryptographic API (API). In Windows 8.1 and newer the CAPI implementation calls the CNG implementation, making this type automatically marginally slower than TripleDESCng.
+* On .NET Core TripleDESCryptoServiceProvider is written as a wrapper over TripleDES.Create(), making this type marginally slower than calling TripleDES.Create() directly.
+
+#### Replacement
+
+`System.Security.Cryptography.TripleDES.Create()`
+
+### `System.Security.Cryptography.X509Certificates.PublicKey.Key`
+
+#### Motivation
+
+* This property returns the same object on each call.  Since the returned value is `IDisposable`, but the containing class is not, it is difficult to properly manage the object lifetime.
+* This property is limited to the RSA and DSA algorithms, it has no support for ECDSA.
+* On .NET Framework this property returns instances of RSACryptoServiceProvider and DSACryptoServiceProvider, which are no longer recommended for use.
+* On .NET Core the returned objects may not be of the same type as .NET Framework, leading to exceptions when the caller performs a hard-cast.
+
+#### Replacement
+
+Usually this property is only invoked in the context of a certificate, e.g. `cert.PublicKey.Key`. In those cases:
+
+* RSA: `cert.GetRSAPublicKey()`
+* DSA: `cert.GetDSAPublicKey()`
+* ECDSA: `cert.GetECDsaPublicKey()`
+
+### `System.Security.Cryptography.X509Certificates.X509Certificate..ctor` (all overloads)
+
+#### Motivation
+
+The X509Certificate2 class provides more functionality than the X509Certificate class and has essentially no extra cost to instantiation.
+
+#### Replacement
+
+The equivalent signature overload of the `System.Security.Cryptography.X509Certificate2` constructor.
+
+### `System.Security.Cryptography.X509Certificates.X509Certificate.Import` (all overloads)
+
+#### Motivation
+
+* Most users of X509Certificate and X509Certificate2 objects assume that the object is immutable except for the `Reset()`/`Dispose()` methods, the use of `Import` violates this assumption.
+* These methods are not implemented in .NET Core.
+
+#### Replacement
+
+The equivalent signature overload of the `System.Security.Cryptography.X509Certificate2` constructor.
+
+### `System.Security.Cryptography.X509Certificates.X509Certificate2.set_FriendlyName`
+
+#### Motivation
+
+This method is only available on Windows (other operating systems result in a `PlatformNotSupportedException`). When used on an X509Certificate2 instance whose underlying PCCERT_CONTEXT belongs to a persisted certificate store, assigning this property changes the value persisted within the store, affecting future copies.
+
+#### Replacement
+
+If `FriendlyName` is being used as a means of temporarily identifying a certificate instance, use an application-local construction, such as a `Dictionary<string, X509Certificate2>`.
+
+If `FriendlyName` is being used for the purpose of a side effect to the persisted Windows certificate store, continue using it, but be aware of the platform-specific limitations.
+
+### `System.Security.Cryptography.X509Certificates.get_PrivateKey`
+
+#### Motivation
+
+* This property returns the same object on each call.  Since the returned value is `IDisposable`, but the containing class is not, it is difficult to properly manage the object lifetime.
+* This property is limited to the RSA and DSA algorithms, it has no support for ECDSA.
+* On .NET Framework this property returns instances of RSACryptoServiceProvider and DSACryptoServiceProvider, which are no longer recommended for use.
+  * The returned RSACryptoServiceProvider will use whatever CSP it had at the time of import (or creation). Frequently this is PROV_RSA_FULL, which is not capable of SHA-2 based signature generation or verification.
+  * RSACryptoServiceProvider and DSACryptoServiceProvider are unable to access keys stored within a CNG Key Storage Provider.
+* On .NET Core the returned objects may not be of the same type as .NET Framework, leading to exceptions when the caller performs a hard-cast.
+
+#### Replacement
+
+* RSA: `cert.GetRSAPrivateKey()`
+* DSA: `cert.GetDSAPrivateKey()`
+* ECDSA: `cert.GetECDsaPrivateKey()`
+
+### `System.Security.Cryptography.X509Certificates.X509Certificate2.set_FriendlyName`
+
+#### Motivation
+
+This property setter is not available in .NET Core (invoking it results in a `PlatformNotSupportedException`).
+
+On .NET Framework, when used on an X509Certificate2 instance whose underlying PCCERT_CONTEXT belongs to a persisted certificate store, assigning this property changes the value persisted within the store, affecting future copies.
+
+Utilizing the property setter may violate assumptions other users of this object may have about object immutability.
+
+#### Replacement
+
+The new methods `cert.CopyWithPrivateKey(RSA)`, `cert.CopyWithPrivateKey(DSA)`, and `cert.CopyWithPrivateKey(ECDsa)` will produce a new X509Certificate2 object with the private key associated.
+
+If the persisted store side effect of this property is desired:
+* Ensure that the private key reference is a persisted key
+  * `if (key is ICspAsymmetricAlgorithm capiKey) check that capiKey.CspKeyContainerInfo.KeyContainerName is not null or empty`
+  * `if (key is RSACng rsaCng) check that rsaCng.Key.KeyName is not null or empty`
+    * (similar for DSACng and ECDsaCng)
+* Use the appropriate `CopyWithPrivateKey` (extension) method.
+* Open the appropriate `X509Store` with `OpenFlags.ReadWrite`
+* Add the new certificate to the store, this will replace the existing store certificate with the new one.
+  * Other data such as FriendlyName, Archived, and other certificate properties may be lost.
+
+Alternatively, P/Invoke `CertSetCertificateContextProperty` appropriately, using `cert.Handle` as the value for `pCertContext`.
+
+### `System.Security.Cryptography.X509Certificate2.Verify()`
+
+#### Motivation
+
+The `Verify` method simply returns the result of `X509Chain.Build(cert)` (revocation-enabled, with DateTime.Now as the effective time).  If `Verify` returns `false` many callers call X509Chain.Build to determine the source of the error, which leads to duplicated work.
+
+#### Replacement
+
+```c#
+using (var chain = new X509Chain())
+{
+    bool verified = chain.Build(cert);
+
+    if (!verified)
+    {
+       // custom logic as needed
+    }
+}
+```
+
+Or, if only the validity period was intended as a check, use the `cert.NotBefore` and `cert.NotAfter` values.
+
+### `System.Security.Cryptography.X509Store.AddRange`
+
+#### Motivation
+
+When an Exception is thrown it is possible that the store is in a modified state.
+
+X509Store.Add has cases where Add has no visible effect, but during attempted cleanup from an Exception being thrown `AddRange` will call `Remove` on every element which was already added.  This may result in a net deletion of certificates from an X509Store.
+
+#### Replacement
+
+Use `X509Store.Add` and application-specific logic for handling rollback (or not) in the event of an Exception.
+
+### `System.Security.Cryptography.X509Store.RemoveRange`
+
+#### Motivation
+
+When an Exception is thrown it is possible that the store is in a modified state.
+
+X509Store.Remove succeeds when invoked with a certificate which is not present in the store.  If an Exception is thrown on a later element `RemoveRange` will try to restore state by calling `Add` on all certificates which have been "removed". In this state it is possible that a net addition of certificate has happened to the X509Store.
+
+#### Replacement
+
+Use `X509Store.Remove` and application-specific logic for handling rollback (or not) in the event of an Exception.
+
+
+### `System.Globalization.CultureTypes.WindowsOnlyCultures`
+### `System.Globalization.CultureTypes.FrameworkCultures`
+
+#### Motivation
+
+After the framework design changed to read all culture data from the underlying OS, the enum values WindowsOnlyCultures and FrameworkCultures became none sense. This applies to all .Net platforms. The applications can continue use these enum values but will get a compilation warning and will not have any noticable effect during the runtime 
+
+
+### Incorporated
+* System.Collections.\* (non-generic) - https://github.com/dotnet/platform-compat/blob/master/docs/DE0006.md
+* System.Security.SecureString - https://github.com/dotnet/platform-compat/blob/master/docs/DE0001.md
+* System.Security.Permissions - https://github.com/dotnet/platform-compat/blob/master/docs/DE0002.md
+* System.Net.\*WebRequest - https://github.com/dotnet/platform-compat/blob/master/docs/DE0003.md
+* System.Net.WebClient - https://github.com/dotnet/platform-compat/blob/master/docs/DE0004.md
+* System.Net.Mail.SmtpClient - https://github.com/dotnet/platform-compat/blob/master/docs/DE0005.md [**Note** the destination topic says "SmtpClient shouldn't be used". SmtpClient is in fact not obsolete in the .NET Framework, although it has a limited implementation in .NET Core.]

--- a/Documentation/wiki/Build-and-run-tests.md
+++ b/Documentation/wiki/Build-and-run-tests.md
@@ -1,0 +1,140 @@
+This page describes the process for compiling the repository and running tests.
+
+### Quick Reference
+
+#### Typical workflow
+
+1. `build` - Builds the product, not tests.
+    * **Note:** You need to **build from root** after each major update of sources.
+2. `build -buildtests` builds test projects. 
+3. `build -test` - **runs** tests, test projects need to be built beforehand.
+4. `build -restore -build -buildtests -test` - **builds** all source and test projects, then **runs** tests.
+
+
+#### Tips & tricks
+
+* `build -clean` - Cleans up the binary output and optionally the working directory (-all). Useful if you get into messy state.
+* Move [NuGet cache](https://github.com/dotnet/corefx/wiki/Build-and-run-tests#nuget-cache-customization) location out of C drive.
+* `build -restore` - Pulls down all external dependencies (so you can do the rest offline).
+
+
+# Build and Run tests
+
+After each major update of sources, you need to **build from root**, otherwise you may encounter weird build errors. On rare occasion, clean is needed.
+Build from root has to happen from command line (we do not have all-repo solution for Visual Studio).
+
+When you iterate on code changes, you can rebuild just sub-projects, using incremental build, in both command line and Visual Studio.
+
+
+## Build from root
+
+From a (non-admin) **Command Prompt window** (You SHOULD find this in your Start Menu under Visual Studio 2015/2017 after they are installed, instead of a Command window from `Run` or `Windows appendage`, also make sure you have PowerShell v3 or later installed), and then run:
+
+1. `build` script (.cmd/.sh) - Builds the shipping libraries in corefx (3+ min). Does not build tests.
+2. `build & build -buildtests -test` - Builds everything and **runs** the corefx tests (4+ min).
+3. *[Optional]* `build -clean` - Cleans up the binary output and optionally the working directory (-all).
+    * Useful when you get your local clone into weird state.
+4. *[Optional]* `build -restore` - Pulls down external dependencies needed to build (i.e. build tools, xunit, coreclr, etc).
+    * Useful to prep for offline work. It will run automatically also during `build`, if you don't run it explicitly.
+    * Expect 2GB+ in clone and 1GB in NuGet cache.
+
+### NuGet Cache Customization
+
+NuGet cache defaults to C drive and can grow quickly to GBs. You can move it to another disk by editing [`%APPDATA%\NuGet\NuGet.Config`](https://docs.microsoft.com/en-us/nuget/schema/nuget-config-file#config-section) file:
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <config>
+        <add key="globalPackagesFolder" value="D:\code\packages" />
+```
+
+To avoid downloading GBs again, just move the directory to its new place when you modify the config.
+
+
+## Incremental Build or Run tests
+
+To rebuild a particular library, run `msbuild` from its 'src' subdirectory. To run tests once, run `msbuild` from its 'tests' subdirectory. On Windows msbuild should be in PATH when running from Developer command prompt.
+
+Example:
+
+```
+cd src\System.Console\src
+dotnet msbuild
+
+cd src\System.Console\tests
+dotnet msbuild /t:rebuildandtest  
+```
+
+
+## Build, Run and Debug tests using Visual Studio
+
+1. Open solution file (.sln) for a specific library (e.g. `src\System.Collections\System.Collections.sln`).
+2. Right-click test project and select `Set as StartUp Project`.
+3. Ctrl+F5 (Run) to run tests.
+4. F5 (Debug) to debug tests (breakpoints work in test and source code).
+    * Trick: Many negative tests throw exceptions caught by xunit test framework. VS treats them as unhandled and breaks on them. To disable this behavior, uncheck `Enable Just My Code` in `Tools | Options | Debugging | General`.
+
+
+### Run and Debug single test in Visual Studio
+
+While you can see and navigate to tests, you cannot currently run them from the Visual Studio Test Explorer. To run or debug a single test from within Visual Studio, you need to temporarily add command line filter options and run/debug the project as described above. These options should be added at the end of the `Application arguments:` in the test project properties `Debug` tab.
+
+The existing arguments will look something like this: `$(RunArguments) -wait -parallel none`. Here are two methods to run specific tests:
+
+1. Specify the test method name.
+2. Add traits to the test and specify the trait name.
+
+The test method filter is specified using `-method FullNameToMethod`. For example: `-method *.ObjectTests.ReadSimpleClass` or `-method System.Text.Json.Tests.ObjectTests.ReadSimpleClass`.
+
+Trait attributes are specified using `-trait MyTrait=MyTraitValue`. Tests need the trait attribute applied, e.g. `[Trait("MyTrait", "MyTraitValue")]`.
+
+Example:
+```c#
+[Fact]
+[Trait("MyTrait", "MyTraitValue")]
+public void MyTest()
+{
+   // ...
+}
+```
+
+These changes need to be undone before making commits and PRs.
+
+### Run and Debug single test in Command Line
+
+To quickly run or debug a single test from the command line, pass the XunitMethodName option to msbuild, specifying the full method name (including namespace).
+For example:
+```
+dotnet msbuild /t:rebuildandtest /p:XunitMethodName=System.MemoryTests.ReadOnlyMemoryTests.ToStringChar_Empty
+```
+It is not necessary to use `/t:rebuildandtest` to force tests to re-run. If you want to skip the build and simply run tests again, use `/t:test /p:ForceRunTests=true`.
+
+The `BuildAndTest`, `RebuildAndTest` and `Test` targets are only available in the test csproj files. Make sure to run this command either on the `test` subdirectory, or invoking it directly on the test csproj file.
+
+Or, you can eliminate the MSBuild wrapper and run the XUnit command directly. The console output shows you how, for example,
+```
+---- start 21:30:12.43 ===============  To repro directly: =====================================================
+pushd C:\git\corefx\bin\tests\System.Text.RegularExpressions.Tests\netcoreapp-Windows_NT-Debug-x64\
+call C:\git\corefx\bin\testhost\netcoreapp-Windows_NT-Debug-x64\\dotnet.exe xunit.console.netcore.exe System.Text.RegularExpressions.Tests.dll  -xml testResults.xml -notrait Benchmark=true -notrait category=nonnetcoreapptests -notrait category=nonwindowstests  -notrait category=OuterLoop -notrait category=failing
+popd
+===========================================================================================================
+```
+
+
+## Outerloop tests
+
+When tests are unavoidably resource intensive (they take significant time to complete due to the nature of what is being tested) and are not expected to be broken easily, consider using the `[Outerloop]` attribute for the test. With this attribute, tests are executed in a dedicated CI loop that runs outside of the default CI loops which get created when you submit a PR.
+
+To run outerloop tests locally you need to use the `-OuterLoop` with build (if using msbuild directly: `/p:TestScope=all`).
+To run outerloop tests in CI you need to mention dotnet-bot and tell him which tests you want to run. See `@dotnet-bot help` for the exact loop names.
+
+
+## Advanced Build options
+
+- `-framework netcoreapp|netfx|uap` - Target specific Framework. Default is `netcoreapp`.
+    * `netcoreapp` - .NET Core
+    * `netfx` - "full" .NET Framework (Windows-only)
+    * `uap` - UWP (Universal Windows Platform) (Windows-only)
+- `-os Windows_NT|Linux|OSX` - Target specific OS (`Windows_NT`=any Windows OS, `OSX`=macOS). Default is current OS.
+- `-c Debug` or `-c Release` - Debug vs. Release build. Default is `-c debug`.
+- `-arch x64|x86|arm|arm64` - Target specific processor architecture. Default is `x64`.

--- a/Documentation/wiki/Building-.NET-Core--2.x-on-FreeBSD.md
+++ b/Documentation/wiki/Building-.NET-Core--2.x-on-FreeBSD.md
@@ -1,0 +1,395 @@
+<a name="home"/>
+
+[Disclaimer](#disclaimer) | [Overview](#overview) | [Building CoreCLR](#building-coreclr) | [Building CoreFX](#building-corefx) | [Troubleshooting](#troubleshooting-and-diag) | [Tips and Tricks](#tips-and-tricks) | [Updates](#updates)
+
+## Disclaimer
+
+Support for FreeBSD is in early stages.
+Instructions bellow may or may not give you what you want. 
+Get ready for bumpy road.
+You have been warned!
+Tested only on basic FreeBSD 11.0 image.
+
+## Overview
+
+### Runtime vs. Software Development Kit (SDK)
+
+In general, there are two products - Runtime and SDK. The Runtime (among other functions), converts the Intermediary Language code (IL) to runnable binaries that are executed on the target system. The SDK consists of the base components that are used by developers to write software. 
+
+There are two parts to each product: Platform specific code, and "managed" dotnet components. The platform specific code is built using Autogen, CMake (and some Python) and compiled against standard C libraries with standard C/C++ compilers (GCC, Clang, musl). The managed dotnet components, however, are built using managed tools written in C# against DotNet. On Windows, this is supported by the .Net Framework and Visual Studio. On Linux, this is supported by DotNetCore 1.0. As FreeBSD does not (fully) support either, we have the following choices:
+- Import the managed components in binary format from another platform
+- Build the components with Mono or Linux DotNet
+
+This instruction set focuses on the former. 
+
+### Repositories
+
+There is no single GitHub repository that represents the entire dotnet core build. It is very difficult at this point to get all the parts glued together. This cohesion will be needed at some point for adding package to ports collection, but is not currently in scope for these instructions. [Source-build](https://github.com/dotnet/source-build) project is trying to make build easier for OS vendors. 
+
+### Building the .NET Repositories
+
+In a simplified way, the build dependencies are cli->core-setup->corefx->coreclr. The Command Line Interface (cli) needs a number of components like MSBuild and the Roslyn compiler. We will attempt to build all the repos in reverse order, starting with the coreclr and the corefx. Most repositories build debug version by default. To change build configuration, append  -release or the release keyword to various build instructions.
+
+### Notes About Cross Platform Builds
+
+It is important to ensure that the repositories and build configurations are the same on FreeBSD and on the cross build platform (Windows or GNU/Linux) for the managed code. Put another way: 
+
+- Both outputs must be of debug or release configuration. You cannot mix the configurations.
+- Both outputs must be from the same git commit (roughly?).
+
+If the platforms do not match, the coreclr tests will fail to run with an error of
+
+```
+coreclr_initialize failed - status: 0x80004005
+```
+
+See https://github.com/dotnet/coreclr/issues/1419 for more details
+
+[Top](#home)
+
+## Building coreclr
+
+First of all, one needs the usual build dependencies:
+
+`pkg install cmake git icu libunwind bash python2 krb5 lttng-ust`
+
+The build system expects all the clang/llvm tools to exist with version number. The clang 3.8 should be sufficient but it was difficult to use with current build system. This instruction was built using clang 3.9.
+
+To build the FreeBSD native parts of coreclr run:
+
+`./build.sh -clang3.9`
+
+
+### Building CoreLib
+
+The second part of coreclr is corelib. The System.Private.CoreLib.dll executable is managed code and expects a functional SDK. This is normally solved by using an older version for bootstrapping, which does not expressly exist yet for FreeBSD.
+
+* Note: It is **mandatory** that the managed part needs to be built from the same branch and/or commit hash.
+Also debug/release flavors are not binary compatible. Managed and native part needs to either be both release or both debug. *
+
+#### Building CoreLib on Windows 
+
+System.Private.CoreLib.dll is to be built for FreeBSD on Windows 10 if the development environment is correctly configured for build dotnet. The instructions are outlined in the Windows build instructions here:
+
+https://github.com/dotnet/coreclr/blob/master/Documentation/building/windows-instructions.md
+
+To build mscorlib run:
+
+``` build.cmd -freebsdmscorlib```
+
+Building the CLR managed tests on Windows is still a work in progress.
+
+#### Building Corelib on Linux
+
+There are two caveats (aside from inconvenience) we need to overcome with Linux build. 
+
+Linux (and other platform) assemblies are "crossgen"ed by default . That is optimization that generates native code for given platform. 
+
+```
+Unhandled Exception: System.BadImageFormatException: Could not load file or assembly 'System.Runtime, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. An attempt was made to load a program with an incorrect format.```
+
+You can use 'file' utility to get basic info about assembly:
+
+```file foo.dll
+
+System.Private.CoreLib.dll: PE32+ executable (DLL) (console) x86-64 Mono/.Net assembly, for MS Windows
+```
+vs
+```
+file foo.dll: PE32 executable (DLL) (console) Intel 80386 Mono/.Net assembly, for MS Windows
+```
+Current branches (2.1) has `-skipcrossgen` option.
+
+Alternativaly one can use `export COMPlus_ZapDisable=1` and COMPlus_ReadyToRun=0 environmental variables to tell runtime to ignore native code in assemblies (currently does not work for corelib).
+
+
+#### When doing "normal" build on Linux, corelib would get some features available only on Linux.
+That may not matter for simple "Hello World" but it will cause troubles. You can see various options in `clr.coreclr.props`.
+We need 
+Long term goal would be to allow cross-platform build. There may be fragments in place but it will need more exploration and testing. Windows build.cmd has 'freebsdmscorlib' option and that can be ported to NIX branches. 
+
+
+With that we can run Linux build:
+
+```
+./build.sh -clang3.9 -skipcrossgen -osgroup FreeBSD 
+```
+
+That will produce `bin/Product/Linux.x64.Debug/System.Private.CoreLib.dll`
+
+Copy that to FreeBSD system to `bin/Product/FreeBSD.x64.Debug` directory.
+To make debug easier copy also `bin/Product/Linux.x64.Debug/PDB/System.Private.CoreLib.pdb` to same location.
+That will be handy for analyzing stack traces. 
+
+#### Building CoreLib on FreeBSD (experimental)
+As of 2.1 it is possible to run Linux SDK under Linux emulation. 
+
+Getting ready:
+
+```
+$ sudo kldload linux64
+$ sudo pkg install linux_base-c7 linux-c7-curl linux-c7-icu linux-c7-openssl-libs
+```
+
+add following entries to /etc/fstab
+
+```
+linprocfs   /compat/linux/proc  linprocfs   rw  0   0`
+linsysfs    /compat/linux/sys   linsysfs    rw  0   0`
+tmpfs    /compat/linux/dev/shm  tmpfs   rw,mode=1777    0   0`
+```
+
+and  run  `$sudo mount -a` (or reboot)
+
+now it should just work. but build calls 'python' regardless or PYTHON variable.
+By default, FreeBSD has python2.7. One can create ~/bin/python as 
+
+```
+#!/bin/sh
+python2.7 "$@"
+```
+
+Now it should be possible to run:
+
+```
+export  SSL_CERT_FILE=/usr/local/share/certs/ca-root-nss.crt
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+export DOTNET_SYSTEM_NET_HTTP_USESOCKETSHTTPHANDLER=0
+
+
+./init-tools.sh
+```
+If everything is OK, Linux tools and SDK should just work...
+```
+ Unsupported OS 'FreeBSD' detected. Downloading linux-x64 tools.`
+ Installing dotnet cli...`
+ Restoring BuildTools version 2.2.0-preview1-02810-02...`
+ Using RID linux-x64 for BuildTools native tools`
+ Initializing BuildTools...`
+ Making all .sh files executable under Tools.`
+ Unsupported OS FreeBSD detected. Skipping crossgen of the toolset.
+ Done initializing tools.`
+```
+
+now, we need to fix run.sh and Tools/msbuild.sh to use #!/usr/local/bin/bash 
+There are two problems on FreeBSD: 
+- /bin/bash does not exit.
+- Process running under Linux emulation is failing to execute FreeBSD code:
+ (run /compat/linux/bin/bash and try ./run.sh)
+
+(there may be some other solution (BSD gurus please chime in)) 
+
+`./build.sh -skiptests -msbuildonunsupportedplatform  `
+
+This should produce /mnt/coreclr-master/bin/Product/FreeBSD.x64.Debug/System.Private.CoreLib.dll
+Note that build 'fails' even if the library is created. That will need some investigation. 
+(note that console will show error about 'syscall sendfile not implemented'. There is fallback if the system call fails (for compatibility with Linux 2.2))
+ 
+
+### Verification and Testing
+If everything is OK, one should be able to run simple assembly on FreeSBD now.
+
+To run PAL tests do from coreclr root:
+
+```
+./src/pal/tests/palsuite/runpaltests.sh $PWD/bin/obj/FreeBSD.x64.Debug $PWD/bin/paltestout
+```
+
+It is important to use absolute path for the parameters e.g. ./bin/XX does not work
+
+To build managed tests we will again need OS capable of producing managed assemblies.
+On Linux one can run
+
+```
+./build-test.sh
+```
+
+and that will create test assemblies. This step will take LONG time and it will needed resources. 
+It was failing on 2 core systems with 2G of RAM. 4G seems ok. It should finish with something like:
+
+```
+Command execution succeeded.
+Command successfully completed.
+Test build successful.
+Test binaries are available at /home/furt/git/wfurt-coreclr/bin/tests/Linux.x64.Debug
+
+To run all tests use 'tests/runtests.sh' where:
+    testRootDir      = /home/furt/git/wfurt-coreclr/bin/tests/Linux.x64.Debug
+    coreClrBinDir    = /home/furt/git/wfurt-coreclr/bin/Product/Linux.x64.Debug
+    coreFxBinDir     = /home/furt/git/wfurt-coreclr/bin/tests/Linux.x64.Debug/Tests/Core_Root
+    testNativeBinDir = /home/furt/git/wfurt-coreclr/bin/obj/Linux.x64.Debug/tests
+```
+
+[Top](#home)
+
+## Building CoreFX
+
+CoreFX provides set of libraries providing compliance with .net standard - 2.0 in current state. 
+That is essentially needed to run any decent application. The challenges here are similar to challenges to building coreCLR. However build of corefx has some preliminary support for cross-targeting platforms. 
+Some managed code in CoreFX has OS specific implementations and we need to pick proper one to run properly on FreeBSD. 
+
+### Building native components
+
+To Build native parts on FreeBSD
+
+```
+./src/Native/build-native.sh -clang3.9
+```
+
+### Building managed components on Windows
+
+To build the manage components in Windows please follow the instructions here:
+Framework (corefx):
+https://github.com/dotnet/corefx/blob/master/Documentation/building/windows-instructions.md
+
+### Building managed components on GNU/Linux
+
+To build managed parts on GNU/Linux
+: 
+```
+./build.sh -OS=FreeBSD -buildtests -skiptests -SkipManagedPackageBuild [-release]
+```
+This will produce assemblies under `bin/*`. `-buildtests` can be omitted if there is no intention to execute test on FreeBSD. Copy everything from `bin/*` to your FreeBSD system.
+
+Just to be sure, remove any possible Linux binaries. 
+```
+rm -rf bin/obj/FreeBSD.x64.Debug bin/FreeBSD.x64.Debug/native
+```
+Cmake may get confused is it sees old artifacts. 
+
+### Testing the SDK
+
+Steps bellow need changes from wfurt/corefx. Pull from there or get patches. 
+For now, there are some unusual steps. The copy instructions assume core-setup, corefx and coreclr are in same diectory next to each other. 
+
+[Top](#home)
+
+##### core-setup
+
+```
+cd core-setup
+mkdir -p  bin/obj
+echo 'static char sccsid[] __attribute__((used)) = "stub";' > bin/obj/version.cpp
+sed -I old  's@../../../version.cpp@bin/obj/version.cpp@' src/corehost/CMakeLists.txt
+src/corehost/build.sh --arch x64 --hostver "2.0.0" --apphostver "2.0.0" --fxrver "2.0.0" --policyver "2.0.0" --commithash `git rev-parse HEAD`
+```
+This will produce native FreeBSD dotnet binary, libhostfxr.so and libhostpolicy
+
+With that, go back to corefx tree:
+```
+cp ../core-setup/cli/exe/dotnet/dotnet bin/testhost/netcoreapp-FreeBSD-Debug-x64/dotnet
+cp ../core-setup/cli/fxr/libhostfxr.so bin/testhost/netcoreapp-FreeBSD-Debug-x64/host/fxr/9.9.9/libhostfxr.so
+cp ../core-setup/cli/dll/libhostpolicy.so bin/testhost/netcoreapp-FreeBSD-Debug-x64/shared/Microsoft.NETCore.App/9.9.9/libhostpolicy.so
+
+cp bin/FreeBSD.x64.Debug/native/*so bin/testhost/netcoreapp-FreeBSD-Debug-x64/shared/Microsoft.NETCore.App/9.9.9/
+cp ../coreclr/bin/Product/FreeBSD.x64.Debug/*so bin/testhost/netcoreapp-FreeBSD-Debug-x64/shared/Microsoft.NETCore.App/9.9.9
+cp ../coreclr/bin/Product/FreeBSD.x64.Debug/System.Private.CoreLib.dll  bin/testhost/netcoreapp-FreeBSD-Debug-x64/shared/Microsoft.NETCore.App/9.9.9
+```
+
+Get `https://github.com/wfurt/blob/blob/master/Microsoft.NETCore.App.deps.json` and replace original version in `bin/testhost/netcoreapp-FreeBSD-Debug-x64/shared/Microsoft.NETCore.App/9.9.9`
+
+Correct TestPlatform
+```
+find bin/ -name RunTests.sh | xargs -I@@ sed -I .old 's/nonlinuxtests/nonfreebsdtests/' @@
+```
+
+Now, you should be able to run `run-test.sh` or 'RunTests.sh' under `bin/AnyOS.AnyCPU.Debug` directory.
+Second needs argument pointing at `bin/testhost/netcoreapp-FreeBSD-Debug-x64`.
+
+[Top](#home)
+
+## Troubleshooting and diag
+
+### Useful variables
+```
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true # skips creating NuGet package cache when running dotnet cli 
+export DOTNET_CLI_TELEMETRY_OPTOUT=1          # disables telemetry - broken on FreeBSD
+export COREHOST_TRACE=1                       # traces loading of assemblies and other useful info 
+export COMPlus_ZapDisable=1                   # ignores native code in assemblies 
+export BUILDTOOLS_SKIP_CROSSGEN=1             # attempt to NOT cross-gen - works only in some repos
+```
+
+[Top](#home)
+
+## Tips and Tricks
+
+### Running FreeBSD on Windows 10
+
+A minimal FreeBSD image can be downloaded and installed and runs well under [Oracle Virtual Box](https://www.virtualbox.org/), but shared folders are not supported. To share data between the Windows 10 host and FreeBSD VM, mount any shared folder (or a Windows users' home directory) via [mount_smbfs(8)](https://www.freebsd.org/cgi/man.cgi?mount_smbfs). A password is required is there is no guest access to the folder. 
+
+To enable sharing between the Host and the VM, Open the FreeBSD virtual machine Settings and add a second network adapter as a [host only adapter](https://www.virtualbox.org/manual/ch06.html#network_hostonly). Once this is set up, any share can be mounted from within FreeBSD. An example mount command to a users home directory:
+
+```
+sudo mount_smbfs -I 192.168.56.1 //russh@layne/Users/russh/ mnt/
+```
+This example will prompt for the *Windows users'* password. mount_smbfs(8) indicates that an RC file can be added to the FreeBSD users home directory for use with fstab, but has not yet been tested. 
+
+### Building FreeBSD SDK
+This is highly experimental set of hacks and it may or may not work at any given time. It assumes recent versions versions of the SDK as old code base does not have all the fixes to build and run the SDK.
+It is based on boot-strap tool described here https://github.com/dotnet/source-build/blob/dev/release/2.0/Documentation/boostrap-new-os.md (https://github.com/dotnet/source-build/blob/dev/release/2.0/scripts/bootstrap/buildbootstrapcli.sh) 
+
+This script allows to to take published .NET SDK and replace native parts of it so it can possibly run on other OS. This was primarily used to get .NET on new Linux distributions without compatible environment. It does not produce functional SDK but it creates very good start. This is transient and it will eventually be replaced by build-from-source project. 
+
+The example below used FreeBSD 11 system, Ubuntu Server 16.04 and 2.2.0-preview1-007816 CLI as base line.  
+(not that 16.10 Ubuntu must not be used because it will fail) 
+1. get baseline Linux SDK - daily builds are published here: https://github.com/dotnet/cli
+2. rebuild native FreeBSD parts (run command bellow on FreeBSD)
+`./buildbootstrapcli.sh -release -os FreeBSD -rid freebsd.11-x64 -seedcli ~/dotnet-2.2.0-preview1-007816`
+That should checkout code and rebuild native FreeBSD parts
+
+now sdk should run (needs COMPlus_ZapDisable=1 COMPlus_ReadyToRun=0) but it will not function correctly.
+This is because managed parts assume Linux.
+
+`dotnet --info` should show information about runtime and sdk.
+
+If you get arror about parsing JSON file, remove extra 'n' characters from `shared/Microsoft.NETCore.App/<version>/Microsoft.NETCore.App.deps.json` file.
+The sed from script does not correctly process '\n'
+
+3. rebuild mscorelib
+* checkout coreclr to same submit hash as presented by bootstrap script
+* ./build.sh -clang3.9 -skipcrossgen -osgroup FreeBSD -release
+* copy corelib to FreeBSD:
+
+`scp linux:coreclr/bin/obj/FreeBSD.x64.Debug/System.Private.CoreLib/System.Private.CoreLib.dll freebsd.11-x64/dotnetcli/shared/Microsoft.NETCore.App/2.1.0-preview1-26013-05/System.Private.CoreLib.dll `
+
+4. rebuild corefx managed parts on Linux (same instructions as above) 
+
+```
+./build.sh -OS=FreeBSD -buildtests -skiptests -SkipManagedPackageBuild -release
+rm -f bin/testhost/netcoreapp-FreeBSD-Release-x64/shared/Microsoft.NETCore.App/9.9.9/System.Private.CoreLib.*
+scp bin/testhost/netcoreapp-FreeBSD-Release-x64/shared/Microsoft.NETCore.App/9.9.9/*.dll dll dotnetcli/shared/Microsoft.NETCore.App/2.1.0-preview1-26013-05
+```
+
+5. set directory on path
+```
+mkdir foo
+cd foo
+export COMPlus_ZapDisable=1
+export COMPlus_ReadyToRun=0
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+dotnet new console 
+dotnet restore
+dotnet build
+dotnet publish
+dotnet --fx-version 2.1.0-preview1-26013-05  bin/Debug/netcoreapp2.0/foo.dll
+Hello World!
+```
+
+Note that first two environmental variables are currently mandatory (see cross-gen notes above) 
+
+
+
+[Top](#home)
+
+## Updates
+
+* 10/04/17: tw - merges done for coreclr and core-setp. Simplified instructions for coreclr, syntax change for osgroup
+* 11/08/17: rh - re-org. Added Windows build links
+* 12/21/17: tw - add notes how to create Frankenstein SDK
+* 05/09/18: tw - FreeBSD build broken note.
+* 05/22/18: tw - notes how to build managed code on FreeBSD
+* 06/15/18: mrm - updates to the Building FreeBSD SDK section steps
+
+[Top](#home)

--- a/Documentation/wiki/Building-.NET-Core-3.x-on-FreeBSD.md
+++ b/Documentation/wiki/Building-.NET-Core-3.x-on-FreeBSD.md
@@ -1,0 +1,282 @@
+Updated instructions how to build .NetCore on FreeBSD. 
+This sort of depends on instructions posted here: https://github.com/dotnet/corefx/wiki/Building-.NET-Core--2.x-on-FreeBSD/
+
+Previous instructions used bootstrap script to create SDK runnable on FreeBSD. 
+Instructions posted bellow assume that runnable SDK for FreeBSD is available and the steps use https://github.com/dotnet/source-build/ to produce SDK from current sources. 
+Also at time of writing 3.0 release is closing and master is going to change. 
+To limit friction, this will focus on building release/3.0 branch and new instruction for master/5.0 will be posted when necessary. (master may keep working with existing instructions) 
+
+Instructions were tested on plain FreeBSD 11.3 Azure image
+
+## Prerequisites
+This needs to be done once on fresh system.
+
+```sudo pkg install cmake git icu libunwind bash python2 krb5 lttng-ust llvm60 libgit2```
+
+some scripts may still assume /bin/bash exists. To workaround it for now do of needed:
+```
+sudo ln -s /usr/local/bin/bash /bin/bash
+```
+
+This is certainly undesirable and it should be avoided if possible.
+
+# Get bootstrap cli
+```
+mkdir ~/dotnet
+cd ~/dotnet
+curl https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-freebsd-x64.tar.gz | tar xfz - 
+```
+if on 12.x you may also need to set `LD_PRELOAD` to `/usr/lib/libpthread.so` to avoid issue when cli freezes. 
+
+
+As of summer 2019 this CLI is no longer good enough to build all repos. If that is your case jump to section [Updating CLI](#updating--bootstrap-cli)
+Binary snapshot can be obtained from https://github.com/wfurt/blob as dotnet-sdk-freebsd-x64-latest.tgz
+
+## Getting sources
+master of source-build pulls in source code of specific snapshot instead of tip of master branches. 
+That is generally OK but in case of FreeBSD it may miss some changes crucial for build. 
+(or pending un-submitted change) 
+
+```
+git clone https://github.com/dotnet/source-build
+```
+
+for now, get master for everything (to get https://github.com/dotnet/coreclr/pull/20459 and build coreclr without clang3.9)
+```
+git submodule init
+git submodule update
+(cd src/coreclr ; git checkout master)
+```
+
+port change from 
+```https://github.com/dotnet/corefx/commit/037859ac403ef17879655bb2f2e821d52e6eb4f3```
+In ideal case we could sync up to **master** but that brings Arcade changes and **breaks** the build. 
+
+Bootstrap Arcade
+```
+mkdir -p src/corefx/.dotnet
+(cd src/corefx/.dotnet; tar xf /tmp/dotnet.tar)
+```
+now edit src/corefx/global.json and set tool:dotnet to"3.0.100-preview1-009019"
+That should make Arcade happy and it should skip attempt to download and install SDK from Internet.
+
+
+and apply following patch (to get https://github.com/dotnet/source-build/pull/631)
+```diff
+[toweinfu@toweinfu-fbsd /usr/home/toweinfu/source-build]$ git diff repos/
+diff --git a/repos/core-setup.proj b/repos/core-setup.proj
+index 768b6fb..c02f76f 100644
+--- a/repos/core-setup.proj
++++ b/repos/core-setup.proj
+@@ -4,6 +4,7 @@
+   <PropertyGroup>
+     <BuildArguments>-ConfigurationGroup=$(Configuration) -PortableBuild=$(PortableBuild) -SkipTests=true </BuildArguments>
+     <BuildArguments Condition="$(Platform.Contains('arm'))">$(BuildArguments) -TargetArchitecture=$(Platform) -DisableCrossgen=true -CrossBuild=true</BuildArguments>
++    <BuildArguments Condition="'$(TargetOS)' == 'FreeBSD'">$(BuildArguments) -DisableCrossgen=true</BuildArguments>
+     <BuildCommand>$(ProjectDirectory)/build$(ShellExtension) $(BuildArguments) -- /p:BuildDebPackage=false /p:BuildAllPackages=true /p:PreReleaseLabel="preview"</BuildCommand>
+     <BuildCommand Condition="$(Platform.Contains('arm'))">$(ArmEnvironmentVariables) $(BuildCommand)</BuildCommand>
+     <OfficialBuildId>20180529-01</OfficialBuildId>
+diff --git a/repos/coreclr.proj b/repos/coreclr.proj
+index 81b8c7b..bb26868 100644
+--- a/repos/coreclr.proj
++++ b/repos/coreclr.proj
+@@ -5,6 +5,7 @@
+     <BuildArguments>$(Platform) $(Configuration) skiptests</BuildArguments>
+     <BuildArguments Condition="'$(SkipDisablePgo)' != 'true'">$(BuildArguments) -nopgooptimize</BuildArguments>
+     <BuildArguments Condition="'$(OS)' != 'Windows_NT'">$(BuildArguments) msbuildonunsupportedplatform</BuildArguments>
++    <BuildArguments Condition="'$(TargetOS)' == 'FreeBSD'">$(BuildArguments) -clang6.0</BuildArguments>
+     <BuildArguments Condition="'$(UseSystemLibraries)' == 'true'">$(BuildArguments) cmakeargs -DCLR_CMAKE_USE_SYSTEM_LIBUNWIND=TRUE</BuildArguments>
+     <BuildArguments Condition="$(Platform.Contains('arm'))">$(BuildArguments) skipnuget cross -skiprestore cmakeargs -DFEATURE_GDBJIT=TRUE</BuildArguments>
+     <BuildArguments>$(BuildArguments) -PortableBuild=$(PortableBuild)</BuildArguments>
+```
+
+Depending of the day and moon phase you may need to get some updates as well. 
+If build breaks look for pending PRs with FreeBSD tag or label and pull pending changes. 
+
+## Building
+
+```
+# point to bootstrap cli
+export DotNetBootstrapCliTarPath=/tmp/dotnet.tar
+echo "3.0.100-preview1-009019" > DotnetCLIVersion.txt # version needs to match SDK version from DotNetBootstrapCliTarPath
+# get new Roslyn
+echo "3.0.0-preview1-03316-04" > BuildToolsVersion.txt
+# optional
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+
+
+./build.sh
+```
+
+In ideal situation this will build whole sdk. Right now it fails somewhere in cli.
+There is problem with rebuild and build will attempt to patch files again and/or make git updates. 
+
+```export SOURCE_BUILD_SKIP_SUBMODULE_CHECK=1```
+
+To build single repo again one can do:
+```./build.sh /p:RootRepo=corefx /p:SkipRepoReferences=true ```
+
+## Resolving issues
+Rebuild or source-build has issues. 
+Often running ```clean.sh``` from top helps. Be careful, that may undo any local pending changes. 
+
+Sometimes it would try to apply patches and it would fail.
+You can pass 
+```/p:SkipPatches=true``` to top level build.sh script. 
+
+
+## Running CoreFX tests
+
+Follow steps above to build at least corefx and it's dependencies. 
+
+TBD
+
+## Updating  bootstrap CLI.
+
+As build changes, previous versions of CLI may not be good enough any more. Changes in runtime or build dependency on 3.0 JSON are some example of braking changes. Following steps outline steps to update published CLI to what build needs. It will require other system where builds is supported. As close similarity and availability Linux will be used in examples bellow but Windows or MacOS should also yield same result. 
+
+Often build would ask for slightly different version without actually  have real dependency on it (that is part of rolling updates across repos).
+One can cheat in this case and simply:
+```
+ln -s ~/dotnet/sdk/old_version ~/dotnet/sdk/new_version
+```
+
+ 
+
+### Finding versions and commit hashes
+First we need to find what version are are trying to recreate. That is 'sdk' section in global.json in each repo. As of preview9ih time, this is set to 3.0.100-preview6-012264 and such version will be used in examples. One advantage of using release branches is that it is in coherent state e.g. all repos should need exactly same version. 
+
+Let's get SDK for supported OS. Sync code base to same version you are trying to build on FreeBSD. 
+```
+./eng/common/build.sh --restore
+Downloading 'https://dot.net/v1/dotnet-install.sh'
+dotnet-install: Downloading link: https://dotnetcli.azureedge.net/dotnet/Sdk/3.0.100-preview6-012264/dotnet-sdk-3.0.100-preview6-012264-linux-x64.tar.gz
+```
+
+When done, there should be build SDK installed in .dotnet directory. (Unless global .net cli is present and already has expected SDK version)
+
+Commit hash for SDK it self is:
+```
+$ cat .dotnet/sdk/3.0.100-preview6-012264/.version
+be3f0c1a03f80492d45396c9f5b855b10a8a0b79
+3.0.100-preview6-012264
+linux-x64
+```
+Commit hash for Runtime (core-setup):
+```
+$ cat .dotnet/shared/Microsoft.NETCore.App/3.0.0-preview6-27804-01/.version
+fdf81c6faf7c7e0463d191a3a1d36c25c201e5cb
+3.0.0-preview6-27804-01
+```
+Commit hash for CoreCLR:
+```
+$ strings .dotnet/shared/Microsoft.NETCore.App/3.0.0-preview6-27804-01/libcoreclr.so | grep @Commit:
+@(#)Version 4.700.19.30373 @Commit: 7ec87b0097fdd4400a8632a2eae56612914579ef
+```
+Commit hash for Core-FX:
+```
+strings .dotnet/shared/Microsoft.NETCore.App/3.0.0-preview6-27804-01/System.Native.so | grep @Commit:
+@(#)Version 4.700.19.30308 @Commit: d47cae744ddfb625db8e391cecb261e4c3d7bb1c
+```
+
+### Rebuild SDK (Roslyn, msbuild, etc)
+If we need only changes to SDK (like to pick up new Roslyn or MSBuild, life is easy.
+
+get sources:
+```
+git clone https://github.com/dotnet/core-sdk
+cd core-sdk
+git checkout be3f0c1a03f80492d45396c9f5b855b10a8a0b79
+```
+
+Set variables and assemble SKD without crossgen. (set DropSuffix=true to strip  `preview6` from version). 
+```
+export DISABLE_CROSSGEN=true
+export CLIBUILD_SKIP_TESTS=true
+export DropSuffix=false
+./build.sh --configuration Release
+```
+(
+Outcome should be in `artifacts/bin/redist/Release/dotnet/sdk/3.0.100-preview6-012264/`
+
+```
+rsync -av artifacts/bin/redist/Release/dotnet/sdk/3.0.100-preview6-012264 bsd:~/dotnet/sdk
+```
+
+### Rebuilding Runtime
+If we also need new runtime, we will need to rebuild CoreCLR and CoreFX as minimum.
+Note that the the repose are deeply intertwine and needs to be built together.
+Release branch should have compatible repro as well as following hashes should work.
+
+#### Building CoreCLR
+```
+git clone https://github.com/dotnet/coreclr
+cd coreclr
+git checkout 7ec87b0097fdd4400a8632a2eae56612914579ef
+```
+
+and build 
+```
+mkdir -p .dotnet
+curl https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-freebsd-x64.tar.gz | tar xfz - -C .dotnet
+ln -s 3.0.100-preview-010021 .dotnet/sdk/3.0.100-preview6-012264  # (from global.json)
+ln -s 3.0.0-preview-27218-01 .dotnet/shared/Microsoft.NETCore.App/3.0.0-preview6-27804-01
+./build.sh -clang6.0 -skiptests -skipmanagedtools -Release /p:SourceRevisionId=7ec87b0097fdd4400a8632a2eae56612914579ef
+```
+
+There may be some LibGit2Sharp errors but the build should finish and produce artifacts in `bin/Product/FreeBSD.x64.Release`
+
+If the build fail you can:
+- try to sync to head or newer version
+- use older compiler (needs cleaning). Usually it is less picky about errors
+- LibGit2Sharp - TBD
+
+#### Building CoreFX
+This has two parts. We need to build managed bits on supported OS. For example on Linux:
+
+```
+git clone https://github.com/dotnet/corefx
+cd corefx
+git checkout d47cae744ddfb625db8e391cecb261e4c3d7bb1c
+./build.sh -c Release /p:osgroup=FreeBSD
+```
+
+on FreeBSD we need to build native bits:
+```
+git clone https://github.com/dotnet/corefx
+cd corefx
+git checkout d47cae744ddfb625db8e391cecb261e4c3d7bb1c
+./src/Native/build-native.sh --clang6.0 -release
+```
+
+#### Building core-setup
+As this has very little platform dependency it is unlikely this needs to be touched. 
+If we want to do this to pick up fix or for consistency than ... TBD
+
+```
+src/corehost/build.sh  --configuration Release  --arch x64 --hostver "3.0.0" --apphostver "3.0.0" --fxrver "3.0.0" --policyver "3.0.0" --commithash `git rev-parse HEAD` -portable
+
+```
+
+#### Constructing updated runtime
+We will use existing CLI as baseline:
+```
+cd ~/dotnet/shared/Microsoft.NETCore.App
+rsync -av 3.0.0-preview-27218-01/ 3.0.0-preview6-27804-01
+```
+get CoreFX and CoreCLR updated bits (corefx needs to come first as Wildcard brings Linux ):
+```
+rsync -av LINUXHOST/corefx/artifacts/bin/runtime/netcoreapp-FreeBSD-Release-x64/*dll 3.0.0-preview6-27804-01
+rsync -av corefx/artifacts/bin/native/FreeBSD-x64-Release/*so 3.0.0-preview6-27804-01
+rsync -av coreclr/bin/Product/FreeBSD.x64.Release/*  3.0.0-preview6-27804-01
+```
+
+if missing add following section to `Microsoft.NETCore.App.deps.json`
+```
+          "runtimes/freebsd-x64/lib/netcoreapp3.0/System.Runtime.CompilerServices.Unsafe.dll": {
+            "assemblyVersion": "4.0.5.0",
+            "fileVersion": "4.0.0.0"
+          },
+```
+

--- a/Documentation/wiki/Checking-out-the-code-repository.md
+++ b/Documentation/wiki/Checking-out-the-code-repository.md
@@ -1,0 +1,95 @@
+This page describes the required steps for checking out the code repository.
+
+### Quick Reference
+
+#### Typical workflow
+
+1. [MS Internal] `\\fxcore\fxkit\install.cmd [<install_dir>]` - Downloads git.exe and friends.
+    * TODO: Figure out public alternative, or publish the tooling repo.
+2. `git clone corefx` - Creates CoreFX repo copy in local dir 'corefx' (350 MB).
+    * WARNING: Do not use directory with space nor '#' (until [#19883](https://github.com/dotnet/corefx/issues/19883) and [#22775](https://github.com/dotnet/corefx/issues/22775) are fixed).
+3. `git remote add upstream dotnet` - Creates connection with https://github.com/dotnet/corefx. Powers `git get` custom command in FxKit.
+
+#### Tips & tricks
+
+* Git cloned directory can be moved around (between disks/machines) without any harm.
+* [MS Internal] FxKit is a git repo (it can be moved around).
+
+
+
+## Fork the repository
+
+Once you have setup your environment it is time to check out the code.
+From the project [home page](https://github.com/dotnet/corefx) create a fork.
+
+Note: It is one-time operation **per GitHub user**, no need to repeat it per computer.
+ 
+![](https://raw.githubusercontent.com/haralabidis/FirstTimeContributors/master/Assets/1-Fork.png)
+
+This will create a fork of the repository in your personal Github account.
+
+
+
+## Clone the repository
+
+Navigate to the repository under your GitHub account, select Clone or download and copy the repository location.
+
+![](https://raw.githubusercontent.com/haralabidis/FirstTimeContributors/master/Assets/2-Clone.png)
+
+Open the command prompt, navigate to the location that you wish to clone the directory to and type the following command:
+```
+git clone <repository_url_copied_from_above>
+```
+
+WARNING: Do not use directory with space nor `#` until [#19883](https://github.com/dotnet/corefx/issues/19883) and [#22775](https://github.com/dotnet/corefx/issues/22775) are fixed.
+
+It will look something like this:
+
+![](https://raw.githubusercontent.com/haralabidis/FirstTimeContributors/master/Assets/3-Clone.png)
+
+It will download ~150MB (10s-3min). In the end you should see a success message like this:
+
+![](https://raw.githubusercontent.com/haralabidis/FirstTimeContributors/master/Assets/4-Clone.png)
+
+
+
+## Configure remote repository for syncing
+
+In order to keep your fork up to date with the original repository you have to configure the remote repository.
+To list your current remote configured remote type the following command:
+```
+git remote -v
+```
+
+You should see your personal repository configured for fetch and push, it will look something like this:
+  * origin https://github.com/YourUsername/corefx.git (fetch) 
+  * origin https://github.com/YourUsername/corefx.git (push)
+
+![](https://raw.githubusercontent.com/haralabidis/FirstTimeContributors/master/Assets/7-RemoteList.png)
+
+Now configure the remote by typing the following command: 
+```
+git remote add upstream https://github.com/dotnet/corefx.git
+```
+
+To verify that the remote has been setup correctly type again: 
+```
+git remote -v
+```
+
+You should now see your personal repository and the remote repository configured for fetch and push, it will look something like this:
+  * origin https://github.com/YourUsername/corefx.git (fetch)
+  * origin https://github.com/YourUsername/corefx.git (push)
+  * upstream https://github.com/dotnet/corefx.git (fetch)
+  * upstream https://github.com/dotnet/corefx.git (push)
+
+![](https://raw.githubusercontent.com/haralabidis/FirstTimeContributors/master/Assets/9-RemoteList2.png)
+
+#### Syncing with the remote repository
+To sync your local master branch with the remote upstream repository simply run:
+```
+git checkout master
+git pull upstream master
+```
+
+Once you have successfully cloned the repository, verify that you can [build and run tests](https://github.com/dotnet/corefx/wiki/Build-and-run-tests).

--- a/Documentation/wiki/Contributing.md
+++ b/Documentation/wiki/Contributing.md
@@ -1,0 +1,1 @@
+See: https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/contributing.md

--- a/Documentation/wiki/Contributions.md
+++ b/Documentation/wiki/Contributions.md
@@ -1,0 +1,78 @@
+Part of [[New contributor Docs]], read first **[Motivation, goals, rules](https://github.com/dotnet/corefx/wiki/New-contributor-Docs#motivation-goals-rules)**
+
+### [Main page section content](https://github.com/dotnet/corefx/wiki/New-contributor-Docs#contributing-guide)
+
+# Notes, ideas
+
+## Old docs
+
+May need updates or to be entirely replaced
+
+* [Contributing Guide](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/contributing.md)
+* [Developer Guide](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/developer-guide.md)
+
+## New content ideas
+
+Link [Contributing to .NET for Dummies](http://rion.io/2017/04/28/contributing-to-net-for-dummies/)
+
+Use parts of first-time Roslyn contribution blog post - [part1](https://blog.decayingcode.com/post/contributing-to-open-source-my-first-roslyn-pull-request-getting-the-environment-ready/) and [part2](https://blog.decayingcode.com/post/contributing-to-open-source-my-first-roslyn-pull-request-fixing-the-bug/)
+
+Use / link [dotnet/docs contributing guide](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md) -- might be a good starter for people to get used to GitHub contributions, PR workflow, etc.
+
+### Enlist + GitHub usage + Prereqs
+* uCRT: https://docs.microsoft.com/en-us/dotnet/articles/core/windows-prerequisites
+
+### Source code structure
+CoreFX source code structure intro (pre-existing text, should be updated & moved appropriately)
+* The repo contains the source for each of the assemblies that comprises .NET Core.  Each ```Microsoft.*``` or ```System.*``` folder under [src](https://github.com/dotnet/corefx/tree/master/src) represents an individual library.  Each such folder may contain a ```ref``` folder, which contains the source representing the "contract" or "reference assembly" for that library.  It may also contain a ```src``` folder, which contains the source for some or all of the implementation for that library (some implementation may live in System.Private.Corelib in the [coreclr repo](https://github.com/dotnet/coreclr), with the build tooling generating type forwards from the library assembly to System.Private.Corelib.)
+* It may also contain a ```test``` folder containing the tests associated with that library, whether the implementation source lives in corefx or in coreclr.
+
+### Small change
+* See [#20570](https://github.com/dotnet/corefx/issues/20570) discussion on the same topic
+* What kind of changes - LINK
+  * Add:
+    * Decisions to take / reject changes: https://github.com/dotnet/corefx/issues/6351#issuecomment-267779077
+    * Breaking changes: https://github.com/dotnet/coreclr/pull/8415#issuecomment-264267267
+      * Note: Was tweeted: https://twitter.com/matthewwarren/status/805711973467955200
+* How to build - build.cmd
+* How to run tests
+  * How to debug test failure
+    * msbuild /t:test /p:testdebugger=devenv.exe
+    * msbuild /t:test /p:testdebugger=c:\debuggers\windbg.exe
+  * How to rerun specific test
+  * How to run Outerloop tets (explain Inner vs. Outer loop tests)
+  * It is ok to test on just 1 platform locally and use CI to test the other platforms. Whatever is more convenient for contributor.
+* How to submit PR
+  * General rules (titles, what kind of changes, don't mix changes, coding style)
+    * Use [GitHub auto-closing](https://help.github.com/articles/closing-issues-via-commit-messages/) (e.g. "Fixes #12345" in PR text) - it creates nice links (see example: [#19732](https://github.com/dotnet/corefx/issues/19732))
+  * @dotnet-bot docs - use command "@dotnet-bot help" in PRs, or [search some older one](https://github.com/dotnet/corefx/pulls?utf8=%E2%9C%93&q=is%3Apr%20%22%40dotnet-bot%20help%22%20)
+
+### Add & expose API in CoreFX (.NET Core only)
+Note: http://aka.ms/api-review LINK is used in file licenses
+* Add it for netcore20 (latest) - see [notes](https://github.com/dotnet/corefx/pull/19885#issuecomment-302827302)
+* How to add tests - see [notes](https://github.com/dotnet/corefx/pull/19885#issuecomment-302827302)
+* Where to put tests (CoreFX)
+    * All new APIs are initially .NET Core-Only, as such any tests covering a new API need to be in their own file (matching the *.netcoreapp.cs naming convention) which is conditioned to only be included in the .NET Core cross-compilation for the test project.
+    * As an end-to-end (using the System.MathF API as an example):
+        * Locate the [folder](https://github.com/dotnet/corefx/blob/master/src/System.Runtime.Extensions/tests/) containing the relevant test project
+        * Validate that the [Configuration.props](https://github.com/dotnet/corefx/blob/master/src/System.Runtime.Extensions/tests/Configurations.props) contains the relevant `BuildConfiguration` entries (this is a single property containing a `;` delimited list). There should be an entry for both `netcoreapp-Windows_NT` and `netcoreapp-Unix`.
+        * Validate that the [test project](https://github.com/dotnet/corefx/blob/master/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj) has a `<DefineConstants Condition="'$(TargetGroup)'=='netcoreapp'">$(DefineConstants);netcoreapp</DefineConstants>` entry.
+        * Validate that the test project contains the relevant build configuration entries (there should be a *-Debug and *-Release entry for each item in the `BuildConfiguration` list from the previous step). These should be `<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />`, `<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Release|AnyCPU'" />`, `<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Debug|AnyCPU'" />`, and `<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Release|AnyCPU'" />`.
+        * In the test project, locate an existing `ItemGroup` (or add a new `ItemGroup`) with `Condition="'$(TargetGroup)'=='netcoreapp'"` (it should be the only condition on the item group) and add a new `Compile` entry for the relevant test file (such as `<Compile Include="System\MathTests.netcoreapp.cs" />`). 
+    * Some other examples are [#19147](https://github.com/dotnet/corefx/pull/19147#issuecomment-301352244) or [#16996](https://github.com/dotnet/corefx/pull/16996) or [#19885](https://github.com/dotnet/corefx/pull/19885#issuecomment-303040875) (which creates new netcoreapp configuration)
+
+### Expose API across CoreCLR/CoreFX
+* How to run tests - https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/developer-guide.md#testing-with-private-coreclr-bits
+* Exposing API: [#16996](https://github.com/dotnet/corefx/pull/16996) (Reflection.Emit)
+* Magic: (JanK) https://github.com/dotnet/corefx/pull/14396#issuecomment-267440477
+
+### Advanced changes
+* Expose API only on Windows/Linux -- use Registry example?
+* Documentation changes
+* Desktop tests
+* Perf tests
+  * https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/performance-tests.md
+  * How to add them: https://github.com/dotnet/corefx/pull/7152
+
+### Random
+See also [Random useful stuff](https://github.com/dotnet/corefx/wiki/New-contributor-Docs#random-useful-stuff)

--- a/Documentation/wiki/Creating-a-Pull-Request.md
+++ b/Documentation/wiki/Creating-a-Pull-Request.md
@@ -1,0 +1,67 @@
+****WORK IN PROGRESS****
+
+# Creating a Pull Request
+
+This page describes how to create a pull request to the [corefx](https://github.com/dotnet/corefx) project. The prerequisites for doing this 
+are:
+
+1. [Machine Setup](https://github.com/dotnet/corefx/wiki/Setting-up-the-development-environment)
+2. [Fork and Clone Repository](https://github.com/dotnet/corefx/wiki/Checking-out-the-code-repository)
+3. [Build and Run Tests](https://github.com/dotnet/corefx/wiki/Build-and-run-tests)
+
+Once you have successfully done those things feel free to proceed here!
+
+## Getting Started
+
+1. Make sure you have the latest code
+   ```
+   git fetch upstream
+   git checkout master
+   git rebase upstream/master
+   ```
+2. [Pick your issue](https://github.com/dotnet/corefx/wiki/Pick-issue)
+3. Create a branch
+   ```
+   git checkout -b MyNewFeature
+   ```
+4. Make your changes
+5. Add the files
+   ```
+   git add --all .
+   ```
+6. Commit to your local repository
+7. Push the changes remotely
+
+   This is a little different than other development you may have done. We are going to do a pull request across repositories. From the branch on my fork, to master on CoreFX.
+8. Open GitHub
+9. See button to PR from your branch on your remote fork to master branch on CoreFX repository
+10. Click button to create Pull Request
+11. Write up the details of your pull request and submit!
+
+## Pull Request Writing Guidelines
+TODO - There was a link floating around to a great blog post on writing PRs. Insert that here.
+
+## Questions and Answers
+
+**Q: How do I make additional changes to my branch?**
+
+A: Just like you normally would! If you commit to your local branch then push it will show up 
+on the remote and run the tests again.
+
+**Q: I am getting a lot of feedback, is this bad?**
+
+A: Nope! Almost all of the tickets going into CoreFX have feedback for how they can be improved. The team appreciates your contributions and expects that people will need feedback. It's not a 
+negative reflection on you or your skills. It takes everyone time to learn new coding standards and how everything works, especially when also contributing to a repository for the first time.
+
+**Q: The steps in this document aren't working, how can I update them?**
+
+A: All of these documents are in GitHub. Simply follow the steps above and do a Pull Request to make changes to this document.
+
+**Q: How can I let a check run, again!?**
+
+A: To be able to run a check again without having to do coding changes, the simplest and easiest way is to add a comment to your pull request.
+
+The boilerplate for such a message is: `/azp run CHECK-PIPELINE`
+So, for example, if you want to run the corefx-ci pipeline again, simply comment: `/azp run corefx-ci`.
+
+The entire pipeline will now run again.

--- a/Documentation/wiki/Development-environment-setup-for-Linux.md
+++ b/Documentation/wiki/Development-environment-setup-for-Linux.md
@@ -1,0 +1,31 @@
+This page describes the necessary steps for setting up your development environment on Linux in order to be able to make contributions to the repository.
+
+## Required Software
+
+1. **x86_64** Linux distribution
+    * Note: 32bit distros are only community supported. ARM needs to cross-compile.
+2. Packages for tools must be installed:
+    * **clang/llvm** 3.5+ (3.9+ for ARM)
+    * **cmake**
+3. Packages for libraries must be installed in -development versions (with appropriate header files):
+    * **openssl**
+    * **curl**
+    * **libunwind**
+    * **libicu**
+
+### Distro specific instructions
+
+#### Fedora
+
+* **Fedora 26**: `dnf install git tar libunwind compat-openssl10-devel libicu cmake clang zlib-devel libcurl-devel krb5-devel`
+* **Fedora 25**: `sudo dnf install git tar libunwind openssl-devel libicu cmake clang zlib-devel libcurl-devel krb5-devel`
+
+#### Ubuntu
+
+* **Ubuntu 18.04**: `sudo apt install git clang-3.9 cmake make libc6-dev libssl-dev libkrb5-dev libcurl4-openssl-dev zlib1g-dev libicu60 libunwind8 curl`
+* **Ubuntu 16.04**: `sudo apt install git clang-3.5 cmake make libc6-dev libssl-dev libkrb5-dev libcurl4-openssl-dev zlib1g-dev libicu55 libunwind8 curl`
+* **Ubuntu 14.04**: `sudo apt-get install git clang-3.5 cmake make libc6-dev libssl-dev libkrb5-dev libcurl4-openssl-dev zlib1g-dev libunwind8 libicu52 curl`
+
+## Optional Software
+
+You can use [Visual Studio Code](https://code.visualstudio.com/) as your development IDE.

--- a/Documentation/wiki/Development-environment-setup-for-MacOS.md
+++ b/Documentation/wiki/Development-environment-setup-for-MacOS.md
@@ -1,0 +1,42 @@
+This page describes the necessary steps for setting up your development environment on MacOS in order to be able to make contributions to the repository.
+
+## Required Software
+
+1. **macOS 10.12** "Sierra", or higher
+    * Note: macOS 10.11 is not sufficient, because it lacks crypto support which we depend on.
+2. **XCode** must be installed (needed for llvm compiler, headers and dependencies).
+    * Go to "App Store" and install XCode from there.
+3. **OpenSSL** must be installed: see detailed steps via [Homebrew ("brew")](https://brew.sh/) package manager below.
+4. **CMake** must be installed: `brew install cmake`.
+
+### OpenSSL
+
+First install [Homebrew ("brew")](https://brew.sh/) package manager.
+After installing *brew*, install *OpenSSL* and *pkg-config* by executing the following commands at a Terminal (command) prompt:
+
+```Terminal
+brew install pkg-config
+brew install openssl
+
+ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/
+ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/
+
+ln -s /usr/local/opt/openssl/lib/pkgconfig/libcrypto.pc /usr/local/lib/pkgconfig/
+ln -s /usr/local/opt/openssl/lib/pkgconfig/libssl.pc /usr/local/lib/pkgconfig/
+ln -s /usr/local/opt/openssl/lib/pkgconfig/openssl.pc /usr/local/lib/pkgconfig/
+```
+
+### CMake
+
+Easiest way to get cmake is also via [Homebrew ("brew")](https://brew.sh/) package manager: `brew install cmake`
+
+Alternatively you can install it directly from the [CMake download page](https://cmake.org/download/#latest), in which case you have to add *CMake* manually to your path by executing the following on a terminal:
+
+```Terminal
+sudo mkdir -p /usr/local/bin
+sudo /Applications/CMake.app/Contents/bin/cmake-gui --install=/usr/local/bin
+```
+
+## Optional Software
+
+You can use [Visual Studio for Mac](https://www.visualstudio.com/vs/visual-studio-mac/) or [Visual Studio Code](https://code.visualstudio.com/) as your development IDE.

--- a/Documentation/wiki/Development-environment-setup-for-Windows.md
+++ b/Documentation/wiki/Development-environment-setup-for-Windows.md
@@ -1,0 +1,58 @@
+This page describes the necessary steps for setting up your development environment on Windows in order to be able to make contributions to the repository.
+
+## Required Software
+
+1. **Visual Studio** must be installed. Supported versions:
+    * [Visual Studio 2019](https://www.visualstudio.com/downloads/) (Community, Professional, Enterprise).  The Community version is completely free.
+    * [Visual Studio 2017](https://www.visualstudio.com/downloads/) (Community, Professional, Enterprise).  The Community version is completely free.
+    * [Visual Studio 2015](https://www.visualstudio.com/vs/older-downloads/) (Community, Professional, Enterprise).  The Community version is completely free.
+2. **[CMake](https://cmake.org/)** must be installed from [the CMake download page](https://cmake.org/download/#latest) and added to your path.
+   If you have an outdated cmake installed you will get error messages of the form 
+     > CMake error : Could not create named generator Visual Studio 15 2017 Win64
+ 
+   In that case uninstall cmake and then install the latest version.
+
+### Visual Studio 2019 RC
+
+Note: You must be using at least [CMake 3.14.0-rc3](https://cmake.org/download/) in order to use VS 2019.
+
+### Visual Studio 2017
+
+Note: If you have both VS 2017 and 2015 installed, you need to copy the `DIA SDK` directory from VS 2015 installation into VS 2017 (VS installer bug). The build script will detect the situation and tell you what to do.
+
+#### Visual Studio 2017 - 'Workloads' based install
+
+The following are the minimum requirements:
+  * .NET desktop development
+    * .NET Framework 4-4.6 Development Tools
+  * Desktop development with C++
+    * VC++ 2017 v141 Toolset (x86, x64)
+    * Windows 10 SDK or Windows 8.1 SDK
+  * .NET Core cross-platform development
+    * All Required components
+
+Estimated size: 10GB
+
+#### Visual Studio 2017 - 'Individual components' based install
+
+The following are the minimum requirements:
+  * .NET
+    * .NET Framework 4.6 targeting pack
+    * .NET Portable Library targeting pack
+  * Code tools
+    * Static analysis tools
+  * Compilers, build tools, and runtimes
+    * C# and Visual Basic Roslyn compilers
+    * MSBuild
+    * VC++ 2017 version 15.8 v14.15 latest v141 tools
+  * Development activities
+    * Visual Studio C++ core features
+  * SDKs, libraries, and frameworks
+    * Windows 10 SDK (latest version) or Windows 8.1 SDK
+
+Estimated size: 6GB
+
+### Visual Studio 2015
+
+* [Visual Studio 2015 Update 1](https://www.visualstudio.com/en-us/news/vs2015-update1-vs.aspx) is required.
+* You must select `Programming Languages | Visual C++ | Common Tools for Visual C++ 2015` while installing VS 2015 (or modify your install to include it).

--- a/Documentation/wiki/Enabling-New-OS.md
+++ b/Documentation/wiki/Enabling-New-OS.md
@@ -1,0 +1,11 @@
+## Overview
+In the future this will (hopefully) be a list of instructions to follow to enable building and packaging .NET Core, in general, and CoreFX, specifically, for a new OS.  For now, the following is a list of links past and current issues and PRs created around enabling a new OS
+
+## Issues
+* [Enabling Android ARM64 for .NET Core](https://github.com/dotnet/core-setup/issues/1651)
+* [Enabling Linux ARM32 for .NET Core](https://github.com/dotnet/core-setup/issues/725)
+* [Enabling CoreFX for New OS](https://github.com/dotnet/corefx/issues/21503)
+
+## PRs
+* [Add RIDs for Android](https://github.com/dotnet/corefx/pull/16729)
+* [First Steps for Generating Packages for ARM64/Android](https://github.com/dotnet/coreclr/pull/10286)

--- a/Documentation/wiki/HTTP-2-Implementation-Status.md
+++ b/Documentation/wiki/HTTP-2-Implementation-Status.md
@@ -1,0 +1,46 @@
+This page tracks our progress on implementing HTTP/2 support in `HttpClient`.
+
+## RFC support
+
+| Status | Issue | Area | Feature | Effort |
+| ------ | ----- | ---- | ------- | -----: |
+| planned | [#41208](../issues/41208) | Headers | Dynamic receiving | low |
+| planned | [#41209](../issues/41209) | Headers | Dynamic sending | medium/high |
+| planned | [#31308](../issues/31308) | Headers | Huffman coding | medium |
+| planned | [#31299](../issues/31299) | Streams | Flow control | medium |
+| planned | [#38559](../issues/38559) | Streams | General-purpose bidirectional content | medium |
+| unplanned | [#41212](../issues/41212) | Streams | Prioritization and dependencies | high |
+| unplanned | [#34192](../issues/34192) | Streams | Server push | high |
+| unplanned | [#41213](../issues/41213) | Proxy | CONNECT over HTTP2 | medium |
+| unplanned | [#41215](../issues/41215) | Security | Frame padding | medium |
+
+For unplanned features, discussion has not yet indicated enough interest. We would encourage giving clear usage scenarios on the issues if these are important for you.
+
+## General architecture
+
+| Issue | Feature | Effort |
+| ----- | ------- | -----: |
+| [#40514](../issues/40514) | MaxConnectionsPerServer | medium |
+| [#39049](../issues/39049) | Duplex cancellation behavior | medium/high |
+| [#38759](../issues/38759) | Post-header exception surface location | medium |
+
+## Test coverage
+
+| Issue | Feature |
+| ----- | ------- |
+| [#39167](../issues/39167) | Connection timeouts |
+| [#39166](../issues/39166) | Connection-level WINDOW_UPDATE |
+| [#39165](../issues/39165) | Header CONTINUATION frames |
+| [#39163](../issues/39163) | Receipt of HEADERS frame with with padding and/or priority |
+| [#39162](../issues/39162) | Receipt of DATA frame with padding |
+| [#39161](../issues/39161) | Buffer flush in StartWriteAsync |
+
+## Performance
+
+| Issue | Feature |
+| ----- | ------- |
+| [#31751](../issues/31751) | Huffman decoding |
+| [#31309](../issues/31309) | HPACK static table decoding |
+| [#41221](../issues/41221) | General HPACK decoder optimizations |
+| [#35387](../issues/35387) | Smarter usage of WINDOW_UPDATE frames |
+| n/a | Create benchmarks and profile |

--- a/Documentation/wiki/Hackathon.md
+++ b/Documentation/wiki/Hackathon.md
@@ -1,0 +1,62 @@
+# .NET Core Community online Hackathon - 6/2
+
+We will hold a hackathon for some .NET Core repos. It will happen on Saturday 6/2 (June 2nd), 2018.
+
+Everyone is welcome to join - new contributors (even new to GitHub), active or seasoned contributors.
+
+We will try to have a couple of .NET Core engineers available during that time to help provide PR feedback and troubleshoot problems (mostly in Pacific timezone). We hope a few of our experienced contributors will join us as well to help get everyone started.
+
+
+## When
+
+**6/2** (Saturday, June 2nd, 2018)
+
+## How to participate?
+
+1. Pick a repo where you want to contribute.
+    * Read repo contribution guidelines, clone it, build it, run tests. Get ready to contribute.
+2. Join repo-specific hackathon gitter chat room.
+    * Useful to get help when getting started. Ask questions about the repo, code or issues. Chat with others and have some fun :).
+3. Pick an issue in the repo you want to work on.
+    * More issues will be marked as Hackathon throughout 6/2.
+    * Comment on the issue that you plan to grab it.
+4. Submit PR.
+    * Work on PR feedback. Expect that code review may need to wait for area expert to approve it (may happen in next couple of days).
+5. Have fun along the way! :)
+
+### Participating repos
+
+* [**CoreFX**](https://github.com/dotnet/corefx/blob/master/README.md) - Hackathon room: [![Gitter](https://badges.gitter.im/dotnet/corefx-hackathon.svg)](https://gitter.im/dotnet/corefx-hackathon?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+    * Base Class Libraries (BCL) of .NET Core, written mostly in C#. Great for new contributors familiar with C#.
+    * Pick an issue from [**Hackathon query**](https://github.com/dotnet/corefx/labels/Hackathon).
+        * Alternatively you can choose from issues marked as [easy](https://github.com/dotnet/corefx/labels/easy), or [up-for-grabs](https://github.com/dotnet/corefx/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Aup-for-grabs+-label%3Aapi-suggestion+-label%3Aapi-needs-work+-label%3Aapi-ready-for-review),
+        * or any other issue you like (just stay away from issues marked as api-suggestion, api-needs-work and api-ready-for-review - they track API additions which need to go through API review first and that takes time)
+    * Read [contribution guide](https://github.com/dotnet/corefx/wiki/New-contributor-Docs#contributing-guide) to get started.
+* [**CoreCLR**](https://github.com/dotnet/coreclr/blob/master/README.md) - Hackathon room: [![Gitter](https://badges.gitter.im/dotnet/coreclr-hackathon.svg)](https://gitter.im/dotnet/coreclr-hackathon?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+    * Runtime of .NET Core (VM, JIT, GC, etc.). Great for contributors familiar with C++ or work on VMs.
+    * Pick an issue from [**Hackathon query**](https://github.com/dotnet/coreclr/labels/Hackathon).
+    * Read [repo contributions docs](https://github.com/dotnet/coreclr#setting-up-your-git-clone-of-the-coreclr-repository) to get started.
+* [**CoreFxLab**](https://github.com/dotnet/corefxlab/blob/master/README.md) - Hackathon room: [![Gitter](https://badges.gitter.im/dotnet/corefxlab-hackathon.svg)](https://gitter.im/dotnet/corefxlab-hackathon?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+    * Experimental place for latest technologies which may or may not end up in production CoreFX repo one day. Great for new contributors familiar with C# who don't mind their PR might not ship.
+    * Pick an issue from [**Hackathon query**](https://github.com/dotnet/corefxlab/labels/Hackathon).
+    * Read [repo contributions docs](https://github.com/dotnet/corefxlab#building-and-testing) to get started.
+
+
+## Do you have questions or suggestions?
+
+Ask on appropriate gitter channel (see per-repo Hackathon channel above).
+
+
+# FAQ
+
+## How can I grab an issue?
+
+Just comment on it that you want to work on it (check that you are the first one).
+
+For easier tracking what is taken vs. not, we would like to assign the issue to you (although it is not mandatory). To do that, we need to add you to repo Collaborators list first (GitHub limitation) - please ping [@karelz](https://github.com/karelz) or [@ViktorHofer](https://github.com/ViktorHofer) to send you a Collaborator invite (we will assign the issue temporarily to ourselves). Once you accept the invite, please us on the issue again stating you accepted the invite, so that we can assign the issue to you. Pro-tip: Being collaborator will automatically subscribe you to all repo notifications (easily 500+ per day), we recommend to switch it to "Not Watching" which will send you notifications only where you are mentioned, assigned or manually subscribed.
+
+# .NET Core Hackathon in Amsterdam, NL
+
+If you happen to be in Amsterdam on that day, you can join the local event to get even more hands on help from experienced .NET Core contributors and interact with others in real-life.
+
+Register here: https://www.infosupport.com/net-core-hackathon-2018/

--- a/Documentation/wiki/Home.md
+++ b/Documentation/wiki/Home.md
@@ -1,0 +1,19 @@
+The .NET Core project does not use GitHub Wikis, but includes [documentation](https://github.com/dotnet/corefx/blob/master/Documentation/README.md) in the repo. We use the repo to enable the [GitHub Flow](https://guides.github.com/introduction/flow/index.html) on documentation, which the wiki does not provide. 
+
+Check out the following links to find helpful information about the .NET Core product and for contributing to and using the code in the repo.
+
+### Learn about .NET Core
+
+- [Getting started with .NET Core](https://docs.microsoft.com/en-us/dotnet/articles/core/tutorials/index)
+- [.NET Core documentation](http://dotnet.github.io/docs/index.html)
+- [Book of the Runtime](https://github.com/dotnet/coreclr/tree/master/Documentation#book-of-the-runtime)
+
+### .NET Core contributor info
+
+- [Contribution guidelines](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/contributing.md)
+
+### Using .NET Core repo:
+
+- [Build the repository](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/developer-guide.md)
+- [Use .NET Core](https://github.com/dotnet/coreclr/blob/master/Documentation#get-net-core)
+- [Repo documentation](https://github.com/dotnet/corefx/blob/master/Documentation)

--- a/Documentation/wiki/Issues.md
+++ b/Documentation/wiki/Issues.md
@@ -1,0 +1,27 @@
+Part of [[New contributor Docs]], read first **[Motivation, goals, rules](https://github.com/dotnet/corefx/wiki/New-contributor-Docs#motivation-goals-rules)**
+
+### [Main page section content](https://github.com/dotnet/corefx/wiki/New-contributor-Docs#issue-guide)
+
+# Notes, ideas
+
+## Old docs
+
+These docs may need updates:
+  * [CoreFX repo issue guide](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/issue-guide.md)
+  * [How we triage](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/triage.md)
+
+## New content ideas
+  * Random useful things:
+    * This is not support replacement, Desktop is not tracked here
+    * Expectations after filing new issue (first-response turnaround - in days, fix turnaround - milestone only)
+    * How to understand labels, milestones
+    * How to escalate important issue (for seasoned contributors) - tag @karelz / other repo-triagers, explain clearly why it is so important
+    * Importance of upvotes (on top post) - they are input to prioritization (not the only one)
+  * Issue guide
+    * .NET Core product areas, various repos - https://github.com/dotnet/core/blob/master/README.md
+      * Note: Setup lives in CLI repo (not core-setup)
+  * API review process
+    * Adding APIs is hard: see HashCode example: https://twitter.com/terrajobst/status/799428189386747904
+    * Which APIs belong / don't belong into CoreFX: https://github.com/dotnet/corefx/issues/18159#issuecomment-293105964
+  * Motivation for formal API reviews and updating top post: https://github.com/dotnet/corefx/issues/4805#issuecomment-276447967
+  * How we prioritize (incl. upvotes)

--- a/Documentation/wiki/Joining-.NET-Core-team.md
+++ b/Documentation/wiki/Joining-.NET-Core-team.md
@@ -1,0 +1,8 @@
+**[Microsoft employees only]**
+
+# Joining .NET Core team
+
+To join .NET Core team (CoreFX, CoreCLR, Roslyn, SDK/CLI, etc.), you should:
+1. Join [Microsoft](https://github.com/Microsoft) organization
+2. Join [dotnet](https://github.com/dotnet) organization
+3. TODO - Rich (Add yourself into CoreFX group - send email? Use some OpenTech tooling?)

--- a/Documentation/wiki/Links.md
+++ b/Documentation/wiki/Links.md
@@ -1,0 +1,47 @@
+## MSBuild 2019 conference links
+
+### .NET Core 3.0
+
+* [.NET Core 3.0 previews](https://github.com/dotnet/core/tree/master/release-notes/3.0)
+    * [.NET Core 3.0 Preview 5](https://devblogs.microsoft.com/dotnet/announcing-net-core-3-0-preview-5/) (on Mon 5/5)
+    * RC (Release Candidate) - July 2019 (see [.NET 5 announcement blog](https://devblogs.microsoft.com/dotnet/introducing-net-5/))
+    * GA (General Availability) - September 2019 (see [.NET 5 announcement blog](https://devblogs.microsoft.com/dotnet/introducing-net-5/))
+* [.NET Core 3 and Support for Windows Desktop Apps](https://blogs.msdn.microsoft.com/dotnet/2018/05/07/net-core-3-and-support-for-windows-desktop-applications/) - WPF, WinForms, etc.
+
+### .NET plans
+
+* .NET Core 3.1 - LTS - November 2019 (see [.NET 5 announcement blog](https://devblogs.microsoft.com/dotnet/introducing-net-5/))
+* [.NET 5](https://devblogs.microsoft.com/dotnet/introducing-net-5/) - November 2020 GA
+
+### .NET Core 2.1/2.2
+
+* 2.1 releases: https://github.com/dotnet/core/tree/master/release-notes/2.1
+    * [2.1.3+](https://github.com/dotnet/core/blob/master/release-notes/2.1/2.1.3/2.1.3.md#213-declared-lts) is [LTS](https://github.com/dotnet/core/blob/e2f22a7106860c0e5dc98bb36dc648a779944ad5/microsoft-support.md#long-term-support-lts-releases) (since 2018/8)
+     * 2.2 releases: https://github.com/dotnet/core/tree/master/release-notes/2.2
+* APIs:
+    * [2.1 Windows Compatibility Pack](https://blogs.msdn.microsoft.com/dotnet/2017/11/16/announcing-the-windows-compatibility-pack-for-net-core/)
+    * [2.0 APIs](https://github.com/dotnet/standard/blob/master/docs/faq.md#if-there-is-no-breaking-change-why-call-it-net-standard-20)
+    * [API portability](https://github.com/Microsoft/dotnet-apiport/blob/master/README.md) and [API lookup](https://apisof.net)
+    * [Platform compat](https://github.com/dotnet/platform-compat)
+* Innovation:
+    * [Bing runs on .NET Core 2.1](https://blogs.msdn.microsoft.com/dotnet/2018/08/20/bing-com-runs-on-net-core-2-1/)
+    * [.NET Core 2.1 perf improvements](https://blogs.msdn.microsoft.com/dotnet/2018/04/18/performance-improvements-in-net-core-2-1/)
+    * [.NET Core 2.0 perf improvements](https://blogs.msdn.microsoft.com/dotnet/2017/06/07/performance-improvements-in-net-core/)
+* [.NET Standard versions](https://github.com/dotnet/standard/blob/master/docs/versions.md)
+    * Next .NET Standard plans - [.NET Standard 2.1](https://github.com/dotnet/standard/blob/master/docs/planning/netstandard-2.1/README.md#net-standard-21)
+* [CoreFX contributors](https://github.com/dotnet/corefx/graphs/contributors)
+    * [Pending PRs from community](https://github.com/dotnet/corefx/pulls) - see those with multiple assignees
+    * [dotnet-bot](https://github.com/dotnet-bot)
+
+### .NET
+
+* Learn: [C# intro - Try .NET](https://docs.microsoft.com/en-us/dotnet/csharp/tutorials/intro-to-csharp/)
+* [.NET Standard Overview](https://weblog.west-wind.com/images/2016/ASP.NET%20Core%20Overview/NetPlatformOverviewTomorrow.png)
+    * [.NET platforms today](https://weblog.west-wind.com/images/2016/ASP.NET%20Core%20Overview/AspNetCoreToday.png)
+* [Search: .NET Core](https://www.bing.com/search?q=.NET+Core)
+* [Value of .NET Core](https://www.microsoft.com/net/core/platform)
+    * [TechEmpower benchmark](https://www.techempower.com/benchmarks/#section=data-r17&hw=ph&test=plaintext) (.NET Core 2.1 results, not 3.0)
+
+### .NET Framework
+
+* [.NET Framework 4.8](https://devblogs.microsoft.com/dotnet/announcing-the-net-framework-4-8/) on 2019/4/18 - [GitHub repo](https://github.com/microsoft/dotnet)

--- a/Documentation/wiki/New-contributor-Docs.md
+++ b/Documentation/wiki/New-contributor-Docs.md
@@ -1,0 +1,68 @@
+## Motivation, Goals, Rules
+We want to create better new-contributor docs, to encourage new contributors in CoreFX repo and to make it easier for existing contributors to find the right information.
+
+To iterate really fast, CoreFX Wiki is now **writable for everyone**. It allows fast collaboration without blocking on PR code reviews, etc. Feel free to improve the docs with your notes, gotchas, ideas, etc. For even easier collaboration: [![Gitter](https://badges.gitter.im/dotnet/corefx-contrib-docs.svg)](https://gitter.im/dotnet/corefx-contrib-docs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+
+When the docs are finalized, we will move them back to CoreFX repo under PR model.
+
+Feel free to create sub-pages as necessary, please try to link/make them reachable from this 'main' page, so that we can eventually just "copy-paste" the content into CoreFX [README.md](https://github.com/dotnet/corefx/blob/master/README.md), without larger restructuring/redesign of the navigation layout. It is fine to leave TODOs and intermittent notes/ideas in all pages for now - just follow the structure you see.
+
+Below is a skeleton to start filling out content.
+
+# NEW CONTRIBUTOR INFORMATION
+
+## Main page section content
+
+This text will replace [Issue Guide](https://github.com/dotnet/corefx/blob/master/README.md#issue-guide) and [Contributing Guide](https://github.com/dotnet/corefx/blob/master/README.md#contributing-guide) sections on main page:
+
+### Issue Guide
+
+Note: Targeted at people just filing bugs - what to expect - e.g. API process, where to file, how to file, etc.
+
+[Old docs](https://github.com/dotnet/corefx/wiki/Issues#existing-docs)
+
+TODO: See ideas in [[Issues]]
+
+### Contributing Guide
+
+Basics:
+* Per-machine setup: [Machine setup](https://github.com/dotnet/corefx/wiki/Setting-up-the-development-environment) and [Fork and clone repo](https://github.com/dotnet/corefx/wiki/Checking-out-the-code-repository)
+* [Build and run tests](https://github.com/dotnet/corefx/wiki/Build-and-run-tests)
+* [git commands and workflow](https://github.com/dotnet/corefx/wiki/git-reference) - for newbies
+* [Pick issue](https://github.com/dotnet/corefx/wiki/Pick-issue)
+* [Coding guidelines](https://github.com/dotnet/corefx/tree/master/Documentation#coding-guidelines)
+* Testing change - TODO
+* [Creating a Pull Request](https://github.com/dotnet/corefx/wiki/Creating-a-Pull-Request)
+
+Advanced:
+* TODO - see ideas in [[Contributions]]
+
+# Raw Notes and TODOs
+
+## Random useful stuff
+
+  * How to debug (VS, VS Code, windbg)
+    * Mixed mode
+    * Linux - [using SOS](https://blogs.msdn.microsoft.com/premier_developer/2017/05/02/debugging-net-core-with-sos-everywhere/)
+    * Mac
+  * How to investigate perf
+    * Production level profiling (e.g. needed in [#13837](https://github.com/dotnet/corefx/issues/13837))
+    * Memory analysis (GC happens too often) (e.g. needed in [#14008](https://github.com/dotnet/corefx/issues/14008))
+    * https://github.com/dotnet/BenchmarkDotNet
+    * Perf Analysis on .NET Core on Windows - [Vance's blog post](https://blogs.msdn.microsoft.com/vancem/2016/11/02/performance-analysis-on-net-core-applications-with-perfview-on-windows/)
+    * Collecting perf data on .NET Core on Linux - [Vance's blog post](https://blogs.msdn.microsoft.com/vancem/2016/10/07/collecting-performance-data-on-linux-using-perfcollect-and-perfview/)
+  * How trace Runtime event
+    * On Windows - PerfView, on [Linux](http://blogs.microsoft.co.il/sasha/2017/03/30/tracing-runtime-events-in-net-core-on-linux/)
+  * How/when to run with GCStress (set environment variable [COMPlus_GCStress](https://github.com/dotnet/coreclr/blob/master/src/vm/eeconfig.h#L654)=3 on **retail build**)
+  * How to change .NET Core docs
+    * Tutorials, samples - https://github.com/dotnet/docs
+    * API reference - https://github.com/dotnet/dotnet-api-docs
+    * MS Only: .NET Core website - https://github.com/dotnet/dotnet-core-website
+  * SharpLab: https://sharplab.io/
+  * How to port .NET Framework app to .NET Core:
+    * https://docs.microsoft.com/dotnet/core/porting/
+    * http://developerblog.redhat.com/2016/12/08/observations-porting-from-net-framework-to-net-core/
+  * Developing .NET Core apps: https://blogs.msdn.microsoft.com/mvpawardprogram/2016/07/19/key-steps-in-developing-net-core-applications/
+  * Using reference source from here is OK: https://github.com/Microsoft/referencesource (same license)
+    * Richard's explanation: https://github.com/dotnet/coreclr/issues/9301#issuecomment-277534312
+  * Useful tips and tricks, tools, education material - https://github.com/quozd/awesome-dotnet (we might bring some links to CoreFX docs)

--- a/Documentation/wiki/New-contributor-docs---TODO-list.md
+++ b/Documentation/wiki/New-contributor-docs---TODO-list.md
@@ -1,0 +1,25 @@
+Page for faster collaboration between people who work actively on the new docs - @haralabidis, @karelz
+
+Feel free to join us on gitter if you want to collaborate with us.
+
+~~**[1]** **DONE in [[Pick issue]]** [Issues main page section](https://github.com/dotnet/corefx/wiki/Issues#main-page-section-content) is too long to be on the main page, we need to move the content into a subpage and keep the text sweet & short - basically few key links (topics), which can be easily used as reference for 2nd read.~~
+
+**[2]** [Getting Started - Installation](https://github.com/dotnet/corefx/wiki/Getting-started#installing-the-necessary-workloads) - I would love to see there a bullet point list of a few things. We may need special version for Windows / Linux / Mac - maybe split into subpages?
+  * The Installation page is used also as reference when you setup a new machine, or another OS for experiments - we should IMO optimize for that - sweet list of things (like other [Quick Reference](https://github.com/dotnet/corefx/wiki/Checking-out-the-code-repository#quick-reference))
+  * Note: Installing VS is already Windows-only
+
+- Working on creating subpages for each OS ... migrating Windows.
+- I'm wondering if I should break up and re-use/re-write parts of the [Build Instructions](https://github.com/dotnet/corefx/blob/master/Documentation/building/unix-instructions.md) for the quick reference section.
+    * karelz: That sounds reasonable
+
+~~**[3]** **DONE** [Getting Started - Installation](https://github.com/dotnet/corefx/wiki/Getting-started#installing-the-necessary-workloads) - "modify Visual Studio" - it doesn't say what/why to modify. Maybe it should be just a list of VS components that need to be installed in the "VS Install" step higher -- I would assume devs can figure out the 'modify' of installation. Maybe add it as Advanced trick / note?~~
+
+~~**[4]** **DONE** - Delete duplicated content (overlap with new subpages)~~
+
+~~**[5]** **DONE** [Build and run tests](https://github.com/dotnet/corefx/wiki/Build-and-run-tests) ... can you plz update the screenshot with search of 1 more letter - i.e. "deve" ... the "Device Manager" on top highlighted confused me quite a bit.~~
+
+~~**[6]** **DONE** Move 'clean' into Advanced, it is not needed in typical dev workflow.~~
+
+~~**[7]** **DONE** [Clone repository](https://github.com/dotnet/corefx/wiki/Checking-out-the-code-repository#clone-the-repository) - Make the cmd line screenshots smaller. To use similar font size as the web page screenshots. It will be still readable. In current form it stands out too much like a heading.~~
+
+**[8]** Update NuGet cache size after sync - [sync details](https://github.com/dotnet/corefx/wiki/Build-and-run-tests#sync) and [Quick Reference](https://github.com/dotnet/corefx/wiki/Build-and-run-tests#quick-reference)

--- a/Documentation/wiki/Pick-issue.md
+++ b/Documentation/wiki/Pick-issue.md
@@ -1,0 +1,34 @@
+## How to pick an issue to work on
+
+### Quick Reference
+
+* [first-timers-only issues] - Query TODO - issues designed for first-time contributors, anyone else should stay away (motivation: http://www.firsttimersonly.com/)
+* [Easy issues](https://github.com/dotnet/corefx/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Aeasy%20no%3Aassignee) - Good for starting contributors.
+* [up-for-grabs issues](https://github.com/dotnet/corefx/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Aup-for-grabs%20no%3Aassignee%20-label%3Aapi-needs-work) - Issues where we welcome help. Typically there is comment with hint where to start and how complex the issue likely is. Feel free to ping [area owners](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/issue-guide.md#areas) if it is not clear.
+* Most impactful issues: (for seasoned contributors)
+  * [wishlist](https://github.com/dotnet/corefx/issues?q=is%3Aissue+is%3Aopen+label%3Awishlist) - Issues on top of our backlog we won't likely get to. Warning: Might not be easy.
+  * [3.0](https://github.com/dotnet/corefx/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20milestone%3A3.0.0) - Issues in our 3.0 (next release) backlog. We think we will get to them. Help is welcome, but might be non-trivial.
+* **Get help** if you're stuck: Ping [area owners](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/issue-guide.md#areas) or [@karelz](https://github.com/karelz) or [@danmosemsft](https://github.com/danmosemsft)
+
+## Details
+
+You can discover available issues by executing a query on the [issues section](https://github.com/dotnet/corefx/issues) of the project.
+
+Below is a list of the labels that you can use in the query:
+
+* easy - This should be an easy fix and is probable the best starting point for new contributors.
+* up-for-grabs - The item is available and can be selected.
+  * Recommended:
+    * test-enhancement - Tests are missing or need to be updated - typically great entry into new code base.
+  * NOT Recommended:
+    * api-approved - Adding APIs is a bit more involved (TODO link). We recommend new contributors to start with easier ones.
+    * api-needs-work - APIs which need to be designed first. Some won't be accepted even if designed. Stay away from them, unless you are seasoned API designer, and are willing to accept long [API review process](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/api-review-process.md) (up to months), with the possibility that the API will be rejected as not best fit for CoreFX repo.
+
+See below an example query for finding issues that are open, up for grabs, api needs work with no assignee. 
+
+QUERY [is:issue is:open label:up-for-grabs no:assignee -label:api-needs-work](https://github.com/dotnet/corefx/issues?utf8=%E2%9C%93&q=is%3Aopen%20label%3Aup-for-grabs%20-label%3Aapi-needs-work%20no%3Aassignee)
+
+If you don't feel comfortable with constructing and typing the query in the issues search box you can use GitHub's GUI.
+Click on the labels dropdown in the issues page and select from the available labels.
+
+![](https://raw.githubusercontent.com/haralabidis/FirstTimeContributors/master/Assets/7-IssueLabels.png) 

--- a/Documentation/wiki/README.md
+++ b/Documentation/wiki/README.md
@@ -1,0 +1,5 @@
+Do NOT edit the md files in this folder.
+
+This section is meant for preserving the corefx wiki information before we merge the repos, and will be removed as soon as we consolidate the Documentation.
+
+See https://github.com/dotnet/corefx/issues/36057 for more information on what will be preserved and in what stage we are in right now.

--- a/Documentation/wiki/Setting-up-the-development-environment.md
+++ b/Documentation/wiki/Setting-up-the-development-environment.md
@@ -1,0 +1,6 @@
+This page describes the necessary steps for setting up your development environment in order to be able to make contributions to the repository.
+
+The instructions are OS specific:
+  * [Windows](https://github.com/dotnet/corefx/wiki/Development-environment-setup-for-Windows)
+  * [MacOS](https://github.com/dotnet/corefx/wiki/Development-environment-setup-for-MacOS)
+  * [Linux](https://github.com/dotnet/corefx/wiki/Development-environment-setup-for-Linux)

--- a/Documentation/wiki/UWP-Compat.md
+++ b/Documentation/wiki/UWP-Compat.md
@@ -1,0 +1,547 @@
+# Behavior change between .NET Core and UWP
+
+This document contains list of not supported APIs on UWP but supported on .NET Core
+
+## Notes
+- This document is for preview only and was semi-generated, information may be incomplete or may contain errors
+- This API list does not include APIs not supported by .NET Core. See https://github.com/dotnet/corefx/wiki/ApiCompat for reference
+
+# Table of Content
+
+<!-- MarkdownTOC depth=2 autolink=true bracket=round -->
+
+- [ACL](#acl)
+    - [Namespaces](#namespaces)
+- [Registry](#registry)
+    - [Types](#types)
+- [Process](#process)
+    - [Members](#members)
+- [Xml / Xml Serialization](#xml--xml-serialization)
+    - [Types](#types-1)
+    - [Members](#members-1)
+- [ServiceController](#servicecontroller)
+    - [Types](#types-2)
+- [System.Net](#systemnet)
+    - [Types](#types-3)
+- [System.Linq](#systemlinq)
+    - [Members](#members-2)
+- [System.IO](#systemio)
+    - [Namespaces](#namespaces-1)
+    - [Members](#members-3)
+- [Crypto](#crypto)
+    - [Members](#members-4)
+- [SqlClient](#sqlclient)
+    - [Members](#members-5)
+- [DirectoryServices](#directoryservices)
+- [System.Security.Cryptography.OpenSsl](#systemsecuritycryptographyopenssl)
+- [System.Reflection.Context](#systemreflectioncontext)
+- [StackFrame](#stackframe)
+- [MemoryMappedFiles](#memorymappedfiles)
+- [System.Threading](#systemthreading)
+    - [Members](#members-6)
+- [System.Runtime*](#systemruntime)
+- [Serialization related APIs](#serialization-related-apis)
+- [System.Reflection](#systemreflection)
+    - [Other APIs throwing PlatformNotSupportedException](#other-apis-throwing-platformnotsupportedexception)
+- [System.Runtime.InteropServices](#systemruntimeinteropservices)
+    - [Other not supported APIs](#other-not-supported-apis)
+- [System.Diagnostics.Debugger](#systemdiagnosticsdebugger)
+- [System.Private.CoreLib](#systemprivatecorelib)
+    - [Other not supported APIs](#other-not-supported-apis-1)
+
+<!-- /MarkdownTOC -->
+
+# ACL
+Note: Note: This assembly is marked with UWPCompatible=false
+
+## Namespaces
+
+```
+System.Security.AccessControl
+```
+
+# Registry
+Note: This assembly is marked with UWPCompatible=false
+
+## Types
+
+```
+Microsoft.Win32.Registry
+Microsoft.Win32.RegistryKey
+Microsoft.Win32.SafeHandles.SafeRegistryHandle
+Microsoft.Win32.RegistryAclExtensions
+```
+
+# Process
+In general retrieving information about processes is not supported
+## Members
+
+```
+P:System.Diagnostics.Process.PagedSystemMemorySize64
+P:System.Diagnostics.Process.MainModule
+P:System.Diagnostics.Process.PagedMemorySize
+P:System.Diagnostics.Process.PrivateMemorySize64
+P:System.Diagnostics.Process.NonpagedSystemMemorySize64
+P:System.Diagnostics.Process.ExitTime
+P:System.Diagnostics.Process.ProcessName
+P:System.Diagnostics.Process.HasExited
+P:System.Diagnostics.Process.PeakVirtualMemorySize
+P:System.Diagnostics.Process.VirtualMemorySize
+M:System.Diagnostics.Process.Start(System.String)
+P:System.Diagnostics.Process.PeakVirtualMemorySize64
+P:System.Diagnostics.Process.PrivateMemorySize
+M:System.Diagnostics.Process.Start(System.String,System.String)
+P:System.Diagnostics.Process.BasePriority
+M:System.Diagnostics.Process.GetProcessesByName(System.String)
+M:System.Diagnostics.Process.GetProcessesByName(System.String,System.String)
+P:System.Diagnostics.Process.PagedMemorySize64
+P:System.Diagnostics.Process.VirtualMemorySize64
+P:System.Diagnostics.Process.WorkingSet
+P:System.Diagnostics.Process.SafeHandle
+P:System.Diagnostics.Process.ExitCode
+M:System.Diagnostics.Process.Start(System.String,System.String,System.String,System.Security.SecureString,System.String)
+P:System.Diagnostics.Process.PagedSystemMemorySize
+P:System.Diagnostics.Process.MachineName
+M:System.Diagnostics.Process.GetProcesses
+P:System.Diagnostics.Process.PeakPagedMemorySize
+P:System.Diagnostics.Process.NonpagedSystemMemorySize
+P:System.Diagnostics.Process.WorkingSet64
+P:System.Diagnostics.Process.HandleCount
+M:System.Diagnostics.Process.GetProcesses(System.String)
+P:System.Diagnostics.Process.PeakPagedMemorySize64
+P:System.Diagnostics.Process.Threads
+P:System.Diagnostics.Process.PeakWorkingSet64
+P:System.Diagnostics.Process.Id
+M:System.Diagnostics.Process.Start(System.String,System.String,System.Security.SecureString,System.String)
+P:System.Diagnostics.Process.SessionId
+P:System.Diagnostics.Process.Modules
+P:System.Diagnostics.Process.PeakWorkingSet
+P:System.Diagnostics.ProcessStartInfo.UseShellExecute
+```
+
+# Xml / Xml Serialization
+Anything depending on Ref.Emit is not supported
+## Types
+
+```
+System.Xml.Xsl.XslCompiledTransform
+```
+
+## Members
+
+```
+M:System.Runtime.Serialization.XmlObjectSerializerReadContextComplex.ResolveDataContractFromTypeName  (only when code is using NetDataContractSerializer)
+```
+
+# ServiceController
+## Types
+
+```
+System.ServiceProcess.ServiceBase
+System.ServiceProcess.ServiceController
+System.ServiceProcess.SessionChangeDescription
+System.ServiceProcess.TimeoutException
+```
+
+# System.Net
+
+Note: This data was collected from comments on UWP specific disabled tests
+- UAP does not allow HTTP/1.0 requests
+- UAP does not support custom proxies
+- UAP doesn't allow revocation checking to be turned off
+- SslProtocols not supported on UAP
+- WinHttpHandler not supported on UAP
+- WebSocket partial send is not supported on UAP
+
+## Types
+
+```
+System.Net.NetworkInformation.Ping
+System.Net.HttpListenerTimeoutManager
+System.Net.Http.RtcRequestFactory
+System.Net.Http.HttpClientHandler
+
+[System.Net.WebSockets] System.Net.WebSockets.WebSocketValidate::ThrowPlatformNotSupportedException()
+[System.Net.WebSockets.Client] System.Net.WebSockets.WinRTWebSocket.<ConnectAsync>d__31::MoveNext()
+[System.Net.HttpListener] System.Net.HttpListenerTimeoutManager
+[System.Net.Http] System.Net.Http.HttpClientHandler
+```
+
+# System.Linq
+## Members
+
+```
+M:System.Linq.Expressions.Expression.GetDelegateType(System.Type[])
+M:System.Linq.Expressions.Expression.Lambda(System.Linq.Expressions.Expression,System.String,System.Boolean,System.Collections.Generic.IEnumerable{System.Linq.Expressions.ParameterExpression})
+[System.Linq.Expressions] System.Linq.Expressions.Compiler.DelegateHelpers::MakeNewCustomDelegate(Type[])
+```
+
+# System.IO
+Note: This data was collected from comments on UWP specific disabled tests
+- Accessing drive format is not permitted inside an AppContainer
+- GetDiskFreeSpaceEx blocked in AppContainer
+
+## Namespaces
+
+```
+System.IO.FileSystemAclExtensions
+```
+
+## Members
+
+```
+M:System.IO.Ports.SerialPort.GetPortNames
+[System.IO.Compression] System.IO.Compression.ZLibException::.ctor(SerializationInfo, StreamingContext)
+[System.IO.FileSystem.DriveInfo] System.IO.DriveInfo::.ctor(SerializationInfo, StreamingContext)
+[System.Collections] System.Collections.Generic.LinkedList`1.Enumerator::.ctor(SerializationInfo, StreamingContext)
+```
+
+# Crypto
+## Members
+
+```
+[System.Security.Cryptography.Cng] System.Security.Cryptography.ECDsaCng::SpecialNistAlgorithmToCurveName(string)
+S.R.Extensions
+[System.Runtime.Extensions] System.Collections.Hashtable.SyncHashtable::.ctor(SerializationInfo, StreamingContext)
+```
+
+# SqlClient
+Note: This assembly is marked with UWPCompatible=false
+
+## Members
+```
+[System.Data.SqlClient] System.Data.LocalDBAPI::LoadProcAddress()
+[System.Data.SqlClient] System.Data.SqlClient.SNI.LocalDB::GetLocalDBConnectionString(string)
+```
+
+# DirectoryServices
+Note: This assembly is marked with UWPCompatible=false
+
+Note: This data was collected from comments on UWP specific disabled tests
+- Getting information about domain is denied inside AppContainer
+
+# System.Security.Cryptography.OpenSsl
+Note: This assembly is marked with UWPCompatible=false
+
+# System.Reflection.Context
+Note: This assembly is marked with UWPCompatible=false
+
+# StackFrame
+Note: This data was collected from comments on UWP specific disabled tests
+- [uapaot] StackFrame is not supported
+
+# MemoryMappedFiles
+Note: This data was collected from comments on UWP specific disabled tests
+- Windows API returns IO exception error code when viewAccess is ReadWriteExecute
+
+# System.Threading
+Note: This data was collected from comments on UWP specific disabled tests
+- [uapaot] ThreadPool.SetMinThreads is not supported
+
+## Members
+
+```
+[System.Private.CoreLib] System.Threading.ThreadPool::BindHandle(IntPtr)
+[System.Private.CoreLib] System.Threading.ThreadPool::BindHandle(SafeHandle)
+```
+
+# System.Runtime*
+Note: This data was collected from comments on UWP specific disabled tests
+- [uapaot] Assembly.Load(byte[])")] not supported
+- [uap, not uapaot] When getting resources from PRI file the casing doesn't matter, if it is there it will always find and return the resource
+- [uapaot] Non-zero lower-bounded arrays not supported 
+- [uapaot] Exception.TargetSite always returns null
+
+# Serialization related APIs
+
+```
+[System.Private.CoreLib] System.MulticastDelegate::GetObjectData(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.NotFiniteNumberException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.NotImplementedException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.NotSupportedException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.NullReferenceException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.ObjectDisposedException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.OperationCanceledException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.OutOfMemoryException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.OverflowException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.PlatformNotSupportedException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.RankException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.Threading.AbandonedMutexException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.Threading.ExecutionContext::GetObjectData(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.Threading.LockRecursionException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.Threading.SemaphoreFullException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.Threading.SynchronizationLockException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.Threading.Tasks.TaskCanceledException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.Threading.Tasks.TaskSchedulerException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.Threading.ThreadInterruptedException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.Threading.ThreadStateException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.Threading.WaitHandleCannotBeOpenedException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.TimeoutException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.TimeZoneNotFoundException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.AccessViolationException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.ApplicationException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.ArgumentException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.ArgumentNullException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.ArgumentOutOfRangeException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.ArithmeticException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.ArrayTypeMismatchException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.BadImageFormatException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.Collections.Generic.KeyNotFoundException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.DivideByZeroException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.DllNotFoundException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.DuplicateWaitObjectException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.Empty::GetObjectData(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.EntryPointNotFoundException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.Delegate::GetObjectData(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.FieldAccessException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.FormatException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.Globalization.CultureNotFoundException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.InvalidCastException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.InvalidOperationException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.InvalidTimeZoneException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.IO.DirectoryNotFoundException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.IO.EndOfStreamException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.IO.FileLoadException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.IO.FileNotFoundException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.IO.IOException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.IO.PathTooLongException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.MemberAccessException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.MethodAccessException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.MissingFieldException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.MissingMemberException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.MissingMethodException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.Runtime.InteropServices.ExternalException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.Runtime.InteropServices.MarshalDirectiveException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.Runtime.Serialization.SerializationException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.Security.Cryptography.CryptographicException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.Security.SecurityException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.Security.VerificationException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.Reflection.StrongNameKeyPair::System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object)
+[System.Private.CoreLib] System.Reflection.StrongNameKeyPair::System.Runtime.Serialization.ISerializable.GetObjectData(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.Reflection.AssemblyName::GetObjectData(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.Reflection.AssemblyName::OnDeserialization(object)
+[System.Private.CoreLib] System.Reflection.CustomAttributeFormatException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.Reflection.InvalidFilterCriteriaException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.Reflection.Missing::System.Runtime.Serialization.ISerializable.GetObjectData(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.Reflection.Pointer::System.Runtime.Serialization.ISerializable.GetObjectData(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.Reflection.TargetException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.Resources.MissingManifestResourceException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.Resources.MissingSatelliteAssemblyException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.Reflection.StrongNameKeyPair::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.RuntimeFieldHandle::GetObjectData(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.RuntimeMethodHandle::GetObjectData(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.RuntimeTypeHandle::GetObjectData(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.SystemException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.Text.Encoding.DefaultDecoder::GetRealObject(StreamingContext)
+[System.Private.CoreLib] System.Text.Encoding.DefaultEncoder::GetRealObject(StreamingContext)
+[System.Private.Interop] System.Runtime.InteropServices.COMException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.Interop] System.Runtime.InteropServices.InvalidComObjectException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.Interop] System.Runtime.InteropServices.InvalidOleVariantTypeException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.TypeAccessException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.TypeLoadException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.TypeUnloadedException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.UnauthorizedAccessException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.Globalization.TextInfo::System.Runtime.Serialization.IDeserializationCallback.OnDeserialization(object)
+[System.Private.Interop] System.Runtime.InteropServices.SafeArrayRankMismatchException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.Interop] System.Runtime.InteropServices.SafeArrayTypeMismatchException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.Interop] System.Runtime.InteropServices.SEHException::.ctor(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.DBNull::GetObjectData(SerializationInfo, StreamingContext)
+[System.Private.Reflection.Core] System.Reflection.Runtime.Assemblies.RuntimeAssembly::GetObjectData(SerializationInfo, StreamingContext)
+[System.Private.CoreLib] System.Exception::add_SerializeObjectState(EventHandler<SafeSerializationEventArgs>)
+[System.Private.CoreLib] System.Exception::remove_SerializeObjectState(EventHandler<SafeSerializationEventArgs>)
+```
+
+# System.Reflection
+
+- Type.InvokeMember will throw PlatformNotSupportedException when passed a wrapped COM object
+- Passing a type not implemented by the runtime type to Type.MakeGenericType(Type[]) is not supported (on CoreCLR, you could do this to produce a RefEmit.TypeBuilder)
+- Type.TypeHandle throws PlatformNotSupportedException on open types or types created by Type.GetTypeFromCLSID()
+- Loading assembly from byte array or file paths is not supported
+- Late-bound invoking delegate constructors is not supported
+- Reflecting over IL bodies is not supported
+- MethodBase.MethodHandle is not supported on array constructor
+- Assembly::GetCallingAssembly() is not supported
+- Multi-module assemblies are not supported
+- Loading modules from paths not supported
+- Satellite assemblies are not supported
+- Loading StrongNameKeyPair from path is not supported
+- Reflection support for global members is not supported
+- System.Reflection.Pointer - while Pointer itself works, passing them as arguments to late-bound invokes will not. Workaround is to pass IntPtr instead. 
+
+```
+[System.Private.Reflection.Core] System.Reflection.Runtime.Modules.RuntimeModule::ResolveField(int, Type[], Type[])
+[System.Private.Reflection.Core] System.Reflection.Runtime.Modules.RuntimeModule::ResolveMember(int, Type[], Type[])
+[System.Private.Reflection.Core] System.Reflection.Runtime.Modules.RuntimeModule::ResolveMethod(int, Type[], Type[])
+[System.Private.Reflection.Core] System.Reflection.Runtime.Modules.RuntimeModule::ResolveSignature(int)
+[System.Private.Reflection.Core] System.Reflection.Runtime.Modules.RuntimeModule::ResolveString(int)
+[System.Private.Reflection.Core] System.Reflection.Runtime.Modules.RuntimeModule::ResolveType(int, Type[], Type[])
+```
+
+- ProgID is not supported:
+
+```
+[System.Private.CoreLib] System.Type::GetCLSIDFromProgID(string, Guid)
+```
+
+- `System.Reflection.AssemblyName::GetAssemblyName(string)` and `System.Reflection.AssemblyName::EscapeCodeBase(string)` are not supported
+
+
+## Other APIs throwing PlatformNotSupportedException
+
+```
+[System.Private.Reflection.Execution] Internal.Reflection.Execution.ExecutionEnvironmentImplementation::GetManifestResourceInfo(Assembly, string)
+[System.Private.Reflection.Execution] Internal.Reflection.Execution.MethodInvokers.IntPtrConstructorMethodInvoker::.ctor(MetadataReader, MethodHandle)
+[System.Private.Reflection.Execution] Internal.Reflection.Execution.MethodInvokers.IntPtrConstructorMethodInvoker::LdFtnResult.get()
+[System.Private.Reflection.Execution] Internal.Reflection.Execution.MethodInvokers.NullableInstanceMethodInvoker::LdFtnResult.get()
+[System.Private.Reflection.Execution] Internal.Reflection.Execution.MethodInvokers.StringConstructorMethodInvoker::LdFtnResult.get()
+[System.Private.Reflection.Execution] Internal.Reflection.Execution.MethodInvokers.SyntheticMethodInvoker::CreateDelegate(RuntimeTypeHandle, object, bool, bool, bool)
+[System.Private.Reflection.Execution] Internal.Reflection.Execution.MethodInvokers.SyntheticMethodInvoker::LdFtnResult.get()
+[System.Private.Reflection.Execution] Internal.Reflection.Execution.MethodInvokers.VirtualMethodInvoker::LdFtnResult.get()
+[System.Private.Reflection.Core] System.Reflection.Runtime.MethodInfos.RuntimeCLSIDNullaryConstructorInfo::MethodHandle.get()
+[System.Private.Reflection.Core] System.Reflection.Runtime.MethodInfos.RuntimeCLSIDNullaryConstructorInfo::UncachedMethodInvoker.get()
+[System.Private.Reflection.Core] System.Reflection.Runtime.MethodInfos.RuntimeConstructorInfo::GetMethodBody()
+[System.Private.Reflection.Core] System.Reflection.Runtime.MethodInfos.RuntimeConstructorInfo::Invoke(object, BindingFlags, Binder, object[], CultureInfo)
+[System.Private.Reflection.Core] System.Reflection.Runtime.MethodInfos.RuntimeMethodInfo::GetMethodBody()
+[System.Private.Reflection.Core] System.Reflection.Runtime.MethodInfos.RuntimeSyntheticConstructorInfo::MethodHandle.get()
+[System.Private.Reflection.Core] System.Reflection.Runtime.MethodInfos.RuntimeSyntheticMethodInfo::MethodHandle.get()
+[System.Private.Reflection.Core] System.Reflection.Runtime.Modules.RuntimeModule::GetField(string, BindingFlags)
+[System.Private.Reflection.Core] System.Reflection.Runtime.Modules.RuntimeModule::GetFields(BindingFlags)
+[System.Private.Reflection.Core] System.Reflection.Runtime.Modules.RuntimeModule::GetMethodImpl(string, BindingFlags, Binder, CallingConventions, Type[], ParameterModifier[])
+[System.Private.Reflection.Core] System.Reflection.Runtime.Modules.RuntimeModule::GetMethods(BindingFlags)
+[System.Private.Reflection.Core] System.ActivatorImplementation::CreateInstance(Type, BindingFlags, Binder, object[], CultureInfo, object[])
+[System.Private.CoreLib] System.Type::ReflectionOnlyGetType(string, bool, bool)
+[System.Private.CoreLib] System.Reflection.Assembly::ReflectionOnlyLoad(byte[])
+[System.Private.CoreLib] System.Reflection.Assembly::ReflectionOnlyLoad(string)
+[System.Private.CoreLib] System.Reflection.Assembly::ReflectionOnlyLoadFrom(string)
+[System.Private.Reflection.Core] System.Reflection.Runtime.Assemblies.RuntimeAssembly::CodeBase.get()
+[System.Private.Reflection.Core] System.Reflection.Runtime.Assemblies.RuntimeAssembly::GetFile(string)
+[System.Private.Reflection.Core] System.Reflection.Runtime.Assemblies.RuntimeAssembly::GetFiles(bool)
+[System.Private.Reflection.Core] System.Reflection.Runtime.Assemblies.RuntimeAssembly::GetModule(string)
+[System.Private.Reflection.Core] System.Reflection.Runtime.Assemblies.RuntimeAssembly::GetReferencedAssemblies()
+[System.Private.Reflection.Core] System.Reflection.Runtime.Assemblies.RuntimeAssembly::GetRuntimeAssembly(AssemblyBindResult)
+[System.Private.Reflection.Core] System.Reflection.Runtime.Assemblies.RuntimeAssembly::GetSatelliteAssembly(CultureInfo)
+[System.Private.Reflection.Core] System.Reflection.Runtime.Assemblies.RuntimeAssembly::GetSatelliteAssembly(CultureInfo, Version)
+[System.Private.Reflection.Core] System.Reflection.Runtime.Assemblies.RuntimeAssembly::LoadModule(string, byte[], byte[])
+[System.Private.Reflection.Core] System.Reflection.Runtime.EventInfos.RuntimeEventInfo::GetOtherMethods(bool)
+[System.Private.Reflection.Core] System.Reflection.Runtime.Modules.RuntimeModule::GetObjectData(SerializationInfo, StreamingContext)
+[System.Private.Reflection.Core] System.Reflection.Runtime.Modules.RuntimeModule::GetPEKind(PortableExecutableKinds, ImageFileMachine)
+[System.Private.Reflection.Core] System.Reflection.Runtime.Modules.RuntimeModule::IsResource()
+[System.Private.Reflection.Core] System.Reflection.Runtime.Modules.RuntimeModule::MDStreamVersion.get()
+[System.Private.Reflection.Core] System.Reflection.Runtime.Modules.RuntimeModule::ScopeName.get()
+[System.Private.Reflection.Core] System.Reflection.Runtime.TypeInfos.RuntimeTypeInfo::GetInterfaceMap(Type)
+[System.Private.CoreLib] System.Reflection.StrongNameKeyPair::.ctor(string)
+[System.Private.CoreLib] System.Reflection.StrongNameKeyPair::PublicKey.get()
+```
+
+# System.Runtime.InteropServices
+
+- PIA/IDispatch not supported
+
+```
+[System.Private.Interop] System.Runtime.InteropServices.ComAwareEventInfo::.ctor(Type, string)
+[System.Private.Interop] System.Runtime.InteropServices.ComAwareEventInfo::AddEventHandler(object, Delegate)
+[System.Private.Interop] System.Runtime.InteropServices.ComAwareEventInfo::Attributes.get()
+[System.Private.Interop] System.Runtime.InteropServices.ComAwareEventInfo::DeclaringType.get()
+[System.Private.Interop] System.Runtime.InteropServices.ComAwareEventInfo::GetAddMethod(bool)
+[System.Private.Interop] System.Runtime.InteropServices.ComAwareEventInfo::GetCustomAttributes(bool)
+[System.Private.Interop] System.Runtime.InteropServices.ComAwareEventInfo::GetCustomAttributes(Type, bool)
+[System.Private.Interop] System.Runtime.InteropServices.ComAwareEventInfo::GetCustomAttributesData()
+[System.Private.Interop] System.Runtime.InteropServices.ComAwareEventInfo::GetRaiseMethod(bool)
+[System.Private.Interop] System.Runtime.InteropServices.ComAwareEventInfo::GetRemoveMethod(bool)
+[System.Private.Interop] System.Runtime.InteropServices.ComAwareEventInfo::IsDefined(Type, bool)
+[System.Private.Interop] System.Runtime.InteropServices.ComAwareEventInfo::Name.get()
+[System.Private.Interop] System.Runtime.InteropServices.ComAwareEventInfo::ReflectedType.get()
+[System.Private.Interop] System.Runtime.InteropServices.ComAwareEventInfo::RemoveEventHandler(object, Delegate)
+[System.Private.Interop] System.Runtime.InteropServices.ComEventsHelper::Combine(object, Guid, int, Delegate)
+[System.Private.Interop] System.Runtime.InteropServices.ComEventsHelper::Remove(object, Guid, int, Delegate)
+[System.Private.Interop] System.Runtime.InteropServices.DispatchWrapper::.ctor(object)
+[System.Private.Interop] System.Runtime.InteropServices.DispatchWrapper::WrappedObject.get()
+```
+
+- binding to moniker is not supported: `System.Runtime.InteropServices.Marshal::BindToMoniker(string)` (not in WACK)
+- Interop feature UnmanagedType.AsAny not supported
+- Interop feature UnmanagedType.CustomMarshaler not supported
+
+```
+[System.Private.Interop] System.Runtime.InteropServices.Marshal::ReadByte(object, int)
+[System.Private.Interop] System.Runtime.InteropServices.Marshal::ReadInt16(object, int)
+[System.Private.Interop] System.Runtime.InteropServices.Marshal::ReadInt32(object, int)
+[System.Private.Interop] System.Runtime.InteropServices.Marshal::ReadInt64(object, int)
+[System.Private.Interop] System.Runtime.InteropServices.Marshal::WriteByte(object, int, byte)
+[System.Private.Interop] System.Runtime.InteropServices.Marshal::WriteInt16(object, int, short)
+[System.Private.Interop] System.Runtime.InteropServices.Marshal::WriteInt32(object, int, int)
+[System.Private.Interop] System.Runtime.InteropServices.Marshal::WriteInt64(object, int, long)
+```
+
+-  `System.Runtime.InteropServices.Marshal::GetExceptionForHR(int, IntPtr)` is not supported for non-null pointers
+- `System.Runtime.InteropServices.ReversePInvokeCallInterceptor::.ctor(IntPtr, object, CallingConvention, LocalVariableType[], LocalVariableType[], BaseMarshaller[], MarshallerArgumentInfo[])` throws for not supported calling conventions
+
+## Other not supported APIs
+
+```
+[System.Private.Interop] System.Runtime.InteropServices.Marshal::ChangeWrapperHandleStrength(object, bool)
+[System.Private.Interop] System.Runtime.InteropServices.Marshal::CreateWrapperOfType(object, Type)
+
+[System.Private.Interop] System.Runtime.InteropServices.Marshal::AreComObjectsAvailableForCleanup()
+[System.Private.Interop] System.Runtime.InteropServices.Marshal::CreateAggregatedObject(IntPtr, object)
+[System.Private.Interop] System.Runtime.InteropServices.Marshal::GetComInterfaceForObject(object, Type, CustomQueryInterfaceMode)
+[System.Private.Interop] System.Runtime.InteropServices.Marshal::GetStartComSlot(Type)
+[System.Private.Interop] System.Runtime.InteropServices.Marshal::GetTypeInfoName(ITypeInfo)
+[System.Private.Interop] System.Runtime.InteropServices.Marshal::GetUniqueObjectForIUnknown(IntPtr)
+[System.Private.Interop] System.Runtime.InteropServices.Marshal::GetExceptionCode()
+```
+
+# System.Diagnostics.Debugger
+
+- `System.Diagnostics.Debugger::Launch()` is not supported
+
+# System.Private.CoreLib
+
+- System.Environment.Exit(int) is not supported
+- System.ArgIterator is not supported (removed from NetStandard 2.0)
+- Remoting not supported
+
+```
+[System.Private.CoreLib] System.MarshalByRefObject::GetLifetimeService()
+[System.Private.CoreLib] System.MarshalByRefObject::InitializeLifetimeService()
+```
+
+```
+[System.Private.CoreLib] System.Runtime.Loader.AssemblyLoadContext::LoadFromAssemblyPath(string)
+```
+
+- Inspecting underlying PE is not supported. IL metadata is gone after native compilation and so are tokens
+
+```
+[System.Private.CoreLib] System.ModuleHandle::GetRuntimeFieldHandleFromMetadataToken(int)
+[System.Private.CoreLib] System.ModuleHandle::GetRuntimeMethodHandleFromMetadataToken(int)
+[System.Private.CoreLib] System.ModuleHandle::GetRuntimeTypeHandleFromMetadataToken(int)
+[System.Private.CoreLib] System.ModuleHandle::ResolveFieldHandle(int)
+[System.Private.CoreLib] System.ModuleHandle::ResolveFieldHandle(int, RuntimeTypeHandle[], RuntimeTypeHandle[])
+[System.Private.CoreLib] System.ModuleHandle::ResolveMethodHandle(int)
+[System.Private.CoreLib] System.ModuleHandle::ResolveMethodHandle(int, RuntimeTypeHandle[], RuntimeTypeHandle[])
+[System.Private.CoreLib] System.ModuleHandle::ResolveTypeHandle(int)
+[System.Private.CoreLib] System.ModuleHandle::ResolveTypeHandle(int, RuntimeTypeHandle[], RuntimeTypeHandle[])
+```
+
+## Other not supported APIs
+
+```
+[System.Private.CoreLib] System.Delegate::.ctor(object, string)
+[System.Private.CoreLib] System.Delegate::.ctor(Type, string)
+[System.Private.CoreLib] System.MulticastDelegate::.ctor(object, string)
+[System.Private.CoreLib] System.MulticastDelegate::.ctor(Type, string)
+[System.Private.CoreLib] System.ModuleHandle::MDStreamVersion.get()
+[System.Private.CoreLib] System.Runtime.CompilerServices.RuntimeHelpers::InitializeArray(Array, RuntimeFieldHandle)
+[System.Private.CoreLib] System.Runtime.CompilerServices.Unsafe::AddByteOffset(T, IntPtr)
+[System.Private.CoreLib] System.Runtime.CompilerServices.Unsafe::AreSame(T, T)
+[System.Private.CoreLib] System.Runtime.CompilerServices.Unsafe::As(object)
+[System.Private.CoreLib] System.Runtime.CompilerServices.Unsafe::As(TFrom)
+[System.Private.CoreLib] System.Runtime.CompilerServices.Unsafe::AsPointer(T)
+[System.Private.CoreLib] System.Runtime.CompilerServices.Unsafe::SizeOf()
+[System.Private.Interop] System.Runtime.InteropServices.ForwardPInvokeCallInterceptor::.ctor(IntPtr, CallingConvention, LocalVariableType[], LocalVariableType[], BaseMarshaller[], MarshallerArgumentInfo[])
+[System.Private.TypeLoader] Internal.Runtime.TypeLoader.Intrinsics::AddrOf(T)
+[System.Private.TypeLoader] Internal.Runtime.TypeLoader.Intrinsics::Call(IntPtr, object)
+[System.Private.TypeLoader] Internal.TypeSystem.NoMetadata.RuntimeMethodDesc::HasCustomAttribute(string, string)
+[System.Private.TypeLoader] Internal.TypeSystem.TypeSystemContext::GetArrayTypesCache(bool, int)
+```

--- a/Documentation/wiki/_Sidebar.md
+++ b/Documentation/wiki/_Sidebar.md
@@ -1,0 +1,10 @@
+[[Home]]
+
+[[New contributor Docs]]
+* [TODO list](https://github.com/dotnet/corefx/wiki/New-contributor-docs---TODO-list)
+
+[API Compat & Deprecated list](https://github.com/dotnet/corefx/wiki/ApiCompat)
+
+[UWP Compat](https://github.com/dotnet/corefx/wiki/UWP-Compat)
+
+[[Links]]

--- a/Documentation/wiki/git-reference.md
+++ b/Documentation/wiki/git-reference.md
@@ -1,0 +1,92 @@
+# git commands and workflow for beginners
+
+Goal: Keep it simple, no fancy stuff - just easiest way to get things done (and to understand them)
+
+## Main text
+
+TODO:
+* We need reference table and also basic workflow (1 computer, 2 computers - move work, PR updates / rebase).
+* The workflow will naturally create branches for each fix (new git concept)
+* Picture with remote, origin and current will be worth thousands words ...
+
+## Quick reference
+The table below describes the Git flow for creating and updating a pull request.
+
+| Task             | Git command             | Details     |
+|------------------|-------------------------|-------------|
+| Fork repository  | Fork the repository from the project's github page | See [Checking out the code repository](https://github.com/dotnet/corefx/wiki/Checking-out-the-code-repository) |
+| Clone repository | `git clone https://github.com/YOUR-USERNAME/corefx.git` | See [Checking out the code repository](https://github.com/dotnet/corefx/wiki/Checking-out-the-code-repository) |
+| Configure remote repository | `git remote add upstream https://github.com/dotnet/corefx.git` | See [Checking out the code repository](https://github.com/dotnet/corefx/wiki/Checking-out-the-code-repository) |
+| Sync repository | `git fetch upstream`| Retrieve the latest code from the original fork. |
+| Sync repository | `git checkout master` | Checkout your fork's master branch. |
+| Sync repository | `git merge upstream/master` | Merge the latest code from the original to your fork's master branch. |
+| Create a branch | `git branch < Name of the branch you want to create >` | Creates a new branch on which you will add your code.|
+| Checkout a branch | `git checkout < Name of the branch created above >` | Sets your newly created branch as your current working branch | 
+| Add changes to the queue | `git add --all` | Stages all the files you have added and edited for commit| 
+| Commit changes with message | `git commit -m < message >` | Commits the changes to your local branch and includes the message as a description |
+| Push the changes to your remote branch | `git push` | Pushes the changes you committed earlier to your local branch to your remote branch| 
+| Raise a pull request| See details | See [Raising a pull request](https://github.com/dotnet/corefx/wiki/Creating-a-Pull-Request) |
+
+## Ideas / Notes
+
+Very useful git blog posts - [Sara Ford's Blog](https://saraford.net/):
+* https://saraford.net/2017/05/02/how-to-fetch-down-updates-from-a-git-remote-repository-122/
+
+Useful starter: [Git and GitHub.com](https://guides.github.com/activities/hello-world/)
+
+[MS internal] GitHub usage help: http://aka.ms/GitHelp
+
+### Logical workflow
+
+Idea: Describe this logical workflow and annotate it with git commands (in a table?)
+
+* Enlist / clone = get sources on your computer
+* Work on a fix/feature = create branch
+    * Tip: What if you forget and realize you have pending files in master, or if you committed to master
+* Update (sync) with latest master branch changes
+* File operations - edit, delete, rename (how)
+    * Note: Rename is auto-detected by file content, no 'rename' records in git
+* Publish (commit) changes locally
+    * Note: Don't worry about history too much, it can be cleaned up before final checkin
+    * ProTip: Don't mix unrelated changes, keep each bug fix / logical work separate - esp. separate larger code cleanup / refactoring / formatting changes (unlikely to introduce regressions) from real functional changes (which may potentially introduce regressions, etc.)
+* Backup changes on GitHub
+* Share changes between 2 computers (e.g. Laptop & main machine)
+* Create PR
+    * Cleanup your history prior to submitting PR
+    * //Link to Dos & Don't in PRs - TODO: Is this the right place?
+* Update PR to incorporate feedback
+    * Note: Do not merge master during PR work! Do rebase instead if history is too messy or if there are conflicting changes in master (which is rare!) - if unsure, do it only if you're asked. If you must merge, then do it only after all feedback is incorporated (to avoid restarting the code review from scratch). Note that rebase can be done automatically (by repo maintainers) upon merging your PR -- that should be the 95% case.
+
+### karelz's reference
+
+**DISCLAIMER:** These are my old newbie zero-experience someone-told-me notes, they need to be validated.
+
+| Task             | Git command             | TFS command |
+|------------------|-------------------------|-------------|
+| **Enlistment**   |                         |             |
+| Enlist           |[one-time per repo] Create new repo or your repo fork (GitHub UI)<ul><li>Creates https://github.com/<your_username>/<repo_name> (on the server)</li></ul>**git clone <repo_name>**<ul><li>Just shortcut for "git clone https://github.com/<your_username>/<repo_name>"</li><li>Creates subdir repo_name (incl. 'origin' info - run "git remote -v")</li></ul>Note: The directory is movable between directories, disks, machines | tf workspace /new |
+| Enlistment info | **git remote -v** | tf workspace |
+| **Modify**   |                         |             |
+| Edit file | Just edit the file <ul><li>To make it part of your to-be-committed changes: git add &lt;file&gt;</li></ul> | tf edit &lt;file&gt; |
+| Add file | **git add &lt;file&gt;** | tf add &lt;file&gt; |
+| Rename file | Just rename file on disk + **git add <new_file>**, git will automatically detect renames | tf rename &lt;file&gt; |
+| Delete file | Just delete file on disk + **git add <old_file>**, git will automatically detect deletes | tf delete &lt;file&gt; |
+| Undo (local) change | **git checkout -- &lt;file&gt;**<ul><li>Note: "git status" tells you the instructions</li></ul> | tf undo &lt;file&gt; |
+| **Sync / checkin / history** | | |
+| List pending & local-only changes | **git log**<ul><li>Lists changes which are not committed locally and which are not pushed to server yet</li></ul> | tf status |
+| Sync | **git pull -r**<ul><li>fetch + rebase</li></ul> | tf get |
+| Resolve conflicts | **tgit resolve** | tf resolve |
+| Diff | **tgit diff** | tf diff |
+| Checkin | <ul><li>Checkin locally (only into local history all edited files): **git commit -a**</li><li>Adjust local checkins before publishing them to server (e.g. squash=merge them together): **git rebase -i**<ul><li>Note: i=interactive mode (pops txt file editor)</li><li>Read the commands - use p/s/f as needed</li></ul></li><li>Push changes to server:<ul><li>**git push <repo_name> <branch_name>**</li><li>**git push origin my-feature**</li>Note: Never push into upstream</li><li>Review changes: **git compare**</li></ul> | tf checkin<br/>tf submit |
+| Revert change | **TODO** | tf revert |
+| History view | **git log**<br/>UI: **gitk** | tf history |
+| **Branches** | | |
+| Create branch / named set of changes ("shelveset") | **git checkout -b <branch_name>**<ul><li>Note: Branches are super-cheap, more like shelvesets</li><li>Beginner hint: Create a new branch before you try anything dangerous with git (pull / squash)</li></ul> | tf shelve |
+| Switch between branches ("shelvesets") | **git checkout <branch_name>**<br/>Hint: Use **master** as branch name | tf unshelve |
+| List active branch | **git status**<ul><li>Starts with active branch "On branch <branch_name>"</li></ul>Also in: **git branch** | -- |
+| List branches | <ol><li>**git branch -a**</li><li>GitHub UI on your repo clone</li></ol> | tf shelvesets |
+| Merge branches | **git checkout <target_branch_name>**<br/>**git merge <source_branch_name>** | tf integrate |
+| Delete branch | <ol><li>Locally: **git branch -d <branch_name>**</li><li>Remotely: **git push origin --delete <branch_name>**</li></ol> | tf shelveset /delete |
+| **Other** | | |
+| Create stash / shelveset backup | <ul><li>Create: **git stash**</li><li>List all: **git stash list**</li><li>Restore: **git stash apply <stash_name>**</li><li>Delete: **git stash drop**</li></ul> | -- |
+| Rewriting history | http://sethrobertson.github.io/GitFixUm/fixup.html (incl. dangerous rewrite published history) | -- |


### PR DESCRIPTION
Before we merge the repos, and potentially lose all the information located in the [wiki](https://github.com/dotnet/corefx/wiki) (the wiki has its own repo), we need to make sure we backup those `*.md` files here.

This is the first step of the documentation consolidation effort I proposed and described here: https://github.com/dotnet/corefx/issues/36057#issuecomment-540237320

I added a `README.md` file to describe the root of the wiki folder, so any visitors know what we're doing.

CC @ViktorHofer @karelz @wtgodbe please review.

Also CC @scalablecory who has been actively modifying [this HTTP2 wiki document](https://github.com/dotnet/corefx/wiki/HTTP-2-Implementation-Status). If you prefer to move this file to another location within the Documentation folder of the corefx repo, please let me know.