### PR TITLE
Clear out packages.builds for 2.1.14

### DIFF
--- a/src/packages.builds
+++ b/src/packages.builds
@@ -24,9 +24,6 @@
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
     <!-- add specific builds / pkgproj's here to include in servicing builds -->
-    <Project Include="$(MSBuildThisFileDirectory)..\pkg\Microsoft.NETCore.Platforms\Microsoft.NETCore.Platforms.builds">
-      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
-    </Project>
   </ItemGroup>
 
   <!-- Need the PackageIndexFile file property from baseline.props -->


### PR DESCRIPTION
The Platforms package hasn't changes since 2.1.13, so we should turn off its build for 2.1.14.

@safern @joperezr PTAL

CC @danmosemsft @Anipik 