### PR TITLE
Remove arcade SolutionBuildTargets hack

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -7,9 +7,10 @@
     <BuildManaged Condition="'$(BuildManaged)' == ''">true</BuildManaged>
     <BuildPackages Condition="'$(BuildPackages)' == '' and '$(DirectoryToBuild)' == ''">true</BuildPackages>
 
-    <BuildDependsOn Condition="'$(BuildNative)' == 'true'">$(BuildDependsOn);BuildNative</BuildDependsOn>
-    <BuildDependsOn Condition="'$(BuildManaged)' == 'true'">$(BuildDependsOn);BuildManaged</BuildDependsOn>
-    <BuildDependsOn Condition="'$(BuildPackages)' == 'true'">$(BuildDependsOn);Pack</BuildDependsOn>
+    <BuildDependsOn Condition="'$(BuildNative)' == 'true' and '$(BuildTests)' != 'only'">$(BuildDependsOn);BuildNative</BuildDependsOn>
+    <BuildDependsOn Condition="'$(BuildManaged)' == 'true' and '$(BuildTests)' != 'only'">$(BuildDependsOn);BuildManaged</BuildDependsOn>
+    <BuildDependsOn Condition="'$(BuildPackages)' == 'true' and '$(BuildTests)' != 'only'">$(BuildDependsOn);Pack</BuildDependsOn>
+    <BuildDependsOn Condition="'$(BuildTests)' != ''">$(BuildDependsOn);BuildTests</BuildDependsOn>
 
     <!-- Explicitly set Configuration based on BuildConfiguration for the root projects -->
     <ProjectProperties>Configuration=$(BuildConfiguration)</ProjectProperties>

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -2,7 +2,4 @@
   <ItemGroup>
     <ProjectToBuild Include="$(RepoRoot)build.proj" />
   </ItemGroup>
-  <ItemGroup>
-    <SolutionBuildTargets Condition="'$(BuildTests)' == 'true'" Include="BuildTests" />
-  </ItemGroup>
 </Project>

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -2,7 +2,7 @@
 Param(
   [switch][Alias('b')]$build,
   [switch][Alias('t')]$test,
-  [switch] $buildtests,
+  [switch]$buildtests,
   [string][Alias('c')]$configuration = "Debug",
   [string][Alias('f')]$framework,
   [string]$vs,
@@ -120,8 +120,8 @@ foreach ($argument in $PSBoundParameters.Keys)
   switch($argument)
   {
     "build"             { $arguments += " -build" }
+    "buildtests"        { if ($build -eq $true) { $arguments += " /p:BuildTests=all" } else { $arguments += " -build /p:BuildTests=only" } }
     "test"              { $arguments += " -test" }
-    "buildtests"        { $arguments += " /p:BuildTests=true" }
     "clean"             { }
     "configuration"     { $configuration = (Get-Culture).TextInfo.ToTitleCase($($PSBoundParameters[$argument])); $arguments += " /p:ConfigurationGroup=$configuration -configuration $configuration" }
     "framework"         { $arguments += " /p:TargetGroup=$($PSBoundParameters[$argument].ToLowerInvariant())"}

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -120,7 +120,7 @@ foreach ($argument in $PSBoundParameters.Keys)
   switch($argument)
   {
     "build"             { $arguments += " -build" }
-    "buildtests"        { if ($build -eq $true) { $arguments += " /p:BuildTests=all" } else { $arguments += " -build /p:BuildTests=only" } }
+    "buildtests"        { if ($build -eq $true) { $arguments += " /p:BuildTests=true" } else { $arguments += " -build /p:BuildTests=only" } }
     "test"              { $arguments += " -test" }
     "clean"             { }
     "configuration"     { $configuration = (Get-Culture).TextInfo.ToTitleCase($($PSBoundParameters[$argument])); $arguments += " /p:ConfigurationGroup=$configuration -configuration $configuration" }

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -140,9 +140,9 @@ done
 
 if [[ "$buildtests" == true ]]; then
   if [[ "$build" == true ]]; then
-    $arguments="$arguments /p:BuildTests=true"
+    arguments="$arguments /p:BuildTests=true"
   else
-    $arguments="$arguments -build /p:BuildTests=only"
+    arguments="$arguments -build /p:BuildTests=only"
   fi
 fi
 

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -47,6 +47,8 @@ usage()
 
 arguments=''
 extraargs=''
+build=false
+buildtests=false
 checkedPossibleDirectoryToBuild=false
 
 # Check if an action is passed in
@@ -96,7 +98,15 @@ while [[ $# > 0 ]]; do
       arguments="$arguments /p:BuildAllConfigurations=true"
       shift 1
       ;;
+     -build)
+      build=true
+      arguments="$arguments -build"
+      shift 1
+      ;;
      -buildtests)
+      buildtests=true
+      shift 1
+      ;;
       arguments="$arguments /p:BuildTests=true"
       shift 1
       ;;
@@ -130,6 +140,14 @@ while [[ $# > 0 ]]; do
       ;;
   esac
 done
+
+if [[ "$buildtests" == true ]]; then
+  if [[ "$build" == true ]]; then
+    $arguments="$arguments /p:BuildTests=true"
+  else
+    $arguments="$arguments -build /p:BuildTests=only"
+  fi
+fi
 
 arguments="$arguments $extraargs"
 

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -107,9 +107,6 @@ while [[ $# > 0 ]]; do
       buildtests=true
       shift 1
       ;;
-      arguments="$arguments /p:BuildTests=true"
-      shift 1
-      ;;
      -testscope)
       arguments="$arguments /p:TestScope=$2"
       shift 2


### PR DESCRIPTION
We need to remove the Arcade `SolutionBuildTargets` hack for the repo consolidation as otherwise every repo would need to provide that target. Also this api wasn't approved and I will remove it in arcade after this change is merged.

The changes guarantee that the existing behavior doesn't regress.