### PR TITLE
use background thread to wait for address changes on OSX

### DIFF
--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.OSX.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.OSX.cs
@@ -181,6 +181,7 @@ namespace System.Net.NetworkInformation
                 }
             }
             s_runLoopThread = new Thread(RunLoopThreadStart);
+            s_runLoopThread.IsBackground = true;
             s_runLoopThread.Start();
             s_runLoopStartedEvent.WaitOne(); // Wait for the new thread to finish initialization.
         }

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkAvailabilityChangedTests.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkAvailabilityChangedTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
-using Microsoft.DotNet.RemoteExecutor;
 
 namespace System.Net.NetworkInformation.Tests
 {

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkAvailabilityChangedTests.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkAvailabilityChangedTests.cs
@@ -34,7 +34,7 @@ namespace System.Net.NetworkInformation.Tests
             // Register without unregistering.
             // This should not block process exit. If it does, this test will pass
             // but we would fail to exit test run at the end.
-            // We cannot test this via RemoteInvoke() as that call System.Exit()
+            // We cannot test this via RemoteInvoke() as that calls Environment.Exit()
             // and forces quit even when foreground threads are running.
             NetworkChange.NetworkAddressChanged += _addressHandler;
             {

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkAvailabilityChangedTests.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkAvailabilityChangedTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
+using Microsoft.DotNet.RemoteExecutor;
 
 namespace System.Net.NetworkInformation.Tests
 {
@@ -25,6 +26,20 @@ namespace System.Net.NetworkInformation.Tests
         public void NetworkAvailabilityChanged_JustRemove_Success()
         {
             NetworkChange.NetworkAvailabilityChanged -= _availabilityHandler;
+        }
+
+        [Fact]
+        [ActiveIssue(33530, TestPlatforms.FreeBSD)]
+        public void NetworkAddressChanged_Add_DoesNotBlock()
+        {
+            // Register without unregistering.
+            // This should not block process exit. If it does, this test will pass
+            // but we would fail to exit test run at the end.
+            // We cannot test this via RemoteInvoke() as that call System.Exit()
+            // and forces quit even when foreground threads are running.
+            NetworkChange.NetworkAddressChanged += _addressHandler;
+            {
+            };
         }
 
         [Fact]


### PR DESCRIPTION
we should not block process exit. 

fixes #41740

