### PR TITLE
[release/3.1] JsonSerializer should ignore extension data if it's null when serializing + additional tests

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleDictionary.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleDictionary.cs
@@ -25,10 +25,9 @@ namespace System.Text.Json
                 enumerable = (IEnumerable)jsonPropertyInfo.GetValueAsObject(state.Current.CurrentValue);
                 if (enumerable == null)
                 {
-                    // If applicable, we only want to ignore object properties.
-                    if (state.Current.ExtensionDataStatus != ExtensionDataWriteStatus.Writing &&
-                        (state.Current.JsonClassInfo.ClassType != ClassType.Object ||
-                        !state.Current.JsonPropertyInfo.IgnoreNullValues))
+                    if ((state.Current.JsonClassInfo.ClassType != ClassType.Object || // Write null dictionary values
+                        !state.Current.JsonPropertyInfo.IgnoreNullValues) && // Ignore ClassType.Object properties if IgnoreNullValues is true
+                        state.Current.ExtensionDataStatus != ExtensionDataWriteStatus.Writing) // Ignore null extension property (which is a dictionary)
                     {
                         // Write a null object or enumerable.
                         state.Current.WriteObjectOrArrayStart(ClassType.Dictionary, writer, options, writeNull: true);

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleDictionary.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleDictionary.cs
@@ -26,8 +26,9 @@ namespace System.Text.Json
                 if (enumerable == null)
                 {
                     // If applicable, we only want to ignore object properties.
-                    if (state.Current.JsonClassInfo.ClassType != ClassType.Object ||
-                        !state.Current.JsonPropertyInfo.IgnoreNullValues)
+                    if (state.Current.ExtensionDataStatus != ExtensionDataWriteStatus.Writing &&
+                        (state.Current.JsonClassInfo.ClassType != ClassType.Object ||
+                        !state.Current.JsonPropertyInfo.IgnoreNullValues))
                     {
                         // Write a null object or enumerable.
                         state.Current.WriteObjectOrArrayStart(ClassType.Dictionary, writer, options, writeNull: true);

--- a/src/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
+++ b/src/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
@@ -63,6 +63,42 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        public static void MultipleExtensionPropertyIgnoredWhenNull()
+        {
+            var obj = new ClassWithMultipleDictionaries();
+            string actual = JsonSerializer.Serialize(obj);
+            Assert.Equal("{\"ActualDictionary\":null}", actual);
+
+            obj = new ClassWithMultipleDictionaries
+            {
+                ActualDictionary = new Dictionary<string, object>()
+            };
+            actual = JsonSerializer.Serialize(obj);
+            Assert.Equal("{\"ActualDictionary\":{}}", actual);
+
+            obj = new ClassWithMultipleDictionaries
+            {
+                MyOverflow = new Dictionary<string, object>
+                {
+                    { "test", "value" }
+                }
+            };
+            actual = JsonSerializer.Serialize(obj);
+            Assert.Equal("{\"ActualDictionary\":null,\"test\":\"value\"}", actual);
+
+            obj = new ClassWithMultipleDictionaries
+            {
+                ActualDictionary = new Dictionary<string, object>(),
+                MyOverflow = new Dictionary<string, object>
+                {
+                    { "test", "value" }
+                }
+            };
+            actual = JsonSerializer.Serialize(obj);
+            Assert.Equal("{\"ActualDictionary\":{},\"test\":\"value\"}", actual);
+        }
+
+        [Fact]
         public static void ExtensionPropertyAlreadyInstantiated()
         {
             Assert.NotNull(new ClassWithExtensionPropertyAlreadyInstantiated().MyOverflow);
@@ -512,6 +548,35 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        public static void DeserializeIntoMultipleDictionaries()
+        {
+            ClassWithMultipleDictionaries obj;
+            string json;
+
+            // Baseline dictionary.
+            json = @"{""ActualDictionary"":{""Key"": {""Property0"":-1}},""MyDict"":{""Property1"":1}}";
+            obj = JsonSerializer.Deserialize<ClassWithMultipleDictionaries>(json);
+            Assert.Equal(1, obj.MyOverflow.Count);
+            Assert.Equal(1, ((JsonElement)obj.MyOverflow["MyDict"]).EnumerateObject().First().Value.GetInt32());
+            Assert.Equal(1, obj.ActualDictionary.Count);
+            Assert.Equal(-1, ((JsonElement)obj.ActualDictionary["Key"]).EnumerateObject().First().Value.GetInt32());
+
+            // Attempt to deserialize null into the dictionary and overflow property. This is also treated as a missing property.
+            json = @"{""ActualDictionary"":null,""MyOverflow"":null}";
+            obj = JsonSerializer.Deserialize<ClassWithMultipleDictionaries>(json);
+            Assert.Equal(1, obj.MyOverflow.Count);
+            Assert.Null(obj.MyOverflow["MyOverflow"]);
+            Assert.Null(obj.ActualDictionary);
+
+            // Attempt to deserialize object into the dictionary and overflow property. This is also treated as a missing property.
+            json = @"{""ActualDictionary"":{},""MyOverflow"":{}}";
+            obj = JsonSerializer.Deserialize<ClassWithMultipleDictionaries>(json);
+            Assert.Equal(1, obj.MyOverflow.Count);
+            Assert.Equal(JsonValueKind.Object, ((JsonElement)obj.MyOverflow["MyOverflow"]).ValueKind);
+            Assert.Equal(0, obj.ActualDictionary.Count);
+        }
+
+        [Fact]
         public static void DeserializeIntoJsonElementProperty()
         {
             ClassWithExtensionPropertyAsJsonElement obj;
@@ -585,6 +650,14 @@ namespace System.Text.Json.Serialization.Tests
         {
             [JsonExtensionData]
             public Dictionary<string, JsonElement> MyOverflow { get; set; }
+        }
+
+        private class ClassWithMultipleDictionaries
+        {
+            [JsonExtensionData]
+            public Dictionary<string, object> MyOverflow { get; set; }
+
+            public Dictionary<string, object> ActualDictionary { get; set; }
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
+++ b/src/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
@@ -55,6 +55,14 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        public static void ExtensionPropertyIgnoredWhenNull()
+        {
+            string expected = @"{}";
+            string actual = JsonSerializer.Serialize(new ClassWithExtensionPropertyAsObject());
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
         public static void ExtensionPropertyAlreadyInstantiated()
         {
             Assert.NotNull(new ClassWithExtensionPropertyAlreadyInstantiated().MyOverflow);

--- a/src/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
+++ b/src/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
@@ -480,6 +480,68 @@ namespace System.Text.Json.Serialization.Tests
             }
         }
 
+        [Fact]
+        public static void DeserializeIntoObjectProperty()
+        {
+            ClassWithExtensionPropertyAsObject obj;
+            string json;
+
+            // Baseline dictionary.
+            json = @"{""MyDict"":{""Property1"":1}}";
+            obj = JsonSerializer.Deserialize<ClassWithExtensionPropertyAsObject>(json);
+            Assert.Equal(1, obj.MyOverflow.Count);
+            Assert.Equal(1, ((JsonElement)obj.MyOverflow["MyDict"]).EnumerateObject().First().Value.GetInt32());
+
+            // Attempt to deserialize directly into the overflow property; this is just added as a normal missing property like MyDict above.
+            json = @"{""MyOverflow"":{""Property1"":1}}";
+            obj = JsonSerializer.Deserialize<ClassWithExtensionPropertyAsObject>(json);
+            Assert.Equal(1, obj.MyOverflow.Count);
+            Assert.Equal(1, ((JsonElement)obj.MyOverflow["MyOverflow"]).EnumerateObject().First().Value.GetInt32());
+
+            // Attempt to deserialize null into the overflow property. This is also treated as a missing property.
+            json = @"{""MyOverflow"":null}";
+            obj = JsonSerializer.Deserialize<ClassWithExtensionPropertyAsObject>(json);
+            Assert.Equal(1, obj.MyOverflow.Count);
+            Assert.Null(obj.MyOverflow["MyOverflow"]);
+
+            // Attempt to deserialize object into the overflow property. This is also treated as a missing property.
+            json = @"{""MyOverflow"":{}}";
+            obj = JsonSerializer.Deserialize<ClassWithExtensionPropertyAsObject>(json);
+            Assert.Equal(1, obj.MyOverflow.Count);
+            Assert.Equal(JsonValueKind.Object, ((JsonElement)obj.MyOverflow["MyOverflow"]).ValueKind);
+        }
+
+        [Fact]
+        public static void DeserializeIntoJsonElementProperty()
+        {
+            ClassWithExtensionPropertyAsJsonElement obj;
+            string json;
+
+            // Baseline dictionary.
+            json = @"{""MyDict"":{""Property1"":1}}";
+            obj = JsonSerializer.Deserialize<ClassWithExtensionPropertyAsJsonElement>(json);
+            Assert.Equal(1, obj.MyOverflow.Count);
+            Assert.Equal(1, obj.MyOverflow["MyDict"].EnumerateObject().First().Value.GetInt32());
+
+            // Attempt to deserialize directly into the overflow property; this is just added as a normal missing property like MyDict above.
+            json = @"{""MyOverflow"":{""Property1"":1}}";
+            obj = JsonSerializer.Deserialize<ClassWithExtensionPropertyAsJsonElement>(json);
+            Assert.Equal(1, obj.MyOverflow.Count);
+            Assert.Equal(1, obj.MyOverflow["MyOverflow"].EnumerateObject().First().Value.GetInt32());
+
+            // Attempt to deserialize null into the overflow property. This is also treated as a missing property.
+            json = @"{""MyOverflow"":null}";
+            obj = JsonSerializer.Deserialize<ClassWithExtensionPropertyAsJsonElement>(json);
+            Assert.Equal(1, obj.MyOverflow.Count);
+            Assert.Equal(JsonValueKind.Null, obj.MyOverflow["MyOverflow"].ValueKind);
+
+            // Attempt to deserialize object into the overflow property. This is also treated as a missing property.
+            json = @"{""MyOverflow"":{}}";
+            obj = JsonSerializer.Deserialize<ClassWithExtensionPropertyAsJsonElement>(json);
+            Assert.Equal(1, obj.MyOverflow.Count);
+            Assert.Equal(JsonValueKind.Object, obj.MyOverflow["MyOverflow"].ValueKind);
+        }
+
         private class ClassWithInvalidExtensionPropertyStringString
         {
             [JsonExtensionData]


### PR DESCRIPTION
Ports https://github.com/dotnet/corefx/pull/40431 and more tests from https://github.com/dotnet/corefx/pull/40488, https://github.com/dotnet/corefx/pull/41877 ~(once this is merged to master)~

### Description

Do not output the extension data property when its null.

### Customer Impact:

Customer reported issue. Overflow properties annotated accordingly shouldn't show up in the generated JSON payload and it showing up in the output is incorrect. Only it's contents should show up (and when null that means nothing). Paraphrasing @CodeBlanch, this better matches the intention of `[JsonExtensionData]` and Newtonsoft.Json behavior so people aren't surprised when using the new lib.

### Regression? 

No, but this is a behavioral change from 3.0 (but that's already changed in master for 5.0).

### Risk

Low. The fix is targeted specific to extension data property. It is theoretically possible someone relies on the property itself showing up in the output, but I would be surprised if that was the case since that's not its intended behavior outside of the "null" case already.

### Tests run / added

More unit tests added.

cc @steveharter, @ericstj, @danmosemsft 