### PR TITLE
Vectorise BitArray

### DIFF
--- a/src/System.Collections/tests/BitArray/BitArray_CtorTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_CtorTests.cs
@@ -79,7 +79,7 @@ namespace System.Collections.Tests
             Random rnd = new Random(0);
 
             yield return new object[] { new bool[0] };
-            foreach (int size in new[] { 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2 })
+            foreach (int size in new[] { 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2, BitsPerInt32 * 4, BitsPerInt32 * 8, BitsPerInt32 * 16})
             {
                 yield return new object[] { Enumerable.Repeat(true, size).ToArray() };
                 yield return new object[] { Enumerable.Repeat(false, size).ToArray() };

--- a/src/System.Collections/tests/BitArray/BitArray_CtorTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_CtorTests.cs
@@ -76,12 +76,22 @@ namespace System.Collections.Tests
 
         public static IEnumerable<object[]> Ctor_BoolArray_TestData()
         {
+            Random rnd = new Random(0);
+
             yield return new object[] { new bool[0] };
             foreach (int size in new[] { 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2 })
             {
                 yield return new object[] { Enumerable.Repeat(true, size).ToArray() };
                 yield return new object[] { Enumerable.Repeat(false, size).ToArray() };
                 yield return new object[] { Enumerable.Range(0, size).Select(x => x % 2 == 0).ToArray() };
+
+                bool[] random = new bool[size];
+                for (int i = 0; i < random.Length; i++)
+                {
+                    random[i] = rnd.Next(0, 2) == 0;
+                }
+
+                yield return new object[] { random };
             }
         }
 

--- a/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
@@ -233,20 +233,17 @@ namespace System.Collections.Tests
             yield return new object[] { new BitArray(0), 0, 0, new byte[0], default(byte) };
             yield return new object[] { new BitArray(0), 0, 0, new int[0], default(int) };
 
-            foreach (int bitArraySize in new[] { 0, 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2 })
+            foreach (int bitArraySize in new[] { 0, 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2, BitsPerInt32 * 4, BitsPerInt32 * 8 })
             {
                 BitArray allTrue = new BitArray(Enumerable.Repeat(true, bitArraySize).ToArray());
                 BitArray allFalse = new BitArray(Enumerable.Repeat(false, bitArraySize).ToArray());
                 BitArray alternating = new BitArray(Enumerable.Range(0, bitArraySize).Select(i => i % 2 == 1).ToArray());
 
-                foreach (Tuple<int, int> d in new[] { Tuple.Create(bitArraySize, 0),
-                    Tuple.Create(bitArraySize * 2 + 1, 0),
-                    Tuple.Create(bitArraySize * 2 + 1, bitArraySize + 1),
-                    Tuple.Create(bitArraySize * 2 + 1, bitArraySize / 2 + 1) })
+                foreach ((int arraySize, int index) in new[] { (bitArraySize, 0),
+                                                               (bitArraySize * 2 + 1, 0),
+                                                               (bitArraySize * 2 + 1, bitArraySize + 1),
+                                                               (bitArraySize * 2 + 1, bitArraySize / 2 + 1) })
                 {
-                    int arraySize = d.Item1;
-                    int index = d.Item2;
-
                     yield return new object[] { allTrue, arraySize, index, Enumerable.Repeat(true, bitArraySize).ToArray(), default(bool) };
                     yield return new object[] { allFalse, arraySize, index, Enumerable.Repeat(false, bitArraySize).ToArray(), default(bool) };
                     yield return new object[] { alternating, arraySize, index, Enumerable.Range(0, bitArraySize).Select(i => i % 2 == 1).ToArray(), default(bool) };
@@ -272,14 +269,11 @@ namespace System.Collections.Tests
                 BitArray allTrue = new BitArray(Enumerable.Repeat(true, bitArraySize).ToArray());
                 BitArray allFalse = new BitArray(Enumerable.Repeat(false, bitArraySize).ToArray());
                 BitArray alternating = new BitArray(Enumerable.Range(0, bitArraySize).Select(i => i % 2 == 1).ToArray());
-
-                foreach (Tuple<int, int> d in new[] { Tuple.Create(bitArraySize, 0),
-                    Tuple.Create(bitArraySize * 2 + 1, 0),
-                    Tuple.Create(bitArraySize * 2 + 1, bitArraySize + 1),
-                    Tuple.Create(bitArraySize * 2 + 1, bitArraySize / 2 + 1)})
+                foreach ((int arraySize, int index) in new[] { (bitArraySize, 0),
+                                                               (bitArraySize * 2 + 1, 0),
+                                                               (bitArraySize * 2 + 1, bitArraySize + 1),
+                                                               (bitArraySize * 2 + 1, bitArraySize / 2 + 1) })
                 {
-                    int arraySize = d.Item1;
-                    int index = d.Item2;
 
                     if (bitArraySize >= BitsPerInt32)
                     {
@@ -295,7 +289,7 @@ namespace System.Collections.Tests
         [MemberData(nameof(CopyTo_Array_TestData))]
         public static void CopyTo<T>(BitArray bitArray, int length, int index, T[] expected, T def)
         {
-            T[] array = (T[])Array.CreateInstance(typeof(T), length);
+            T[] array = new T[length];
             ICollection collection = bitArray;
             collection.CopyTo(array, index);
             for (int i = 0; i < index; i++)

--- a/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
@@ -233,43 +233,54 @@ namespace System.Collections.Tests
             yield return new object[] { new BitArray(0), 0, 0, new byte[0], default(byte) };
             yield return new object[] { new BitArray(0), 0, 0, new int[0], default(int) };
 
-            foreach (int bitArraySize in new[] { 0, 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2, BitsPerInt32 * 4, BitsPerInt32 * 8 })
+            foreach (int bitArraySize in new[] { 0, 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2, BitsPerInt32 * 4, BitsPerInt32 * 8, BitsPerInt32 * 16 })
             {
-                BitArray allTrue = new BitArray(Enumerable.Repeat(true, bitArraySize).ToArray());
-                BitArray allFalse = new BitArray(Enumerable.Repeat(false, bitArraySize).ToArray());
+                BitArray allTrue = new BitArray(bitArraySize, true);
+                BitArray allFalse = new BitArray(bitArraySize, false);
                 BitArray alternating = new BitArray(Enumerable.Range(0, bitArraySize).Select(i => i % 2 == 1).ToArray());
 
-                foreach ((int arraySize, int index) in new[] { (bitArraySize, 0),
+                Random rnd = new Random(0);
+
+                foreach ((int arraySize, int startIndex) in new[] { (bitArraySize, 0),
                                                                (bitArraySize * 2 + 1, 0),
                                                                (bitArraySize * 2 + 1, bitArraySize + 1),
                                                                (bitArraySize * 2 + 1, bitArraySize / 2 + 1) })
                 {
-                    yield return new object[] { allTrue, arraySize, index, Enumerable.Repeat(true, bitArraySize).ToArray(), default(bool) };
-                    yield return new object[] { allFalse, arraySize, index, Enumerable.Repeat(false, bitArraySize).ToArray(), default(bool) };
-                    yield return new object[] { alternating, arraySize, index, Enumerable.Range(0, bitArraySize).Select(i => i % 2 == 1).ToArray(), default(bool) };
+                    yield return new object[] { allTrue, arraySize, startIndex, Enumerable.Repeat(true, bitArraySize).ToArray(), default(bool) };
+                    yield return new object[] { allFalse, arraySize, startIndex, Enumerable.Repeat(false, bitArraySize).ToArray(), default(bool) };
+                    yield return new object[] { alternating, arraySize, startIndex, Enumerable.Range(0, bitArraySize).Select(i => i % 2 == 1).ToArray(), default(bool) };
+
+                    bool[] randomBools = new bool[bitArraySize];
+                    for (int i = 0; i < bitArraySize; i++)
+                    {
+                        randomBools[i] = rnd.Next(0, 2) == 0;
+                    }
+                    BitArray random = new BitArray(randomBools);
+
+                    yield return new object[] { random, arraySize, startIndex, randomBools, default(bool) };
 
                     if (bitArraySize >= BitsPerByte)
                     {
-                        yield return new object[] { allTrue, arraySize / BitsPerByte, index / BitsPerByte, Enumerable.Repeat((byte)0xff, bitArraySize / BitsPerByte).ToArray(), default(byte) };
-                        yield return new object[] { allFalse, arraySize / BitsPerByte, index / BitsPerByte, Enumerable.Repeat((byte)0x00, bitArraySize / BitsPerByte).ToArray(), default(byte) };
-                        yield return new object[] { alternating, arraySize / BitsPerByte, index / BitsPerByte, Enumerable.Repeat((byte)0xaa, bitArraySize / BitsPerByte).ToArray(), default(byte) };
+                        yield return new object[] { allTrue, arraySize / BitsPerByte, startIndex / BitsPerByte, Enumerable.Repeat((byte)0xff, bitArraySize / BitsPerByte).ToArray(), default(byte) };
+                        yield return new object[] { allFalse, arraySize / BitsPerByte, startIndex / BitsPerByte, Enumerable.Repeat((byte)0x00, bitArraySize / BitsPerByte).ToArray(), default(byte) };
+                        yield return new object[] { alternating, arraySize / BitsPerByte, startIndex / BitsPerByte, Enumerable.Repeat((byte)0xaa, bitArraySize / BitsPerByte).ToArray(), default(byte) };
                     }
 
                     if (bitArraySize >= BitsPerInt32)
                     {
-                        yield return new object[] { allTrue, arraySize / BitsPerInt32, index / BitsPerInt32, Enumerable.Repeat(unchecked((int)0xffffffff), bitArraySize / BitsPerInt32).ToArray(), default(int) };
-                        yield return new object[] { allFalse, arraySize / BitsPerInt32, index / BitsPerInt32, Enumerable.Repeat(0x00000000, bitArraySize / BitsPerInt32).ToArray(), default(int) };
-                        yield return new object[] { alternating, arraySize / BitsPerInt32, index / BitsPerInt32, Enumerable.Repeat(unchecked((int)0xaaaaaaaa), bitArraySize / BitsPerInt32).ToArray(), default(int) };
+                        yield return new object[] { allTrue, arraySize / BitsPerInt32, startIndex / BitsPerInt32, Enumerable.Repeat(unchecked((int)0xffffffff), bitArraySize / BitsPerInt32).ToArray(), default(int) };
+                        yield return new object[] { allFalse, arraySize / BitsPerInt32, startIndex / BitsPerInt32, Enumerable.Repeat(0x00000000, bitArraySize / BitsPerInt32).ToArray(), default(int) };
+                        yield return new object[] { alternating, arraySize / BitsPerInt32, startIndex / BitsPerInt32, Enumerable.Repeat(unchecked((int)0xaaaaaaaa), bitArraySize / BitsPerInt32).ToArray(), default(int) };
                     }
                 }
             }
 
             foreach (int bitArraySize in new[] { BitsPerInt32 - 1, BitsPerInt32 * 2 - 1 })
             {
-                BitArray allTrue = new BitArray(Enumerable.Repeat(true, bitArraySize).ToArray());
-                BitArray allFalse = new BitArray(Enumerable.Repeat(false, bitArraySize).ToArray());
+                BitArray allTrue = new BitArray(bitArraySize, true);
+                BitArray allFalse = new BitArray(bitArraySize, false);
                 BitArray alternating = new BitArray(Enumerable.Range(0, bitArraySize).Select(i => i % 2 == 1).ToArray());
-                foreach ((int arraySize, int index) in new[] { (bitArraySize, 0),
+                foreach ((int arraySize, int startIndex) in new[] { (bitArraySize, 0),
                                                                (bitArraySize * 2 + 1, 0),
                                                                (bitArraySize * 2 + 1, bitArraySize + 1),
                                                                (bitArraySize * 2 + 1, bitArraySize / 2 + 1) })
@@ -277,9 +288,9 @@ namespace System.Collections.Tests
 
                     if (bitArraySize >= BitsPerInt32)
                     {
-                        yield return new object[] { allTrue, (arraySize - 1) / BitsPerInt32 + 1, index / BitsPerInt32, Enumerable.Repeat(unchecked((int)0xffffffff), bitArraySize / BitsPerInt32).Concat(new[] { unchecked((int)(0xffffffffu >> 1)) }).ToArray(), default(int) };
-                        yield return new object[] { allFalse, (arraySize - 1) / BitsPerInt32 + 1, index / BitsPerInt32, Enumerable.Repeat(0x00000000, bitArraySize / BitsPerInt32 + 1).ToArray(), default(int) };
-                        yield return new object[] { alternating, (arraySize - 1) / BitsPerInt32 + 1, index / BitsPerInt32, Enumerable.Repeat(unchecked((int)0xaaaaaaaa), bitArraySize / BitsPerInt32).Concat(new[] { unchecked((int)(0xaaaaaaaau >> 2)) }).ToArray(), default(int) };
+                        yield return new object[] { allTrue, (arraySize - 1) / BitsPerInt32 + 1, startIndex / BitsPerInt32, Enumerable.Repeat(unchecked((int)0xffffffff), bitArraySize / BitsPerInt32).Concat(new[] { unchecked((int)(0xffffffffu >> 1)) }).ToArray(), default(int) };
+                        yield return new object[] { allFalse, (arraySize - 1) / BitsPerInt32 + 1, startIndex / BitsPerInt32, Enumerable.Repeat(0x00000000, bitArraySize / BitsPerInt32 + 1).ToArray(), default(int) };
+                        yield return new object[] { alternating, (arraySize - 1) / BitsPerInt32 + 1, startIndex / BitsPerInt32, Enumerable.Repeat(unchecked((int)0xaaaaaaaa), bitArraySize / BitsPerInt32).Concat(new[] { unchecked((int)(0xaaaaaaaau >> 2)) }).ToArray(), default(int) };
                     }
                 }
             }
@@ -287,22 +298,25 @@ namespace System.Collections.Tests
 
         [Theory]
         [MemberData(nameof(CopyTo_Array_TestData))]
-        public static void CopyTo<T>(BitArray bitArray, int length, int index, T[] expected, T def)
+        public static void CopyTo<T>(BitArray bitArray, int destinationLength, int startIndex, T[] expected, T def)
         {
-            T[] array = new T[length];
+            T[] array = new T[destinationLength];
             ICollection collection = bitArray;
-            collection.CopyTo(array, index);
-            for (int i = 0; i < index; i++)
+            collection.CopyTo(array, startIndex);
+            for (int i = 0; i < startIndex; i++)
             {
-                Assert.Equal(def, array[i]);
+                //Assert.Equal(def, array[i]);
+                Assert.True(def.Equals(array[i]), $"Elements before the start index have been modified. Expected {def} at index {i}, actual {array[i]}");
             }
             for (int i = 0; i < expected.Length; i++)
             {
-                Assert.Equal(expected[i], array[i + index]);
+                //Assert.Equal(expected[i], array[i + startIndex]);
+                Assert.True(expected[i].Equals(array[i + startIndex]), $"Elements that are copied over does not match the expected value. Expected {expected[i]} at index {i + startIndex}, actual {array[i]}");
             }
-            for (int i = index + expected.Length; i < array.Length; i++)
+            for (int i = startIndex + expected.Length; i < array.Length; i++)
             {
-                Assert.Equal(def, array[i]);
+                //Assert.Equal(def, array[i]);
+                Assert.True(def.Equals(array[i]), $"Elements after the copied area have been modified. Expected {def} at index {i}, actual {array[i]}");
             }
         }
 

--- a/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
@@ -305,17 +305,14 @@ namespace System.Collections.Tests
             collection.CopyTo(array, startIndex);
             for (int i = 0; i < startIndex; i++)
             {
-                //Assert.Equal(def, array[i]);
                 Assert.True(def.Equals(array[i]), $"Elements before the start index have been modified. Expected {def} at index {i}, actual {array[i]}");
             }
             for (int i = 0; i < expected.Length; i++)
             {
-                //Assert.Equal(expected[i], array[i + startIndex]);
                 Assert.True(expected[i].Equals(array[i + startIndex]), $"Elements that are copied over does not match the expected value. Expected {expected[i]} at index {i + startIndex}, actual {array[i]}");
             }
             for (int i = startIndex + expected.Length; i < array.Length; i++)
             {
-                //Assert.Equal(def, array[i]);
                 Assert.True(def.Equals(array[i]), $"Elements after the copied area have been modified. Expected {def} at index {i}, actual {array[i]}");
             }
         }

--- a/src/System.Collections/tests/BitArray/BitArray_OperatorsTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_OperatorsTests.cs
@@ -15,7 +15,7 @@ namespace System.Collections.Tests
 
         public static IEnumerable<object[]> Not_Operator_Data()
         {
-            foreach (int size in new[] { 0, 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2, short.MaxValue })
+            foreach (int size in new[] { 0, 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2, BitsPerInt32 * 3, BitsPerInt32 * 4, BitsPerInt32 * 5, BitsPerInt32 * 6, BitsPerInt32 * 7, BitsPerInt32 * 8, BitsPerInt32 * 8 + BitsPerInt32 - 1, short.MaxValue })
             {
                 yield return new object[] { Enumerable.Repeat(true, size).ToArray() };
                 yield return new object[] { Enumerable.Repeat(false, size).ToArray() };
@@ -41,7 +41,7 @@ namespace System.Collections.Tests
         public static IEnumerable<object[]> And_Operator_Data()
         {
             yield return new object[] { new bool[0], new bool[0], new bool[0] };
-            foreach (int size in new[] { 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2, short.MaxValue })
+            foreach (int size in new[] { 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2, BitsPerInt32 * 3, BitsPerInt32 * 4, BitsPerInt32 * 5, BitsPerInt32 * 6, BitsPerInt32 * 7, BitsPerInt32 * 8, BitsPerInt32 * 8 + BitsPerInt32 - 1, short.MaxValue })
             {
                 bool[] allTrue = Enumerable.Repeat(true, size).ToArray();
                 bool[] allFalse = Enumerable.Repeat(false, size).ToArray();
@@ -77,7 +77,7 @@ namespace System.Collections.Tests
         public static IEnumerable<object[]> Or_Operator_Data()
         {
             yield return new object[] { new bool[0], new bool[0], new bool[0] };
-            foreach (int size in new[] { 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2, short.MaxValue })
+            foreach (int size in new[] { 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2, BitsPerInt32 * 3, BitsPerInt32 * 4, BitsPerInt32 * 5, BitsPerInt32 * 6, BitsPerInt32 * 7, BitsPerInt32 * 8, BitsPerInt32 * 8 + BitsPerInt32 - 1, short.MaxValue })
             {
                 bool[] allTrue = Enumerable.Repeat(true, size).ToArray();
                 bool[] allFalse = Enumerable.Repeat(false, size).ToArray();
@@ -113,7 +113,7 @@ namespace System.Collections.Tests
         public static IEnumerable<object[]> Xor_Operator_Data()
         {
             yield return new object[] { new bool[0], new bool[0], new bool[0] };
-            foreach (int size in new[] { 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2, short.MaxValue })
+            foreach (int size in new[] { 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2, BitsPerInt32 * 3, BitsPerInt32 * 4, BitsPerInt32 * 5, BitsPerInt32 * 6, BitsPerInt32 * 7, BitsPerInt32 * 8, BitsPerInt32 * 8 + BitsPerInt32 - 1, short.MaxValue })
             {
                 bool[] allTrue = Enumerable.Repeat(true, size).ToArray();
                 bool[] allFalse = Enumerable.Repeat(false, size).ToArray();


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/41762 and https://github.com/dotnet/corefx/issues/37946
Related https://github.com/dotnet/corefx/pull/39173

This PR continues from the previous PR from @BruceForstall (#39173) in an attempt to speed up various operations of BitArray by vectorisation and using AVX2 256-bit wide instructions.

The performance difference, compared to before the optimizations were applied are as following, when operating on arrays of size 4/512/32768 (Threshold 5%):
```
summary:
better: 17, geomean: 3.773
worse: 3, geomean: 2.094
total diff: 20
```

| Slower                                                                | diff/base | Base Median (ns) | Diff Median (ns) | Modality|
| --------------------------------------------------------------------- | ---------:| ----------------:| ----------------:| --------:|
| System.Collections.Tests.Perf_BitArray.BitArraySetAll(Size: 4)        |      4.76 |             0.78 |             3.72 |         |
| System.Collections.Tests.Perf_BitArray.BitArrayNot(Size: 4)           |      1.79 |             0.92 |             1.64 |         |
| System.Collections.Tests.Perf_BitArray.BitArrayBoolArrayCtor(Size: 4) |      1.08 |             9.83 |            10.61 |         |

| Faster                                                                      | base/diff | Base Median (ns) | Diff Median (ns) | Modality|
| --------------------------------------------------------------------------- | ---------:| ----------------:| ----------------:| --------:|
| System.Collections.Tests.Perf_BitArray.BitArrayBoolArrayCtor(Size: 32768)   |     88.64 |        116382.63 |          1312.93 |         |
| System.Collections.Tests.Perf_BitArray.BitArrayCopyToBoolArray(Size: 32768) |     33.88 |        323823.66 |          9557.69 |         |
| System.Collections.Tests.Perf_BitArray.BitArrayCopyToBoolArray(Size: 512)   |     25.40 |          5096.80 |           200.63 |         |
| System.Collections.Tests.Perf_BitArray.BitArrayBoolArrayCtor(Size: 512)     |     14.80 |           407.56 |            27.54 |         |
| System.Collections.Tests.Perf_BitArray.BitArrayNot(Size: 32768)             |      7.83 |          3679.64 |           469.90 |         |
| System.Collections.Tests.Perf_BitArray.BitArrayNot(Size: 512)               |      6.55 |            61.56 |             9.39 |         |
| System.Collections.Tests.Perf_BitArray.BitArrayCopyToBoolArray(Size: 4)     |      1.98 |            71.92 |            36.26 |         |
| System.Collections.Tests.Perf_BitArray.BitArrayOr(Size: 512)                |      1.82 |            19.69 |            10.83 |         |
| System.Collections.Tests.Perf_BitArray.BitArraySetAll(Size: 512)            |      1.75 |            53.17 |            30.31 |         |
| System.Collections.Tests.Perf_BitArray.BitArrayAnd(Size: 512)               |      1.66 |            17.88 |            10.78 |         |
| System.Collections.Tests.Perf_BitArray.BitArraySetAll(Size: 32768)          |      1.63 |          3078.29 |          1883.64 |         |
| System.Collections.Tests.Perf_BitArray.BitArrayXor(Size: 512)               |      1.55 |            17.15 |            11.06 |         |
| System.Collections.Tests.Perf_BitArray.BitArrayAnd(Size: 32768)             |      1.49 |          1259.86 |           847.41 |         |
| System.Collections.Tests.Perf_BitArray.BitArrayXor(Size: 32768)             |      1.48 |          1261.98 |           853.47 |         |
| System.Collections.Tests.Perf_BitArray.BitArrayOr(Size: 32768)              |      1.47 |          1238.11 |           842.76 |         |
| System.Collections.Tests.Perf_BitArray.BitArrayLeftShift(Size: 4)           |      1.16 |             4.63 |             3.98 |         |
| System.Collections.Tests.Perf_BitArray.BitArrayCopyToByteArray(Size: 4)     |      1.10 |            23.14 |            21.08 |         |

Regarding the slowdown of `BitArraySetAll`, I have re-run the benchmarks with various sizes to see at which point the new implementation outrun the current implementation.
(Threshold 5%)
```
summary:                                                                                                                                                                                  better: 6, geomean: 1.345
worse: 2, geomean: 1.729
total diff: 8
```
| Slower                                                          | diff/base | Base Median (ns) | Diff Median (ns) | Modality|
| --------------------------------------------------------------- | ---------:| ----------------:| ----------------:| --------:|
| System.Collections.Tests.Perf_BitArray.BitArraySetAll(Size: 4)  |      2.69 |             1.39 |             3.74 |         |
| System.Collections.Tests.Perf_BitArray.BitArraySetAll(Size: 16) |      1.11 |             3.16 |             3.50 |         |

| Faster                                                           | base/diff | Base Median (ns) | Diff Median (ns) | Modality|
| ---------------------------------------------------------------- | ---------:| ----------------:| ----------------:| --------:|
| System.Collections.Tests.Perf_BitArray.BitArraySetAll(Size: 512) |      1.76 |            53.79 |            30.51 |         |
| System.Collections.Tests.Perf_BitArray.BitArraySetAll(Size: 64)  |      1.35 |             7.03 |             5.23 |         |
| System.Collections.Tests.Perf_BitArray.BitArraySetAll(Size: 96)  |      1.31 |             9.52 |             7.25 |         |
| System.Collections.Tests.Perf_BitArray.BitArraySetAll(Size: 128) |      1.30 |            11.93 |             9.21 |         |
| System.Collections.Tests.Perf_BitArray.BitArraySetAll(Size: 256) |      1.22 |            22.09 |            18.09 |         |
| System.Collections.Tests.Perf_BitArray.BitArraySetAll(Size: 32)  |      1.20 |             4.08 |             3.40 |         |

Which suggests that it may be faster for filling BitArray that contains more than 32 elements. One thing to note though, is that the numbers for small sizes seem to fluctuate around for small sizes, so I suppose the results may be inaccurate. (Even for this benchmark, I expect the numbers to be similar for Size 4/16/32, since they are all stored in one `int` and therefore should be just a single copy of an int; but they all seem to give different results)

Furthermore, since the current implementation of `SetAll` operates on the whole of the backing array, this may result in unnecessary copying to unused area when the `BitArray.Length` has been set to make the BitArray smaller but the backing array hasn't been resized due to the new length not meeting the `_ShrinkThreshold` (in `int` counts): https://github.com/dotnet/corefx/blob/2b92fc0930b941cd0d9146971745cd717689434c/src/System.Collections/src/System/Collections/BitArray.cs#L23

The new implementation uses `GetInt32ArrayLengthFromBitLength(Length)` method to calculate where the used area are and only copies to that region. Unfortunately, since this happens for smaller sized arrays as well, this check on itself seem to results in approximately 0.7x slowdown when the array has less than 32 elements.

Regarding the use of AVX2, I figured out that AVX2 generally improved the performance despite the concerns about downclocking. This is an example comparison between various paths for BitArray(Array, int) with bool arrays (See https://github.com/dotnet/corefx/issues/41762#issuecomment-542658154 and https://github.com/dotnet/corefx/issues/41762#issuecomment-542831649 for benchmarks of And/or/xor/not and `BitArray(bool[])`):
```
// * Summary *                                                                                                          
BenchmarkDotNet=v0.11.5.1159-nightly, OS=Windows 10.0.18999                                                             Intel Core i7-8700 CPU 3.20GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=5.0.100-alpha1-014899
  [Host]              : .NET Core 5.0.0-alpha1.19507.3 (CoreCLR 5.0.19.50101, CoreFX 5.0.19.50407), X64 RyuJIT
  Job-VRDFCM          : .NET Core ? (CoreCLR 5.0.19.51405, CoreFX 5.0.19.51801), X64 RyuJIT
  AVX2 Disabled       : .NET Core ? (CoreCLR 5.0.19.51405, CoreFX 5.0.19.51801), X64 RyuJIT
  Intrinsics Disabled : .NET Core ? (CoreCLR 5.0.19.51405, CoreFX 5.0.19.51801), X64 RyuJIT
```

|                  Method |                 Job |        EnvironmentVariables |                        PowerPlanMode | Toolchain | IterationTime | MaxIterationCount | MinIterationCount | WarmupCount |  Size |          Mean |      Error |     StdDev |        Median |           Min |           Max | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------ |-------------------- |---------------------------- |------------------------------------- |---------- |-------------- |------------------ |------------------ |------------ |------ |--------------:|-----------:|-----------:|--------------:|--------------:|--------------:|------:|------:|------:|----------:|
| BitArrayCopyToBoolArray |             Default |                       Empty | 00000000-0000-0000-0000-000000000000 |   CoreRun |   250.0000 ms |                20 |                15 |           1 |     4 |      35.90 ns |   0.218 ns |   0.203 ns |      35.84 ns |      35.60 ns |      36.26 ns |     - |     - |     - |         - |
| BitArrayCopyToBoolArray |       AVX2 Disabled |        COMPlus_EnableAVX2=0 | 8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c |    Before |       Default |           Default |           Default |     Default |     4 |      35.90 ns |   0.142 ns |   0.132 ns |      35.89 ns |      35.65 ns |      36.13 ns |     - |     - |     - |         - |
| BitArrayCopyToBoolArray | Intrinsics Disabled | COMPlus_EnableHWIntrinsic=0 | 8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c |    Before |       Default |           Default |           Default |     Default |     4 |      73.08 ns |   0.333 ns |   0.311 ns |      73.06 ns |      72.56 ns |      73.76 ns |     - |     - |     - |         - |
| BitArrayCopyToBoolArray |             Default |                       Empty | 00000000-0000-0000-0000-000000000000 |   CoreRun |   250.0000 ms |                20 |                15 |           1 |   512 |     191.24 ns |   1.056 ns |   0.988 ns |     191.25 ns |     189.72 ns |     192.84 ns |     - |     - |     - |         - |
| BitArrayCopyToBoolArray |       AVX2 Disabled |        COMPlus_EnableAVX2=0 | 8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c |    Before |       Default |           Default |           Default |     Default |   512 |     220.78 ns |   0.819 ns |   0.766 ns |     220.75 ns |     219.00 ns |     221.94 ns |     - |     - |     - |         - |
| BitArrayCopyToBoolArray | Intrinsics Disabled | COMPlus_EnableHWIntrinsic=0 | 8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c |    Before |       Default |           Default |           Default |     Default |   512 |   5,221.48 ns |  16.221 ns |  12.664 ns |   5,227.59 ns |   5,202.04 ns |   5,235.70 ns |     - |     - |     - |         - |
| BitArrayCopyToBoolArray |             Default |                       Empty | 00000000-0000-0000-0000-000000000000 |   CoreRun |   250.0000 ms |                20 |                15 |           1 | 32768 |   9,776.74 ns |  89.691 ns |  74.896 ns |   9,756.03 ns |   9,696.10 ns |   9,976.58 ns |     - |     - |     - |         - |
| BitArrayCopyToBoolArray |       AVX2 Disabled |        COMPlus_EnableAVX2=0 | 8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c |    Before |       Default |           Default |           Default |     Default | 32768 |  11,746.34 ns |  50.812 ns |  42.431 ns |  11,735.14 ns |  11,679.19 ns |  11,834.34 ns |     - |     - |     - |         - |
| BitArrayCopyToBoolArray | Intrinsics Disabled | COMPlus_EnableHWIntrinsic=0 | 8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c |    Before |       Default |           Default |           Default |     Default | 32768 | 331,026.89 ns | 936.011 ns | 781.612 ns | 331,110.79 ns | 330,069.53 ns | 332,353.66 ns |     - |     - |     - |         - |