### PR TITLE
Re-enable NoCallback_RevokedCertificate_NoRevocationChecking_Succeeds

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
@@ -318,7 +318,6 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ActiveIssue(41108)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "UAP doesn't allow revocation checking to be turned off")]
         [OuterLoop("Uses external server")]
         [ConditionalFact(nameof(ClientSupportsDHECipherSuites))]


### PR DESCRIPTION
The third-party server we use for this test, revoked.badssl.com, now has a new
certificate that is good for another two years and is also revoked. So, we can
re-enable this test.

Fixes #41108