### PR TITLE
[release/3.0] Fixing NullReferenceException in XmlSchemaAnyAttribute.Namespace

### DIFF
--- a/src/System.Private.Xml/src/System/Xml/Schema/XmlSchemaAnyAttribute.cs
+++ b/src/System.Private.Xml/src/System/Xml/Schema/XmlSchemaAnyAttribute.cs
@@ -17,7 +17,7 @@ namespace System.Xml.Schema
         [XmlAttribute("namespace")]
         public string Namespace
         {
-            get { return _ns ?? NamespaceList.ToString(); }
+            get { return _ns ?? NamespaceList?.ToString(); }
             set { _ns = value; }
         }
 

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_AnyAttribute.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_AnyAttribute.cs
@@ -240,6 +240,26 @@ namespace System.Xml.Tests
             CompareWildcardNamespaces(expectedNs, attributeWildcard.Namespace);
         }
 
+        [Fact]
+        public void NewInstanceReturnsNullNamespace()
+        {
+            var any = new XmlSchemaAnyAttribute();
+            Assert.Null(any.Namespace);
+        }
+
+        [Fact]
+        public void ReadFromFileWithoutNamespaceReturnsNull()
+        {
+            var xsd = @"<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema' targetNamespace='ns'>
+                        <xs:complexType name = 't'>
+                            <xs:anyAttribute/>
+                        </xs:complexType>
+                        </xs:schema>";
+            XmlSchema xs = XmlSchema.Read(new StringReader(xsd), null);
+            XmlSchemaAnyAttribute any = ((XmlSchemaComplexType)xs.Items[0]).AnyAttribute;
+            Assert.Null(any.Namespace);
+        }
+
         private static void CompareWildcardNamespaces(string expected, string actual)
         {
             var orderedExpected = string.Join(" ", expected.Split(' ').OrderBy(ns => ns));


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/41704
Ports https://github.com/dotnet/corefx/pull/41731
Regressed by https://github.com/dotnet/corefx/commit/2c22af8903522e54f71225c40ddd383b15632ae0

#### Description

This is a regression. Customer reports that using "empty" instance of XmlSchemaAnyAttribute (i.e. `<xs:anyAttribute/>`) and accessing Namespace property is causing NRE. This feature is used to to tell that any attribute not defined by schema is allowed which is not very rare scenario. Reported by 2 customers at least one of which is porting.
		
#### Customer Impact

Customers using XML Schema moving forward to 3.0 may get NRE in an app which previously worked correctly. The only workaround is not to use `Namespace` property since there is currently no way of predicting when it will throw with public APIs except for manually re-parsing XML and searching for this specific case.

#### Regression?

Yes. Regressing fix came with tests but did not check for empty namespace.

#### Risk

Small. Adds extra null check. Fix comes with a test exercising this and similar scenario.

cc: @danmosemsft @buyaa-n @martin-frydl @stephentoub 