### PR TITLE
Annotate System.Runtime.CompilerServices.VisualC for nullable reference types

### DIFF
--- a/src/System.Runtime.CompilerServices.VisualC/ref/System.Runtime.CompilerServices.VisualC.csproj
+++ b/src/System.Runtime.CompilerServices.VisualC/ref/System.Runtime.CompilerServices.VisualC.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <Nullable>enable</Nullable>
     <Configurations>netcoreapp-Debug;netcoreapp-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Runtime.CompilerServices.VisualC/src/System.Runtime.CompilerServices.VisualC.csproj
+++ b/src/System.Runtime.CompilerServices.VisualC/src/System.Runtime.CompilerServices.VisualC.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>System.Runtime.CompilerServices.VisualC</AssemblyName>
+    <Nullable>enable</Nullable>
     <Configurations>netcoreapp-Debug;netcoreapp-Release</Configurations>
   </PropertyGroup>
   <!-- Shared CoreCLR -->


### PR DESCRIPTION
Contributes to https://github.com/dotnet/corefx/issues/40623
cc: @buyaa-n, @safern

This assembly really doesn't matter for nullability, as it's only meant to be used with C++/CLI and only by infrastructure.  There's also no annotations necessary on any of the contained attributes, as they are either parameterless or take a parameter that shouldn't be null.  Even so, we may as well mark the assembly as being annotated, so that its status is appropriately reflected by tools.