### PR TITLE
Add `Replace()` methods to `ImmutableList` builder

### DIFF
--- a/src/System.Collections.Immutable/ref/System.Collections.Immutable.cs
+++ b/src/System.Collections.Immutable/ref/System.Collections.Immutable.cs
@@ -680,6 +680,8 @@ namespace System.Collections.Immutable
             public int LastIndexOf(T item, int startIndex, int count, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
             public bool Remove(T item) { throw null; }
             public int RemoveAll(System.Predicate<T> match) { throw null; }
+            public void Replace(T oldValue, T newValue) { throw null; }
+            public void Replace(T oldValue, T newValue, System.Collections.Generic.IEqualityComparer<T> equalityComparer) { throw null; }
             public void RemoveAt(int index) { }
             public void Reverse() { }
             public void Reverse(int index, int count) { }

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.Builder.cs
@@ -770,6 +770,19 @@ namespace System.Collections.Immutable
                 return count - this.Count;
             }
 
+            public void Replace(T oldValue, T newValue) => this.Replace(oldValue, newValue, EqualityComparer<T>.Default);
+
+            public void Replace(T oldValue, T newValue, IEqualityComparer<T> equalityComparer)
+            {
+                int index = this.IndexOf(oldValue, 0, this.Count, equalityComparer);
+                if (index < 0)
+                {
+                    throw new ArgumentException(SR.CannotFindOldValue, nameof(oldValue));
+                }
+
+                this.Root = this.Root.ReplaceAt(index, newValue);
+            }
+
             /// <summary>
             /// Reverses the order of the elements in the entire ImmutableList&lt;T&gt;.
             /// </summary>

--- a/src/System.Collections.Immutable/tests/ImmutableListBuilderTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableListBuilderTest.cs
@@ -281,6 +281,56 @@ namespace System.Collections.Immutable.Tests
         }
 
         [Fact]
+        public void ReplaceTest()
+        {
+            // Verify replace at beginning.
+            var mutable = ImmutableList.Create(3, 5, 8).ToBuilder();
+            mutable.Replace(3, 4);
+            Assert.Equal(new[] { 4, 5, 8 }, mutable);
+
+            // Verify replace at middle.
+            mutable = ImmutableList.Create(3, 5, 8).ToBuilder();
+            mutable.Replace(5, 6);
+            Assert.Equal(new[] { 3, 6, 8 }, mutable);
+
+            // Verify replace at end.
+            mutable = ImmutableList.Create(3, 5, 8).ToBuilder();
+            mutable.Replace(8, 9);
+            Assert.Equal(new[] { 3, 5, 9 }, mutable);
+
+            // Verify replacement of first element when there are duplicates.
+            mutable = ImmutableList.Create(3, 3, 5).ToBuilder();
+            mutable.Replace(3, 4);
+            Assert.Equal(new[] { 4, 3, 5 }, mutable);
+
+            // Verify repeated replacement of first element when there are duplicates.
+            mutable = ImmutableList.Create(3, 3, 5).ToBuilder();
+            mutable.Replace(3, 4);
+            mutable.Replace(3, 4);
+            Assert.Equal(new[] { 4, 4, 5 }, mutable);
+        }
+
+        [Fact]
+        public void ReplaceWithEqualityComparerTest()
+        {
+            var mutable = ImmutableList.Create(new Person { Name = "Andrew", Age = 20 }).ToBuilder();
+            var newAge = new Person { Name = "Andrew", Age = 21 };
+            mutable.Replace(newAge, newAge, new NameOnlyEqualityComparer());
+            Assert.Equal(newAge.Age, mutable[0].Age);
+
+            // Try again with a null equality comparer, which should use the default EQ.
+            mutable = ImmutableList.Create(new Person { Name = "Andrew", Age = 20 }).ToBuilder();
+            mutable.Replace(mutable[0], newAge);
+            Assert.Equal(newAge, mutable[0]);
+        }
+
+        [Fact]
+        public void ReplaceMissingThrowsTest()
+        {
+            AssertExtensions.Throws<ArgumentException>("oldValue", () => ImmutableList<int>.Empty.ToBuilder().Replace(5, 3));
+        }
+
+        [Fact]
         public void GetEnumeratorExplicit()
         {
             ICollection<int> builder = ImmutableList.Create<int>().ToBuilder();
@@ -469,6 +519,25 @@ namespace System.Collections.Immutable.Tests
             var builder = list.ToBuilder();
             builder.Sort(index, count, comparer);
             return builder.ToImmutable().ToList();
+        }
+
+        private struct Person
+        {
+            public string Name { get; set; }
+            public int Age { get; set; }
+        }
+
+        private class NameOnlyEqualityComparer : IEqualityComparer<Person>
+        {
+            public bool Equals(Person x, Person y)
+            {
+                return x.Name == y.Name;
+            }
+
+            public int GetHashCode(Person obj)
+            {
+                return obj.Name.GetHashCode();
+            }
         }
     }
 }


### PR DESCRIPTION
`ImmutableList<T>.Builder` is missing the `Replace()` methods `ImmutableList<T>` has. This PR adds them.

The implementation is very similar to [`ImmutableList<T>.Replace()`](https://github.com/dotnet/corefx/blob/5e4bf872154c17a1407997a38cc013fb12d5d1af/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.cs#L397), so there is some duplication. The test cases naturally also kind of duplicate the [tests for `ImmutableList<T>.Replace()`](https://github.com/dotnet/corefx/blob/5e4bf872154c17a1407997a38cc013fb12d5d1af/src/System.Collections.Immutable/tests/ImmutableListTest.cs#L527).