### PR TITLE
Fix XSLT tests to deterministically pick newer xsltc.exe

### DIFF
--- a/src/System.Private.Xml/tests/Xslt/XsltCompiler/XsltCommon.cs
+++ b/src/System.Private.Xml/tests/Xslt/XsltCompiler/XsltCommon.cs
@@ -355,8 +355,6 @@ namespace XmlCoreTest.Common
                 throw new FileNotFoundException(fileName);
 
             // Prefer newer versions, for stability
-            foreach (string file in files)
-
             files.Sort((left, right) =>
             {
                 int comparison = Comparer<float>.Default.Compare(GetVersion(left), GetVersion(right));

--- a/src/System.Private.Xml/tests/Xslt/XsltCompiler/XsltCommon.cs
+++ b/src/System.Private.Xml/tests/Xslt/XsltCompiler/XsltCommon.cs
@@ -371,7 +371,7 @@ namespace XmlCoreTest.Common
         // Pull the version out of a path like "C:\Program Files (x86)\Microsoft SDKs\Windows\v7.0A\bin\xsltc.exe"
         private static float GetVersion(string s)
         {
-            var match = Regex.Match(s, @"\\v(\d+.\d*)\w?\\", RegexOptions.IgnoreCase);
+            var match = Regex.Match(s, @"\\v(\d+.\d+)\w?\\", RegexOptions.IgnoreCase);
 
             float val = 0;
             if (match.Success)

--- a/src/System.Private.Xml/tests/Xslt/XsltCompiler/XsltCommon.cs
+++ b/src/System.Private.Xml/tests/Xslt/XsltCompiler/XsltCommon.cs
@@ -357,7 +357,7 @@ namespace XmlCoreTest.Common
             // Prefer newer versions, for stability
             files.Sort((left, right) =>
             {
-                int comparison = Comparer<float>.Default.Compare(GetVersion(left), GetVersion(right));
+                int comparison = Comparer<float>.Default.Compare(GetVersionFromSDKPath(left), GetVersionFromSDKPath(right));
 
                 if (comparison == 0)
                     comparison = string.Compare(left, right, StringComparison.OrdinalIgnoreCase);
@@ -369,9 +369,9 @@ namespace XmlCoreTest.Common
         }
 
         // Pull the version out of a path like "C:\Program Files (x86)\Microsoft SDKs\Windows\v7.0A\bin\xsltc.exe"
-        private static float GetVersion(string s)
+        private static float GetVersionFromSDKPath(string s)
         {
-            var match = Regex.Match(s, @"\\v(\d+.\d+)\w?\\", RegexOptions.IgnoreCase);
+            Match match = Regex.Match(s, @"\\v(\d+\.\d+)\w?\\", RegexOptions.IgnoreCase);
 
             float val = 0;
             if (match.Success)


### PR DESCRIPTION
My machine had several:
```
C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.7.2 Tools\xsltc.exe
C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\xsltc.exe
C:\Program Files (x86)\Microsoft SDKs\Windows\v7.0A\bin\x64\xsltc.exe
C:\Program Files (x86)\Microsoft SDKs\Windows\v7.0A\bin\xsltc.exe
```
It picked the 4th one above. It should pick the 2nd one in order to produce results matching the expected baseline.