### PR TITLE
update DualModeConnect_BeginAccept_Helper to be more liberal and consistent with DualModeConnect_AcceptAsync_Helper

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
@@ -861,7 +861,6 @@ namespace System.Net.Sockets.Tests
                     {
                         Assert.Equal(connectTo.MapToIPv6(), ((IPEndPoint)clientSocket.LocalEndPoint).Address);
                     }
-                    Assert.Equal(connectTo.MapToIPv6(), ((IPEndPoint)clientSocket.LocalEndPoint).Address);
                 }
                 catch (ObjectDisposedException) { }
                 catch (SocketException) { }


### PR DESCRIPTION
We have seen BeginAcceptV4BoundToAnyV6_Success and DualModeBeginAccept.BeginAcceptV4BoundToAnyV4_Success failing occasionally in CI with:

```
18:18:24       Assert.Equal() Failure
18:18:24       Expected: ::ffff:127.0.0.1
18:18:24       Actual:   ::127.0.0.1
```

I could not reproduce it on my system. However when looking at the tests, I notices that when connecting on v4 loopback ( like two tests above), there is also ready code to accept variations from ValidIPv6Loopbacks: 


https://github.com/dotnet/corefx/blob/901c370c2379ad0885bcc5a1921c4164104586aa/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs#L856-L864

and 

```c# 
       protected static IPAddress[] ValidIPv6Loopbacks = new IPAddress[] {
            new IPAddress(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 127, 0, 0, 1 }, 0),  // ::127.0.0.1
            IPAddress.Loopback.MapToIPv6(),                                                     // ::ffff:127.0.0.1
            IPAddress.IPv6Loopback                                                              // ::1
        };
```

But it seems like the 864 line is there extra by mistake, invalidating previous statement. I also look at DualModeConnect_AcceptAsync_Helper and it validates result same way as we will now with this change.

fixes #6681
fixes #41685
