### PR TITLE
Remove dead code null check from DirectoryEntry

### DIFF
--- a/src/System.DirectoryServices/src/System/DirectoryServices/DirectoryEntry.cs
+++ b/src/System.DirectoryServices/src/System/DirectoryServices/DirectoryEntry.cs
@@ -984,11 +984,6 @@ namespace System.DirectoryServices
         {
             Bind();
 
-            if (propertyNames == null)
-            {
-                return;
-            }
-
             //Consider there shouldn't be any marshaling issues
             //by just doing: AdsObject.GetInfoEx(object[]propertyNames, 0);
             object[] names = new object[propertyNames.Length];

--- a/src/System.DirectoryServices/src/System/DirectoryServices/DirectoryEntry.cs
+++ b/src/System.DirectoryServices/src/System/DirectoryServices/DirectoryEntry.cs
@@ -984,6 +984,11 @@ namespace System.DirectoryServices
         {
             Bind();
 
+            if (propertyNames == null)
+            {
+                return;
+            }
+
             //Consider there shouldn't be any marshaling issues
             //by just doing: AdsObject.GetInfoEx(object[]propertyNames, 0);
             object[] names = new object[propertyNames.Length];
@@ -1001,7 +1006,7 @@ namespace System.DirectoryServices
             // this is a half-lie, but oh well. Without it, this method is pointless.
             _cacheFilled = true;
             // we need to partially refresh that properties table.
-            if (_propertyCollection != null && propertyNames != null)
+            if (_propertyCollection != null)
             {
                 for (int i = 0; i < propertyNames.Length; i++)
                 {


### PR DESCRIPTION
https://github.com/dotnet/corefx/blob/b49a8a9be1d53cd9e50cb68fd8540be25c65d433/src/System.DirectoryServices/src/System/DirectoryServices/DirectoryEntry.cs#L983-L991
In the method, there's a check `propertyNames != null`. But above you can see a few access operations by this potentially null reference — `propertyNames.Length` and `propertyNames[i]`. The result is quite predictable — the occurrence of an exception of the `NullReferenceExcepption` type in case if a null reference is passed to the method.

As a `RefreshCache` is a public method in the public class then we can do this to break it down:
```csharp
DirectoryEntry de = new DirectoryEntry();
de.RefreshCache(null);
```

Please review
Thank you in advance