### PR TITLE
Add tests to verify that JSON deserializer doesn't do any multiplication or addition on the string length

### DIFF
--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
@@ -380,9 +380,31 @@ namespace System.Text.Json.Serialization.Tests
         public static void LongInputString(int length)
         {
             // Verify boundary conditions in Deserialize() that inspect the size to determine allocation strategy.
-            string repeated = new string('x', length - 2);
+            DeserializeLongJsonString(length);
+        }
+
+        // NOTE: VeryLongInputString test is constrained to run on Windows and MacOSX because it causes
+        //       problems on Linux due to the way deferred memory allocation works. On Linux, the allocation can
+        //       succeed even if there is not enough memory but then the test may get killed by the OOM killer at the
+        //       time the memory is accessed which triggers the full memory allocation.
+        [ConditionalTheory(nameof(IsX64))]
+        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX)]
+        [InlineData(int.MaxValue - 3)]
+        [InlineData(int.MaxValue - 2)]
+        [InlineData(int.MaxValue - 1)]
+        [InlineData(int.MaxValue)]
+        [OuterLoop]
+        public static void VeryLongInputString(int length)
+        {
+            // Verify that deserializer does not do any multiplication or addition on the length
+            DeserializeLongJsonString(length);
+        }
+
+        private static void DeserializeLongJsonString(int stringLength)
+        {
+            string repeated = new string('x', stringLength - 2);
             string json = $"\"{repeated}\"";
-            Assert.Equal(length, json.Length);
+            Assert.Equal(stringLength, json.Length);
 
             string str = JsonSerializer.Deserialize<string>(json);
             Assert.Equal(repeated, str);

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
@@ -429,7 +429,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(stringLength, json.Length);
 
             string str = JsonSerializer.Deserialize<string>(json);
-            Assert.True(json.AsSpan(1, json.Length - 2).SequenceEqual(str));
+            Assert.True(json.AsSpan(1, json.Length - 2).SequenceEqual(str.AsSpan()));
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
@@ -412,30 +412,24 @@ namespace System.Text.Json.Serialization.Tests
 
         private static void DeserializeLongJsonString(int stringLength)
         {
-            string json, str;
+            string json;
+            char fillChar = 'x';
 
 #if BUILDING_INBOX_LIBRARY
-            char fillChar = 'x';
             json = string.Create(stringLength, fillChar, (chars, fillChar) =>
             {
                 chars.Fill(fillChar);
                 chars[0] = '"';
                 chars[chars.Length - 1] = '"';
             });
-
-            Assert.Equal(stringLength, json.Length);
-
-            str = JsonSerializer.Deserialize<string>(json);
-            Assert.True(json.AsSpan(1, json.Length - 2).SequenceEqual(str));
 #else
-            string repeated = new string('x', stringLength - 2);
+            string repeated = new string(fillChar, stringLength - 2);
             json = $"\"{repeated}\"";
-
+#endif
             Assert.Equal(stringLength, json.Length);
 
-            str = JsonSerializer.Deserialize<string>(json);
-            Assert.Equal(repeated, str);
-#endif
+            string str = JsonSerializer.Deserialize<string>(json);
+            Assert.True(json.AsSpan(1, json.Length - 2).SequenceEqual(str));
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
@@ -392,13 +392,7 @@ namespace System.Text.Json.Serialization.Tests
         //       time the memory is accessed which triggers the full memory allocation.
         [ConditionalTheory(nameof(IsX64))]
         [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX)]
-        [InlineData(MaxInt - 3)]
-        [InlineData(MaxInt - 2)]
-        [InlineData(MaxInt - 1)]
         [InlineData(MaxInt)]
-        [InlineData(MaxInt + 1)]
-        [InlineData(MaxInt + 2)]
-        [InlineData(MaxInt + 3)]
         [InlineData(MaximumPossibleStringLength)]
         [OuterLoop]
         public static void VeryLongInputString(int length)

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
@@ -383,20 +383,25 @@ namespace System.Text.Json.Serialization.Tests
             DeserializeLongJsonString(length);
         }
 
+        private const int MaxInt = int.MaxValue / MaxExpansionFactorWhileTranscoding;
+
         // NOTE: VeryLongInputString test is constrained to run on Windows and MacOSX because it causes
         //       problems on Linux due to the way deferred memory allocation works. On Linux, the allocation can
         //       succeed even if there is not enough memory but then the test may get killed by the OOM killer at the
         //       time the memory is accessed which triggers the full memory allocation.
         [ConditionalTheory(nameof(IsX64))]
         [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.OSX)]
-        [InlineData(int.MaxValue - 3)]
-        [InlineData(int.MaxValue - 2)]
-        [InlineData(int.MaxValue - 1)]
-        [InlineData(int.MaxValue)]
+        [InlineData(MaxInt - 3)]
+        [InlineData(MaxInt - 2)]
+        [InlineData(MaxInt - 1)]
+        [InlineData(MaxInt)]
+        [InlineData(MaxInt + 1)]
+        [InlineData(MaxInt + 2)]
+        [InlineData(MaxInt + 3)]
         [OuterLoop]
         public static void VeryLongInputString(int length)
         {
-            // Verify that deserializer does not do any multiplication or addition on the length
+            // Verify that deserializer does not do any multiplication on the length
             DeserializeLongJsonString(length);
         }
 

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
@@ -399,9 +399,6 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData(MaxInt + 1)]
         [InlineData(MaxInt + 2)]
         [InlineData(MaxInt + 3)]
-        [InlineData(MaximumPossibleStringLength - 3)]
-        [InlineData(MaximumPossibleStringLength - 2)]
-        [InlineData(MaximumPossibleStringLength - 1)]
         [InlineData(MaximumPossibleStringLength)]
         [OuterLoop]
         public static void VeryLongInputString(int length)

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
@@ -384,6 +384,7 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         private const int MaxInt = int.MaxValue / MaxExpansionFactorWhileTranscoding;
+        private const int MaximumPossibleStringLength = (int.MaxValue / 2) - 32;
 
         // NOTE: VeryLongInputString test is constrained to run on Windows and MacOSX because it causes
         //       problems on Linux due to the way deferred memory allocation works. On Linux, the allocation can
@@ -398,10 +399,14 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData(MaxInt + 1)]
         [InlineData(MaxInt + 2)]
         [InlineData(MaxInt + 3)]
+        [InlineData(MaximumPossibleStringLength - 3)]
+        [InlineData(MaximumPossibleStringLength - 2)]
+        [InlineData(MaximumPossibleStringLength - 1)]
+        [InlineData(MaximumPossibleStringLength)]
         [OuterLoop]
         public static void VeryLongInputString(int length)
         {
-            // Verify that deserializer does not do any multiplication on the length
+            // Verify that deserializer does not do any multiplication or addition on the string length
             DeserializeLongJsonString(length);
         }
 


### PR DESCRIPTION
Fixes #41687

Unfortuntately, I'm unable to run these tests locally due to OutOfMemoryException.

cc @steveharter @ahsonkhan