### PR TITLE
Optimize FindFirstCharToEncode for JavaScriptEncoder.Default and Relaxed using Sse2 intrinsics.

### DIFF
--- a/src/System.Text.Encodings.Web/src/Configurations.props
+++ b/src/System.Text.Encodings.Web/src/Configurations.props
@@ -1,6 +1,7 @@
 ﻿<Project DefaultTargets="Build">
   <PropertyGroup>
     <BuildConfigurations>
+      netcoreapp;
       netstandard2.1;
       netstandard;
     </BuildConfigurations>

--- a/src/System.Text.Encodings.Web/src/System.Text.Encodings.Web.csproj
+++ b/src/System.Text.Encodings.Web/src/System.Text.Encodings.Web.csproj
@@ -2,9 +2,10 @@
   <PropertyGroup>
     <RootNamespace>System.Text.Encodings.Web</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Configurations>netstandard-Debug;netstandard-Release;netstandard2.1-Debug;netstandard2.1-Release</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release;netstandard2.1-Debug;netstandard2.1-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="System\Text\Encodings\Web\DefaultJavaScriptEncoderBasicLatin.cs" />
     <Compile Include="System\Text\Encodings\Web\HexUtil.cs" />
     <Compile Include="System\Text\Encodings\Web\HtmlEncoder.cs" />
     <Compile Include="System\Text\Encodings\Web\JavaScriptEncoder.cs" />
@@ -30,5 +31,12 @@
   <ItemGroup>
     <Reference Include="System.Memory" />
     <Reference Include="System.Resources.ResourceManager" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetCoreApp)' == 'true'">
+    <Reference Include="System.Diagnostics.Debug" />
+    <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.Extensions" />
+    <Reference Include="System.Runtime.Intrinsics" />
+    <Reference Include="System.Threading" />
   </ItemGroup>
 </Project>

--- a/src/System.Text.Encodings.Web/src/System.Text.Encodings.Web.csproj
+++ b/src/System.Text.Encodings.Web/src/System.Text.Encodings.Web.csproj
@@ -5,6 +5,7 @@
     <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release;netstandard2.1-Debug;netstandard2.1-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="System\Text\Encodings\Web\DefaultJavaScriptEncoder.cs" />
     <Compile Include="System\Text\Encodings\Web\DefaultJavaScriptEncoderBasicLatin.cs" />
     <Compile Include="System\Text\Encodings\Web\HexUtil.cs" />
     <Compile Include="System\Text\Encodings\Web\HtmlEncoder.cs" />

--- a/src/System.Text.Encodings.Web/src/System.Text.Encodings.Web.csproj
+++ b/src/System.Text.Encodings.Web/src/System.Text.Encodings.Web.csproj
@@ -20,6 +20,9 @@
     <Compile Include="System\Text\Unicode\UnicodeRanges.cs" />
     <Compile Include="System\Text\Unicode\UnicodeRanges.generated.cs" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetCoreApp)' == 'true'">
+    <Compile Include="System\Text\Encodings\Web\Sse2Helper.cs" />
+  </ItemGroup>
   <ItemGroup>
     <Compile Include="$(CommonPath)\CoreLib\System\Text\UnicodeDebug.cs">
       <Link>System\Text\UnicodeDebug.cs</Link>

--- a/src/System.Text.Encodings.Web/src/System.Text.Encodings.Web.csproj
+++ b/src/System.Text.Encodings.Web/src/System.Text.Encodings.Web.csproj
@@ -9,6 +9,7 @@
     <Compile Include="System\Text\Encodings\Web\HexUtil.cs" />
     <Compile Include="System\Text\Encodings\Web\HtmlEncoder.cs" />
     <Compile Include="System\Text\Encodings\Web\JavaScriptEncoder.cs" />
+    <Compile Include="System\Text\Encodings\Web\JavaScriptEncoderHelper.cs" />
     <Compile Include="System\Text\Encodings\Web\TextEncoder.cs" />
     <Compile Include="System\Text\Encodings\Web\TextEncoderSettings.cs" />
     <Compile Include="System\Text\Encodings\Web\UnsafeRelaxedJavaScriptEncoder.cs" />

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/DefaultJavaScriptEncoder.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/DefaultJavaScriptEncoder.cs
@@ -9,22 +9,24 @@ using System.Text.Internal;
 using System.Text.Unicode;
 
 #if NETCOREAPP
-using System.Numerics;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 #endif
 
 namespace System.Text.Encodings.Web
 {
-    internal sealed class UnsafeRelaxedJavaScriptEncoder : JavaScriptEncoder
+    internal sealed class DefaultJavaScriptEncoder : JavaScriptEncoder
     {
         private readonly AllowedCharactersBitmap _allowedCharacters;
 
-        internal static readonly UnsafeRelaxedJavaScriptEncoder s_singleton = new UnsafeRelaxedJavaScriptEncoder();
+        private readonly int[] _asciiNeedsEscaping = new int[0x80];
 
-        private UnsafeRelaxedJavaScriptEncoder()
+        public DefaultJavaScriptEncoder(TextEncoderSettings filter)
         {
-            var filter = new TextEncoderSettings(UnicodeRanges.All);
+            if (filter == null)
+            {
+                throw new ArgumentNullException(nameof(filter));
+            }
 
             _allowedCharacters = filter.GetAllowedCharacters();
 
@@ -32,13 +34,28 @@ namespace System.Text.Encodings.Web
             // (includes categories Cc, Cs, Co, Cn, Zs [except U+0020 SPACE], Zl, Zp)
             _allowedCharacters.ForbidUndefinedCharacters();
 
-            // '"' (U+0022 QUOTATION MARK) must always be escaped in Javascript / ECMAScript / JSON.
-            _allowedCharacters.ForbidCharacter('\"'); // can be used to escape attributes
+            // Forbid characters that are special in HTML.
+            // Even though this is a not HTML encoder,
+            // it's unfortunately common for developers to
+            // forget to HTML-encode a string once it has been JS-encoded,
+            // so this offers extra protection.
+            DefaultHtmlEncoder.ForbidHtmlCharacters(_allowedCharacters);
 
             // '\' (U+005C REVERSE SOLIDUS) must always be escaped in Javascript / ECMAScript / JSON.
             // '/' (U+002F SOLIDUS) is not Javascript / ECMAScript / JSON-sensitive so doesn't need to be escaped.
             _allowedCharacters.ForbidCharacter('\\');
+
+            // '`' (U+0060 GRAVE ACCENT) is ECMAScript-sensitive (see ECMA-262).
+            _allowedCharacters.ForbidCharacter('`');
+
+            for (int i = 0; i < _asciiNeedsEscaping.Length; i++)
+            {
+                _asciiNeedsEscaping[i] = WillEncode(i) ? 1 : -1;
+            }
         }
+
+        public DefaultJavaScriptEncoder(params UnicodeRange[] allowedRanges) : this(new TextEncoderSettings(allowedRanges))
+        { }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override bool WillEncode(int unicodeScalar)
@@ -61,81 +78,9 @@ namespace System.Text.Encodings.Web
                 throw new ArgumentNullException(nameof(text));
             }
 
-            int idx = 0;
-
-#if NETCOREAPP
-            if (Sse2.IsSupported)
-            {
-                short* startingAddress = (short*)text;
-                while (textLength - 8 >= idx)
-                {
-                    Debug.Assert(startingAddress >= text && startingAddress <= (text + textLength - 8));
-
-                    // Load the next 8 characters.
-                    Vector128<short> sourceValue = Sse2.LoadVector128(startingAddress);
-
-                    Vector128<short> mask = Sse2Helper.CreateAsciiMask(sourceValue);
-                    int index = Sse2.MoveMask(mask.AsByte());
-
-                    if (index != 0)
-                    {
-                        // At least one of the following 8 characters is non-ASCII.
-                        int processNextEight = idx + 8;
-                        Debug.Assert(processNextEight <= textLength);
-                        for (; idx < processNextEight; idx++)
-                        {
-                            Debug.Assert((text + idx) <= (text + textLength));
-                            if (!_allowedCharacters.IsCharacterAllowed(*(text + idx)))
-                            {
-                                goto Return;
-                            }
-                        }
-                        startingAddress += 8;
-                    }
-                    else
-                    {
-                        // Check if any of the 8 characters need to be escaped.
-                        mask = Sse2Helper.CreateEscapingMask_UnsafeRelaxedJavaScriptEncoder(sourceValue);
-
-                        index = Sse2.MoveMask(mask.AsByte());
-                        // If index == 0, that means none of the 8 characters needed to be escaped.
-                        // TrailingZeroCount is relatively expensive, avoid it if possible.
-                        if (index != 0)
-                        {
-                            // Found at least one character that needs to be escaped, figure out the index of
-                            // the first one found that needed to be escaped within the 8 characters.
-                            Debug.Assert(index > 0 && index <= 65_535);
-                            int tzc = BitOperations.TrailingZeroCount(index);
-                            Debug.Assert(tzc % 2 == 0 && tzc >= 0 && tzc <= 16);
-                            idx += tzc >> 1;
-                            goto Return;
-                        }
-                        idx += 8;
-                        startingAddress += 8;
-                    }
-                }
-
-                // Process the remaining characters.
-                Debug.Assert(textLength - idx < 8);
-            }
-#endif
-
-            for (; idx < textLength; idx++)
-            {
-                Debug.Assert((text + idx) <= (text + textLength));
-                if (!_allowedCharacters.IsCharacterAllowed(*(text + idx)))
-                {
-                    goto Return;
-                }
-            }
-
-            idx = -1; // All characters are allowed.
-
-        Return:
-            return idx;
+            return _allowedCharacters.FindFirstCharacterToEncode(text, textLength);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override unsafe int FindFirstCharacterToEncodeUtf8(ReadOnlySpan<byte> utf8Text)
         {
             fixed (byte* ptr = utf8Text)
@@ -169,7 +114,7 @@ namespace System.Text.Encodings.Web
 
                                 if (UnicodeUtility.IsAsciiCodePoint(ptr[idx]))
                                 {
-                                    if (!_allowedCharacters.IsUnicodeScalarAllowed(ptr[idx]))
+                                    if (DoesAsciiNeedEncoding(ptr[idx]) == 1)
                                     {
                                         goto Return;
                                     }
@@ -189,29 +134,35 @@ namespace System.Text.Encodings.Web
                                     idx += utf8BytesConsumedForScalar;
                                 }
                             }
-                            startingAddress = (sbyte*)ptr + idx;
                         }
                         else
                         {
-                            // Check if any of the 16 bytes need to be escaped.
-                            mask = Sse2Helper.CreateEscapingMask_UnsafeRelaxedJavaScriptEncoder(sourceValue);
+                            if (DoesAsciiNeedEncoding(ptr[idx]) == 1
 
-                            index = Sse2.MoveMask(mask.AsByte());
-                            // If index == 0, that means none of the 16 bytes needed to be escaped.
-                            // TrailingZeroCount is relatively expensive, avoid it if possible.
-                            if (index != 0)
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1)
                             {
-                                // Found at least one byte that needs to be escaped, figure out the index of
-                                // the first one found that needed to be escaped within the 16 bytes.
-                                Debug.Assert(index > 0 && index <= 65_535);
-                                int tzc = BitOperations.TrailingZeroCount(index);
-                                Debug.Assert(tzc >= 0 && tzc <= 16);
-                                idx += tzc;
                                 goto Return;
                             }
-                            idx += 16;
-                            startingAddress += 16;
+                            idx++;
                         }
+                        startingAddress = (sbyte*)ptr + idx;
                     }
 
                     // Process the remaining bytes.
@@ -225,7 +176,7 @@ namespace System.Text.Encodings.Web
 
                     if (UnicodeUtility.IsAsciiCodePoint(ptr[idx]))
                     {
-                        if (!_allowedCharacters.IsUnicodeScalarAllowed(ptr[idx]))
+                        if (DoesAsciiNeedEncoding(ptr[idx]) == 1)
                         {
                             goto Return;
                         }
@@ -253,6 +204,18 @@ namespace System.Text.Encodings.Web
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private int DoesAsciiNeedEncoding(byte value)
+        {
+            Debug.Assert(value <= 0x7F);
+
+            int needsEscaping = _asciiNeedsEscaping[value];
+
+            Debug.Assert(needsEscaping == 1 || needsEscaping == -1);
+
+            return needsEscaping;
+        }
+
         // The worst case encoding is 6 output chars per input char: [input] U+FFFF -> [output] "\uFFFF"
         // We don't need to worry about astral code points since they're represented as encoded
         // surrogate pairs in the output.
@@ -264,7 +227,6 @@ namespace System.Text.Encodings.Web
         private static readonly char[] s_f = new char[] { '\\', 'f' };
         private static readonly char[] s_r = new char[] { '\\', 'r' };
         private static readonly char[] s_back = new char[] { '\\', '\\' };
-        private static readonly char[] s_doubleQuote = new char[] { '\\', '"' };
 
         // Writes a scalar value as a JavaScript-escaped character (or sequence of characters).
         // See ECMA-262, Sec. 7.8.4, and ECMA-404, Sec. 9
@@ -295,29 +257,13 @@ namespace System.Text.Encodings.Web
             char[] toCopy;
             switch (unicodeScalar)
             {
-                case '\"':
-                    toCopy = s_doubleQuote;
-                    break;
-                case '\b':
-                    toCopy = s_b;
-                    break;
-                case '\t':
-                    toCopy = s_t;
-                    break;
-                case '\n':
-                    toCopy = s_n;
-                    break;
-                case '\f':
-                    toCopy = s_f;
-                    break;
-                case '\r':
-                    toCopy = s_r;
-                    break;
-                case '\\':
-                    toCopy = s_back;
-                    break;
-                default:
-                    return JavaScriptEncoderHelper.TryWriteEncodedScalarAsNumericEntity(unicodeScalar, buffer, bufferLength, out numberOfCharactersWritten);
+                case '\b': toCopy = s_b; break;
+                case '\t': toCopy = s_t; break;
+                case '\n': toCopy = s_n; break;
+                case '\f': toCopy = s_f; break;
+                case '\r': toCopy = s_r; break;
+                case '\\': toCopy = s_back; break;
+                default: return JavaScriptEncoderHelper.TryWriteEncodedScalarAsNumericEntity(unicodeScalar, buffer, bufferLength, out numberOfCharactersWritten);
             }
             return TryCopyCharacters(toCopy, buffer, bufferLength, out numberOfCharactersWritten);
         }

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/DefaultJavaScriptEncoder.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/DefaultJavaScriptEncoder.cs
@@ -99,7 +99,7 @@ namespace System.Text.Encodings.Web
                         Vector128<sbyte> sourceValue = Sse2.LoadVector128(startingAddress);
 
                         Vector128<sbyte> mask = Sse2Helper.CreateAsciiMask(sourceValue);
-                        int index = Sse2.MoveMask(mask.AsByte());
+                        int index = Sse2.MoveMask(mask);
 
                         if (index != 0)
                         {

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/DefaultJavaScriptEncoderBasicLatin.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/DefaultJavaScriptEncoderBasicLatin.cs
@@ -155,7 +155,7 @@ namespace System.Text.Encodings.Web
                         // Check if any of the 16 bytes need to be escaped.
                         Vector128<sbyte> mask = Sse2Helper.CreateEscapingMask_DefaultJavaScriptEncoderBasicLatin(sourceValue);
 
-                        int index = Sse2.MoveMask(mask.AsByte());
+                        int index = Sse2.MoveMask(mask);
                         // If index == 0, that means none of the 16 bytes needed to be escaped.
                         // TrailingZeroCount is relatively expensive, avoid it if possible.
                         if (index != 0)

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/DefaultJavaScriptEncoderBasicLatin.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/DefaultJavaScriptEncoderBasicLatin.cs
@@ -252,66 +252,9 @@ namespace System.Text.Encodings.Web
                     toCopy = s_back;
                     break;
                 default:
-                    return TryWriteEncodedScalarAsNumericEntity(unicodeScalar, buffer, bufferLength, out numberOfCharactersWritten);
+                    return JavaScriptEncoderHelper.TryWriteEncodedScalarAsNumericEntity(unicodeScalar, buffer, bufferLength, out numberOfCharactersWritten);
             }
             return TryCopyCharacters(toCopy, buffer, bufferLength, out numberOfCharactersWritten);
-        }
-
-        private static unsafe bool TryWriteEncodedScalarAsNumericEntity(int unicodeScalar, char* buffer, int length, out int numberOfCharactersWritten)
-        {
-            Debug.Assert(buffer != null && length >= 0);
-
-            if (UnicodeHelpers.IsSupplementaryCodePoint(unicodeScalar))
-            {
-                // Convert this back to UTF-16 and write out both characters.
-                UnicodeHelpers.GetUtf16SurrogatePairFromAstralScalarValue(unicodeScalar, out char leadingSurrogate, out char trailingSurrogate);
-                if (TryWriteEncodedSingleCharacter(leadingSurrogate, buffer, length, out int leadingSurrogateCharactersWritten) &&
-                    TryWriteEncodedSingleCharacter(trailingSurrogate, buffer + leadingSurrogateCharactersWritten, length - leadingSurrogateCharactersWritten, out numberOfCharactersWritten)
-                )
-                {
-                    numberOfCharactersWritten += leadingSurrogateCharactersWritten;
-                    return true;
-                }
-                else
-                {
-                    numberOfCharactersWritten = 0;
-                    return false;
-                }
-            }
-            else
-            {
-                // This is only a single character.
-                return TryWriteEncodedSingleCharacter(unicodeScalar, buffer, length, out numberOfCharactersWritten);
-            }
-        }
-
-        // Writes an encoded scalar value (in the BMP) as a JavaScript-escaped character.
-        private static unsafe bool TryWriteEncodedSingleCharacter(int unicodeScalar, char* buffer, int length, out int numberOfCharactersWritten)
-        {
-            Debug.Assert(buffer != null && length >= 0);
-            Debug.Assert(!UnicodeHelpers.IsSupplementaryCodePoint(unicodeScalar), "The incoming value should've been in the BMP.");
-
-            if (length < 6)
-            {
-                numberOfCharactersWritten = 0;
-                return false;
-            }
-
-            // Encode this as 6 chars "\uFFFF".
-            *buffer = '\\';
-            buffer++;
-            *buffer = 'u';
-            buffer++;
-            *buffer = HexUtil.Int32LsbToHexDigit(unicodeScalar >> 12);
-            buffer++;
-            *buffer = HexUtil.Int32LsbToHexDigit((int)((unicodeScalar >> 8) & 0xFU));
-            buffer++;
-            *buffer = HexUtil.Int32LsbToHexDigit((int)((unicodeScalar >> 4) & 0xFU));
-            buffer++;
-            *buffer = HexUtil.Int32LsbToHexDigit((int)(unicodeScalar & 0xFU));
-
-            numberOfCharactersWritten = 6;
-            return true;
         }
 
         private static ReadOnlySpan<byte> AllowList => new byte[byte.MaxValue + 1]

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/JavaScriptEncoder.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/JavaScriptEncoder.cs
@@ -20,7 +20,7 @@ namespace System.Text.Encodings.Web
         /// </summary>
         public static JavaScriptEncoder Default
         {
-            get { return DefaultJavaScriptEncoder.Singleton; }
+            get { return DefaultJavaScriptEncoderBasicLatin.s_singleton; }
         }
 
         /// <summary>
@@ -71,8 +71,6 @@ namespace System.Text.Encodings.Web
     internal sealed class DefaultJavaScriptEncoder : JavaScriptEncoder
     {
         private readonly AllowedCharactersBitmap _allowedCharacters;
-
-        internal static readonly DefaultJavaScriptEncoder Singleton = new DefaultJavaScriptEncoder(new TextEncoderSettings(UnicodeRanges.BasicLatin));
 
         public DefaultJavaScriptEncoder(TextEncoderSettings filter)
         {

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/JavaScriptEncoder.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/JavaScriptEncoder.cs
@@ -168,63 +168,9 @@ namespace System.Text.Encodings.Web
                 case '\f': toCopy = s_f; break;
                 case '\r': toCopy = s_r; break;
                 case '\\': toCopy = s_back; break;
-                default: return TryWriteEncodedScalarAsNumericEntity(unicodeScalar, buffer, bufferLength, out numberOfCharactersWritten);
+                default: return JavaScriptEncoderHelper.TryWriteEncodedScalarAsNumericEntity(unicodeScalar, buffer, bufferLength, out numberOfCharactersWritten);
             }
             return TryCopyCharacters(toCopy, buffer, bufferLength, out numberOfCharactersWritten);
-        }
-
-        private static unsafe bool TryWriteEncodedScalarAsNumericEntity(int unicodeScalar, char* buffer, int length, out int numberOfCharactersWritten)
-        {
-            Debug.Assert(buffer != null && length >= 0);
-
-            if (UnicodeHelpers.IsSupplementaryCodePoint(unicodeScalar))
-            {
-                // Convert this back to UTF-16 and write out both characters.
-                char leadingSurrogate, trailingSurrogate;
-                UnicodeHelpers.GetUtf16SurrogatePairFromAstralScalarValue(unicodeScalar, out leadingSurrogate, out trailingSurrogate);
-                int leadingSurrogateCharactersWritten;
-                if (TryWriteEncodedSingleCharacter(leadingSurrogate, buffer, length, out leadingSurrogateCharactersWritten) &&
-                    TryWriteEncodedSingleCharacter(trailingSurrogate, buffer + leadingSurrogateCharactersWritten, length - leadingSurrogateCharactersWritten, out numberOfCharactersWritten)
-                )
-                {
-                    numberOfCharactersWritten += leadingSurrogateCharactersWritten;
-                    return true;
-                }
-                else
-                {
-                    numberOfCharactersWritten = 0;
-                    return false;
-                }
-            }
-            else
-            {
-                // This is only a single character.
-                return TryWriteEncodedSingleCharacter(unicodeScalar, buffer, length, out numberOfCharactersWritten);
-            }
-        }
-
-        // Writes an encoded scalar value (in the BMP) as a JavaScript-escaped character.
-        private static unsafe bool TryWriteEncodedSingleCharacter(int unicodeScalar, char* buffer, int length, out int numberOfCharactersWritten)
-        {
-            Debug.Assert(buffer != null && length >= 0);
-            Debug.Assert(!UnicodeHelpers.IsSupplementaryCodePoint(unicodeScalar), "The incoming value should've been in the BMP.");
-
-            if (length < 6)
-            {
-                numberOfCharactersWritten = 0;
-                return false;
-            }
-
-            // Encode this as 6 chars "\uFFFF".
-            *buffer = '\\'; buffer++;
-            *buffer = 'u'; buffer++;
-            *buffer = HexUtil.Int32LsbToHexDigit(unicodeScalar >> 12); buffer++;
-            *buffer = HexUtil.Int32LsbToHexDigit((int)((unicodeScalar >> 8) & 0xFU)); buffer++;
-            *buffer = HexUtil.Int32LsbToHexDigit((int)((unicodeScalar >> 4) & 0xFU)); buffer++;
-            *buffer = HexUtil.Int32LsbToHexDigit((int)(unicodeScalar & 0xFU)); buffer++;
-
-            numberOfCharactersWritten = 6;
-            return true;
         }
     }
 }

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/JavaScriptEncoder.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/JavaScriptEncoder.cs
@@ -2,10 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.ComponentModel;
-using System.Diagnostics;
-using System.Runtime.CompilerServices;
-using System.Text.Internal;
 using System.Text.Unicode;
 
 namespace System.Text.Encodings.Web
@@ -18,10 +14,7 @@ namespace System.Text.Encodings.Web
         /// <summary>
         /// Returns a default built-in instance of <see cref="JavaScriptEncoder"/>.
         /// </summary>
-        public static JavaScriptEncoder Default
-        {
-            get { return DefaultJavaScriptEncoderBasicLatin.s_singleton; }
-        }
+        public static JavaScriptEncoder Default => DefaultJavaScriptEncoderBasicLatin.s_singleton;
 
         /// <summary>
         /// Returns a built-in instance of <see cref="JavaScriptEncoder"/> that is less strict about what gets encoded.
@@ -41,10 +34,7 @@ namespace System.Text.Encodings.Web
         /// Unlike the <see cref="Default"/>, this encoder instance allows some other characters to go through unescaped (for example, '+'), and hence must be used cautiously.
         /// </para>
         /// </remarks>
-        public static JavaScriptEncoder UnsafeRelaxedJsonEscaping
-        {
-            get { return UnsafeRelaxedJavaScriptEncoder.s_singleton; }
-        }
+        public static JavaScriptEncoder UnsafeRelaxedJsonEscaping => UnsafeRelaxedJavaScriptEncoder.s_singleton;
 
         /// <summary>
         /// Creates a new instance of JavaScriptEncoder with provided settings.
@@ -65,112 +55,6 @@ namespace System.Text.Encodings.Web
         public static JavaScriptEncoder Create(params UnicodeRange[] allowedRanges)
         {
             return new DefaultJavaScriptEncoder(allowedRanges);
-        }
-    }
-
-    internal sealed class DefaultJavaScriptEncoder : JavaScriptEncoder
-    {
-        private readonly AllowedCharactersBitmap _allowedCharacters;
-
-        public DefaultJavaScriptEncoder(TextEncoderSettings filter)
-        {
-            if (filter == null)
-            {
-                throw new ArgumentNullException(nameof(filter));
-            }
-
-            _allowedCharacters = filter.GetAllowedCharacters();
-
-            // Forbid codepoints which aren't mapped to characters or which are otherwise always disallowed
-            // (includes categories Cc, Cs, Co, Cn, Zs [except U+0020 SPACE], Zl, Zp)
-            _allowedCharacters.ForbidUndefinedCharacters();
-
-            // Forbid characters that are special in HTML.
-            // Even though this is a not HTML encoder,
-            // it's unfortunately common for developers to
-            // forget to HTML-encode a string once it has been JS-encoded,
-            // so this offers extra protection.
-            DefaultHtmlEncoder.ForbidHtmlCharacters(_allowedCharacters);
-
-            // '\' (U+005C REVERSE SOLIDUS) must always be escaped in Javascript / ECMAScript / JSON.
-            // '/' (U+002F SOLIDUS) is not Javascript / ECMAScript / JSON-sensitive so doesn't need to be escaped.
-            _allowedCharacters.ForbidCharacter('\\');
-
-            // '`' (U+0060 GRAVE ACCENT) is ECMAScript-sensitive (see ECMA-262).
-            _allowedCharacters.ForbidCharacter('`');
-        }
-
-        public DefaultJavaScriptEncoder(params UnicodeRange[] allowedRanges) : this(new TextEncoderSettings(allowedRanges))
-        { }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override bool WillEncode(int unicodeScalar)
-        {
-            if (UnicodeHelpers.IsSupplementaryCodePoint(unicodeScalar)) return true;
-            return !_allowedCharacters.IsUnicodeScalarAllowed(unicodeScalar);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe override int FindFirstCharacterToEncode(char* text, int textLength)
-        {
-            if (text == null)
-            {
-                throw new ArgumentNullException(nameof(text));
-            }
-
-            return _allowedCharacters.FindFirstCharacterToEncode(text, textLength);
-        }
-
-        // The worst case encoding is 6 output chars per input char: [input] U+FFFF -> [output] "\uFFFF"
-        // We don't need to worry about astral code points since they're represented as encoded
-        // surrogate pairs in the output.
-        public override int MaxOutputCharactersPerInputCharacter
-        {
-            get { return 12; } // "\uFFFF\uFFFF" is the longest encoded form
-        }
-
-        private static readonly char[] s_b = new char[] { '\\', 'b' };
-        private static readonly char[] s_t = new char[] { '\\', 't' };
-        private static readonly char[] s_n = new char[] { '\\', 'n' };
-        private static readonly char[] s_f = new char[] { '\\', 'f' };
-        private static readonly char[] s_r = new char[] { '\\', 'r' };
-        private static readonly char[] s_back = new char[] { '\\', '\\' };
-
-        // Writes a scalar value as a JavaScript-escaped character (or sequence of characters).
-        // See ECMA-262, Sec. 7.8.4, and ECMA-404, Sec. 9
-        // http://www.ecma-international.org/ecma-262/5.1/#sec-7.8.4
-        // http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf
-        public unsafe override bool TryEncodeUnicodeScalar(int unicodeScalar, char* buffer, int bufferLength, out int numberOfCharactersWritten)
-        {
-            if (buffer == null)
-            {
-                throw new ArgumentNullException(nameof(buffer));
-            }
-            // ECMA-262 allows encoding U+000B as "\v", but ECMA-404 does not.
-            // Both ECMA-262 and ECMA-404 allow encoding U+002F SOLIDUS as "\/"
-            // (in ECMA-262 this character is a NonEscape character); however, we
-            // don't encode SOLIDUS by default unless the caller has provided an
-            // explicit bitmap which does not contain it. In this case we'll assume
-            // that the caller didn't want a SOLIDUS written to the output at all,
-            // so it should be written using "\u002F" encoding.
-            // HTML-specific characters (including apostrophe and quotes) will
-            // be written out as numeric entities for defense-in-depth.
-            // See UnicodeEncoderBase ctor comments for more info.
-
-            if (!WillEncode(unicodeScalar)) { return TryWriteScalarAsChar(unicodeScalar, buffer, bufferLength, out numberOfCharactersWritten); }
-
-            char[] toCopy;
-            switch (unicodeScalar)
-            {
-                case '\b': toCopy = s_b; break;
-                case '\t': toCopy = s_t; break;
-                case '\n': toCopy = s_n; break;
-                case '\f': toCopy = s_f; break;
-                case '\r': toCopy = s_r; break;
-                case '\\': toCopy = s_back; break;
-                default: return JavaScriptEncoderHelper.TryWriteEncodedScalarAsNumericEntity(unicodeScalar, buffer, bufferLength, out numberOfCharactersWritten);
-            }
-            return TryCopyCharacters(toCopy, buffer, bufferLength, out numberOfCharactersWritten);
         }
     }
 }

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/JavaScriptEncoderHelper.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/JavaScriptEncoderHelper.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Text.Unicode;
+
+namespace System.Text.Encodings.Web
+{
+    internal static class JavaScriptEncoderHelper
+    {
+        public static unsafe bool TryWriteEncodedScalarAsNumericEntity(int unicodeScalar, char* buffer, int length, out int numberOfCharactersWritten)
+        {
+            Debug.Assert(buffer != null && length >= 0);
+
+            if (UnicodeHelpers.IsSupplementaryCodePoint(unicodeScalar))
+            {
+                // Convert this back to UTF-16 and write out both characters.
+                UnicodeHelpers.GetUtf16SurrogatePairFromAstralScalarValue(unicodeScalar, out char leadingSurrogate, out char trailingSurrogate);
+                if (TryWriteEncodedSingleCharacter(leadingSurrogate, buffer, length, out int leadingSurrogateCharactersWritten) &&
+                    TryWriteEncodedSingleCharacter(trailingSurrogate, buffer + leadingSurrogateCharactersWritten, length - leadingSurrogateCharactersWritten, out numberOfCharactersWritten)
+                )
+                {
+                    numberOfCharactersWritten += leadingSurrogateCharactersWritten;
+                    return true;
+                }
+                else
+                {
+                    numberOfCharactersWritten = 0;
+                    return false;
+                }
+            }
+            else
+            {
+                // This is only a single character.
+                return TryWriteEncodedSingleCharacter(unicodeScalar, buffer, length, out numberOfCharactersWritten);
+            }
+        }
+
+        // Writes an encoded scalar value (in the BMP) as a JavaScript-escaped character.
+        private static unsafe bool TryWriteEncodedSingleCharacter(int unicodeScalar, char* buffer, int length, out int numberOfCharactersWritten)
+        {
+            Debug.Assert(buffer != null && length >= 0);
+            Debug.Assert(!UnicodeHelpers.IsSupplementaryCodePoint(unicodeScalar), "The incoming value should've been in the BMP.");
+
+            if (length < 6)
+            {
+                numberOfCharactersWritten = 0;
+                return false;
+            }
+
+            // Encode this as 6 chars "\uFFFF".
+            *buffer = '\\';
+            buffer++;
+            *buffer = 'u';
+            buffer++;
+            *buffer = HexUtil.Int32LsbToHexDigit(unicodeScalar >> 12);
+            buffer++;
+            *buffer = HexUtil.Int32LsbToHexDigit((int)((unicodeScalar >> 8) & 0xFU));
+            buffer++;
+            *buffer = HexUtil.Int32LsbToHexDigit((int)((unicodeScalar >> 4) & 0xFU));
+            buffer++;
+            *buffer = HexUtil.Int32LsbToHexDigit((int)(unicodeScalar & 0xFU));
+
+            numberOfCharactersWritten = 6;
+            return true;
+        }
+    }
+}

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/Sse2Helper.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/Sse2Helper.cs
@@ -1,0 +1,132 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Numerics;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+
+namespace System.Text.Encodings.Web
+{
+    internal static class Sse2Helper
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector128<short> CreateEscapingMask_UnsafeRelaxedJavaScriptEncoder(Vector128<short> sourceValue)
+        {
+            Debug.Assert(Sse2.IsSupported);
+
+            Vector128<short> mask = Sse2.CompareLessThan(sourceValue, s_mask_UInt16_0x20); // Space ' ', anything in the control characters range
+
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_UInt16_0x22)); // Quotation Mark '"'
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_UInt16_0x5C)); // Reverse Solidus '\'
+
+            return mask;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector128<sbyte> CreateEscapingMask_UnsafeRelaxedJavaScriptEncoder(Vector128<sbyte> sourceValue)
+        {
+            Debug.Assert(Sse2.IsSupported);
+
+            Vector128<sbyte> mask = Sse2.CompareLessThan(sourceValue, s_mask_SByte_0x20); // Space ' ', anything in the control characters range
+
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_SByte_0x22)); // Quotation Mark "
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_SByte_0x5C)); // Reverse Solidus \
+
+            return mask;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector128<short> CreateEscapingMask_DefaultJavaScriptEncoderBasicLatin(Vector128<short> sourceValue)
+        {
+            Debug.Assert(Sse2.IsSupported);
+
+            Vector128<short> mask = Sse2.CompareLessThan(sourceValue, s_mask_UInt16_0x20); // Space ' ', anything in the control characters range
+
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_UInt16_0x22)); // Quotation Mark '"'
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_UInt16_0x26)); // Ampersand '&'
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_UInt16_0x27)); // Apostrophe '''
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_UInt16_0x2B)); // Plus sign '+'
+
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_UInt16_0x3C)); // Less Than Sign '<'
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_UInt16_0x3E)); // Greater Than Sign '>'
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_UInt16_0x5C)); // Reverse Solidus '\'
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_UInt16_0x60)); // Grave Access '`'
+
+            mask = Sse2.Or(mask, Sse2.CompareGreaterThan(sourceValue, s_mask_UInt16_0x7E)); // Tilde '~', anything above the ASCII range
+
+            return mask;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector128<sbyte> CreateEscapingMask_DefaultJavaScriptEncoderBasicLatin(Vector128<sbyte> sourceValue)
+        {
+            Debug.Assert(Sse2.IsSupported);
+
+            Vector128<sbyte> mask = Sse2.CompareLessThan(sourceValue, s_mask_SByte_0x20); // Control characters, and anything above 0x7E since sbyte.MaxValue is 0x7E
+
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_SByte_0x22)); // Quotation Mark "
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_SByte_0x26)); // Ampersand &
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_SByte_0x27)); // Apostrophe '
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_SByte_0x2B)); // Plus sign +
+
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_SByte_0x3C)); // Less Than Sign <
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_SByte_0x3E)); // Greater Than Sign >
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_SByte_0x5C)); // Reverse Solidus \
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_SByte_0x60)); // Grave Access `
+
+            return mask;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector128<short> CreateAsciiMask(Vector128<short> sourceValue)
+        {
+            Debug.Assert(Sse2.IsSupported);
+
+            Vector128<short> mask = Sse2.CompareLessThan(sourceValue, s_mask_UInt16_0x00); // Null, anything above short.MaxValue but less than or equal char.MaxValue
+            mask = Sse2.Or(mask, Sse2.CompareGreaterThan(sourceValue, s_mask_UInt16_0x7E)); // Tilde '~', anything above the ASCII range
+
+            return mask;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector128<sbyte> CreateAsciiMask(Vector128<sbyte> sourceValue)
+        {
+            Debug.Assert(Sse2.IsSupported);
+
+            // Null, anything above sbyte.MaxValue but less than or equal byte.MaxValue (i.e. anything above the ASCII range)
+            Vector128<sbyte> mask = Sse2.CompareLessThan(sourceValue, s_mask_SByte_0x00);
+            return mask;
+        }
+
+        private static readonly Vector128<short> s_mask_UInt16_0x00 = Vector128.Create((short)0x00); // Null
+
+        private static readonly Vector128<short> s_mask_UInt16_0x20 = Vector128.Create((short)0x20); // Space ' '
+
+        private static readonly Vector128<short> s_mask_UInt16_0x22 = Vector128.Create((short)0x22); // Quotation Mark '"'
+        private static readonly Vector128<short> s_mask_UInt16_0x26 = Vector128.Create((short)0x26); // Ampersand '&'
+        private static readonly Vector128<short> s_mask_UInt16_0x27 = Vector128.Create((short)0x27); // Apostrophe '''
+        private static readonly Vector128<short> s_mask_UInt16_0x2B = Vector128.Create((short)0x2B); // Plus sign '+'
+        private static readonly Vector128<short> s_mask_UInt16_0x3C = Vector128.Create((short)0x3C); // Less Than Sign '<'
+        private static readonly Vector128<short> s_mask_UInt16_0x3E = Vector128.Create((short)0x3E); // Greater Than Sign '>'
+        private static readonly Vector128<short> s_mask_UInt16_0x5C = Vector128.Create((short)0x5C); // Reverse Solidus '\'
+        private static readonly Vector128<short> s_mask_UInt16_0x60 = Vector128.Create((short)0x60); // Grave Access '`'
+
+        private static readonly Vector128<short> s_mask_UInt16_0x7E = Vector128.Create((short)0x7E); // Tilde '~'
+
+        private static readonly Vector128<sbyte> s_mask_SByte_0x00 = Vector128.Create((sbyte)0x00); // Null
+
+        private static readonly Vector128<sbyte> s_mask_SByte_0x20 = Vector128.Create((sbyte)0x20); // Space ' '
+
+        private static readonly Vector128<sbyte> s_mask_SByte_0x22 = Vector128.Create((sbyte)0x22); // Quotation Mark '"'
+        private static readonly Vector128<sbyte> s_mask_SByte_0x26 = Vector128.Create((sbyte)0x26); // Ampersand '&'
+        private static readonly Vector128<sbyte> s_mask_SByte_0x27 = Vector128.Create((sbyte)0x27); // Apostrophe '''
+        private static readonly Vector128<sbyte> s_mask_SByte_0x2B = Vector128.Create((sbyte)0x2B); // Plus sign '+'
+        private static readonly Vector128<sbyte> s_mask_SByte_0x3C = Vector128.Create((sbyte)0x3C); // Less Than Sign '<'
+        private static readonly Vector128<sbyte> s_mask_SByte_0x3E = Vector128.Create((sbyte)0x3E); // Greater Than Sign '>'
+        private static readonly Vector128<sbyte> s_mask_SByte_0x5C = Vector128.Create((sbyte)0x5C); // Reverse Solidus '\'
+        private static readonly Vector128<sbyte> s_mask_SByte_0x60 = Vector128.Create((sbyte)0x60); // Grave Access '`'
+    }
+}

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/Sse2Helper.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/Sse2Helper.cs
@@ -17,7 +17,8 @@ namespace System.Text.Encodings.Web
         {
             Debug.Assert(Sse2.IsSupported);
 
-            Vector128<short> mask = Sse2.CompareLessThan(sourceValue, s_mask_UInt16_0x20); // Space ' ', anything in the control characters range
+            // Space ' ', anything in the control characters range, and anything above short.MaxValue but less than or equal char.MaxValue
+            Vector128<short> mask = Sse2.CompareLessThan(sourceValue, s_mask_UInt16_0x20);
 
             mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_UInt16_0x22)); // Quotation Mark '"'
             mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_UInt16_0x5C)); // Reverse Solidus '\'

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/Sse2Helper.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/Sse2Helper.cs
@@ -30,7 +30,7 @@ namespace System.Text.Encodings.Web
         {
             Debug.Assert(Sse2.IsSupported);
 
-            Vector128<sbyte> mask = Sse2.CompareLessThan(sourceValue, s_mask_SByte_0x20); // Space ' ', anything in the control characters range
+            Vector128<sbyte> mask = Sse2.CompareLessThan(sourceValue, s_mask_SByte_0x20); // Control characters, and anything above 0x7E since sbyte.MaxValue is 0x7E
 
             mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_SByte_0x22)); // Quotation Mark "
             mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_SByte_0x5C)); // Reverse Solidus \
@@ -43,16 +43,13 @@ namespace System.Text.Encodings.Web
         {
             Debug.Assert(Sse2.IsSupported);
 
-            Vector128<short> mask = Sse2.CompareLessThan(sourceValue, s_mask_UInt16_0x20); // Space ' ', anything in the control characters range
+            Vector128<short> mask = CreateEscapingMask_UnsafeRelaxedJavaScriptEncoder(sourceValue);
 
-            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_UInt16_0x22)); // Quotation Mark '"'
             mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_UInt16_0x26)); // Ampersand '&'
             mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_UInt16_0x27)); // Apostrophe '''
             mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_UInt16_0x2B)); // Plus sign '+'
-
             mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_UInt16_0x3C)); // Less Than Sign '<'
             mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_UInt16_0x3E)); // Greater Than Sign '>'
-            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_UInt16_0x5C)); // Reverse Solidus '\'
             mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_UInt16_0x60)); // Grave Access '`'
 
             mask = Sse2.Or(mask, Sse2.CompareGreaterThan(sourceValue, s_mask_UInt16_0x7E)); // Tilde '~', anything above the ASCII range
@@ -65,16 +62,13 @@ namespace System.Text.Encodings.Web
         {
             Debug.Assert(Sse2.IsSupported);
 
-            Vector128<sbyte> mask = Sse2.CompareLessThan(sourceValue, s_mask_SByte_0x20); // Control characters, and anything above 0x7E since sbyte.MaxValue is 0x7E
+            Vector128<sbyte> mask = CreateEscapingMask_UnsafeRelaxedJavaScriptEncoder(sourceValue);
 
-            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_SByte_0x22)); // Quotation Mark "
             mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_SByte_0x26)); // Ampersand &
             mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_SByte_0x27)); // Apostrophe '
             mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_SByte_0x2B)); // Plus sign +
-
             mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_SByte_0x3C)); // Less Than Sign <
             mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_SByte_0x3E)); // Greater Than Sign >
-            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_SByte_0x5C)); // Reverse Solidus \
             mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_SByte_0x60)); // Grave Access `
 
             return mask;
@@ -101,7 +95,7 @@ namespace System.Text.Encodings.Web
             return mask;
         }
 
-        private static readonly Vector128<short> s_mask_UInt16_0x00 = Vector128.Create((short)0x00); // Null
+        private static readonly Vector128<short> s_mask_UInt16_0x00 = Vector128<short>.Zero; // Null
 
         private static readonly Vector128<short> s_mask_UInt16_0x20 = Vector128.Create((short)0x20); // Space ' '
 
@@ -116,7 +110,7 @@ namespace System.Text.Encodings.Web
 
         private static readonly Vector128<short> s_mask_UInt16_0x7E = Vector128.Create((short)0x7E); // Tilde '~'
 
-        private static readonly Vector128<sbyte> s_mask_SByte_0x00 = Vector128.Create((sbyte)0x00); // Null
+        private static readonly Vector128<sbyte> s_mask_SByte_0x00 = Vector128<sbyte>.Zero; // Null
 
         private static readonly Vector128<sbyte> s_mask_SByte_0x20 = Vector128.Create((sbyte)0x20); // Space ' '
 

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/TextEncoder.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/TextEncoder.cs
@@ -725,11 +725,13 @@ namespace System.Text.Encodings.Web
                         Vector128<sbyte> mask = Sse2Helper.CreateAsciiMask(sourceValue);
                         int index = Sse2.MoveMask(mask.AsByte());
 
-                        int processNextSixteen = idx + 16;
-                        Debug.Assert(processNextSixteen <= utf8Text.Length);
                         if (index != 0)
                         {
                             // At least one of the following 16 bytes is non-ASCII.
+
+                            int processNextSixteen = idx + 16;
+                            Debug.Assert(processNextSixteen <= utf8Text.Length);
+
                             while (idx < processNextSixteen)
                             {
                                 Debug.Assert((ptr + idx) <= (ptr + utf8Text.Length));

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/TextEncoder.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/TextEncoder.cs
@@ -10,6 +10,11 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text.Unicode;
 
+#if NETCOREAPP
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+#endif
+
 namespace System.Text.Encodings.Web
 {
     /// <summary>
@@ -23,6 +28,8 @@ namespace System.Text.Encodings.Web
     {
         // Fast cache for Ascii
         private readonly byte[][] _asciiEscape = new byte[0x80][];
+
+        private readonly int[] _asciiNeedsEscaping = new int[0x80];
 
         // Keep a reference to Array.Empty<byte> as this is used as a singleton for comparisons
         // and there is no guarantee that Array.Empty<byte>() will always be the same instance.
@@ -693,46 +700,130 @@ namespace System.Text.Encodings.Web
         /// current encoder instance, or -1 if no data in <paramref name="utf8Text"/> requires escaping.
         /// </returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual int FindFirstCharacterToEncodeUtf8(ReadOnlySpan<byte> utf8Text)
+        public virtual unsafe int FindFirstCharacterToEncodeUtf8(ReadOnlySpan<byte> utf8Text)
         {
-            int originalUtf8TextLength = utf8Text.Length;
-
             // Loop through the input text, terminating when we see ill-formed UTF-8 or when we decode a scalar value
             // that must be encoded. If we see either of these things then we'll return its index in the original
             // input sequence. If we consume the entire text without seeing either of these, return -1 to indicate
             // that the text can be copied as-is without escaping.
 
-            int i = 0;
-            while (i < utf8Text.Length)
+            fixed (byte* ptr = utf8Text)
             {
-                byte value = utf8Text[i];
-                if (UnicodeUtility.IsAsciiCodePoint(value))
+                int idx = 0;
+
+#if NETCOREAPP
+                if (Sse2.IsSupported)
                 {
-                    if (!ReferenceEquals(GetAsciiEncoding(value), s_noEscape))
+                    sbyte* startingAddress = (sbyte*)ptr;
+                    while (utf8Text.Length - 16 >= idx)
                     {
-                        return originalUtf8TextLength - utf8Text.Length + i;
+                        Debug.Assert(startingAddress >= ptr && startingAddress <= (ptr + utf8Text.Length - 16));
+
+                        // Load the next 16 bytes.
+                        Vector128<sbyte> sourceValue = Sse2.LoadVector128(startingAddress);
+
+                        Vector128<sbyte> mask = Sse2Helper.CreateAsciiMask(sourceValue);
+                        int index = Sse2.MoveMask(mask.AsByte());
+
+                        int processNextSixteen = idx + 16;
+                        Debug.Assert(processNextSixteen <= utf8Text.Length);
+                        if (index != 0)
+                        {
+                            // At least one of the following 16 bytes is non-ASCII.
+                            while (idx < processNextSixteen)
+                            {
+                                Debug.Assert((ptr + idx) <= (ptr + utf8Text.Length));
+
+                                if (UnicodeUtility.IsAsciiCodePoint(ptr[idx]))
+                                {
+                                    if (DoesAsciiNeedEncoding(ptr[idx]) == 1)
+                                    {
+                                        goto Return;
+                                    }
+                                    idx++;
+                                }
+                                else
+                                {
+                                    OperationStatus opStatus = UnicodeHelpers.DecodeScalarValueFromUtf8(utf8Text.Slice(idx), out uint nextScalarValue, out int utf8BytesConsumedForScalar);
+
+                                    Debug.Assert(nextScalarValue <= int.MaxValue);
+                                    if (opStatus != OperationStatus.Done || WillEncode((int)nextScalarValue))
+                                    {
+                                        goto Return;
+                                    }
+
+                                    Debug.Assert(opStatus == OperationStatus.Done);
+                                    idx += utf8BytesConsumedForScalar;
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (DoesAsciiNeedEncoding(ptr[idx]) == 1
+
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1)
+                            {
+                                goto Return;
+                            }
+                            idx++;
+                        }
+                        startingAddress = (sbyte*)ptr + idx;
                     }
 
-                    i++;
+                    // Process the remaining bytes.
+                    Debug.Assert(utf8Text.Length - idx < 16);
                 }
-                else
+#endif
+
+                while (idx < utf8Text.Length)
                 {
-                    if (i > 0)
-                    {
-                        utf8Text = utf8Text.Slice(i);
-                    }
+                    Debug.Assert((ptr + idx) <= (ptr + utf8Text.Length));
 
-                    if (UnicodeHelpers.DecodeScalarValueFromUtf8(utf8Text, out uint nextScalarValue, out int bytesConsumedThisIteration) != OperationStatus.Done
-                      || WillEncode((int)nextScalarValue))
+                    if (UnicodeUtility.IsAsciiCodePoint(ptr[idx]))
                     {
-                        return originalUtf8TextLength - utf8Text.Length;
+                        if (DoesAsciiNeedEncoding(ptr[idx]) == 1)
+                        {
+                            goto Return;
+                        }
+                        idx++;
                     }
+                    else
+                    {
+                        OperationStatus opStatus = UnicodeHelpers.DecodeScalarValueFromUtf8(utf8Text.Slice(idx), out uint nextScalarValue, out int utf8BytesConsumedForScalar);
 
-                    i = bytesConsumedThisIteration;
+                        Debug.Assert(nextScalarValue <= int.MaxValue);
+                        if (opStatus != OperationStatus.Done || WillEncode((int)nextScalarValue))
+                        {
+                            goto Return;
+                        }
+
+                        Debug.Assert(opStatus == OperationStatus.Done);
+                        idx += utf8BytesConsumedForScalar;
+                    }
                 }
+
+                idx = -1; // All bytes are allowed.
+
+            Return:
+                return idx;
             }
-
-            return -1; // no input data needs to be escaped
         }
 
         /// <summary>
@@ -813,8 +904,24 @@ namespace System.Text.Encodings.Web
                     _asciiEscape[value] = encoding;
                 }
             }
-
             return encoding;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private int DoesAsciiNeedEncoding(byte value)
+        {
+            Debug.Assert(value <= 0x7F);
+
+            int needsEscaping = _asciiNeedsEscaping[value];
+
+            Debug.Assert(needsEscaping == 0 || needsEscaping == 1 || needsEscaping == -1);
+
+            if (needsEscaping == 0)
+            {
+                needsEscaping = WillEncode(value) ? 1 : -1;
+                _asciiNeedsEscaping[value] = needsEscaping;
+            }
+            return needsEscaping;
         }
 
         private static void ThrowArgumentException_MaxOutputCharsPerInputChar()

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/TextEncoder.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/TextEncoder.cs
@@ -723,7 +723,7 @@ namespace System.Text.Encodings.Web
                         Vector128<sbyte> sourceValue = Sse2.LoadVector128(startingAddress);
 
                         Vector128<sbyte> mask = Sse2Helper.CreateAsciiMask(sourceValue);
-                        int index = Sse2.MoveMask(mask.AsByte());
+                        int index = Sse2.MoveMask(mask);
 
                         if (index != 0)
                         {

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/UnsafeRelaxedJavaScriptEncoder.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/UnsafeRelaxedJavaScriptEncoder.cs
@@ -315,66 +315,9 @@ namespace System.Text.Encodings.Web
                     toCopy = s_back;
                     break;
                 default:
-                    return TryWriteEncodedScalarAsNumericEntity(unicodeScalar, buffer, bufferLength, out numberOfCharactersWritten);
+                    return JavaScriptEncoderHelper.TryWriteEncodedScalarAsNumericEntity(unicodeScalar, buffer, bufferLength, out numberOfCharactersWritten);
             }
             return TryCopyCharacters(toCopy, buffer, bufferLength, out numberOfCharactersWritten);
-        }
-
-        private static unsafe bool TryWriteEncodedScalarAsNumericEntity(int unicodeScalar, char* buffer, int length, out int numberOfCharactersWritten)
-        {
-            Debug.Assert(buffer != null && length >= 0);
-
-            if (UnicodeHelpers.IsSupplementaryCodePoint(unicodeScalar))
-            {
-                // Convert this back to UTF-16 and write out both characters.
-                UnicodeHelpers.GetUtf16SurrogatePairFromAstralScalarValue(unicodeScalar, out char leadingSurrogate, out char trailingSurrogate);
-                if (TryWriteEncodedSingleCharacter(leadingSurrogate, buffer, length, out int leadingSurrogateCharactersWritten) &&
-                    TryWriteEncodedSingleCharacter(trailingSurrogate, buffer + leadingSurrogateCharactersWritten, length - leadingSurrogateCharactersWritten, out numberOfCharactersWritten)
-                )
-                {
-                    numberOfCharactersWritten += leadingSurrogateCharactersWritten;
-                    return true;
-                }
-                else
-                {
-                    numberOfCharactersWritten = 0;
-                    return false;
-                }
-            }
-            else
-            {
-                // This is only a single character.
-                return TryWriteEncodedSingleCharacter(unicodeScalar, buffer, length, out numberOfCharactersWritten);
-            }
-        }
-
-        // Writes an encoded scalar value (in the BMP) as a JavaScript-escaped character.
-        private static unsafe bool TryWriteEncodedSingleCharacter(int unicodeScalar, char* buffer, int length, out int numberOfCharactersWritten)
-        {
-            Debug.Assert(buffer != null && length >= 0);
-            Debug.Assert(!UnicodeHelpers.IsSupplementaryCodePoint(unicodeScalar), "The incoming value should've been in the BMP.");
-
-            if (length < 6)
-            {
-                numberOfCharactersWritten = 0;
-                return false;
-            }
-
-            // Encode this as 6 chars "\uFFFF".
-            *buffer = '\\';
-            buffer++;
-            *buffer = 'u';
-            buffer++;
-            *buffer = HexUtil.Int32LsbToHexDigit(unicodeScalar >> 12);
-            buffer++;
-            *buffer = HexUtil.Int32LsbToHexDigit((int)((unicodeScalar >> 8) & 0xFU));
-            buffer++;
-            *buffer = HexUtil.Int32LsbToHexDigit((int)((unicodeScalar >> 4) & 0xFU));
-            buffer++;
-            *buffer = HexUtil.Int32LsbToHexDigit((int)(unicodeScalar & 0xFU));
-
-            numberOfCharactersWritten = 6;
-            return true;
         }
     }
 }

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/UnsafeRelaxedJavaScriptEncoder.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/UnsafeRelaxedJavaScriptEncoder.cs
@@ -178,7 +178,7 @@ namespace System.Text.Encodings.Web
                                     OperationStatus opStatus = UnicodeHelpers.DecodeScalarValueFromUtf8(utf8Text.Slice(idx), out uint nextScalarValue, out int utf8BytesConsumedForScalar);
 
                                     Debug.Assert(nextScalarValue <= int.MaxValue);
-                                    if (opStatus != OperationStatus.Done || !_allowedCharacters.IsUnicodeScalarAllowed((int)nextScalarValue))
+                                    if (opStatus != OperationStatus.Done || WillEncode((int)nextScalarValue))
                                     {
                                         goto Return;
                                     }
@@ -234,7 +234,7 @@ namespace System.Text.Encodings.Web
                         OperationStatus opStatus = UnicodeHelpers.DecodeScalarValueFromUtf8(utf8Text.Slice(idx), out uint nextScalarValue, out int utf8BytesConsumedForScalar);
 
                         Debug.Assert(nextScalarValue <= int.MaxValue);
-                        if (opStatus != OperationStatus.Done || !_allowedCharacters.IsUnicodeScalarAllowed((int)nextScalarValue))
+                        if (opStatus != OperationStatus.Done || WillEncode((int)nextScalarValue))
                         {
                             goto Return;
                         }

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/UnsafeRelaxedJavaScriptEncoder.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/UnsafeRelaxedJavaScriptEncoder.cs
@@ -154,7 +154,7 @@ namespace System.Text.Encodings.Web
                         Vector128<sbyte> sourceValue = Sse2.LoadVector128(startingAddress);
 
                         Vector128<sbyte> mask = Sse2Helper.CreateAsciiMask(sourceValue);
-                        int index = Sse2.MoveMask(mask.AsByte());
+                        int index = Sse2.MoveMask(mask);
 
                         if (index != 0)
                         {
@@ -196,7 +196,7 @@ namespace System.Text.Encodings.Web
                             // Check if any of the 16 bytes need to be escaped.
                             mask = Sse2Helper.CreateEscapingMask_UnsafeRelaxedJavaScriptEncoder(sourceValue);
 
-                            index = Sse2.MoveMask(mask.AsByte());
+                            index = Sse2.MoveMask(mask);
                             // If index == 0, that means none of the 16 bytes needed to be escaped.
                             // TrailingZeroCount is relatively expensive, avoid it if possible.
                             if (index != 0)

--- a/src/System.Text.Encodings.Web/src/System/Text/Internal/AllowedCharactersBitmap.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Internal/AllowedCharactersBitmap.cs
@@ -80,6 +80,7 @@ namespace System.Text.Internal
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsUnicodeScalarAllowed(int unicodeScalar)
         {
+            Debug.Assert(unicodeScalar < 0x10000);
             int index = unicodeScalar >> 5;
             int offset = unicodeScalar & 0x1F;
             return (_allowedCharacters[index] & (0x1U << offset)) != 0;

--- a/src/System.Text.Encodings.Web/src/System/Text/Internal/AllowedCharactersBitmap.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Internal/AllowedCharactersBitmap.cs
@@ -90,7 +90,7 @@ namespace System.Text.Internal
         {
             int i = 0;
 
-            while (i < textLength - 8)
+            while (i <= textLength - 8)
             {
                 if (!IsCharacterAllowed(text[i])
                     || !IsCharacterAllowed(text[++i])
@@ -106,7 +106,7 @@ namespace System.Text.Internal
                 i++;
             }
 
-            while (i < textLength - 4)
+            while (i <= textLength - 4)
             {
                 if (!IsCharacterAllowed(text[i])
                     || !IsCharacterAllowed(text[++i])

--- a/src/System.Text.Encodings.Web/src/System/Text/Internal/AllowedCharactersBitmap.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Internal/AllowedCharactersBitmap.cs
@@ -85,19 +85,49 @@ namespace System.Text.Internal
             return (_allowedCharacters[index] & (0x1U << offset)) != 0;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe int FindFirstCharacterToEncode(char* text, int textLength)
         {
             int i = 0;
-            for (; i < textLength; i++)
+
+            while (i < textLength - 8)
+            {
+                if (!IsCharacterAllowed(text[i])
+                    || !IsCharacterAllowed(text[++i])
+                    || !IsCharacterAllowed(text[++i])
+                    || !IsCharacterAllowed(text[++i])
+                    || !IsCharacterAllowed(text[++i])
+                    || !IsCharacterAllowed(text[++i])
+                    || !IsCharacterAllowed(text[++i])
+                    || !IsCharacterAllowed(text[++i]))
+                {
+                    goto Return;
+                }
+                i++;
+            }
+
+            while (i < textLength - 4)
+            {
+                if (!IsCharacterAllowed(text[i])
+                    || !IsCharacterAllowed(text[++i])
+                    || !IsCharacterAllowed(text[++i])
+                    || !IsCharacterAllowed(text[++i]))
+                {
+                    goto Return;
+                }
+                i++;
+            }
+
+            while (i < textLength)
             {
                 if (!IsCharacterAllowed(text[i]))
                 {
                     goto Return;
                 }
+                i++;
             }
 
             i = -1;
+
         Return:
             return i;
         }

--- a/src/System.Text.Encodings.Web/src/System/Text/Internal/AllowedCharactersBitmap.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Internal/AllowedCharactersBitmap.cs
@@ -73,10 +73,7 @@ namespace System.Text.Internal
         // Determines whether the given character can be returned unencoded.
         public bool IsCharacterAllowed(char character)
         {
-            int codePoint = character;
-            int index = codePoint >> 5;
-            int offset = codePoint & 0x1F;
-            return ((_allowedCharacters[index] >> offset) & 0x1U) != 0;
+            return IsUnicodeScalarAllowed(character);
         }
 
         // Determines whether the given character can be returned unencoded.
@@ -85,18 +82,24 @@ namespace System.Text.Internal
         {
             int index = unicodeScalar >> 5;
             int offset = unicodeScalar & 0x1F;
-            return ((_allowedCharacters[index] >> offset) & 0x1U) != 0;
+            return (_allowedCharacters[index] & (0x1U << offset)) != 0;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe int FindFirstCharacterToEncode(char* text, int textLength)
         {
-            for (int i = 0; i < textLength; i++)
+            int i = 0;
+            for (; i < textLength; i++)
             {
                 if (!IsCharacterAllowed(text[i]))
-                { return i; }
+                {
+                    goto Return;
+                }
             }
-            return -1;
+
+            i = -1;
+        Return:
+            return i;
         }
     }
 }

--- a/src/System.Text.Encodings.Web/tests/JavaScriptStringEncoderTests.cs
+++ b/src/System.Text.Encodings.Web/tests/JavaScriptStringEncoderTests.cs
@@ -107,6 +107,7 @@ namespace System.Text.Encodings.Web.Tests
                     new object[] { '`', JavaScriptEncoder.Default, true },               // ASCII but escaped by default
                     new object[] { '\'', JavaScriptEncoder.Default, true },              // ASCII but escaped by default
                     new object[] { '+', JavaScriptEncoder.Default, true },               // ASCII but escaped by default
+                    new object[] { '\uFFFD', JavaScriptEncoder.Default, true },          // Default replacement character
 
                     new object[] { 'a', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin), false },
                     new object[] { '\u001F', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin), true },
@@ -122,6 +123,7 @@ namespace System.Text.Encodings.Web.Tests
                     new object[] { '`', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin), true },
                     new object[] { '\'', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin), true },
                     new object[] { '+', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin), true },
+                    new object[] { '\uFFFD', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin), true },
 
                     new object[] { 'a', JavaScriptEncoder.Create(UnicodeRanges.All), false },
                     new object[] { '\u001F', JavaScriptEncoder.Create(UnicodeRanges.All), true },
@@ -137,6 +139,7 @@ namespace System.Text.Encodings.Web.Tests
                     new object[] { '`', JavaScriptEncoder.Create(UnicodeRanges.All), true },
                     new object[] { '\'', JavaScriptEncoder.Create(UnicodeRanges.All), true },
                     new object[] { '+', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '\uFFFD', JavaScriptEncoder.Create(UnicodeRanges.All), false },
 
                     new object[] { 'a', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
                     new object[] { '\u001F', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, true },
@@ -152,6 +155,7 @@ namespace System.Text.Encodings.Web.Tests
                     new object[] { '`', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
                     new object[] { '\'', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
                     new object[] { '+', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '\uFFFD', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
                 };
             }
         }
@@ -211,6 +215,7 @@ namespace System.Text.Encodings.Web.Tests
                     new object[] { '`', JavaScriptEncoder.Create(UnicodeRanges.All), true },
                     new object[] { '\'', JavaScriptEncoder.Create(UnicodeRanges.All), true },
                     new object[] { '+', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '\uFFFD', JavaScriptEncoder.Create(UnicodeRanges.All), false },
 
                     new object[] { 'a', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
                     new object[] { '\u001F', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, true },
@@ -226,6 +231,7 @@ namespace System.Text.Encodings.Web.Tests
                     new object[] { '`', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
                     new object[] { '\'', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
                     new object[] { '+', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '\uFFFD', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
                 };
             }
         }

--- a/src/System.Text.Encodings.Web/tests/JavaScriptStringEncoderTests.cs
+++ b/src/System.Text.Encodings.Web/tests/JavaScriptStringEncoderTests.cs
@@ -25,6 +25,9 @@ namespace System.Text.Encodings.Web.Tests
             Assert.Throws<ArgumentNullException>(() => JavaScriptEncoder.Default.TryEncodeUnicodeScalar('a', null, 0, out _));
             Assert.Throws<ArgumentNullException>(() => JavaScriptEncoder.UnsafeRelaxedJsonEscaping.TryEncodeUnicodeScalar('a', null, 0, out _));
             Assert.Throws<ArgumentNullException>(() => JavaScriptEncoder.Create(UnicodeRanges.All).TryEncodeUnicodeScalar('a', null, 0, out _));
+
+            Assert.Throws<ArgumentNullException>(() => JavaScriptEncoder.Create((TextEncoderSettings)null));
+            Assert.Throws<ArgumentNullException>(() => JavaScriptEncoder.Create((UnicodeRange)null));
         }
 
         [Theory]
@@ -38,7 +41,7 @@ namespace System.Text.Encodings.Web.Tests
             }
 
             var random = new Random(42);
-            for (int dataLength = 0; dataLength < 47; dataLength++)
+            for (int dataLength = 0; dataLength < 50; dataLength++)
             {
                 char[] str = new char[dataLength];
                 for (int i = 0; i < dataLength; i++)
@@ -67,6 +70,20 @@ namespace System.Text.Encodings.Web.Tests
                         Assert.Equal(requiresEscaping ? i : -1, encoder.FindFirstCharacterToEncode(ptr, source.Length));
                     }
                 }
+
+                if (dataLength != 0)
+                {
+                    char[] changed = baseStr.ToCharArray();
+                    changed.AsSpan().Fill(replacementChar);
+                    string source = new string(changed);
+                    sourceUtf8 = Encoding.UTF8.GetBytes(source);
+
+                    Assert.Equal(requiresEscaping ? 0 : -1, encoder.FindFirstCharacterToEncodeUtf8(sourceUtf8));
+                    fixed (char* ptr = source)
+                    {
+                        Assert.Equal(requiresEscaping ? 0 : -1, encoder.FindFirstCharacterToEncode(ptr, source.Length));
+                    }
+                }
             }
         }
 
@@ -76,41 +93,133 @@ namespace System.Text.Encodings.Web.Tests
             {
                 return new List<object[]>
                 {
-                    new object[] { 'a', JavaScriptEncoder.Default, false },         // ASCII not escaped
-                    new object[] { '<', JavaScriptEncoder.Default, true },          // ASCII but escaped by default
-                    new object[] { '\u001F', JavaScriptEncoder.Default, true },     // control character within single byte range
-                    new object[] { '\u2000', JavaScriptEncoder.Default, true },     // space character outside single byte range
-                    new object[] { '\u00A2', JavaScriptEncoder.Default, true },     // non-ASCII but < 255
-                    new object[] { '\u6C49', JavaScriptEncoder.Default, true },     // non-ASCII from chinese alphabet - multibyte
-                    new object[] { '"', JavaScriptEncoder.Default, true },          // ASCII But must always be escaped in JSON
-                    new object[] { '\\', JavaScriptEncoder.Default, true },         // ASCII But must always be escaped in JSON
-
-                    new object[] { 'a', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
-                    new object[] { '<', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
-                    new object[] { '\u001F', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, true },
-                    new object[] { '\u2000', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, true },
-                    new object[] { '\u00A2', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
-                    new object[] { '\u6C49', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
-                    new object[] { '"', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, true },
-                    new object[] { '\\', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, true },
-
-                    new object[] { 'a', JavaScriptEncoder.Create(UnicodeRanges.All), false },
-                    new object[] { '<', JavaScriptEncoder.Create(UnicodeRanges.All), true },
-                    new object[] { '\u001F', JavaScriptEncoder.Create(UnicodeRanges.All), true },
-                    new object[] { '\u2000', JavaScriptEncoder.Create(UnicodeRanges.All), true },
-                    new object[] { '\u00A2', JavaScriptEncoder.Create(UnicodeRanges.All), false },
-                    new object[] { '\u6C49', JavaScriptEncoder.Create(UnicodeRanges.All), false },
-                    new object[] { '"', JavaScriptEncoder.Create(UnicodeRanges.All), true },
-                    new object[] { '\\', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { 'a', JavaScriptEncoder.Default, false },              // ASCII not escaped
+                    new object[] { '\u001F', JavaScriptEncoder.Default, true },          // control character within single byte range
+                    new object[] { '\u2000', JavaScriptEncoder.Default, true },          // space character outside single byte range
+                    new object[] { '\u00A2', JavaScriptEncoder.Default, true },          // non-ASCII but < 255
+                    new object[] { '\u6C49', JavaScriptEncoder.Default, true },          // non-ASCII from chinese alphabet - multibyte
+                    new object[] { '"', JavaScriptEncoder.Default, true },               // ASCII but must always be escaped in JSON
+                    new object[] { '\\', JavaScriptEncoder.Default, true },              // ASCII but must always be escaped in JSON
+                    new object[] { '<', JavaScriptEncoder.Default, true },               // ASCII but escaped by default
+                    new object[] { '>', JavaScriptEncoder.Default, true },               // ASCII but escaped by default
+                    new object[] { '&', JavaScriptEncoder.Default, true },               // ASCII but escaped by default
+                    new object[] { '`', JavaScriptEncoder.Default, true },               // ASCII but escaped by default
+                    new object[] { '\'', JavaScriptEncoder.Default, true },              // ASCII but escaped by default
+                    new object[] { '+', JavaScriptEncoder.Default, true },               // ASCII but escaped by default
 
                     new object[] { 'a', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin), false },
-                    new object[] { '<', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin), true },
                     new object[] { '\u001F', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin), true },
                     new object[] { '\u2000', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin), true },
                     new object[] { '\u00A2', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin), true },
                     new object[] { '\u6C49', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin), true },
                     new object[] { '"', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin), true },
                     new object[] { '\\', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin), true },
+                    new object[] { '<', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin), true },
+                    new object[] { '>', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin), true },
+                    new object[] { '&', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin), true },
+                    new object[] { '`', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin), true },
+                    new object[] { '\'', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin), true },
+                    new object[] { '+', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin), true },
+
+                    new object[] { 'a', JavaScriptEncoder.Create(UnicodeRanges.All), false },
+                    new object[] { '\u001F', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '\u2000', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '\u00A2', JavaScriptEncoder.Create(UnicodeRanges.All), false },
+                    new object[] { '\u6C49', JavaScriptEncoder.Create(UnicodeRanges.All), false },
+                    new object[] { '"', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '\\', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '<', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '>', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '&', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '`', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '\'', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '+', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+
+                    new object[] { 'a', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '\u001F', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, true },
+                    new object[] { '\u2000', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, true },
+                    new object[] { '\u00A2', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '\u6C49', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '"', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, true },
+                    new object[] { '\\', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, true },
+                    new object[] { '<', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '>', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '&', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '`', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '\'', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '+', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(EscapingTestData_NonAscii))]
+        public unsafe void FindFirstCharacterToEncode_NonAscii(char replacementChar, JavaScriptEncoder encoder, bool requiresEscaping)
+        {
+            var random = new Random(42);
+            for (int dataLength = 1; dataLength < 50; dataLength++)
+            {
+                char[] str = new char[dataLength];
+                for (int i = 0; i < dataLength; i++)
+                {
+                    str[i] = (char)random.Next(0x2E9B, 0x2EF4); // CJK Radicals Supplement characters
+                }
+                string baseStr = new string(str);
+                byte[] sourceUtf8 = Encoding.UTF8.GetBytes(baseStr);
+
+                Assert.Equal(-1, encoder.FindFirstCharacterToEncodeUtf8(sourceUtf8));
+                fixed (char* ptr = baseStr)
+                {
+                    Assert.Equal(-1, encoder.FindFirstCharacterToEncode(ptr, baseStr.Length));
+                }
+
+                for (int i = 0; i < dataLength; i++)
+                {
+                    string source = baseStr.Insert(i, new string(replacementChar, 1));
+                    sourceUtf8 = Encoding.UTF8.GetBytes(source);
+
+                    Assert.Equal(requiresEscaping ? i * 3 : -1, encoder.FindFirstCharacterToEncodeUtf8(sourceUtf8)); // Each CJK character expands to 3 utf-8 bytes.
+                    fixed (char* ptr = source)
+                    {
+                        Assert.Equal(requiresEscaping ? i : -1, encoder.FindFirstCharacterToEncode(ptr, source.Length));
+                    }
+                }
+            }
+        }
+
+        public static IEnumerable<object[]> EscapingTestData_NonAscii
+        {
+            get
+            {
+                return new List<object[]>
+                {
+                    new object[] { 'a', JavaScriptEncoder.Create(UnicodeRanges.All), false },
+                    new object[] { '\u001F', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '\u2000', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '\u00A2', JavaScriptEncoder.Create(UnicodeRanges.All), false },
+                    new object[] { '\u6C49', JavaScriptEncoder.Create(UnicodeRanges.All), false },
+                    new object[] { '"', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '\\', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '<', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '>', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '&', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '`', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '\'', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '+', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+
+                    new object[] { 'a', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '\u001F', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, true },
+                    new object[] { '\u2000', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, true },
+                    new object[] { '\u00A2', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '\u6C49', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '"', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, true },
+                    new object[] { '\\', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, true },
+                    new object[] { '<', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '>', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '&', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '`', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '\'', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '+', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
                 };
             }
         }


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/corefx/pull/41845 to optimize the built-in `JavascriptEncoder` using a similar approach.

Also added some tests to improve code coverage.

- Escaping UTF-16 (for strings of length >= 16)
   - using Default improved 2x
   - using Relaxed improved 3x
   - using Custom improved 15-20%
   - small regression for lengths <= 4.
- Escaping UTF-8 (for strings of length >= 16)
   - using Default improved 2-5x
   - using Relaxed improved 6-10x
   - using Custom improved 2-3x
   - small regression for lengths <= 2.

```C#
public unsafe class NeedsEscapingTest
{
    [Params(E.Default, E.Relaxed, E.Custom)]
    public E Encoder { get; set; }

    [Params(1, 2, 4, 7, 8, 15, 16, 17, 31, 32, 33, 47, 100, 1000)]
    public int DataLength { get; set; }

    public enum E
    {
        Default,
        Relaxed,
        Custom
    }

    private string _source;
    private byte[] _sourceUtf8;
    private JavaScriptEncoder _encoder;

    [GlobalSetup]
    public void Setup()
    {
        var random = new Random(42);

        var array = new char[DataLength];
        for (int i = 0; i < DataLength; i++)
        {
            array[i] = (char)random.Next(97, 123);
        }
        _source = new string(array);
        _sourceUtf8 = Encoding.UTF8.GetBytes(_source);

        _encoder = null;
        switch (Encoder)
        {
            case E.Default:
                _encoder = JavaScriptEncoder.Default;
                break;
            case E.Relaxed:
                _encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping;
                break;
            case E.Custom:
                _encoder = JavaScriptEncoder.Create(new TextEncoderSettings(UnicodeRanges.All));
                break;
        }
        _encoder.FindFirstCharacterToEncodeUtf8(_sourceUtf8);
    }

    [BenchmarkCategory(Categories.CoreFX, Categories.JSON)]
    [Benchmark (Baseline = true)]
    public int NeedsEscapingUtf16()
    {
        fixed (char* ptr = _source)
        {
            return _encoder.FindFirstCharacterToEncode(ptr, _source.Length);
        }
    }

    [BenchmarkCategory(Categories.CoreFX, Categories.JSON)]
    [Benchmark]
    public int NeedsEscapingUtf8()
    {
        return _encoder.FindFirstCharacterToEncodeUtf8(_sourceUtf8);
    }
}
```

Method | Encoder | DataLength | Before (ns) | After (ns) | Ratio
-- | -- | -- | -- | -- | --
NeedsEscapingUtf16 | Default | 1 | 2.845 | 5.359 | 1.884
NeedsEscapingUtf8 | Default | 1 | 5.286 | 5.32 | 1.006
NeedsEscapingUtf16 | Default | 2 | 3.836 | 5.651 | 1.473
NeedsEscapingUtf8 | Default | 2 | 6.866 | 6.117 | 0.891
NeedsEscapingUtf16 | Default | 4 | 5.96 | 7.406 | 1.243
NeedsEscapingUtf8 | Default | 4 | 11.188 | 7.489 | 0.669
NeedsEscapingUtf16 | Default | 7 | 9.746 | 10.047 | 1.031
NeedsEscapingUtf8 | Default | 7 | 18.271 | 9.449 | 0.517
NeedsEscapingUtf16 | Default | 8 | 10.732 | 8.708 | 0.811
NeedsEscapingUtf8 | Default | 8 | 19.119 | 9.904 | 0.518
NeedsEscapingUtf16 | Default | 15 | 18.068 | 14.783 | 0.818
NeedsEscapingUtf8 | Default | 15 | 35.961 | 14.552 | 0.405
NeedsEscapingUtf16 | Default | 16 | 19.266 | 10.416 | 0.541
NeedsEscapingUtf8 | Default | 16 | 34.358 | 9.519 | 0.277
NeedsEscapingUtf16 | Default | 17 | 20.162 | 11.761 | 0.583
NeedsEscapingUtf8 | Default | 17 | 38.229 | 9.16 | 0.240
NeedsEscapingUtf16 | Default | 31 | 35.119 | 22.04 | 0.628
NeedsEscapingUtf8 | Default | 31 | 70.864 | 18.698 | 0.264
NeedsEscapingUtf16 | Default | 32 | 37.013 | 18.846 | 0.509
NeedsEscapingUtf8 | Default | 32 | 80.238 | 10.797 | 0.135
NeedsEscapingUtf16 | Default | 33 | 41.737 | 20.024 | 0.480
NeedsEscapingUtf8 | Default | 33 | 74.927 | 11.542 | 0.154
NeedsEscapingUtf16 | Default | 47 | 53.155 | 31.701 | 0.596
NeedsEscapingUtf8 | Default | 47 | 102.116 | 20.617 | 0.202
NeedsEscapingUtf16 | Default | 100 | 118.166 | 57.782 | 0.489
NeedsEscapingUtf8 | Default | 100 | 208.161 | 23.387 | 0.112
NeedsEscapingUtf16 | Default | 1000 | 1,068.02 | 537.261 | 0.503
NeedsEscapingUtf8 | Default | 1000 | 2,077.12 | 129.447 | 0.062
  |   |   |   |   |  
NeedsEscapingUtf16 | Relaxed | 1 | 3.523 | 4.45 | 1.263
NeedsEscapingUtf8 | Relaxed | 1 | 5.164 | 5.382 | 1.042
NeedsEscapingUtf16 | Relaxed | 2 | 6.617 | 5.444 | 0.823
NeedsEscapingUtf8 | Relaxed | 2 | 9.37 | 6.744 | 0.720
NeedsEscapingUtf16 | Relaxed | 4 | 7.057 | 7.594 | 1.076
NeedsEscapingUtf8 | Relaxed | 4 | 13.711 | 9.583 | 0.699
NeedsEscapingUtf16 | Relaxed | 7 | 9.742 | 10.223 | 1.049
NeedsEscapingUtf8 | Relaxed | 7 | 20.175 | 13.549 | 0.672
NeedsEscapingUtf16 | Relaxed | 8 | 10.666 | 5.822 | 0.546
NeedsEscapingUtf8 | Relaxed | 8 | 20.463 | 15.222 | 0.744
NeedsEscapingUtf16 | Relaxed | 15 | 18.347 | 13.148 | 0.717
NeedsEscapingUtf8 | Relaxed | 15 | 36.851 | 24.855 | 0.674
NeedsEscapingUtf16 | Relaxed | 16 | 19.439 | 7.579 | 0.390
NeedsEscapingUtf8 | Relaxed | 16 | 39.43 | 6.166 | 0.156
NeedsEscapingUtf16 | Relaxed | 17 | 19.919 | 8.377 | 0.421
NeedsEscapingUtf8 | Relaxed | 17 | 42.782 | 7.535 | 0.176
NeedsEscapingUtf16 | Relaxed | 31 | 34.941 | 18.058 | 0.517
NeedsEscapingUtf8 | Relaxed | 31 | 78.846 | 27.82 | 0.353
NeedsEscapingUtf16 | Relaxed | 32 | 36.679 | 13.355 | 0.364
NeedsEscapingUtf8 | Relaxed | 32 | 80.051 | 8.601 | 0.107
NeedsEscapingUtf16 | Relaxed | 33 | 38.289 | 14.08 | 0.368
NeedsEscapingUtf8 | Relaxed | 33 | 83.212 | 10.119 | 0.122
NeedsEscapingUtf16 | Relaxed | 47 | 52.697 | 23.491 | 0.446
NeedsEscapingUtf8 | Relaxed | 47 | 112.786 | 33.978 | 0.301
NeedsEscapingUtf16 | Relaxed | 100 | 119.245 | 41.575 | 0.349
NeedsEscapingUtf8 | Relaxed | 100 | 235.103 | 21.904 | 0.093
NeedsEscapingUtf16 | Relaxed | 1000 | 1,083.64 | 360.613 | 0.333
NeedsEscapingUtf8 | Relaxed | 1000 | 2,306.57 | 142.98 | 0.062
  |   |   |   |   |  
NeedsEscapingUtf16 | Custom | 1 | 2.794 | 3.789 | 1.356
NeedsEscapingUtf8 | Custom | 1 | 4.726 | 5.637 | 1.193
NeedsEscapingUtf16 | Custom | 2 | 3.679 | 4.455 | 1.211
NeedsEscapingUtf8 | Custom | 2 | 7.586 | 6.657 | 0.878
NeedsEscapingUtf16 | Custom | 4 | 5.993 | 6.336 | 1.057
NeedsEscapingUtf8 | Custom | 4 | 12.065 | 8.793 | 0.729
NeedsEscapingUtf16 | Custom | 7 | 9.794 | 9.196 | 0.939
NeedsEscapingUtf8 | Custom | 7 | 20.017 | 12.328 | 0.616
NeedsEscapingUtf16 | Custom | 8 | 10.898 | 9.973 | 0.915
NeedsEscapingUtf8 | Custom | 8 | 21.423 | 13.255 | 0.619
NeedsEscapingUtf16 | Custom | 15 | 18.924 | 16.201 | 0.856
NeedsEscapingUtf8 | Custom | 15 | 37.769 | 21.461 | 0.568
NeedsEscapingUtf16 | Custom | 16 | 21.059 | 17.102 | 0.812
NeedsEscapingUtf8 | Custom | 16 | 39.721 | 17.138 | 0.431
NeedsEscapingUtf16 | Custom | 17 | 21.333 | 17.613 | 0.826
NeedsEscapingUtf8 | Custom | 17 | 42.232 | 18.459 | 0.437
NeedsEscapingUtf16 | Custom | 31 | 35.81 | 30.757 | 0.859
NeedsEscapingUtf8 | Custom | 31 | 77.807 | 37.533 | 0.482
NeedsEscapingUtf16 | Custom | 32 | 37.572 | 31.069 | 0.827
NeedsEscapingUtf8 | Custom | 32 | 81.055 | 28.39 | 0.350
NeedsEscapingUtf16 | Custom | 33 | 37.351 | 30.971 | 0.829
NeedsEscapingUtf8 | Custom | 33 | 85.248 | 30.07 | 0.353
NeedsEscapingUtf16 | Custom | 47 | 54.932 | 43.93 | 0.800
NeedsEscapingUtf8 | Custom | 47 | 115.287 | 48.567 | 0.421
NeedsEscapingUtf16 | Custom | 100 | 118.678 | 91.347 | 0.770
NeedsEscapingUtf8 | Custom | 100 | 237.319 | 79.042 | 0.333
NeedsEscapingUtf16 | Custom | 1000 | 1,066.93 | 882.03 | 0.827
NeedsEscapingUtf8 | Custom | 1000 | 2,288.41 | 722.101 | 0.316



## Next Steps:
1) Evaluate if we can get rid of the special-casing in `S.T.Json`

cc @GrabYourPitchforks, @gfoidl, @tarekgh, @tannergooding, @ViktorHofer, @steveharter  