### PR TITLE
HTTP2: Add a property-based test

### DIFF
--- a/src/System.Net.Http/tests/UnitTests/HPack/HPackRoundtripTests.cs
+++ b/src/System.Net.Http/tests/UnitTests/HPack/HPackRoundtripTests.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Net.Http.HPack;
 using System.Net.Http.Headers;
 using System.Text;
-using System.Web;
 using FsCheck;
 using FsCheck.Xunit;
 using Xunit;
@@ -194,7 +193,7 @@ namespace System.Net.Http.Unit.Tests.HPack
                     return Arb.From<NonEmptyString>().Generator.Select(s => Normalize(s.Get));
 
                     string Normalize(string x) =>
-                        HttpUtility
+                        WebUtility
                             .UrlEncode(x)
                             // HttpUtility does not encode parens
                             .Replace("(", "%28")

--- a/src/System.Net.Http/tests/UnitTests/HPack/HPackRoundtripTests.cs
+++ b/src/System.Net.Http/tests/UnitTests/HPack/HPackRoundtripTests.cs
@@ -18,7 +18,7 @@ namespace System.Net.Http.Unit.Tests.HPack
     public class HPackRoundtripTests
     {
 
-        [Property(Arbitrary = new[] { typeof(HeadersGenerator) }, MaxTest = 100, QuietOnSuccess = true)]
+        [Property(Arbitrary = new[] { typeof(HeadersGenerator) }, MaxTest = 100, QuietOnSuccess = true, Replay = "(0,0)")]
         public void HPack_HeaderEncodeDecodeRoundtrip_ShouldMatchOriginalInput(HttpHeaders headers)
         {
             Memory<byte> encoding = HPackEncode(headers);
@@ -40,7 +40,7 @@ namespace System.Net.Http.Unit.Tests.HPack
             FillAvailableSpaceWithOnes(buffer);
             string[] headerValues = Array.Empty<string>();
 
-            foreach (KeyValuePair<HeaderDescriptor, HttpHeaders.HeaderStoreItemInfo> header in headers.HeaderStore ?? Enumerable.Empty<KeyValuePair<HeaderDescriptor, HttpHeaders.HeaderStoreItemInfo>>())
+            foreach (KeyValuePair<HeaderDescriptor, HttpHeaders.HeaderStoreItemInfo> header in headers.HeaderStore)
             {
                 int headerValuesCount = HttpHeaders.GetValuesAsStrings(header.Key, header.Value, ref headerValues);
                 Assert.InRange(headerValuesCount, 0, int.MaxValue);

--- a/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -4,6 +4,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <Configurations>netcoreapp-OSX-Debug;netcoreapp-OSX-Release;netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release</Configurations>
+    <!-- Suppress compiler complaining about FsCheck not having a strong name -->
+    <NoWarn>$(NoWarn),8002</NoWarn>
   </PropertyGroup>
   <!-- Do not reference these assemblies from the TargetingPack since we are building part of the source code for tests. -->
   <ItemGroup>
@@ -505,5 +507,8 @@
     <Compile Include="..\..\..\System.Net.Http.WinHttpHandler\tests\UnitTests\TestServer.cs">
       <Link>WinHttpHandler\UnitTests\TestServer.cs</Link>
     </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FsCheck.Xunit" Version="2.14.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR is a proof of concept demonstrating [property-based testing](http://www.aaronstannard.com/fscheck-property-testing-csharp-part1/) for the HPack implementation. It converts the existing HPack roundtrip unit test into a property-based test. Please do not merge as it introduces an unsigned nuget dependency to the http unit tests projects.