### PR TITLE
Formatting and parsing changes to JsonString

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
@@ -670,8 +670,7 @@ namespace System.Text.Json
 
             Debug.Assert(segment.IndexOf(JsonConstants.BackSlash) == -1);
 
-            if (segment.Length <= JsonConstants.MaximumDateTimeOffsetParseLength
-                && JsonHelpers.TryParseAsISO(segment, out DateTime tmp))
+            if (JsonHelpers.TryParseAsISO(segment, out DateTime tmp))
             {
                 value = tmp;
                 return true;
@@ -706,8 +705,7 @@ namespace System.Text.Json
 
             Debug.Assert(segment.IndexOf(JsonConstants.BackSlash) == -1);
 
-            if (segment.Length <= JsonConstants.MaximumDateTimeOffsetParseLength
-                && JsonHelpers.TryParseAsISO(segment, out DateTimeOffset tmp))
+            if (JsonHelpers.TryParseAsISO(segment, out DateTimeOffset tmp))
             {
                 value = tmp;
                 return true;

--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
@@ -656,7 +656,7 @@ namespace System.Text.Json
             ReadOnlySpan<byte> data = _utf8Json.Span;
             ReadOnlySpan<byte> segment = data.Slice(row.Location, row.SizeOrLength);
 
-            if (!JsonReaderHelper.IsValidDateTimeOffsetParseLength(segment.Length))
+            if (!JsonHelpers.IsValidDateTimeOffsetParseLength(segment.Length))
             {
                 value = default;
                 return false;
@@ -692,7 +692,7 @@ namespace System.Text.Json
             ReadOnlySpan<byte> data = _utf8Json.Span;
             ReadOnlySpan<byte> segment = data.Slice(row.Location, row.SizeOrLength);
 
-            if (!JsonReaderHelper.IsValidDateTimeOffsetParseLength(segment.Length))
+            if (!JsonHelpers.IsValidDateTimeOffsetParseLength(segment.Length))
             {
                 value = default;
                 return false;

--- a/src/System.Text.Json/src/System/Text/Json/JsonHelpers.Date.cs
+++ b/src/System.Text.Json/src/System/Text/Json/JsonHelpers.Date.cs
@@ -52,11 +52,13 @@ namespace System.Text.Json
 
             int length = JsonReaderHelper.GetUtf8ByteCount(source);
 
-            Span<byte> bytes = length <= JsonConstants.StackallocThreshold ? stackalloc byte[length] : new byte[length];
+            Span<byte> bytes = length <= JsonConstants.StackallocThreshold
+                ? stackalloc byte[JsonConstants.StackallocThreshold]
+                : new byte[length];
 
             JsonReaderHelper.GetUtf8FromText(source, bytes);
 
-            return TryParseAsISO(bytes, out value);
+            return TryParseAsISO(bytes.Slice(0, length), out value);
         }
 
         public static bool TryParseAsISO(ReadOnlySpan<char> source, out DateTimeOffset value)
@@ -69,11 +71,13 @@ namespace System.Text.Json
 
             int length = JsonReaderHelper.GetUtf8ByteCount(source);
 
-            Span<byte> bytes = length <= JsonConstants.StackallocThreshold ? stackalloc byte[length] : new byte[length];
+            Span<byte> bytes = length <= JsonConstants.StackallocThreshold
+                ? stackalloc byte[JsonConstants.StackallocThreshold]
+                : new byte[length];
 
             JsonReaderHelper.GetUtf8FromText(source, bytes);
 
-            return TryParseAsISO(bytes, out value);
+            return TryParseAsISO(bytes.Slice(0, length), out value);
         }
 
         /// <summary>

--- a/src/System.Text.Json/src/System/Text/Json/JsonHelpers.Date.cs
+++ b/src/System.Text.Json/src/System/Text/Json/JsonHelpers.Date.cs
@@ -30,7 +30,7 @@ namespace System.Text.Json
 
             JsonWriterHelper.WriteDateTimeOffsetTrimmed(span, value, out int bytesWritten);
 
-            return Encoding.UTF8.GetString(span.Slice(0, bytesWritten));
+            return JsonReaderHelper.GetTextFromUtf8(span.Slice(0, bytesWritten));
         }
 
         public static string FormatDateTime(DateTime value)
@@ -39,7 +39,7 @@ namespace System.Text.Json
 
             JsonWriterHelper.WriteDateTimeTrimmed(span, value, out int bytesWritten);
 
-            return Encoding.UTF8.GetString(span.Slice(0, bytesWritten));
+            return JsonReaderHelper.GetTextFromUtf8(span.Slice(0, bytesWritten));
         }
 
         public static bool TryParseAsISO(ReadOnlySpan<char> source, out DateTime value)
@@ -50,11 +50,11 @@ namespace System.Text.Json
                 return false;
             }
 
-            Span<byte> bytes = source.Length <= JsonConstants.StackallocThreshold
-                ? stackalloc byte[source.Length]
-                : new byte[source.Length];
+            int length = JsonReaderHelper.GetUtf8ByteCount(source);
 
-            Encoding.UTF8.GetBytes(source, bytes);
+            Span<byte> bytes = length <= JsonConstants.StackallocThreshold ? stackalloc byte[length] : new byte[length];
+
+            JsonReaderHelper.GetUtf8FromText(source, bytes);
 
             return TryParseAsISO(bytes, out value);
         }
@@ -67,11 +67,11 @@ namespace System.Text.Json
                 return false;
             }
 
-            Span<byte> bytes = source.Length <= JsonConstants.StackallocThreshold
-                ? stackalloc byte[source.Length]
-                : new byte[source.Length];
+            int length = JsonReaderHelper.GetUtf8ByteCount(source);
 
-            Encoding.UTF8.GetBytes(source, bytes);
+            Span<byte> bytes = length <= JsonConstants.StackallocThreshold ? stackalloc byte[length] : new byte[length];
+
+            JsonReaderHelper.GetUtf8FromText(source, bytes);
 
             return TryParseAsISO(bytes, out value);
         }

--- a/src/System.Text.Json/src/System/Text/Json/JsonHelpers.Date.cs
+++ b/src/System.Text.Json/src/System/Text/Json/JsonHelpers.Date.cs
@@ -28,7 +28,7 @@ namespace System.Text.Json
         {
             Span<byte> span = stackalloc byte[JsonConstants.MaximumFormatDateTimeOffsetLength];
 
-            JsonWriterHelper.WriteDateTimeOffset(span, value, out int bytesWritten);
+            JsonWriterHelper.WriteDateTimeOffsetTrimmed(span, value, out int bytesWritten);
 
             return Encoding.UTF8.GetString(span.Slice(0, bytesWritten));
         }
@@ -37,7 +37,7 @@ namespace System.Text.Json
         {
             Span<byte> span = stackalloc byte[JsonConstants.MaximumFormatDateTimeOffsetLength];
 
-            JsonWriterHelper.WriteDateTime(span, value, out int bytesWritten);
+            JsonWriterHelper.WriteDateTimeTrimmed(span, value, out int bytesWritten);
 
             return Encoding.UTF8.GetString(span.Slice(0, bytesWritten));
         }

--- a/src/System.Text.Json/src/System/Text/Json/JsonHelpers.Date.cs
+++ b/src/System.Text.Json/src/System/Text/Json/JsonHelpers.Date.cs
@@ -44,7 +44,7 @@ namespace System.Text.Json
 
         public static bool TryParseAsISO(ReadOnlySpan<char> source, out DateTime value)
         {
-            if (!JsonReaderHelper.IsValidDateTimeOffsetParseLength(source.Length))
+            if (!IsValidDateTimeOffsetParseLength(source.Length))
             {
                 value = default;
                 return false;
@@ -63,7 +63,7 @@ namespace System.Text.Json
 
         public static bool TryParseAsISO(ReadOnlySpan<char> source, out DateTimeOffset value)
         {
-            if (!JsonReaderHelper.IsValidDateTimeOffsetParseLength(source.Length))
+            if (!IsValidDateTimeOffsetParseLength(source.Length))
             {
                 value = default;
                 return false;
@@ -78,6 +78,18 @@ namespace System.Text.Json
             JsonReaderHelper.GetUtf8FromText(source, bytes);
 
             return TryParseAsISO(bytes.Slice(0, length), out value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsValidDateTimeOffsetParseLength(int length)
+        {
+            return IsInRangeInclusive(length, JsonConstants.MinimumDateTimeParseLength, JsonConstants.MaximumEscapedDateTimeOffsetParseLength);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsValidDateTimeOffsetParseLength(long length)
+        {
+            return IsInRangeInclusive(length, JsonConstants.MinimumDateTimeParseLength, JsonConstants.MaximumEscapedDateTimeOffsetParseLength);
         }
 
         /// <summary>

--- a/src/System.Text.Json/src/System/Text/Json/JsonHelpers.Date.cs
+++ b/src/System.Text.Json/src/System/Text/Json/JsonHelpers.Date.cs
@@ -50,13 +50,11 @@ namespace System.Text.Json
                 return false;
             }
 
-            int length = JsonReaderHelper.GetUtf8ByteCount(source);
+            Debug.Assert(JsonReaderHelper.GetUtf8ByteCount(source) <= JsonConstants.StackallocThreshold);
 
-            Span<byte> bytes = length <= JsonConstants.StackallocThreshold
-                ? stackalloc byte[JsonConstants.StackallocThreshold]
-                : new byte[length];
+            Span<byte> bytes = stackalloc byte[JsonConstants.StackallocThreshold];
 
-            JsonReaderHelper.GetUtf8FromText(source, bytes);
+            int length = JsonReaderHelper.GetUtf8FromText(source, bytes);
 
             return TryParseAsISO(bytes.Slice(0, length), out value);
         }
@@ -69,13 +67,11 @@ namespace System.Text.Json
                 return false;
             }
 
-            int length = JsonReaderHelper.GetUtf8ByteCount(source);
+            Debug.Assert(JsonReaderHelper.GetUtf8ByteCount(source) <= JsonConstants.StackallocThreshold);
 
-            Span<byte> bytes = length <= JsonConstants.StackallocThreshold
-                ? stackalloc byte[JsonConstants.StackallocThreshold]
-                : new byte[length];
+            Span<byte> bytes = stackalloc byte[JsonConstants.StackallocThreshold];
 
-            JsonReaderHelper.GetUtf8FromText(source, bytes);
+            int length = JsonReaderHelper.GetUtf8FromText(source, bytes);
 
             return TryParseAsISO(bytes.Slice(0, length), out value);
         }

--- a/src/System.Text.Json/src/System/Text/Json/JsonHelpers.Date.cs
+++ b/src/System.Text.Json/src/System/Text/Json/JsonHelpers.Date.cs
@@ -50,11 +50,13 @@ namespace System.Text.Json
                 return false;
             }
 
-            Debug.Assert(JsonReaderHelper.GetUtf8ByteCount(source) <= JsonConstants.StackallocThreshold);
+            int length = JsonReaderHelper.GetUtf8ByteCount(source);
 
-            Span<byte> bytes = stackalloc byte[JsonConstants.StackallocThreshold];
+            Span<byte> bytes = length <= JsonConstants.StackallocThreshold
+                ? stackalloc byte[JsonConstants.StackallocThreshold]
+                : new byte[length];
 
-            int length = JsonReaderHelper.GetUtf8FromText(source, bytes);
+            JsonReaderHelper.GetUtf8FromText(source, bytes);
 
             return TryParseAsISO(bytes.Slice(0, length), out value);
         }
@@ -67,11 +69,13 @@ namespace System.Text.Json
                 return false;
             }
 
-            Debug.Assert(JsonReaderHelper.GetUtf8ByteCount(source) <= JsonConstants.StackallocThreshold);
+            int length = JsonReaderHelper.GetUtf8ByteCount(source);
 
-            Span<byte> bytes = stackalloc byte[JsonConstants.StackallocThreshold];
+            Span<byte> bytes = length <= JsonConstants.StackallocThreshold
+                ? stackalloc byte[JsonConstants.StackallocThreshold]
+                : new byte[length];
 
-            int length = JsonReaderHelper.GetUtf8FromText(source, bytes);
+            JsonReaderHelper.GetUtf8FromText(source, bytes);
 
             return TryParseAsISO(bytes.Slice(0, length), out value);
         }

--- a/src/System.Text.Json/src/System/Text/Json/JsonHelpers.Date.cs
+++ b/src/System.Text.Json/src/System/Text/Json/JsonHelpers.Date.cs
@@ -44,6 +44,12 @@ namespace System.Text.Json
 
         public static bool TryParseAsISO(ReadOnlySpan<char> source, out DateTime value)
         {
+            if (!JsonReaderHelper.IsValidDateTimeOffsetParseLength(source.Length))
+            {
+                value = default;
+                return false;
+            }
+
             Span<byte> bytes = source.Length <= JsonConstants.StackallocThreshold
                 ? stackalloc byte[source.Length]
                 : new byte[source.Length];
@@ -55,6 +61,12 @@ namespace System.Text.Json
 
         public static bool TryParseAsISO(ReadOnlySpan<char> source, out DateTimeOffset value)
         {
+            if (!JsonReaderHelper.IsValidDateTimeOffsetParseLength(source.Length))
+            {
+                value = default;
+                return false;
+            }
+
             Span<byte> bytes = source.Length <= JsonConstants.StackallocThreshold
                 ? stackalloc byte[source.Length]
                 : new byte[source.Length];

--- a/src/System.Text.Json/src/System/Text/Json/JsonHelpers.Date.cs
+++ b/src/System.Text.Json/src/System/Text/Json/JsonHelpers.Date.cs
@@ -24,6 +24,46 @@ namespace System.Text.Json
             public byte OffsetToken;
         }
 
+        public static string FormatDateTimeOffset(DateTimeOffset value)
+        {
+            Span<byte> span = stackalloc byte[JsonConstants.MaximumFormatDateTimeOffsetLength];
+
+            JsonWriterHelper.WriteDateTimeOffset(span, value, out int bytesWritten);
+
+            return Encoding.UTF8.GetString(span.Slice(0, bytesWritten));
+        }
+
+        public static string FormatDateTime(DateTime value)
+        {
+            Span<byte> span = stackalloc byte[JsonConstants.MaximumFormatDateTimeOffsetLength];
+
+            JsonWriterHelper.WriteDateTime(span, value, out int bytesWritten);
+
+            return Encoding.UTF8.GetString(span.Slice(0, bytesWritten));
+        }
+
+        public static bool TryParseAsISO(ReadOnlySpan<char> source, out DateTime value)
+        {
+            Span<byte> bytes = source.Length <= JsonConstants.StackallocThreshold
+                ? stackalloc byte[source.Length]
+                : new byte[source.Length];
+
+            Encoding.UTF8.GetBytes(source, bytes);
+
+            return TryParseAsISO(bytes, out value);
+        }
+
+        public static bool TryParseAsISO(ReadOnlySpan<char> source, out DateTimeOffset value)
+        {
+            Span<byte> bytes = source.Length <= JsonConstants.StackallocThreshold
+                ? stackalloc byte[source.Length]
+                : new byte[source.Length];
+
+            Encoding.UTF8.GetBytes(source, bytes);
+
+            return TryParseAsISO(bytes, out value);
+        }
+
         /// <summary>
         /// Parse the given UTF-8 <paramref name="source"/> as extended ISO 8601 format.
         /// </summary>

--- a/src/System.Text.Json/src/System/Text/Json/Node/JsonString.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Node/JsonString.cs
@@ -46,7 +46,7 @@ namespace System.Text.Json
         /// <exception cref="ArgumentOutOfRangeException">
         ///   The date and time is outside the range of dates supported by the calendar used by the invariant culture.
         /// </exception>
-        public JsonString(DateTime value) => Value = value.ToString("s", CultureInfo.InvariantCulture);
+        public JsonString(DateTime value) => Value = JsonHelpers.FormatDateTime(value);
 
         /// <summary>
         ///  Initializes a new instance of the <see cref="JsonString"/> with an ISO 8601 representation of the <see cref="DateTimeOffset"/> structure.
@@ -55,7 +55,7 @@ namespace System.Text.Json
         /// <exception cref="ArgumentOutOfRangeException">
         ///   The date and time is outside the range of dates supported by the calendar used by the invariant culture.
         /// </exception>
-        public JsonString(DateTimeOffset value) => Value = value.ToString("s", CultureInfo.InvariantCulture);
+        public JsonString(DateTimeOffset value) => Value = JsonHelpers.FormatDateTimeOffset(value);
 
         /// <summary>
         ///   Gets or sets the text value represented by the instance.
@@ -82,7 +82,7 @@ namespace System.Text.Json
         /// <exception cref="FormatException">
         ///   Text value of this instance is not in an ISO 8601 defined DateTime format.
         /// </exception>
-        public DateTime GetDateTime() => DateTime.ParseExact(_value, "s", CultureInfo.InvariantCulture);
+        public DateTime GetDateTime() => JsonHelpers.TryParseAsISO(_value, out DateTime value) ? value : throw new FormatException(SR.FormatDateTime);
 
         /// <summary>
         ///   Converts the ISO 8601 text value of this instance to <see cref="DateTimeOffset"/> equivalent.
@@ -91,7 +91,7 @@ namespace System.Text.Json
         /// <exception cref="FormatException">
         ///   Text value of this instance is not in an ISO 8601 defined DateTimeOffset format.
         /// </exception>
-        public DateTimeOffset GetDateTimeOffset() => DateTimeOffset.ParseExact(_value, "s", CultureInfo.InvariantCulture);
+        public DateTimeOffset GetDateTimeOffset() => JsonHelpers.TryParseAsISO(_value, out DateTimeOffset value) ? value : throw new FormatException(SR.FormatDateTimeOffset);
 
         /// <summary>
         ///   Converts the text value of this instance to its <see cref="Guid"/> equivalent.
@@ -114,7 +114,7 @@ namespace System.Text.Json
         ///  <see langword="true"/> if instance was converted successfully;
         ///  otherwise, <see langword="false"/>
         /// </returns>
-        public bool TryGetDateTime(out DateTime value) => DateTime.TryParseExact(_value, "s", CultureInfo.InvariantCulture, DateTimeStyles.None, out value);
+        public bool TryGetDateTime(out DateTime value) => JsonHelpers.TryParseAsISO(_value, out value);
 
         /// <summary>
         ///   Converts the ISO 8601 text value of this instance to its <see cref="DateTimeOffset"/> equivalent.
@@ -128,7 +128,7 @@ namespace System.Text.Json
         ///  <see langword="true"/> if instance was converted successfully;
         ///  otherwise, <see langword="false"/>
         /// </returns>
-        public bool TryGetDateTimeOffset(out DateTimeOffset value) => DateTimeOffset.TryParseExact(_value, "s", CultureInfo.InvariantCulture, DateTimeStyles.None, out value);
+        public bool TryGetDateTimeOffset(out DateTimeOffset value) => JsonHelpers.TryParseAsISO(_value, out value);
 
         /// <summary>
         ///   Converts the text value of this instance to its <see cref="Guid"/> equivalent.

--- a/src/System.Text.Json/src/System/Text/Json/Node/JsonString.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Node/JsonString.cs
@@ -82,7 +82,7 @@ namespace System.Text.Json
         /// <exception cref="FormatException">
         ///   Text value of this instance is not in an ISO 8601 defined DateTime format.
         /// </exception>
-        public DateTime GetDateTime() => JsonHelpers.TryParseAsISO(_value, out DateTime value) ? value : throw new FormatException(SR.FormatDateTime);
+        public DateTime GetDateTime() => JsonHelpers.TryParseAsISO(_value.AsSpan(), out DateTime value) ? value : throw new FormatException(SR.FormatDateTime);
 
         /// <summary>
         ///   Converts the ISO 8601 text value of this instance to <see cref="DateTimeOffset"/> equivalent.
@@ -91,7 +91,7 @@ namespace System.Text.Json
         /// <exception cref="FormatException">
         ///   Text value of this instance is not in an ISO 8601 defined DateTimeOffset format.
         /// </exception>
-        public DateTimeOffset GetDateTimeOffset() => JsonHelpers.TryParseAsISO(_value, out DateTimeOffset value) ? value : throw new FormatException(SR.FormatDateTimeOffset);
+        public DateTimeOffset GetDateTimeOffset() => JsonHelpers.TryParseAsISO(_value.AsSpan(), out DateTimeOffset value) ? value : throw new FormatException(SR.FormatDateTimeOffset);
 
         /// <summary>
         ///   Converts the text value of this instance to its <see cref="Guid"/> equivalent.
@@ -114,7 +114,7 @@ namespace System.Text.Json
         ///  <see langword="true"/> if instance was converted successfully;
         ///  otherwise, <see langword="false"/>
         /// </returns>
-        public bool TryGetDateTime(out DateTime value) => JsonHelpers.TryParseAsISO(_value, out value);
+        public bool TryGetDateTime(out DateTime value) => JsonHelpers.TryParseAsISO(_value.AsSpan(), out value);
 
         /// <summary>
         ///   Converts the ISO 8601 text value of this instance to its <see cref="DateTimeOffset"/> equivalent.
@@ -128,7 +128,7 @@ namespace System.Text.Json
         ///  <see langword="true"/> if instance was converted successfully;
         ///  otherwise, <see langword="false"/>
         /// </returns>
-        public bool TryGetDateTimeOffset(out DateTimeOffset value) => JsonHelpers.TryParseAsISO(_value, out value);
+        public bool TryGetDateTimeOffset(out DateTimeOffset value) => JsonHelpers.TryParseAsISO(_value.AsSpan(), out value);
 
         /// <summary>
         ///   Converts the text value of this instance to its <see cref="Guid"/> equivalent.

--- a/src/System.Text.Json/src/System/Text/Json/Reader/JsonReaderHelper.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/JsonReaderHelper.cs
@@ -250,18 +250,6 @@ namespace System.Text.Json
                                                0x02ul << 40 |
                                                0x01ul << 48) + 1;
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsValidDateTimeOffsetParseLength(int length)
-        {
-            return JsonHelpers.IsInRangeInclusive(length, JsonConstants.MinimumDateTimeParseLength, JsonConstants.MaximumEscapedDateTimeOffsetParseLength);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsValidDateTimeOffsetParseLength(long length)
-        {
-            return JsonHelpers.IsInRangeInclusive(length, JsonConstants.MinimumDateTimeParseLength, JsonConstants.MaximumEscapedDateTimeOffsetParseLength);
-        }
-
         public static bool TryGetEscapedDateTime(ReadOnlySpan<byte> source, out DateTime value)
         {
             int backslash = source.IndexOf(JsonConstants.BackSlash);

--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
@@ -823,7 +823,7 @@ namespace System.Text.Json
             {
                 long sequenceLength = ValueSequence.Length;
 
-                if (!JsonReaderHelper.IsValidDateTimeOffsetParseLength(sequenceLength))
+                if (!JsonHelpers.IsValidDateTimeOffsetParseLength(sequenceLength))
                 {
                     value = default;
                     return false;
@@ -837,7 +837,7 @@ namespace System.Text.Json
             }
             else
             {
-                if (!JsonReaderHelper.IsValidDateTimeOffsetParseLength(ValueSpan.Length))
+                if (!JsonHelpers.IsValidDateTimeOffsetParseLength(ValueSpan.Length))
                 {
                     value = default;
                     return false;
@@ -887,7 +887,7 @@ namespace System.Text.Json
             {
                 long sequenceLength = ValueSequence.Length;
 
-                if (!JsonReaderHelper.IsValidDateTimeOffsetParseLength(sequenceLength))
+                if (!JsonHelpers.IsValidDateTimeOffsetParseLength(sequenceLength))
                 {
                     value = default;
                     return false;
@@ -901,7 +901,7 @@ namespace System.Text.Json
             }
             else
             {
-                if (!JsonReaderHelper.IsValidDateTimeOffsetParseLength(ValueSpan.Length))
+                if (!JsonHelpers.IsValidDateTimeOffsetParseLength(ValueSpan.Length))
                 {
                     value = default;
                     return false;

--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
@@ -853,8 +853,7 @@ namespace System.Text.Json
 
             Debug.Assert(span.IndexOf(JsonConstants.BackSlash) == -1);
 
-            if (span.Length <= JsonConstants.MaximumDateTimeOffsetParseLength
-                && JsonHelpers.TryParseAsISO(span, out DateTime tmp))
+            if (JsonHelpers.TryParseAsISO(span, out DateTime tmp))
             {
                 value = tmp;
                 return true;
@@ -917,8 +916,7 @@ namespace System.Text.Json
 
             Debug.Assert(span.IndexOf(JsonConstants.BackSlash) == -1);
 
-            if (span.Length <= JsonConstants.MaximumDateTimeOffsetParseLength
-                && JsonHelpers.TryParseAsISO(span, out DateTimeOffset tmp))
+            if (JsonHelpers.TryParseAsISO(span, out DateTimeOffset tmp))
             {
                 value = tmp;
                 return true;

--- a/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Date.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Date.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
+using System.Buffers.Text;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
@@ -9,6 +11,20 @@ namespace System.Text.Json
 {
     internal static partial class JsonWriterHelper
     {
+        private static readonly StandardFormat s_dateTimeStandardFormat = new StandardFormat('O');
+
+        public static void WriteDateTime(Span<byte> buffer, DateTime value, out int bytesWritten)
+        {
+            Debug.Assert(Utf8Formatter.TryFormat(value, buffer, out bytesWritten, s_dateTimeStandardFormat));
+            TrimDateTimeOffset(buffer.Slice(0, bytesWritten), out bytesWritten);
+        }
+
+        public static void WriteDateTimeOffset(Span<byte> buffer, DateTimeOffset value, out int bytesWritten)
+        {
+            Debug.Assert(Utf8Formatter.TryFormat(value, buffer, out bytesWritten, s_dateTimeStandardFormat));
+            TrimDateTimeOffset(buffer.Slice(0, bytesWritten), out bytesWritten);
+        }
+
         //
         // Trims roundtrippable DateTime(Offset) input.
         // If the milliseconds part of the date is zero, we omit the fraction part of the date,

--- a/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Date.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Date.cs
@@ -15,13 +15,15 @@ namespace System.Text.Json
 
         public static void WriteDateTimeTrimmed(Span<byte> buffer, DateTime value, out int bytesWritten)
         {
-            Debug.Assert(Utf8Formatter.TryFormat(value, buffer, out bytesWritten, s_dateTimeStandardFormat));
+            bool result = Utf8Formatter.TryFormat(value, buffer, out bytesWritten, s_dateTimeStandardFormat);
+            Debug.Assert(result);
             TrimDateTimeOffset(buffer.Slice(0, bytesWritten), out bytesWritten);
         }
 
         public static void WriteDateTimeOffsetTrimmed(Span<byte> buffer, DateTimeOffset value, out int bytesWritten)
         {
-            Debug.Assert(Utf8Formatter.TryFormat(value, buffer, out bytesWritten, s_dateTimeStandardFormat));
+            bool result = Utf8Formatter.TryFormat(value, buffer, out bytesWritten, s_dateTimeStandardFormat);
+            Debug.Assert(result);
             TrimDateTimeOffset(buffer.Slice(0, bytesWritten), out bytesWritten);
         }
 

--- a/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Date.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Date.cs
@@ -13,13 +13,13 @@ namespace System.Text.Json
     {
         private static readonly StandardFormat s_dateTimeStandardFormat = new StandardFormat('O');
 
-        public static void WriteDateTime(Span<byte> buffer, DateTime value, out int bytesWritten)
+        public static void WriteDateTimeTrimmed(Span<byte> buffer, DateTime value, out int bytesWritten)
         {
             Debug.Assert(Utf8Formatter.TryFormat(value, buffer, out bytesWritten, s_dateTimeStandardFormat));
             TrimDateTimeOffset(buffer.Slice(0, bytesWritten), out bytesWritten);
         }
 
-        public static void WriteDateTimeOffset(Span<byte> buffer, DateTimeOffset value, out int bytesWritten)
+        public static void WriteDateTimeOffsetTrimmed(Span<byte> buffer, DateTimeOffset value, out int bytesWritten)
         {
             Debug.Assert(Utf8Formatter.TryFormat(value, buffer, out bytesWritten, s_dateTimeStandardFormat));
             TrimDateTimeOffset(buffer.Slice(0, bytesWritten), out bytesWritten);

--- a/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Date.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Date.cs
@@ -15,16 +15,20 @@ namespace System.Text.Json
 
         public static void WriteDateTimeTrimmed(Span<byte> buffer, DateTime value, out int bytesWritten)
         {
-            bool result = Utf8Formatter.TryFormat(value, buffer, out bytesWritten, s_dateTimeStandardFormat);
+            Span<byte> tempSpan = stackalloc byte[JsonConstants.MaximumFormatDateTimeOffsetLength];
+            bool result = Utf8Formatter.TryFormat(value, tempSpan, out bytesWritten, s_dateTimeStandardFormat);
             Debug.Assert(result);
-            TrimDateTimeOffset(buffer.Slice(0, bytesWritten), out bytesWritten);
+            TrimDateTimeOffset(tempSpan.Slice(0, bytesWritten), out bytesWritten);
+            tempSpan.Slice(0, bytesWritten).CopyTo(buffer);
         }
 
         public static void WriteDateTimeOffsetTrimmed(Span<byte> buffer, DateTimeOffset value, out int bytesWritten)
         {
-            bool result = Utf8Formatter.TryFormat(value, buffer, out bytesWritten, s_dateTimeStandardFormat);
+            Span<byte> tempSpan = stackalloc byte[JsonConstants.MaximumFormatDateTimeOffsetLength];
+            bool result = Utf8Formatter.TryFormat(value, tempSpan, out bytesWritten, s_dateTimeStandardFormat);
             Debug.Assert(result);
-            TrimDateTimeOffset(buffer.Slice(0, bytesWritten), out bytesWritten);
+            TrimDateTimeOffset(tempSpan.Slice(0, bytesWritten), out bytesWritten);
+            tempSpan.Slice(0, bytesWritten).CopyTo(buffer);
         }
 
         //

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTime.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTime.cs
@@ -238,11 +238,7 @@ namespace System.Text.Json
 
             output[BytesPending++] = JsonConstants.Quote;
 
-            Span<byte> tempSpan = stackalloc byte[JsonConstants.MaximumFormatDateTimeOffsetLength];
-            bool result = Utf8Formatter.TryFormat(value, tempSpan, out int bytesWritten, s_dateTimeStandardFormat);
-            Debug.Assert(result);
-            JsonWriterHelper.TrimDateTimeOffset(tempSpan.Slice(0, bytesWritten), out bytesWritten);
-            tempSpan.Slice(0, bytesWritten).CopyTo(output.Slice(BytesPending));
+            JsonWriterHelper.WriteDateTime(output.Slice(BytesPending), value, out int bytesWritten);
             BytesPending += bytesWritten;
 
             output[BytesPending++] = JsonConstants.Quote;
@@ -276,11 +272,7 @@ namespace System.Text.Json
 
             output[BytesPending++] = JsonConstants.Quote;
 
-            Span<byte> tempSpan = stackalloc byte[JsonConstants.MaximumFormatDateTimeOffsetLength];
-            bool result = Utf8Formatter.TryFormat(value, tempSpan, out int bytesWritten, s_dateTimeStandardFormat);
-            Debug.Assert(result);
-            JsonWriterHelper.TrimDateTimeOffset(tempSpan.Slice(0, bytesWritten), out bytesWritten);
-            tempSpan.Slice(0, bytesWritten).CopyTo(output.Slice(BytesPending));
+            JsonWriterHelper.WriteDateTime(output.Slice(BytesPending), value, out int bytesWritten);
             BytesPending += bytesWritten;
 
             output[BytesPending++] = JsonConstants.Quote;
@@ -329,11 +321,7 @@ namespace System.Text.Json
 
             output[BytesPending++] = JsonConstants.Quote;
 
-            Span<byte> tempSpan = stackalloc byte[JsonConstants.MaximumFormatDateTimeOffsetLength];
-            bool result = Utf8Formatter.TryFormat(value, tempSpan, out int bytesWritten, s_dateTimeStandardFormat);
-            Debug.Assert(result);
-            JsonWriterHelper.TrimDateTimeOffset(tempSpan.Slice(0, bytesWritten), out bytesWritten);
-            tempSpan.Slice(0, bytesWritten).CopyTo(output.Slice(BytesPending));
+            JsonWriterHelper.WriteDateTime(output.Slice(BytesPending), value, out int bytesWritten);
             BytesPending += bytesWritten;
 
             output[BytesPending++] = JsonConstants.Quote;
@@ -382,11 +370,7 @@ namespace System.Text.Json
 
             output[BytesPending++] = JsonConstants.Quote;
 
-            Span<byte> tempSpan = stackalloc byte[JsonConstants.MaximumFormatDateTimeOffsetLength];
-            bool result = Utf8Formatter.TryFormat(value, tempSpan, out int bytesWritten, s_dateTimeStandardFormat);
-            Debug.Assert(result);
-            JsonWriterHelper.TrimDateTimeOffset(tempSpan.Slice(0, bytesWritten), out bytesWritten);
-            tempSpan.Slice(0, bytesWritten).CopyTo(output.Slice(BytesPending));
+            JsonWriterHelper.WriteDateTime(output.Slice(BytesPending), value, out int bytesWritten);
             BytesPending += bytesWritten;
 
             output[BytesPending++] = JsonConstants.Quote;

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTime.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTime.cs
@@ -238,7 +238,7 @@ namespace System.Text.Json
 
             output[BytesPending++] = JsonConstants.Quote;
 
-            JsonWriterHelper.WriteDateTime(output.Slice(BytesPending), value, out int bytesWritten);
+            JsonWriterHelper.WriteDateTimeTrimmed(output.Slice(BytesPending), value, out int bytesWritten);
             BytesPending += bytesWritten;
 
             output[BytesPending++] = JsonConstants.Quote;
@@ -272,7 +272,7 @@ namespace System.Text.Json
 
             output[BytesPending++] = JsonConstants.Quote;
 
-            JsonWriterHelper.WriteDateTime(output.Slice(BytesPending), value, out int bytesWritten);
+            JsonWriterHelper.WriteDateTimeTrimmed(output.Slice(BytesPending), value, out int bytesWritten);
             BytesPending += bytesWritten;
 
             output[BytesPending++] = JsonConstants.Quote;
@@ -321,7 +321,7 @@ namespace System.Text.Json
 
             output[BytesPending++] = JsonConstants.Quote;
 
-            JsonWriterHelper.WriteDateTime(output.Slice(BytesPending), value, out int bytesWritten);
+            JsonWriterHelper.WriteDateTimeTrimmed(output.Slice(BytesPending), value, out int bytesWritten);
             BytesPending += bytesWritten;
 
             output[BytesPending++] = JsonConstants.Quote;
@@ -370,7 +370,7 @@ namespace System.Text.Json
 
             output[BytesPending++] = JsonConstants.Quote;
 
-            JsonWriterHelper.WriteDateTime(output.Slice(BytesPending), value, out int bytesWritten);
+            JsonWriterHelper.WriteDateTimeTrimmed(output.Slice(BytesPending), value, out int bytesWritten);
             BytesPending += bytesWritten;
 
             output[BytesPending++] = JsonConstants.Quote;

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTimeOffset.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTimeOffset.cs
@@ -237,7 +237,7 @@ namespace System.Text.Json
 
             output[BytesPending++] = JsonConstants.Quote;
 
-            JsonWriterHelper.WriteDateTimeOffset(output.Slice(BytesPending), value, out int bytesWritten);
+            JsonWriterHelper.WriteDateTimeOffsetTrimmed(output.Slice(BytesPending), value, out int bytesWritten);
             BytesPending += bytesWritten;
 
             output[BytesPending++] = JsonConstants.Quote;
@@ -271,7 +271,7 @@ namespace System.Text.Json
 
             output[BytesPending++] = JsonConstants.Quote;
 
-            JsonWriterHelper.WriteDateTimeOffset(output.Slice(BytesPending), value, out int bytesWritten);
+            JsonWriterHelper.WriteDateTimeOffsetTrimmed(output.Slice(BytesPending), value, out int bytesWritten);
             BytesPending += bytesWritten;
 
             output[BytesPending++] = JsonConstants.Quote;
@@ -320,7 +320,7 @@ namespace System.Text.Json
 
             output[BytesPending++] = JsonConstants.Quote;
 
-            JsonWriterHelper.WriteDateTimeOffset(output.Slice(BytesPending), value, out int bytesWritten);
+            JsonWriterHelper.WriteDateTimeOffsetTrimmed(output.Slice(BytesPending), value, out int bytesWritten);
             BytesPending += bytesWritten;
 
             output[BytesPending++] = JsonConstants.Quote;
@@ -369,7 +369,7 @@ namespace System.Text.Json
 
             output[BytesPending++] = JsonConstants.Quote;
 
-            JsonWriterHelper.WriteDateTimeOffset(output.Slice(BytesPending), value, out int bytesWritten);
+            JsonWriterHelper.WriteDateTimeOffsetTrimmed(output.Slice(BytesPending), value, out int bytesWritten);
             BytesPending += bytesWritten;
 
             output[BytesPending++] = JsonConstants.Quote;

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTimeOffset.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTimeOffset.cs
@@ -237,11 +237,7 @@ namespace System.Text.Json
 
             output[BytesPending++] = JsonConstants.Quote;
 
-            Span<byte> tempSpan = stackalloc byte[JsonConstants.MaximumFormatDateTimeOffsetLength];
-            bool result = Utf8Formatter.TryFormat(value, tempSpan, out int bytesWritten, s_dateTimeStandardFormat);
-            Debug.Assert(result);
-            JsonWriterHelper.TrimDateTimeOffset(tempSpan.Slice(0, bytesWritten), out bytesWritten);
-            tempSpan.Slice(0, bytesWritten).CopyTo(output.Slice(BytesPending));
+            JsonWriterHelper.WriteDateTimeOffset(output.Slice(BytesPending), value, out int bytesWritten);
             BytesPending += bytesWritten;
 
             output[BytesPending++] = JsonConstants.Quote;
@@ -275,11 +271,7 @@ namespace System.Text.Json
 
             output[BytesPending++] = JsonConstants.Quote;
 
-            Span<byte> tempSpan = stackalloc byte[JsonConstants.MaximumFormatDateTimeOffsetLength];
-            bool result = Utf8Formatter.TryFormat(value, tempSpan, out int bytesWritten, s_dateTimeStandardFormat);
-            Debug.Assert(result);
-            JsonWriterHelper.TrimDateTimeOffset(tempSpan.Slice(0, bytesWritten), out bytesWritten);
-            tempSpan.Slice(0, bytesWritten).CopyTo(output.Slice(BytesPending));
+            JsonWriterHelper.WriteDateTimeOffset(output.Slice(BytesPending), value, out int bytesWritten);
             BytesPending += bytesWritten;
 
             output[BytesPending++] = JsonConstants.Quote;
@@ -328,11 +320,7 @@ namespace System.Text.Json
 
             output[BytesPending++] = JsonConstants.Quote;
 
-            Span<byte> tempSpan = stackalloc byte[JsonConstants.MaximumFormatDateTimeOffsetLength];
-            bool result = Utf8Formatter.TryFormat(value, tempSpan, out int bytesWritten, s_dateTimeStandardFormat);
-            Debug.Assert(result);
-            JsonWriterHelper.TrimDateTimeOffset(tempSpan.Slice(0, bytesWritten), out bytesWritten);
-            tempSpan.Slice(0, bytesWritten).CopyTo(output.Slice(BytesPending));
+            JsonWriterHelper.WriteDateTimeOffset(output.Slice(BytesPending), value, out int bytesWritten);
             BytesPending += bytesWritten;
 
             output[BytesPending++] = JsonConstants.Quote;
@@ -381,11 +369,7 @@ namespace System.Text.Json
 
             output[BytesPending++] = JsonConstants.Quote;
 
-            Span<byte> tempSpan = stackalloc byte[JsonConstants.MaximumFormatDateTimeOffsetLength];
-            bool result = Utf8Formatter.TryFormat(value, tempSpan, out int bytesWritten, s_dateTimeStandardFormat);
-            Debug.Assert(result);
-            JsonWriterHelper.TrimDateTimeOffset(tempSpan.Slice(0, bytesWritten), out bytesWritten);
-            tempSpan.Slice(0, bytesWritten).CopyTo(output.Slice(BytesPending));
+            JsonWriterHelper.WriteDateTimeOffset(output.Slice(BytesPending), value, out int bytesWritten);
             BytesPending += bytesWritten;
 
             output[BytesPending++] = JsonConstants.Quote;

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.DateTime.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.DateTime.cs
@@ -54,7 +54,7 @@ namespace System.Text.Json
 
             output[BytesPending++] = JsonConstants.Quote;
 
-            JsonWriterHelper.WriteDateTime(output.Slice(BytesPending), value, out int bytesWritten);
+            JsonWriterHelper.WriteDateTimeTrimmed(output.Slice(BytesPending), value, out int bytesWritten);
             BytesPending += bytesWritten;
 
             output[BytesPending++] = JsonConstants.Quote;
@@ -92,7 +92,7 @@ namespace System.Text.Json
 
             output[BytesPending++] = JsonConstants.Quote;
 
-            JsonWriterHelper.WriteDateTime(output.Slice(BytesPending), value, out int bytesWritten);
+            JsonWriterHelper.WriteDateTimeTrimmed(output.Slice(BytesPending), value, out int bytesWritten);
             BytesPending += bytesWritten;
 
             output[BytesPending++] = JsonConstants.Quote;

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.DateTime.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.DateTime.cs
@@ -54,11 +54,7 @@ namespace System.Text.Json
 
             output[BytesPending++] = JsonConstants.Quote;
 
-            Span<byte> tempSpan = stackalloc byte[JsonConstants.MaximumFormatDateTimeOffsetLength];
-            bool result = Utf8Formatter.TryFormat(value, tempSpan, out int bytesWritten, s_dateTimeStandardFormat);
-            Debug.Assert(result);
-            JsonWriterHelper.TrimDateTimeOffset(tempSpan.Slice(0, bytesWritten), out bytesWritten);
-            tempSpan.Slice(0, bytesWritten).CopyTo(output.Slice(BytesPending));
+            JsonWriterHelper.WriteDateTime(output.Slice(BytesPending), value, out int bytesWritten);
             BytesPending += bytesWritten;
 
             output[BytesPending++] = JsonConstants.Quote;
@@ -96,16 +92,10 @@ namespace System.Text.Json
 
             output[BytesPending++] = JsonConstants.Quote;
 
-            Span<byte> tempSpan = stackalloc byte[JsonConstants.MaximumFormatDateTimeOffsetLength];
-            bool result = Utf8Formatter.TryFormat(value, tempSpan, out int bytesWritten, s_dateTimeStandardFormat);
-            Debug.Assert(result);
-            JsonWriterHelper.TrimDateTimeOffset(tempSpan.Slice(0, bytesWritten), out bytesWritten);
-            tempSpan.Slice(0, bytesWritten).CopyTo(output.Slice(BytesPending));
+            JsonWriterHelper.WriteDateTime(output.Slice(BytesPending), value, out int bytesWritten);
             BytesPending += bytesWritten;
 
             output[BytesPending++] = JsonConstants.Quote;
         }
-
-        private static readonly StandardFormat s_dateTimeStandardFormat = new StandardFormat('O');
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.DateTimeOffset.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.DateTimeOffset.cs
@@ -55,11 +55,7 @@ namespace System.Text.Json
 
             output[BytesPending++] = JsonConstants.Quote;
 
-            Span<byte> tempSpan = stackalloc byte[JsonConstants.MaximumFormatDateTimeOffsetLength];
-            bool result = Utf8Formatter.TryFormat(value, tempSpan, out int bytesWritten, s_dateTimeStandardFormat);
-            Debug.Assert(result);
-            JsonWriterHelper.TrimDateTimeOffset(tempSpan.Slice(0, bytesWritten), out bytesWritten);
-            tempSpan.Slice(0, bytesWritten).CopyTo(output.Slice(BytesPending));
+            JsonWriterHelper.WriteDateTimeOffset(output.Slice(BytesPending), value, out int bytesWritten);
             BytesPending += bytesWritten;
 
             output[BytesPending++] = JsonConstants.Quote;
@@ -97,11 +93,7 @@ namespace System.Text.Json
 
             output[BytesPending++] = JsonConstants.Quote;
 
-            Span<byte> tempSpan = stackalloc byte[JsonConstants.MaximumFormatDateTimeOffsetLength];
-            bool result = Utf8Formatter.TryFormat(value, tempSpan, out int bytesWritten, s_dateTimeStandardFormat);
-            Debug.Assert(result);
-            JsonWriterHelper.TrimDateTimeOffset(tempSpan.Slice(0, bytesWritten), out bytesWritten);
-            tempSpan.Slice(0, bytesWritten).CopyTo(output.Slice(BytesPending));
+            JsonWriterHelper.WriteDateTimeOffset(output.Slice(BytesPending), value, out int bytesWritten);
             BytesPending += bytesWritten;
 
             output[BytesPending++] = JsonConstants.Quote;

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.DateTimeOffset.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.DateTimeOffset.cs
@@ -55,7 +55,7 @@ namespace System.Text.Json
 
             output[BytesPending++] = JsonConstants.Quote;
 
-            JsonWriterHelper.WriteDateTimeOffset(output.Slice(BytesPending), value, out int bytesWritten);
+            JsonWriterHelper.WriteDateTimeOffsetTrimmed(output.Slice(BytesPending), value, out int bytesWritten);
             BytesPending += bytesWritten;
 
             output[BytesPending++] = JsonConstants.Quote;
@@ -93,7 +93,7 @@ namespace System.Text.Json
 
             output[BytesPending++] = JsonConstants.Quote;
 
-            JsonWriterHelper.WriteDateTimeOffset(output.Slice(BytesPending), value, out int bytesWritten);
+            JsonWriterHelper.WriteDateTimeOffsetTrimmed(output.Slice(BytesPending), value, out int bytesWritten);
             BytesPending += bytesWritten;
 
             output[BytesPending++] = JsonConstants.Quote;

--- a/src/System.Text.Json/tests/JsonObjectTests.cs
+++ b/src/System.Text.Json/tests/JsonObjectTests.cs
@@ -99,29 +99,27 @@ namespace System.Text.Json.Tests
             Assert.Equal(guidString, ((JsonString)jsonObject["guid"]).Value);
         }
 
-        public static IEnumerable<object[]> DateTimeData =>
-            new List<object[]>
-            {
-                new object[] { new DateTime(DateTime.MinValue.Ticks, DateTimeKind.Utc) },
-                new object[] { new DateTime(2019, 1, 1) },
-                new object[] { new DateTime(2019, 1, 1, new GregorianCalendar()) },
-                new object[] { new DateTime(2019, 1, 1, new ChineseLunisolarCalendar()) }
-            };
-
         [Theory]
-        [MemberData(nameof(DateTimeData))]
-        public static void TestDateTime(DateTime dateTime)
+        [MemberData(nameof(JsonDateTimeTestData.DateTimeFractionTrimBaseTests), MemberType = typeof(JsonDateTimeTestData))]
+        [MemberData(nameof(JsonDateTimeTestData.DateTimeFractionTrimUtcOffsetTests), MemberType = typeof(JsonDateTimeTestData))]
+        public static void TestDateTime(string testStr, string expectedStr)
         {
+            var dateTime = DateTime.ParseExact(testStr, "O", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+
             var jsonObject = new JsonObject { { "dateTime", dateTime } };
-            Assert.Equal(dateTime.ToString("O", CultureInfo.InvariantCulture).Replace(".0000000", string.Empty), ((JsonString)jsonObject["dateTime"]).Value);
+
+            Assert.Equal(expectedStr, ((JsonString)jsonObject["dateTime"]).Value);
         }
 
         [Theory]
-        [MemberData(nameof(DateTimeData))]
-        public static void TestDateTimeOffset(DateTimeOffset dateTimeOffset)
+        [MemberData(nameof(JsonDateTimeTestData.DateTimeOffsetFractionTrimTests), MemberType = typeof(JsonDateTimeTestData))]
+        public static void TestDateTimeOffset(string testStr, string expectedStr)
         {
+            var dateTimeOffset = DateTimeOffset.ParseExact(testStr, "O", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+
             var jsonObject = new JsonObject { { "dateTimeOffset", dateTimeOffset } };
-            Assert.Equal(dateTimeOffset.ToString("O", CultureInfo.InvariantCulture).Replace(".0000000", string.Empty), ((JsonString)jsonObject["dateTimeOffset"]).Value);
+
+            Assert.Equal(expectedStr, ((JsonString)jsonObject["dateTimeOffset"]).Value);
         }
 
         [Fact]

--- a/src/System.Text.Json/tests/JsonObjectTests.cs
+++ b/src/System.Text.Json/tests/JsonObjectTests.cs
@@ -113,7 +113,7 @@ namespace System.Text.Json.Tests
         public static void TestDateTime(DateTime dateTime)
         {
             var jsonObject = new JsonObject { { "dateTime", dateTime } };
-            Assert.Equal(dateTime.ToString("s", CultureInfo.InvariantCulture), ((JsonString)jsonObject["dateTime"]).Value);
+            Assert.Equal(dateTime.ToString("O", CultureInfo.InvariantCulture).Replace(".0000000", string.Empty), ((JsonString)jsonObject["dateTime"]).Value);
         }
 
         [Theory]
@@ -121,7 +121,7 @@ namespace System.Text.Json.Tests
         public static void TestDateTimeOffset(DateTimeOffset dateTimeOffset)
         {
             var jsonObject = new JsonObject { { "dateTimeOffset", dateTimeOffset } };
-            Assert.Equal(dateTimeOffset.ToString("s", CultureInfo.InvariantCulture), ((JsonString)jsonObject["dateTimeOffset"]).Value);
+            Assert.Equal(dateTimeOffset.ToString("O", CultureInfo.InvariantCulture).Replace(".0000000", string.Empty), ((JsonString)jsonObject["dateTimeOffset"]).Value);
         }
 
         [Fact]

--- a/src/System.Text.Json/tests/JsonStringTests.cs
+++ b/src/System.Text.Json/tests/JsonStringTests.cs
@@ -99,7 +99,7 @@ namespace System.Text.Json.Tests
         public static void TestDateTime(DateTime dateTime)
         {
             var jsonString = new JsonString(dateTime);
-            Assert.Equal(dateTime.ToString("s", CultureInfo.InvariantCulture), jsonString.Value);
+            Assert.Equal(dateTime.ToString("O", CultureInfo.InvariantCulture).Replace(".0000000", string.Empty), jsonString.Value);
             Assert.Equal(dateTime, jsonString.GetDateTime());
             Assert.True(jsonString.TryGetDateTime(out DateTime dateTime2));
             Assert.Equal(dateTime, dateTime2);
@@ -107,11 +107,10 @@ namespace System.Text.Json.Tests
 
         [Theory]
         [MemberData(nameof(DateTimeData))]
-        public static void TestDateTimeOffset(DateTime dateTime)
+        public static void TestDateTimeOffset(DateTimeOffset dateTimeOffset)
         {
-            var dateTimeOffset = DateTimeOffset.ParseExact(dateTime.ToString("s"), "s", CultureInfo.InvariantCulture);
             var jsonString = new JsonString(dateTimeOffset);
-            Assert.Equal(dateTimeOffset.ToString("s", CultureInfo.InvariantCulture), jsonString.Value);
+            Assert.Equal(dateTimeOffset.ToString("O", CultureInfo.InvariantCulture).Replace(".0000000", string.Empty), jsonString.Value);
             Assert.Equal(dateTimeOffset, jsonString.GetDateTimeOffset());
             Assert.True(jsonString.TryGetDateTimeOffset(out DateTimeOffset dateTimeOffset2));
             Assert.Equal(dateTimeOffset, dateTimeOffset2);

--- a/src/System.Text.Json/tests/JsonStringTests.cs
+++ b/src/System.Text.Json/tests/JsonStringTests.cs
@@ -43,7 +43,7 @@ namespace System.Text.Json.Tests
             // Value constructor:
             Assert.Equal(value, new JsonString(value).Value);
 
-            // Implicit operator:            
+            // Implicit operator:
             JsonNode jsonNode = value;
             JsonString implicitlyInitializiedJsonString = (JsonString)jsonNode;
             Assert.Equal(value, implicitlyInitializiedJsonString.Value);
@@ -85,32 +85,26 @@ namespace System.Text.Json.Tests
             Assert.Equal(guid, guid2);
         }
 
-        public static IEnumerable<object[]> DateTimeData =>
-           new List<object[]>
-           {
-                new object[] { new DateTime(DateTime.MinValue.Ticks, DateTimeKind.Utc) },
-                new object[] { new DateTime(2019, 1, 1) },
-                new object[] { new DateTime(2019, 1, 1, new GregorianCalendar()) },
-                new object[] { new DateTime(2019, 1, 1, new ChineseLunisolarCalendar()) }
-           };
-
         [Theory]
-        [MemberData(nameof(DateTimeData))]
-        public static void TestDateTime(DateTime dateTime)
+        [MemberData(nameof(JsonDateTimeTestData.DateTimeFractionTrimBaseTests), MemberType = typeof(JsonDateTimeTestData))]
+        [MemberData(nameof(JsonDateTimeTestData.DateTimeFractionTrimUtcOffsetTests), MemberType = typeof(JsonDateTimeTestData))]
+        public static void TestDateTime(string testStr, string expectedStr)
         {
+            var dateTime = DateTime.ParseExact(testStr, "O", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
             var jsonString = new JsonString(dateTime);
-            Assert.Equal(dateTime.ToString("O", CultureInfo.InvariantCulture).Replace(".0000000", string.Empty), jsonString.Value);
+            Assert.Equal(expectedStr, jsonString.Value);
             Assert.Equal(dateTime, jsonString.GetDateTime());
             Assert.True(jsonString.TryGetDateTime(out DateTime dateTime2));
             Assert.Equal(dateTime, dateTime2);
         }
 
         [Theory]
-        [MemberData(nameof(DateTimeData))]
-        public static void TestDateTimeOffset(DateTimeOffset dateTimeOffset)
+        [MemberData(nameof(JsonDateTimeTestData.DateTimeOffsetFractionTrimTests), MemberType = typeof(JsonDateTimeTestData))]
+        public static void TestDateTimeOffset(string testStr, string expectedStr)
         {
+            var dateTimeOffset = DateTimeOffset.ParseExact(testStr, "O", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
             var jsonString = new JsonString(dateTimeOffset);
-            Assert.Equal(dateTimeOffset.ToString("O", CultureInfo.InvariantCulture).Replace(".0000000", string.Empty), jsonString.Value);
+            Assert.Equal(expectedStr, jsonString.Value);
             Assert.Equal(dateTimeOffset, jsonString.GetDateTimeOffset());
             Assert.True(jsonString.TryGetDateTimeOffset(out DateTimeOffset dateTimeOffset2));
             Assert.Equal(dateTimeOffset, dateTimeOffset2);
@@ -125,7 +119,7 @@ namespace System.Text.Json.Tests
             jsonString.Value = "different property value";
             Assert.Equal("different property value", jsonString.Value);
         }
-        
+
         [Fact]
         public static void TestGettersFail()
         {


### PR DESCRIPTION
This consolidates parsing and formatting between `Json[Reader|Writer]` and `JsonString` and fixes some bugs in the process.

Fixes #41706
Fixes #41779