### PR TITLE
Only pass the needed sub-struct in WriteUncompressedPublicKey.

### DIFF
--- a/src/Common/src/System/Security/Cryptography/EccKeyFormatHelper.cs
+++ b/src/Common/src/System/Security/Cryptography/EccKeyFormatHelper.cs
@@ -732,12 +732,12 @@ namespace System.Security.Cryptography
 
             writer.WriteBitString(
                 publicKeyLength,
-                ecParameters,
-                (publicKeyBytes, ecParams) =>
+                ecParameters.Q,
+                (publicKeyBytes, point) =>
                 {
                     publicKeyBytes[0] = 0x04;
-                    ecParams.Q.X.AsSpan().CopyTo(publicKeyBytes.Slice(1));
-                    ecParams.Q.Y.AsSpan().CopyTo(publicKeyBytes.Slice(1 + ecParams.Q.X.Length));
+                    point.X.AsSpan().CopyTo(publicKeyBytes.Slice(1));
+                    point.Y.AsSpan().CopyTo(publicKeyBytes.Slice(1 + point.X.Length));
                 });
         }
 


### PR DESCRIPTION
Just some general tidiness that was in a prototyping branch that seemed worth keeping.