### PR TITLE
Add back TraceListener handling for Callstack/LogicalOperationStack

### DIFF
--- a/src/System.Diagnostics.TextWriterTraceListener/src/System/Diagnostics/DelimitedListTraceListener.cs
+++ b/src/System.Diagnostics.TextWriterTraceListener/src/System/Diagnostics/DelimitedListTraceListener.cs
@@ -179,6 +179,9 @@ namespace System.Diagnostics
                 if (IsEnabled(TraceOptions.Timestamp))
                     Write(eventCache.Timestamp.ToString(CultureInfo.InvariantCulture));
                 Write(Delimiter); // Use get_Delimiter
+
+                if (IsEnabled(TraceOptions.Callstack))
+                    WriteEscaped(eventCache.Callstack);
             }
             else
             {

--- a/src/System.Diagnostics.TextWriterTraceListener/tests/CommonUtilities.cs
+++ b/src/System.Diagnostics.TextWriterTraceListener/tests/CommonUtilities.cs
@@ -95,6 +95,7 @@ namespace System.Diagnostics.TextWriterTraceListenerTests
                 builder.Append(delimiter);
                 builder.Append(cache.Timestamp.ToString(CultureInfo.InvariantCulture));
                 builder.Append(delimiter);
+                builder.Append(EscapedString(cache.Callstack));
             }
             else
             {

--- a/src/System.Diagnostics.TextWriterTraceListener/tests/DelimiterWriteMethodTests.cs
+++ b/src/System.Diagnostics.TextWriterTraceListener/tests/DelimiterWriteMethodTests.cs
@@ -86,7 +86,7 @@ namespace System.Diagnostics.TextWriterTraceListenerTests
             using (var target = GetListener())
             {
                 target.Filter = filter;
-                target.TraceOutputOptions = TraceOptions.ProcessId | TraceOptions.ThreadId | TraceOptions.DateTime | TraceOptions.Timestamp | TraceOptions.LogicalOperationStack;
+                target.TraceOutputOptions = TraceOptions.ProcessId | TraceOptions.ThreadId | TraceOptions.DateTime | TraceOptions.Timestamp | TraceOptions.LogicalOperationStack | TraceOptions.Callstack;
                 target.TraceEvent(eventCache, source, eventType, id, format, args);
             }
 
@@ -102,7 +102,7 @@ namespace System.Diagnostics.TextWriterTraceListenerTests
             using (var target = GetListener())
             {
                 target.Filter = filter;
-                target.TraceOutputOptions = TraceOptions.ProcessId | TraceOptions.ThreadId | TraceOptions.DateTime | TraceOptions.Timestamp | TraceOptions.LogicalOperationStack;
+                target.TraceOutputOptions = TraceOptions.ProcessId | TraceOptions.ThreadId | TraceOptions.DateTime | TraceOptions.Timestamp | TraceOptions.LogicalOperationStack | TraceOptions.Callstack;
                 target.TraceEvent(eventCache, source, eventType, id, message);
             }
 
@@ -138,7 +138,7 @@ namespace System.Diagnostics.TextWriterTraceListenerTests
             using (var target = GetListener())
             {
                 target.Filter = filter;
-                target.TraceOutputOptions = TraceOptions.ProcessId | TraceOptions.ThreadId | TraceOptions.DateTime | TraceOptions.Timestamp | TraceOptions.LogicalOperationStack;
+                target.TraceOutputOptions = TraceOptions.ProcessId | TraceOptions.ThreadId | TraceOptions.DateTime | TraceOptions.Timestamp | TraceOptions.LogicalOperationStack | TraceOptions.Callstack;
                 target.TraceData(eventCache, source, eventType, id, data);
             }
 
@@ -174,7 +174,7 @@ namespace System.Diagnostics.TextWriterTraceListenerTests
             {
                 target.Delimiter = delimiter;
                 target.Filter = filter;
-                target.TraceOutputOptions = TraceOptions.ProcessId | TraceOptions.ThreadId | TraceOptions.DateTime | TraceOptions.Timestamp | TraceOptions.LogicalOperationStack;
+                target.TraceOutputOptions = TraceOptions.ProcessId | TraceOptions.ThreadId | TraceOptions.DateTime | TraceOptions.Timestamp | TraceOptions.LogicalOperationStack | TraceOptions.Callstack;
                 target.TraceData(eventCache, source, eventType, id, data);
             }
 

--- a/src/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceListener.cs
+++ b/src/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceListener.cs
@@ -418,8 +418,31 @@ namespace System.Diagnostics
                 return;
 
             _indentLevel++;
+
             if (IsEnabled(TraceOptions.ProcessId))
                 WriteLine("ProcessId=" + eventCache.ProcessId);
+
+            if (IsEnabled(TraceOptions.LogicalOperationStack))
+            {
+                Write("LogicalOperationStack=");
+                Stack operationStack = eventCache.LogicalOperationStack;
+                bool first = true;
+                foreach (object obj in operationStack)
+                {
+                    if (!first)
+                    {
+                        Write(", ");
+                    }
+                    else
+                    {
+                        first = false;
+                    }
+
+                    Write(obj.ToString());
+                }
+
+                WriteLine(string.Empty);
+            }
 
             if (IsEnabled(TraceOptions.ThreadId))
                 WriteLine("ThreadId=" + eventCache.ThreadId);
@@ -429,6 +452,9 @@ namespace System.Diagnostics
 
             if (IsEnabled(TraceOptions.Timestamp))
                 WriteLine("Timestamp=" + eventCache.Timestamp);
+
+            if (IsEnabled(TraceOptions.Callstack))
+                WriteLine("Callstack=" + eventCache.Callstack);
 
             _indentLevel--;
         }


### PR DESCRIPTION
For .NET Core 2.0, PR https://github.com/dotnet/corefx/pull/13320 added back TraceOptions.Callstack and TraceOptions.LogicalOperationStack, but it didn't add back the code in TraceListener.WriteFooter that respects these options.    Then PR https://github.com/dotnet/corefx/pull/18185 added back checking for TraceOptions.LogicalOperationStack in DelimitedListTraceListener.WriteFooter, but for some reason didn't do so for TraceOptions.Callstack.

This adds back the handling for both, copying the product code from reference source.

Contributes to https://github.com/dotnet/corefx/issues/41837
cc: @safern