### PR TITLE
Add runtime id for Arch Linux

### DIFF
--- a/src/pkg/Microsoft.NETCore.Platforms/runtime.compatibility.json
+++ b/src/pkg/Microsoft.NETCore.Platforms/runtime.compatibility.json
@@ -270,6 +270,23 @@
     "any",
     "base"
   ],
+  "arch": [
+    "arch",
+    "linux",
+    "unix",
+    "any",
+    "base"
+  ],
+  "arch-x64": [
+    "arch-x64",
+    "arch",
+    "linux-x64",
+    "linux",
+    "unix-x64",
+    "unix",
+    "any",
+    "base"
+  ],
   "base": [
     "base"
   ],

--- a/src/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/src/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -121,6 +121,17 @@
         "any"
       ]
     },
+    "arch": {
+      "#import": [
+        "linux"
+      ]
+    },
+    "arch-x64": {
+      "#import": [
+        "arch",
+        "linux-x64"
+      ]
+    },
     "base": {
       "#import": []
     },

--- a/src/pkg/Microsoft.NETCore.Platforms/runtimeGroups.props
+++ b/src/pkg/Microsoft.NETCore.Platforms/runtimeGroups.props
@@ -25,6 +25,11 @@
       <Versions>21</Versions>
     </RuntimeGroup>
 
+    <RuntimeGroup Include="arch">
+      <Parent>linux</Parent>
+      <Architectures>x64</Architectures>
+    </RuntimeGroup>
+
     <RuntimeGroup Include="centos">
       <Parent>rhel</Parent>
       <Architectures>x64</Architectures>


### PR DESCRIPTION
Like gentoo, Arch Linux is a rolling release and doesn't have explicit version numbers.

```
$ docker run -it archlinux/base cat /etc/os-release
NAME="Arch Linux"
PRETTY_NAME="Arch Linux"
ID=arch
BUILD_ID=rolling
ANSI_COLOR="0;36"
HOME_URL="https://www.archlinux.org/"
DOCUMENTATION_URL="https://wiki.archlinux.org/"
SUPPORT_URL="https://bbs.archlinux.org/"
BUG_REPORT_URL="https://bugs.archlinux.org/"
LOGO=archlinux
```

cc @alucryd