### PR TITLE
Add stable versions for Microsoft.Bcl.* packages

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -20,8 +20,21 @@
         "net45": "4.0.0.0"
       }
     },
+    "Microsoft.Bcl.AsyncInterfaces": {
+      "StableVersions": [
+        "1.0.0"
+      ],
+      "BaselineVersion": "1.0.0",
+      "InboxOn": {},
+      "AssemblyVersionInPackageVersion": {
+        "1.0.0.0": "1.0.0"
+      }
+    },
     "Microsoft.Bcl.HashCode": {
-      "BaselineVersion": "1.2.0",
+      "StableVersions": [
+        "1.0.0"
+      ],
+      "BaselineVersion": "1.0.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "1.0.0.0": "1.0.0"


### PR DESCRIPTION
Core-Setup hasn't consumed CoreFx in 11 days failing with error:
/root/coresetup/src/managed/Microsoft.Extensions.DependencyModel/Microsoft.Extensions.DependencyModel.csproj(0,0): error NU1603: System.Text.Json 5.0.0-alpha1.19515.2 depends on Microsoft.Bcl.AsyncInterfaces (>= 1.0.0-alpha1.19515.2) but Microsoft.Bcl.AsyncInterfaces 1.0.0-alpha1.19515.2 was not found. An approximate best match of Microsoft.Bcl.AsyncInterfaces 1.0.0-preview6.19230.11 was resolved.

https://github.com/dotnet/core-setup/pull/8477

The reason for that is because we removed the `Microsoft.Bcl` packages in: https://github.com/dotnet/corefx/pull/41270

However, the package index was not updated accordingly, since we were lacking the stable versions in the package index for these packages, System.Text.Json, was getting a dependency to a `non-stable` package based on the current build version suffix.

FYI: @scalablecory 