### PR TITLE
System.IO.FileSystem.MoveFile(...) Delete Source File When Overwrite is True

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/FileSystem.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileSystem.Unix.cs
@@ -169,6 +169,7 @@ namespace System.IO
                     if (errorInfo.Error == Interop.Error.EXDEV) // rename fails across devices / mount points
                     {
                         CopyFile(sourceFullPath, destFullPath, overwrite);
+                        DeleteFile(sourceFullPath);
                     }
                     else
                     {


### PR DESCRIPTION
Solves #41009. System.IO.FileSystem.MoveFile(...) did not remove the source file after copying the file to a different file system.

No tests added since it requires two filesystems, but it was tested locally on my own machine and it worked. No tests cover this branch since before, and therefore I assume that a test is not necessary. If you have suggestions for how it can be tested, feel free to point it out.