### PR TITLE
Annotate System.Runtime.CompilerServices.Unsafe for nullable reference types

### DIFF
--- a/src/System.Runtime.CompilerServices.Unsafe/ref/Configurations.props
+++ b/src/System.Runtime.CompilerServices.Unsafe/ref/Configurations.props
@@ -3,7 +3,7 @@
     <BuildConfigurations>
       netstandard1.0;
       netstandard;
-      netcoreapp;
+      netstandard2.1;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.CompilerServices.Unsafe/ref/Configurations.props
+++ b/src/System.Runtime.CompilerServices.Unsafe/ref/Configurations.props
@@ -3,6 +3,7 @@
     <BuildConfigurations>
       netstandard1.0;
       netstandard;
+      netcoreapp;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.CompilerServices.Unsafe/ref/System.Runtime.CompilerServices.Unsafe.cs
+++ b/src/System.Runtime.CompilerServices.Unsafe/ref/System.Runtime.CompilerServices.Unsafe.cs
@@ -17,7 +17,11 @@ namespace System.Runtime.CompilerServices
         public static unsafe void* AsPointer<T>(ref T value) { throw null; }
         public static unsafe ref T AsRef<T>(void* source) { throw null; }
         public static ref T AsRef<T>(in T source) { throw null; }
-        public static T As<T>(object o) where T : class { throw null; }
+#if NETCOREAPP
+        [return: System.Diagnostics.CodeAnalysis.MaybeNull]
+        [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull("o")]
+#endif
+        public static T As<T>(object? o) where T : class? { throw null; }
         public static ref TTo As<TFrom, TTo>(ref TFrom source) { throw null; }
         public static System.IntPtr ByteOffset<T>(ref T origin, ref T target) { throw null; }
         public static void CopyBlock(ref byte destination, ref byte source, uint byteCount) { }

--- a/src/System.Runtime.CompilerServices.Unsafe/ref/System.Runtime.CompilerServices.Unsafe.cs
+++ b/src/System.Runtime.CompilerServices.Unsafe/ref/System.Runtime.CompilerServices.Unsafe.cs
@@ -17,7 +17,7 @@ namespace System.Runtime.CompilerServices
         public static unsafe void* AsPointer<T>(ref T value) { throw null; }
         public static unsafe ref T AsRef<T>(void* source) { throw null; }
         public static ref T AsRef<T>(in T source) { throw null; }
-#if NETCOREAPP
+#if NETSTANDARD2_1
         [return: System.Diagnostics.CodeAnalysis.MaybeNull]
         [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull("o")]
 #endif

--- a/src/System.Runtime.CompilerServices.Unsafe/ref/System.Runtime.CompilerServices.Unsafe.csproj
+++ b/src/System.Runtime.CompilerServices.Unsafe/ref/System.Runtime.CompilerServices.Unsafe.csproj
@@ -2,7 +2,8 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLSCompliant>false</CLSCompliant>
-    <Configurations>netstandard-Debug;netstandard-Release;netstandard1.0-Debug;netstandard1.0-Release</Configurations>
+    <Nullable>enable</Nullable>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release;netstandard1.0-Debug;netstandard1.0-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Runtime.CompilerServices.Unsafe.cs" />

--- a/src/System.Runtime.CompilerServices.Unsafe/ref/System.Runtime.CompilerServices.Unsafe.csproj
+++ b/src/System.Runtime.CompilerServices.Unsafe/ref/System.Runtime.CompilerServices.Unsafe.csproj
@@ -3,7 +3,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLSCompliant>false</CLSCompliant>
     <Nullable>enable</Nullable>
-    <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release;netstandard1.0-Debug;netstandard1.0-Release</Configurations>
+    <Configurations>netstandard2.1-Debug;netstandard2.1-Release;netstandard-Debug;netstandard-Release;netstandard1.0-Debug;netstandard1.0-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Runtime.CompilerServices.Unsafe.cs" />


### PR DESCRIPTION
Contributes to https://github.com/dotnet/corefx/issues/40623
cc: @buyaa-n, @safern 

The actual implementation is in IL, and there'd be no benefit to adding annotations there, so I've only annotated the C# ref assembly.