### PR TITLE
Regenerating the System.Runtime.Intrinsics.Experimental ref assembly

### DIFF
--- a/src/System.Runtime.Intrinsics.Experimental/ref/System.Runtime.Intrinsics.Experimental.cs
+++ b/src/System.Runtime.Intrinsics.Experimental/ref/System.Runtime.Intrinsics.Experimental.cs
@@ -61,7 +61,7 @@ namespace System.Runtime.Intrinsics.Arm
             public static new bool IsSupported { get { throw null; } }
             public static System.Runtime.Intrinsics.Vector128<double> Abs(System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
             public static System.Runtime.Intrinsics.Vector128<ulong> Abs(System.Runtime.Intrinsics.Vector128<long> value) { throw null; }
-            public static System.Runtime.Intrinsics.Vector128<double> Add(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
+            public static System.Runtime.Intrinsics.Vector128<double> Add(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
         }
     }
     [System.CLSCompliantAttribute(false)]

--- a/src/System.Runtime.Intrinsics.Experimental/src/ApiCompatBaseline.txt
+++ b/src/System.Runtime.Intrinsics.Experimental/src/ApiCompatBaseline.txt
@@ -1,3 +1,0 @@
-Compat issues with assembly System.Runtime.Intrinsics.Experimental:
-CannotSealType : Type 'System.Runtime.Intrinsics.Arm.AdvSimd.Arm64' is effectively (has a private constructor) sealed in the reference but not sealed in the implementation.
-Total Issues: 1

--- a/src/System.Runtime.Intrinsics.Experimental/src/MatchingRefApiCompatBaseline.txt
+++ b/src/System.Runtime.Intrinsics.Experimental/src/MatchingRefApiCompatBaseline.txt
@@ -1,4 +1,0 @@
-Compat issues with assembly System.Runtime.Intrinsics.Experimental:
-CannotSealType : Type 'System.Runtime.Intrinsics.Arm.AdvSimd.Arm64' is effectively (has a private constructor) sealed in the reference but not sealed in the implementation.
-MembersMustExist : Member 'System.Runtime.Intrinsics.Arm.AdvSimd.Arm64..ctor()' does not exist in the reference but it does exist in the implementation.
-Total Issues: 2


### PR DESCRIPTION
CoreFX side changes to https://github.com/dotnet/coreclr/pull/25508