### PR TITLE
Rewrite Uri.EscapeString

### DIFF
--- a/src/System.Private.Uri/src/System.Private.Uri.csproj
+++ b/src/System.Private.Uri/src/System.Private.Uri.csproj
@@ -37,6 +37,9 @@
     <Compile Include="System\UriPartial.cs" />
     <Compile Include="System\UriScheme.cs" />
     <Compile Include="System\UriSyntax.cs" />
+    <Compile Include="$(CommonPath)\CoreLib\System\Text\ValueStringBuilder.cs">
+      <Link>Common\CoreLib\System\Text\ValueStringBuilder.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
     <Compile Include="System\Uri.Windows.cs" />

--- a/src/System.Private.Uri/src/System/UriBuilder.cs
+++ b/src/System.Private.Uri/src/System/UriBuilder.cs
@@ -242,11 +242,9 @@ namespace System
             }
             set
             {
-                if ((value == null) || (value.Length == 0))
-                {
-                    value = "/";
-                }
-                _path = Uri.InternalEscapeString(value.Replace('\\', '/'));
+                _path = string.IsNullOrEmpty(value) ?
+                    "/" :
+                    Uri.InternalEscapeString(value.Replace('\\', '/'));
                 _changed = true;
             }
         }

--- a/src/System.Private.Uri/src/System/UriHelper.cs
+++ b/src/System.Private.Uri/src/System/UriHelper.cs
@@ -10,9 +10,11 @@ namespace System
 {
     internal static class UriHelper
     {
-        internal static readonly char[] s_hexUpperChars = {
-                                   '0', '1', '2', '3', '4', '5', '6', '7',
-                                   '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
+        internal static ReadOnlySpan<byte> HexUpperChars => new byte[16]
+        {
+            (byte)'0', (byte)'1', (byte)'2', (byte)'3', (byte)'4', (byte)'5', (byte)'6', (byte)'7',
+            (byte)'8', (byte)'9', (byte)'A', (byte)'B', (byte)'C', (byte)'D', (byte)'E', (byte)'F'
+        };
 
         internal static readonly Encoding s_noFallbackCharUTF8 = Encoding.GetEncoding(
             Encoding.UTF8.CodePage, new EncoderReplacementFallback(""), new DecoderReplacementFallback(""));
@@ -114,141 +116,186 @@ namespace System
             return true;
         }
 
-        // - forceX characters are always escaped if found
-        // - rsvd character will remain unescaped
-        //
-        // start    - starting offset from input
-        // end      - the exclusive ending offset in input
-        // destPos  - starting offset in dest for output, on return this will be an exclusive "end" in the output.
-        //
-        // In case "dest" has lack of space it will be reallocated by preserving the _whole_ content up to current destPos
-        //
-        // Returns null if nothing has to be escaped AND passed dest was null, otherwise the resulting array with the updated destPos
-        //
-        private const short c_MaxAsciiCharsReallocate = 40;
-        private const short c_MaxUnicodeCharsReallocate = 40;
-        private const short c_MaxUTF_8BytesPerUnicodeChar = 4;
-        private const short c_EncodedCharsPerByte = 3;
-
-        [return: NotNullIfNotNull("dest")]
-        internal static unsafe char[]? EscapeString(string input, int start, int end, char[]? dest, ref int destPos,
-            bool isUriString, char force1, char force2, char rsvd)
+        internal static string EscapeString(
+            string stringToEscape, // same name as public API
+            bool checkExistingEscaped, ReadOnlySpan<bool> unreserved, char forceEscape1 = '\0', char forceEscape2 = '\0')
         {
-            int i = start;
-            int prevInputPos = start;
-            byte* bytes = stackalloc byte[c_MaxUnicodeCharsReallocate * c_MaxUTF_8BytesPerUnicodeChar];   // 40*4=160
-
-            fixed (char* pStr = input)
+            if (stringToEscape is null)
             {
-                for (; i < end; ++i)
-                {
-                    char ch = pStr[i];
-
-                    // a Unicode ?
-                    if (ch > '\x7F')
-                    {
-                        short maxSize = (short)Math.Min(end - i, (int)c_MaxUnicodeCharsReallocate - 1);
-
-                        short count = 1;
-                        for (; count < maxSize && pStr[i + count] > '\x7f'; ++count)
-                            ;
-
-                        // Is the last a high surrogate?
-                        if (pStr[i + count - 1] >= 0xD800 && pStr[i + count - 1] <= 0xDBFF)
-                        {
-                            // Should be a rare case where the app tries to feed an invalid Unicode surrogates pair
-                            if (count == 1 || count == end - i)
-                                throw new UriFormatException(SR.net_uri_BadString);
-                            // need to grab one more char as a Surrogate except when it's a bogus input
-                            ++count;
-                        }
-
-                        dest = EnsureDestinationSize(pStr, dest, i,
-                            (short)(count * c_MaxUTF_8BytesPerUnicodeChar * c_EncodedCharsPerByte),
-                            c_MaxUnicodeCharsReallocate * c_MaxUTF_8BytesPerUnicodeChar * c_EncodedCharsPerByte,
-                            ref destPos, prevInputPos);
-
-                        short numberOfBytes = (short)Encoding.UTF8.GetBytes(pStr + i, count, bytes,
-                            c_MaxUnicodeCharsReallocate * c_MaxUTF_8BytesPerUnicodeChar);
-
-                        // This is the only exception that built in UriParser can throw after a Uri ctor.
-                        // Should not happen unless the app tries to feed an invalid Unicode String
-                        if (numberOfBytes == 0)
-                            throw new UriFormatException(SR.net_uri_BadString);
-
-                        i += (count - 1);
-
-                        for (count = 0; count < numberOfBytes; ++count)
-                            EscapeAsciiChar((char)bytes[count], dest, ref destPos);
-
-                        prevInputPos = i + 1;
-                    }
-                    else if (ch == '%' && rsvd == '%')
-                    {
-                        // Means we don't reEncode '%' but check for the possible escaped sequence
-                        dest = EnsureDestinationSize(pStr, dest, i, c_EncodedCharsPerByte,
-                            c_MaxAsciiCharsReallocate * c_EncodedCharsPerByte, ref destPos, prevInputPos);
-                        if (i + 2 < end && EscapedAscii(pStr[i + 1], pStr[i + 2]) != Uri.c_DummyChar)
-                        {
-                            // leave it escaped
-                            dest[destPos++] = '%';
-                            dest[destPos++] = pStr[i + 1];
-                            dest[destPos++] = pStr[i + 2];
-                            i += 2;
-                        }
-                        else
-                        {
-                            EscapeAsciiChar('%', dest, ref destPos);
-                        }
-                        prevInputPos = i + 1;
-                    }
-                    else if (ch == force1 || ch == force2)
-                    {
-                        dest = EnsureDestinationSize(pStr, dest, i, c_EncodedCharsPerByte,
-                            c_MaxAsciiCharsReallocate * c_EncodedCharsPerByte, ref destPos, prevInputPos);
-                        EscapeAsciiChar(ch, dest, ref destPos);
-                        prevInputPos = i + 1;
-                    }
-                    else if (ch != rsvd && (isUriString ? !IsReservedUnreservedOrHash(ch) : !IsUnreserved(ch)))
-                    {
-                        dest = EnsureDestinationSize(pStr, dest, i, c_EncodedCharsPerByte,
-                            c_MaxAsciiCharsReallocate * c_EncodedCharsPerByte, ref destPos, prevInputPos);
-                        EscapeAsciiChar(ch, dest, ref destPos);
-                        prevInputPos = i + 1;
-                    }
-                }
-
-                if (prevInputPos != i)
-                {
-                    // need to fill up the dest array ?
-                    if (prevInputPos != start || dest != null)
-                        dest = EnsureDestinationSize(pStr, dest, i, 0, 0, ref destPos, prevInputPos);
-                }
+                throw new ArgumentNullException(nameof(stringToEscape));
+            }
+            if (stringToEscape.Length == 0)
+            {
+                return string.Empty;
             }
 
-            return dest;
+            // Get the table of characters that do not need to be escaped.
+            Debug.Assert(unreserved.Length == 0x80);
+            ReadOnlySpan<bool> noEscape = stackalloc bool[0];
+            if ((forceEscape1 | forceEscape2) == 0)
+            {
+                noEscape = unreserved;
+            }
+            else
+            {
+                Span<bool> tmp = stackalloc bool[0x80];
+                unreserved.CopyTo(tmp);
+                tmp[forceEscape1] = false;
+                tmp[forceEscape2] = false;
+                noEscape = tmp;
+            }
+
+            // If the whole string is made up of ASCII unreserved chars, just return it.
+            Debug.Assert(!noEscape['%'], "Need to treat % specially; it should be part of any escaped set");
+            int i = 0;
+            char c;
+            for (; i < stringToEscape.Length && (c = stringToEscape[i]) <= 0x7F && noEscape[c]; i++) ;
+            if (i == stringToEscape.Length)
+            {
+                return stringToEscape;
+            }
+
+            // Otherwise, create a ValueStringBuilder to store the escaped data into,
+            // append to it all of the noEscape chars we already iterated through,
+            // escape the rest, and return the result as a string.
+            var vsb = new ValueStringBuilder(stackalloc char[256]);
+            vsb.Append(stringToEscape.AsSpan(0, i));
+            EscapeStringToBuilder(stringToEscape.AsSpan(i), ref vsb, noEscape, checkExistingEscaped);
+            return vsb.ToString();
         }
 
-        //
-        // ensure destination array has enough space and contains all the needed input stuff
-        //
-        private static unsafe char[] EnsureDestinationSize(char* pStr, char[]? dest, int currentInputPos,
-            short charsToAdd, short minReallocateChars, ref int destPos, int prevInputPos)
+        // forceX characters are always escaped if found
+        // destPos  - starting offset in dest for output, on return this will be an exclusive "end" in the output.
+        // In case "dest" has lack of space it will be reallocated by preserving the _whole_ content up to current destPos
+        // Returns null if nothing has to be escaped AND passed dest was null, otherwise the resulting array with the updated destPos
+        [return: NotNullIfNotNull("dest")]
+        internal static char[]? EscapeString(
+            ReadOnlySpan<char> stringToEscape,
+            char[]? dest, ref int destPos,
+            bool checkExistingEscaped, char forceEscape1 = '\0', char forceEscape2 = '\0')
         {
-            if ((object?)dest == null || dest.Length < destPos + (currentInputPos - prevInputPos) + charsToAdd)
+            // Get the table of characters that do not need to be escaped.
+            ReadOnlySpan<bool> noEscape = stackalloc bool[0];
+            if ((forceEscape1 | forceEscape2) == 0)
             {
-                // allocating or reallocating array by ensuring enough space based on maxCharsToAdd.
-                char[] newresult = new char[destPos + (currentInputPos - prevInputPos) + minReallocateChars];
-
-                if ((object?)dest != null && destPos != 0)
-                    Buffer.BlockCopy(dest, 0, newresult, 0, destPos << 1);
-                dest = newresult;
+                noEscape = UnreservedReservedTable;
+            }
+            else
+            {
+                Span<bool> tmp = stackalloc bool[0x80];
+                UnreservedReservedTable.CopyTo(tmp);
+                tmp[forceEscape1] = false;
+                tmp[forceEscape2] = false;
+                noEscape = tmp;
             }
 
-            // ensuring we copied everything form the input string left before last escaping
-            while (prevInputPos != currentInputPos)
-                dest[destPos++] = pStr[prevInputPos++];
+            // If the whole string is made up of ASCII unreserved chars, take a fast pasth.  Per the contract, if
+            // dest is null, just return it.  If it's not null, copy everything to it and update destPos accordingly;
+            // if that requires resizing it, do so.
+            Debug.Assert(!noEscape['%'], "Need to treat % specially in case checkExistingEscaped is true");
+            int i = 0;
+            char c;
+            for (; i < stringToEscape.Length && (c = stringToEscape[i]) <= 0x7F && noEscape[c]; i++) ;
+            if (i == stringToEscape.Length)
+            {
+                if (dest != null)
+                {
+                    EnsureCapacity(dest, destPos, stringToEscape.Length);
+                    stringToEscape.CopyTo(dest.AsSpan(destPos));
+                    destPos += stringToEscape.Length;
+                }
+
+                return dest;
+            }
+
+            // Otherwise, create a ValueStringBuilder to store the escaped data into,
+            // append to it all of the noEscape chars we already iterated through, and
+            // escape the rest into the ValueStringBuilder.
+            var vsb = new ValueStringBuilder(stackalloc char[256]);
+            vsb.Append(stringToEscape.Slice(0, i));
+            EscapeStringToBuilder(stringToEscape.Slice(i), ref vsb, noEscape, checkExistingEscaped);
+
+            // Finally update dest with the result.
+            EnsureCapacity(dest, destPos, vsb.Length);
+            vsb.TryCopyTo(dest.AsSpan(destPos), out int charsWritten);
+            destPos += charsWritten;
             return dest;
+
+            static void EnsureCapacity(char[]? dest, int destSize, int requiredSize)
+            {
+                if (dest == null || dest.Length - destSize < requiredSize)
+                {
+                    Array.Resize(ref dest, destSize + requiredSize + 120); // 120 == arbitrary minimum-empty space copied from previous implementation
+                }
+            }
+        }
+
+        private static void EscapeStringToBuilder(
+            ReadOnlySpan<char> stringToEscape, ref ValueStringBuilder vsb,
+            ReadOnlySpan<bool> noEscape, bool checkExistingEscaped)
+        {
+            // Allocate enough stack space to hold any Rune's UTF8 encoding.
+            Span<byte> utf8Bytes = stackalloc byte[4];
+
+            // Then enumerate every rune in the input.
+            SpanRuneEnumerator e = stringToEscape.EnumerateRunes();
+            while (e.MoveNext())
+            {
+                Rune r = e.Current;
+
+                if (!r.IsAscii)
+                {
+                    // The rune is non-ASCII, so encode it as UTF8, and escape each UTF8 byte.
+                    r.TryEncodeToUtf8(utf8Bytes, out int bytesWritten);
+                    foreach (byte b in utf8Bytes.Slice(0, bytesWritten))
+                    {
+                        vsb.Append('%');
+                        vsb.Append((char)HexUpperChars[(b & 0xf0) >> 4]);
+                        vsb.Append((char)HexUpperChars[b & 0xf]);
+                    }
+                    continue;
+                }
+
+                // If the value doesn't need to be escaped, append it and continue.
+                byte value = (byte)r.Value;
+                if (noEscape[value])
+                {
+                    vsb.Append((char)value);
+                    continue;
+                }
+
+                // If we're checking for existing escape sequences, then if this is the beginning of
+                // one, check the next two characters in the sequence.  This is a little tricky to do
+                // as we're using an enumerator, but luckily it's a ref struct-based enumerator: we can
+                // make a copy and iterate through the copy without impacting the original, and then only
+                // push the original ahead if we find what we're looking for in the copy.
+                if (checkExistingEscaped && value == '%')
+                {
+                    // If the next two characters are valid escaped ASCII, then just output them as-is.
+                    SpanRuneEnumerator tmpEnumerator = e;
+                    if (tmpEnumerator.MoveNext())
+                    {
+                        Rune r1 = tmpEnumerator.Current;
+                        if (r1.IsAscii && IsHexDigit((char)r1.Value) && tmpEnumerator.MoveNext())
+                        {
+                            Rune r2 = tmpEnumerator.Current;
+                            if (r2.IsAscii && IsHexDigit((char)r2.Value))
+                            {
+                                vsb.Append('%');
+                                vsb.Append((char)r1.Value);
+                                vsb.Append((char)r2.Value);
+                                e = tmpEnumerator;
+                                continue;
+                            }
+                        }
+                    }
+                }
+
+                // Otherwise, append the escaped character.
+                vsb.Append('%');
+                vsb.Append((char)HexUpperChars[(value & 0xf0) >> 4]);
+                vsb.Append((char)HexUpperChars[value & 0xf]);
+            }
         }
 
         //
@@ -627,8 +674,8 @@ namespace System
         internal static void EscapeAsciiChar(char ch, char[] to, ref int pos)
         {
             to[pos++] = '%';
-            to[pos++] = s_hexUpperChars[(ch & 0xf0) >> 4];
-            to[pos++] = s_hexUpperChars[ch & 0xf];
+            to[pos++] = (char)HexUpperChars[(ch & 0xf0) >> 4];
+            to[pos++] = (char)HexUpperChars[ch & 0xf];
         }
 
         internal static char EscapedAscii(char digit, char next)
@@ -664,7 +711,6 @@ namespace System
 
         internal const string RFC3986ReservedMarks = @";/?:@&=+$,#[]!'()*";
         private const string RFC2396ReservedMarks = @";/?:@&=+$,";
-        private const string RFC3986UnreservedMarks = @"-_.~";
         private const string AdditionalUnsafeToUnescape = @"%\#"; // While not specified as reserved, these are still unsafe to unescape.
 
         // When unescaping in safe mode, do not unescape the RFC 3986 reserved set:
@@ -699,32 +745,33 @@ namespace System
             return false;
         }
 
-        private static unsafe bool IsReservedUnreservedOrHash(char c)
+        internal static ReadOnlySpan<bool> UnreservedReservedTable => new bool[0x80]
         {
-            if (IsUnreserved(c))
-            {
-                return true;
-            }
-            return (RFC3986ReservedMarks.IndexOf(c) >= 0);
-        }
+            // true for all ASCII letters and digits, as well as the RFC3986 reserved characters, unreserved characters, and hash
+            false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
+            false, true,  false, true,  true,  false, true,  true,  true,  true,  true,  true,  true,  true,  true,  true,
+            true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  false, true,  false, true,
+            true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,
+            true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  false, true,  false, true,
+            false, true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,
+            true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  false, false, false, true,  false,
+        };
 
-        internal static unsafe bool IsUnreserved(char c)
-        {
-            if (UriHelper.IsAsciiLetterOrDigit(c))
-            {
-                return true;
-            }
-            return (RFC3986UnreservedMarks.IndexOf(c) >= 0);
-        }
+        internal static bool IsUnreserved(int c) => c < 0x80 && UnreservedTable[c];
 
-        internal static bool Is3986Unreserved(char c)
+        internal static ReadOnlySpan<bool> UnreservedTable => new bool[0x80]
         {
-            if (UriHelper.IsAsciiLetterOrDigit(c))
-            {
-                return true;
-            }
-            return (RFC3986UnreservedMarks.IndexOf(c) >= 0);
-        }
+            // true for all ASCII letters and digits, as well as the RFC3986 unreserved marks '-', '_', '.', and '~'
+            false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false, false, false, false, false, false, true,  true,  false,
+            true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  false, false, false, false, false, false,
+            false, true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,
+            true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  false, false, false, false, true,
+            false, true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,
+            true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  true,  false, false, false, true,  false,
+        };
 
         //
         // Is this a gen delim char from RFC 3986
@@ -742,16 +789,19 @@ namespace System
         }
 
         //Only consider ASCII characters
-        internal static bool IsAsciiLetter(char character)
-        {
-            return (character >= 'a' && character <= 'z') ||
-                   (character >= 'A' && character <= 'Z');
-        }
+        internal static bool IsAsciiLetter(char character) =>
+            ((uint)(character - 'a') <= 'z' - 'a') ||
+            ((uint)(character - 'A') <= 'Z' - 'A');
 
-        internal static bool IsAsciiLetterOrDigit(char character)
-        {
-            return IsAsciiLetter(character) || (character >= '0' && character <= '9');
-        }
+        internal static bool IsAsciiLetterOrDigit(char character) =>
+            ((uint)(character - 'a') <= 'z' - 'a') ||
+            ((uint)(character - 'A') <= 'Z' - 'A') ||
+            ((uint)(character - '0') <= '9' - '0');
+
+        internal static bool IsHexDigit(char character) =>
+            ((uint)(character - 'A') <= 'F' - 'A') ||
+            ((uint)(character - 'a') <= 'f' - 'a') ||
+            ((uint)(character - '0') <= '9' - '0');
 
         //
         // Is this a Bidirectional control char.. These get stripped

--- a/src/System.Private.Uri/src/System/UriHelper.cs
+++ b/src/System.Private.Uri/src/System/UriHelper.cs
@@ -744,6 +744,8 @@ namespace System
             }
             return false;
         }
+        
+        // "Reserved" and "Unreserved" characters are based on RFC 3986.
 
         internal static ReadOnlySpan<bool> UnreservedReservedTable => new bool[0x80]
         {

--- a/src/System.Private.Uri/src/System/UriHelper.cs
+++ b/src/System.Private.Uri/src/System/UriHelper.cs
@@ -788,20 +788,16 @@ namespace System
             return (ch <= ' ') && (ch == ' ' || ch == '\n' || ch == '\r' || ch == '\t');
         }
 
-        //Only consider ASCII characters
         internal static bool IsAsciiLetter(char character) =>
-            ((uint)(character - 'a') <= 'z' - 'a') ||
-            ((uint)(character - 'A') <= 'Z' - 'A');
+            (((uint)character - 'A') & ~0x20) < 26;
 
         internal static bool IsAsciiLetterOrDigit(char character) =>
-            ((uint)(character - 'a') <= 'z' - 'a') ||
-            ((uint)(character - 'A') <= 'Z' - 'A') ||
-            ((uint)(character - '0') <= '9' - '0');
+            ((((uint)character - 'A') & ~0x20) < 26) ||
+            (((uint)character - '0') < 10);
 
         internal static bool IsHexDigit(char character) =>
-            ((uint)(character - 'A') <= 'F' - 'A') ||
-            ((uint)(character - 'a') <= 'f' - 'a') ||
-            ((uint)(character - '0') <= '9' - '0');
+            ((((uint)character - 'A') & ~0x20) < 6) ||
+            (((uint)character - '0') < 10);
 
         //
         // Is this a Bidirectional control char.. These get stripped

--- a/src/System.Private.Uri/tests/UnitTests/System.Private.Uri.Unit.Tests.csproj
+++ b/src/System.Private.Uri/tests/UnitTests/System.Private.Uri.Unit.Tests.csproj
@@ -20,5 +20,8 @@
     <Compile Include="..\..\src\System\UriHelper.cs" />
     <Compile Include="..\..\src\System\IriHelper.cs" />
     <Compile Include="..\..\src\System\UriEnumTypes.cs" />
+    <Compile Include="$(CommonPath)\CoreLib\System\Text\ValueStringBuilder.cs">
+      <Link>Common\CoreLib\System\Text\ValueStringBuilder.cs</Link>
+    </Compile>
   </ItemGroup>
 </Project>

--- a/src/System.Runtime/tests/System/Uri.MethodsTests.cs
+++ b/src/System.Runtime/tests/System/Uri.MethodsTests.cs
@@ -416,9 +416,12 @@ namespace System.Tests
         }
 
         [Fact]
-        public void EscapeDataString_HighSurrogatePair()
+        public void EscapeDataString_InvalidSurrogatePairs()
         {
-            EscapeDataString("abc\uD800\uD800abc", "abc%EF%BF%BD%EF%BF%BD%61bc");
+            EscapeDataString("\uD800", "%EF%BF%BD");
+            EscapeDataString("abc\uD800", "abc%EF%BF%BD");
+            EscapeDataString("abc\uD800\uD800abc", "abc%EF%BF%BD%EF%BF%BDabc");
+            EscapeDataString("\xD800\xD800\xDFFF", "%EF%BF%BD%F0%90%8F%BF");
         }
 
         [Fact]
@@ -435,12 +438,9 @@ namespace System.Tests
         }
 
         [Fact]
-        public void EscapeDataString_Invalid()
+        public void EscapeDataString_NullArgument()
         {
-            AssertExtensions.Throws<ArgumentNullException>("stringToEscape", () => Uri.EscapeDataString(null)); // StringToEscape is null
-
-            Assert.Throws<UriFormatException>(() => Uri.EscapeDataString("\uD800")); // Incomplete surrogate pair provided
-            Assert.Throws<UriFormatException>(() => Uri.EscapeDataString("abc\uD800")); // Incomplete surrogate pair provided
+            AssertExtensions.Throws<ArgumentNullException>("stringToEscape", () => Uri.EscapeDataString(null));
         }
 
         [Theory]
@@ -470,9 +470,12 @@ namespace System.Tests
         }
 
         [Fact]
-        public void EscapeUriString_HighSurrogatePair()
+        public void EscapeUriString_InvalidSurrogatePairs()
         {
-            EscapeUriString("abc\uD800\uD800abc", "abc%EF%BF%BD%EF%BF%BD%61bc");
+            EscapeUriString("\uD800", "%EF%BF%BD");
+            EscapeUriString("abc\uD800", "abc%EF%BF%BD");
+            EscapeUriString("abc\uD800\uD800abc", "abc%EF%BF%BD%EF%BF%BDabc");
+            EscapeUriString("\xD800\xD800\xDFFF", "%EF%BF%BD%F0%90%8F%BF");
         }
 
         [Fact]
@@ -492,9 +495,6 @@ namespace System.Tests
         public void EscapeUriString_Invalid()
         {
             AssertExtensions.Throws<ArgumentNullException>("stringToEscape", () => Uri.EscapeUriString(null)); // StringToEscape is null
-
-            Assert.Throws<UriFormatException>(() => Uri.EscapeUriString("\uD800")); // Incomplete surrogate pair provided
-            Assert.Throws<UriFormatException>(() => Uri.EscapeUriString("abc\uD800")); // Incomplete surrogate pair provided
         }
 
         public static IEnumerable<object[]> GetComponents_Basic_TestData()


### PR DESCRIPTION
Several public methods (Uri.EscapeDataString, Uri.EscapeUriString) and a bunch of internal call sites rely on the internal EscapeString helper.  This helper has several issues with it:
- It uses unsafe code.
- It unnecessarily requires and copies through a char[] to get to a string when a string is the required result.
- It has a lot of complexity around the handling of unicode.

This PR rewrites it to utilize Span, Rune, and other newer features in a way that enables it to be both safe and efficient.  Most inputs ends up being faster, and for very long inputs, it's much, much faster.  The use of ValueStringBuilder also results in less memory allocation, in some cases significantly.

The use of Rune also fixes two arguable bugs in the existing implementation around invalid Unicode sequences, which is why a couple tests were tweaked:
- Some but not all invalid unicode patterns result in replacement characters being used: a few invalid sequences (e.g. just a high surrogate) result in an exception.  We should be standardized on using replacement characters for all such invalid sequences.
- Some patterns with invalid unicode patterns actually result in unnecessary encoding, e.g. `Uri.EscapeDataString("\uD800\uD800a")` results in `a` being encoded.

|     Method | Tool | Length |                 Kind |                Mean | Ratio |    Allocated |
|----------- |---------- |------- |--------------------- |--------------------:|------:|-------------:|
| EscapeData | new       |     10 |           Unreserved |            19.92 ns |  0.23 |            - |
| EscapeData | old       |     10 |           Unreserved |            84.86 ns |  1.00 |            - |
|            |           |        |                      |                     |       |              |
|  EscapeUri | new       |     10 |           Unreserved |            17.00 ns |  0.17 |            - |
|  EscapeUri | old       |     10 |           Unreserved |           103.09 ns |  1.00 |            - |
|            |           |        |                      |                     |       |              |
| EscapeData | new       |     10 |              Unicode |           316.53 ns |  0.96 |        264 B |
| EscapeData | old       |     10 |              Unicode |           330.18 ns |  1.00 |       1248 B |
|            |           |        |                      |                     |       |              |
|  EscapeUri | new       |     10 |              Unicode |           313.91 ns |  0.95 |        264 B |
|  EscapeUri | old       |     10 |              Unicode |           328.76 ns |  1.00 |       1248 B |
|            |           |        |                      |                     |       |              |
| EscapeData | new       |     10 | OneRe(...)erved [25] |           154.93 ns |  1.04 |         48 B |
| EscapeData | old       |     10 | OneRe(...)erved [25] |           149.36 ns |  1.00 |        312 B |
|            |           |        |                      |                     |       |              |
|  EscapeUri | new       |     10 | OneRe(...)erved [25] |           152.34 ns |  0.85 |         48 B |
|  EscapeUri | old       |     10 | OneRe(...)erved [25] |           179.05 ns |  1.00 |        312 B |
|            |           |        |                      |                     |       |              |
| EscapeData | new       |     10 |          Alternating |           192.87 ns |  0.73 |        120 B |
| EscapeData | old       |     10 |          Alternating |           262.74 ns |  1.00 |        392 B |
|            |           |        |                      |                     |       |              |
|  EscapeUri | new       |     10 |          Alternating |           189.67 ns |  0.65 |        120 B |
|  EscapeUri | old       |     10 |          Alternating |           289.09 ns |  1.00 |        392 B |
|            |           |        |                      |                     |       |              |
| EscapeData | new       |    100 |           Unreserved |            83.99 ns |  0.13 |            - |
| EscapeData | old       |    100 |           Unreserved |           660.66 ns |  1.00 |            - |
|            |           |        |                      |                     |       |              |
|  EscapeUri | new       |    100 |           Unreserved |            83.69 ns |  0.09 |            - |
|  EscapeUri | old       |    100 |           Unreserved |           943.46 ns |  1.00 |            - |
|            |           |        |                      |                     |       |              |
| EscapeData | new       |    100 |              Unicode |         3,015.49 ns |  0.96 |       2424 B |
| EscapeData | old       |    100 |              Unicode |         3,150.40 ns |  1.00 |      12144 B |
|            |           |        |                      |                     |       |              |
|  EscapeUri | new       |    100 |              Unicode |         3,004.75 ns |  0.90 |       2424 B |
|  EscapeUri | old       |    100 |              Unicode |         3,334.80 ns |  1.00 |      12144 B |
|            |           |        |                      |                     |       |              |
| EscapeData | new       |    100 | OneRe(...)erved [25] |           997.48 ns |  0.96 |        232 B |
| EscapeData | old       |    100 | OneRe(...)erved [25] |         1,034.85 ns |  1.00 |        496 B |
|            |           |        |                      |                     |       |              |
|  EscapeUri | new       |    100 | OneRe(...)erved [25] |         1,009.19 ns |  0.89 |        232 B |
|  EscapeUri | old       |    100 | OneRe(...)erved [25] |         1,126.74 ns |  1.00 |        496 B |
|            |           |        |                      |                     |       |              |
| EscapeData | new       |    100 |          Alternating |         1,705.95 ns |  0.72 |       1080 B |
| EscapeData | old       |    100 |          Alternating |         2,361.35 ns |  1.00 |       2536 B |
|            |           |        |                      |                     |       |              |
|  EscapeUri | new       |    100 |          Alternating |         1,690.50 ns |  0.63 |       1080 B |
|  EscapeUri | old       |    100 |          Alternating |         2,691.28 ns |  1.00 |       2536 B |
|            |           |        |                      |                     |       |              |
| EscapeData | new       | 100000 |           Unreserved |        66,052.21 ns |  0.09 |            - |
| EscapeData | old       | 100000 |           Unreserved |       710,216.92 ns |  1.00 |            - |
|            |           |        |                      |                     |       |              |
|  EscapeUri | new       | 100000 |           Unreserved |        66,393.07 ns |  0.08 |            - |
|  EscapeUri | old       | 100000 |           Unreserved |       874,426.80 ns |  1.00 |          1 B |
|            |           |        |                      |                     |       |              |
| EscapeData | new       | 100000 |              Unicode |     4,295,295.08 ns | 0.003 |    6594352 B |
| EscapeData | old       | 100000 |              Unicode | 1,490,528,971.72 ns | 1.000 | 6006095568 B |
|            |           |        |                      |                     |       |              |
|  EscapeUri | new       | 100000 |              Unicode |     4,214,907.36 ns | 0.003 |    6594359 B |
|  EscapeUri | old       | 100000 |              Unicode | 1,517,378,125.77 ns | 1.000 | 6006096360 B |
|            |           |        |                      |                     |       |              |
| EscapeData | new       | 100000 | OneRe(...)erved [25] |       939,019.21 ns |  0.94 |     200033 B |
| EscapeData | old       | 100000 | OneRe(...)erved [25] |       984,792.58 ns |  1.00 |     400328 B |
|            |           |        |                      |                     |       |              |
|  EscapeUri | new       | 100000 | OneRe(...)erved [25] |       966,883.99 ns |  0.89 |     200040 B |
|  EscapeUri | old       | 100000 | OneRe(...)erved [25] |     1,082,288.94 ns |  1.00 |     400331 B |
|            |           |        |                      |                     |       |              |
| EscapeData | new       | 100000 |          Alternating |     1,751,153.61 ns |  0.01 |    1066679 B |
| EscapeData | old       | 100000 |          Alternating |   146,994,750.75 ns |  1.00 |  615528622 B |
|            |           |        |                      |                     |       |              |
|  EscapeUri | new       | 100000 |          Alternating |     1,735,597.85 ns |  0.01 |    1066676 B |
|  EscapeUri | old       | 100000 |          Alternating |   151,358,658.00 ns |  1.00 |  615528920 B |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Diagnosers;
using BenchmarkDotNet.Running;
using System;
using System.Linq;
using System.Text;

[MemoryDiagnoser]
public class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromTypes(new[] { typeof(Program) }).Run(args);

    [Params(10, 100, 100_000)]
    public int Length { get; set; }

    [Params(InputKind.Unreserved, InputKind.Unicode, InputKind.OneReservedThenUnreserved, InputKind.Alternating)]
    public InputKind Kind { get; set; }

    public enum InputKind
    {
        Unreserved, Unicode, OneReservedThenUnreserved, Alternating
    }

    [GlobalSetup]
    public void Setup()
    {
        switch (Kind)
        {
            case InputKind.Unreserved: _input = new string('s', Length); break;
            case InputKind.Unicode: _input = string.Concat(Enumerable.Repeat("\xD83D\xDE00", Length)); break;
            case InputKind.OneReservedThenUnreserved: _input = "<" + new string('s', Length - 1); break;
            case InputKind.Alternating:
                var sb = new StringBuilder(Length);
                for (int i = 0; i < Length; i++)
                {
                    switch (i % 3)
                    {
                        case 0: sb.Append('s'); break;
                        case 1: sb.Append('<'); break;
                        default: sb.Append("\xD83D\xDE00"); break;
                    }
                }
                _input = sb.ToString();
                break;
        }
    }

    private string _input;

    [Benchmark] public string EscapeData() => Uri.EscapeDataString(_input);
    [Benchmark] public string EscapeUri() => Uri.EscapeUriString(_input);
}
```

cc: @davidsh, @GrabYourPitchforks, @alnikola 

@alnikola, I realize this conflicts with your PR.  Apologies.  But seeing your PR is what led me to want to do this.  I suggest we look at doing something similar to this PR for the "Unescape" paths as well.