### PR TITLE
Store Description value of ConfigurationProperty

### DIFF
--- a/src/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigurationProperty.cs
+++ b/src/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigurationProperty.cs
@@ -22,7 +22,7 @@ namespace System.Configuration
         {
             object defaultValue = null;
 
-            ConstructorInit(name, type, ConfigurationPropertyOptions.None, null, null);
+            ConstructorInit(name, type, ConfigurationPropertyOptions.None, null, null, null);
 
             if (type == typeof(string))
             {
@@ -61,7 +61,7 @@ namespace System.Configuration
             ConfigurationPropertyOptions options,
             string description)
         {
-            ConstructorInit(name, type, options, validator, typeConverter);
+            ConstructorInit(name, type, options, validator, typeConverter, description);
 
             SetDefaultValue(defaultValue);
         }
@@ -147,19 +147,16 @@ namespace System.Configuration
                 info.PropertyType,
                 propertyAttribute.Options,
                 validator,
-                typeConverter);
+                typeConverter,
+                descriptionAttribute?.Description);
 
             // Figure out the default value
             InitDefaultValueFromTypeInfo(propertyAttribute, defaultValueAttribute);
-
-            // Get the description
-            if (!string.IsNullOrEmpty(descriptionAttribute?.Description))
-                Description = descriptionAttribute.Description;
         }
 
         public string Name { get; private set; }
 
-        public string Description { get; }
+        public string Description { get; private set; }
 
         internal string ProvidedName { get; private set; }
 
@@ -216,7 +213,8 @@ namespace System.Configuration
             Type type,
             ConfigurationPropertyOptions options,
             ConfigurationValidatorBase validator,
-            TypeConverter converter)
+            TypeConverter converter,
+            string description)
         {
             if (typeof(ConfigurationSection).IsAssignableFrom(type))
             {
@@ -237,6 +235,7 @@ namespace System.Configuration
             }
 
             Name = name;
+            Description = description;
             Type = type;
             _options = options;
             Validator = validator;

--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/ConfigurationPropertyTests.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/ConfigurationPropertyTests.cs
@@ -138,6 +138,15 @@ namespace System.ConfigurationTests
             Assert.IsType<DummyCanConverter>(property.Converter);
         }
 
+        [Fact]
+        public void DescriptionValueIsExposed()
+        {
+            FooFailsValidator validator = new FooFailsValidator();
+            DummyCanConverter converter = new DummyCanConverter();
+            ConfigurationProperty property = new ConfigurationProperty("foo", typeof(MyConvertableClass), null, converter, validator, ConfigurationPropertyOptions.None, "bar");
+            Assert.Equal("bar", property.Description);
+        }
+
         [TypeConverter(typeof(DummyCantConverter))]
         public class MyUnconvertableClass
         {


### PR DESCRIPTION
It seems that description parameter isn't used:
https://github.com/dotnet/corefx/blob/58a4d24eb808936f7dc61e68265e968291470b42/src/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigurationProperty.cs#L56-L67

but according to [docs](https://docs.microsoft.com/en-us/dotnet/api/system.configuration.configurationproperty.-ctor?view=netframework-4.8#System_Configuration_ConfigurationProperty__ctor_System_String_System_Type_System_Object_System_ComponentModel_TypeConverter_System_Configuration_ConfigurationValidatorBase_System_Configuration_ConfigurationPropertyOptions_System_String_) it should

Please review and let me know if code authors intentionally don't use it or it is a bug
Thank you in advance