### PR TITLE
Fix a build error on ARM

### DIFF
--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.c
@@ -321,7 +321,7 @@ int32_t CryptoNative_X509StoreCtxGetErrorDepth(X509_STORE_CTX* ctx)
 
 const char* CryptoNative_X509VerifyCertErrorString(X509VerifyStatusCode n)
 {
-    return X509_verify_cert_error_string(n);
+    return X509_verify_cert_error_string((long)n);
 }
 
 void CryptoNative_X509CrlDestroy(X509_CRL* a)


### PR DESCRIPTION
- Add type casting in CryptoNative_X509VerifyCertErrorString