### PR TITLE
A few more test scenarios for casting of nullables and open generic arrays.

### DIFF
--- a/src/System.Reflection/tests/TypeInfoTests.cs
+++ b/src/System.Reflection/tests/TypeInfoTests.cs
@@ -613,7 +613,7 @@ namespace System.Reflection.Tests
             s_x = (object)1234;
             Assert.True((s_x is int?) && (int?)s_x == 1234);
 
-            // test construction again to cath caching issues
+            // test construction again to catch caching issues
             Assert.Throws<ArgumentException>(() => typeof(G<,>).MakeGenericType(typeof(int), typeof(int?)));
         }
 

--- a/src/System.Reflection/tests/TypeInfoTests.cs
+++ b/src/System.Reflection/tests/TypeInfoTests.cs
@@ -578,7 +578,7 @@ namespace System.Reflection.Tests
         {
         }
 
-        static object s_x;
+        static volatile object s_boxedInt32;
 
         [Fact]
         public void IsAssignableFromNullable()
@@ -610,8 +610,8 @@ namespace System.Reflection.Tests
             Assert.Throws<ArgumentException>(() => typeof(G<,>).MakeGenericType(typeof(int), typeof(int?)));
 
             // Test trivial object casts 
-            s_x = (object)1234;
-            Assert.True((s_x is int?) && (int?)s_x == 1234);
+            s_boxedInt32 = (object)1234;
+            Assert.True((s_boxedInt32 is int?) && (int?)s_boxedInt32 == 1234);
 
             // test construction again to catch caching issues
             Assert.Throws<ArgumentException>(() => typeof(G<,>).MakeGenericType(typeof(int), typeof(int?)));

--- a/src/System.Reflection/tests/TypeInfoTests.cs
+++ b/src/System.Reflection/tests/TypeInfoTests.cs
@@ -574,6 +574,12 @@ namespace System.Reflection.Tests
             Assert.Equal(expected, type.GetTypeInfo().IsAssignableFrom(c?.GetTypeInfo()));
         }
 
+        class G<T, U> where T : U
+        {
+        }
+
+        static object s_x;
+
         [Fact]
         public void IsAssignableFromNullable()
         {
@@ -599,6 +605,55 @@ namespace System.Reflection.Tests
             // Nullable<T> is not assignable from T
             Assert.False(nubOfT.IsAssignableFrom(T));
             Assert.False(T.IsAssignableFrom(nubOfT));
+
+            // illegal type construction due to T->T?
+            Assert.Throws<ArgumentException>(() => typeof(G<,>).MakeGenericType(typeof(int), typeof(int?)));
+
+            // Test trivial object casts 
+            s_x = (object)1234;
+            Assert.True((s_x is int?) && (int?)s_x == 1234);
+
+            // test construction again to cath caching issues
+            Assert.Throws<ArgumentException>(() => typeof(G<,>).MakeGenericType(typeof(int), typeof(int?)));
+        }
+
+        interface IFace
+        {
+        }
+
+        class G<T> where T : class, IFace
+        {
+            //void OpenGenericArrays()
+            //{
+            //    // this is valid, reflection checks below should agree 
+            //    IFace[] arr2 = default(T[]);
+            //    IEnumerable<IFace> ie = default(T[]);
+            //}
+        }
+
+        class GG<T, U> where T : class, U
+        {
+            //void OpenGenericArrays()
+            //{
+            //    // this is valid, reflection checks below should agree 
+            //    U[] arr2 = default(T[]);
+            //    IEnumerable<U> ie = default(T[]);
+            //}
+        }
+
+        [Fact]
+        public void OpenGenericArrays()
+        {
+            Type a = typeof(G<>).GetGenericArguments()[0].MakeArrayType();
+            Assert.True(typeof(IFace[]).IsAssignableFrom(a));
+            Assert.True(typeof(IEnumerable<IFace>).IsAssignableFrom(a));
+
+            Type a1 = typeof(GG<,>).GetGenericArguments()[0].MakeArrayType();
+            Type a2 = typeof(GG<,>).GetGenericArguments()[1].MakeArrayType();
+            Assert.True(a2.IsAssignableFrom(a1));
+
+            Type ie = typeof(IEnumerable<>).MakeGenericType(typeof(GG<,>).GetGenericArguments()[1]);
+            Assert.True(ie.IsAssignableFrom(a1));
         }
 
         public static IEnumerable<object[]> IsEquivilentTo_TestData()


### PR DESCRIPTION
- nullables have different rules for object/type/reflection casting. Since castability depends on who is asking, there is some fragility and need for test coverage. 

- internal representation of open `T[]` arrays may reuse methodtable from `object[]` assuming that instances will not be created anyways. Type analysis must be careful to not use method tables as type info or identity for these.