### PR TITLE
Clear out packages.builds for 2.2.8

### DIFF
--- a/src/packages.builds
+++ b/src/packages.builds
@@ -29,9 +29,6 @@
       to this build if they contain unique 2.2 features. If they are added here you need to ensure their
       versions are bumped higher then what has shipped in release/2.1.
     -->
-    <Project Include="$(MSBuildThisFileDirectory)..\pkg\Microsoft.NETCore.Platforms\Microsoft.NETCore.Platforms.builds">
-      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
-    </Project>
   </ItemGroup>
 
   <!-- Need the PackageIndexFile file property from baseline.props -->


### PR DESCRIPTION
The Platforms package hasn't changes since 2.2.7, so we should turn off its build for 2.2.8.

@safern @joperezr PTAL

CC @danmosemsft @Anipik 