### PR TITLE
Don't tie Platform Package version to Product version

### DIFF
--- a/eng/Packaging.props
+++ b/eng/Packaging.props
@@ -26,7 +26,7 @@
     <PackageVersion Condition="'$(PackageVersion)' == ''">4.6.0</PackageVersion>
     <!-- major.minor.release version of the platforms package we're currently building
          Pre-release will be appended during build -->
-    <PlatformPackageVersion>$(ProductVersion)</PlatformPackageVersion>
+    <PlatformPackageVersion>3.0.0</PlatformPackageVersion>
     <SkipValidatePackageTargetFramework>true</SkipValidatePackageTargetFramework>
     <SkipGenerationCheck>true</SkipGenerationCheck>
   </PropertyGroup>


### PR DESCRIPTION
Decouples the platforms package version from the product version, as we only want to increment this version when we ship changes to it. Unblocks https://github.com/dotnet/core-setup/pull/8554

CC @ericstj @safern @joperezr @mmitche 