### PR TITLE
DiagnosticSourceEventSource fixes/improvements for distributed tracing

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/src/ILLinkTrim.xml
+++ b/src/System.Diagnostics.DiagnosticSource/src/ILLinkTrim.xml
@@ -1,7 +1,15 @@
 <linker>
   <assembly fullname="System.Diagnostics.DiagnosticSource">
     <type fullname="System.Diagnostics.DiagnosticSourceEventSource" />
-    <type fullname="System.Diagnostics.DiagnosticSourceEventSource/TransformSpec/PropertySpec/PropertyFetch/TypedFetchProperty`2">
+    <type fullname="System.Diagnostics.DiagnosticSourceEventSource/TransformSpec/PropertySpec/PropertyFetch/RefTypedFetchProperty`2">
+      <!-- Instantiated via reflection -->
+      <method name=".ctor" />
+    </type>
+    <type fullname="System.Diagnostics.DiagnosticSourceEventSource/TransformSpec/PropertySpec/PropertyFetch/ValueTypedFetchProperty`2">
+      <!-- Instantiated via reflection -->
+      <method name=".ctor" />
+    </type>
+    <type fullname="System.Diagnostics.DiagnosticSourceEventSource/TransformSpec/PropertySpec/PropertyFetch/EnumeratePropertyFetch`1">
       <!-- Instantiated via reflection -->
       <method name=".ctor" />
     </type>

--- a/src/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
@@ -10,6 +10,8 @@
     <NoWarn>$(NoWarn);SA1205</NoWarn>
     <Nullable>enable</Nullable>
     <DefineConstants Condition="'$(TargetFramework)' == 'netstandard1.1' OR '$(TargetFramework)' == 'net45'">$(DefineConstants);NO_EVENTSOURCE_COMPLEX_TYPE_SUPPORT</DefineConstants>
+    <DefineConstants Condition="'$(TargetFramework)' != 'netstandard1.1'">$(DefineConstants);EVENTSOURCE_ACTIVITY_SUPPORT</DefineConstants>
+    <DefineConstants Condition="'$(TargetFramework)' != 'netstandard1.1' AND '$(TargetFramework)' != 'netstandard1.3'">$(DefineConstants);EVENTSOURCE_ENUMERATE_SUPPORT</DefineConstants>
     <DefineConstants Condition="'$(TargetsNetFx)' == 'true'">$(DefineConstants);ALLOW_PARTIALLY_TRUSTED_CALLERS;ENABLE_HTTP_HANDLER</DefineConstants>
     <Configurations>net45-Debug;net45-Release;net46-Debug;net46-Release;netcoreapp-Debug;netcoreapp-Release;netfx-Debug;netfx-Release;netstandard-Debug;netstandard-Release;netstandard1.1-Debug;netstandard1.1-Release;netstandard1.3-Debug;netstandard1.3-Release</Configurations>
   </PropertyGroup>

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
@@ -1000,7 +1000,7 @@ namespace System.Diagnostics
                         public override object? Fetch(object? obj)
                         {
                             Debug.Assert(obj is IEnumerable<ElementType>);
-                            return string.Join(',', (IEnumerable<ElementType>)obj);
+                            return string.Join(",", (IEnumerable<ElementType>)obj);
                         }
                     }
                     #endregion

--- a/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceEventSourceBridgeTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceEventSourceBridgeTests.cs
@@ -801,7 +801,6 @@ namespace System.Diagnostics.Tests
                         );
 
                     Activity activity1 = new Activity("TestActivity1");
-                    //activity1.SetParentId("|foo123");
                     activity1.SetIdFormat(ActivityIdFormat.W3C);
                     activity1.TraceStateString = "hi_there";
                     activity1.AddTag("one", "1");

--- a/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceEventSourceBridgeTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceEventSourceBridgeTests.cs
@@ -771,6 +771,96 @@ namespace System.Diagnostics.Tests
                 }
             }).Dispose();
         }
+
+        [Fact]
+        public void ActivityObjectsAreInspectable()
+        {
+            RemoteExecutor.Invoke(() =>
+            {
+                using (var eventListener = new TestDiagnosticSourceEventListener())
+                using (var diagnosticListener = new DiagnosticListener("MySource"))
+                {
+                    string activityProps =
+                        "-DummyProp" +
+                        ";ActivityId=*Activity.Id" +
+                        ";ActivityStartTime=*Activity.StartTimeUtc.Ticks" +
+                        ";ActivityDuration=*Activity.Duration.Ticks" +
+                        ";ActivityOperationName=*Activity.OperationName" +
+                        ";ActivityIdFormat=*Activity.IdFormat" +
+                        ";ActivityParentId=*Activity.ParentId" +
+                        ";ActivityTags=*Activity.Tags.*Enumerate" +
+                        ";ActivityTraceId=*Activity.TraceId" +
+                        ";ActivitySpanId=*Activity.SpanId" +
+                        ";ActivityTraceStateString=*Activity.TraceStateString" +
+                        ";ActivityParentSpanId=*Activity.ParentSpanId";
+                    eventListener.Enable(
+                        "MySource/TestActivity1.Start@Activity1Start:" + activityProps + "\r\n" +
+                        "MySource/TestActivity1.Stop@Activity1Stop:" + activityProps + "\r\n" +
+                        "MySource/TestActivity2.Start@Activity2Start:" + activityProps + "\r\n" +
+                        "MySource/TestActivity2.Stop@Activity2Stop:" + activityProps + "\r\n"
+                        );
+
+                    Activity activity1 = new Activity("TestActivity1");
+                    //activity1.SetParentId("|foo123");
+                    activity1.SetIdFormat(ActivityIdFormat.W3C);
+                    activity1.TraceStateString = "hi_there";
+                    activity1.AddTag("one", "1");
+                    activity1.AddTag("two", "2");
+
+                    diagnosticListener.StartActivity(activity1, new { DummyProp = "val" });
+                    Assert.Equal(1, eventListener.EventCount);
+                    AssertActivityMatchesEvent(activity1, eventListener.LastEvent, isStart: true);
+                    
+                    Activity activity2 = new Activity("TestActivity2");
+                    diagnosticListener.StartActivity(activity2, new { DummyProp = "val" });
+                    Assert.Equal(2, eventListener.EventCount);
+                    AssertActivityMatchesEvent(activity2, eventListener.LastEvent, isStart: true);
+
+                    diagnosticListener.StopActivity(activity2, new { DummyProp = "val" });
+                    Assert.Equal(3, eventListener.EventCount);
+                    AssertActivityMatchesEvent(activity2, eventListener.LastEvent, isStart: false);
+
+                    diagnosticListener.StopActivity(activity1, new { DummyProp = "val" });
+                    Assert.Equal(4, eventListener.EventCount);
+                    AssertActivityMatchesEvent(activity1, eventListener.LastEvent, isStart: false);
+
+                }
+            }).Dispose();
+        }
+
+        private void AssertActivityMatchesEvent(Activity a, DiagnosticSourceEvent e, bool isStart)
+        {
+            Assert.Equal("MySource", e.SourceName);
+            Assert.Equal(a.OperationName + (isStart ? ".Start" : ".Stop"), e.EventName);
+            Assert.Equal("val", e.Arguments["DummyProp"]);
+            Assert.Equal(a.Id, e.Arguments["ActivityId"]);
+            Assert.Equal(a.StartTimeUtc.Ticks.ToString(), e.Arguments["ActivityStartTime"]);
+            if (!isStart)
+            {
+                Assert.Equal(a.Duration.Ticks.ToString(), e.Arguments["ActivityDuration"]);
+            }
+            Assert.Equal(a.OperationName, e.Arguments["ActivityOperationName"]);
+            if (a.ParentId == null)
+            {
+                Assert.True(!e.Arguments.ContainsKey("ActivityParentId"));
+            }
+            else
+            {
+                Assert.Equal(a.ParentId, e.Arguments["ActivityParentId"]);
+            }
+            Assert.Equal(a.IdFormat.ToString(), e.Arguments["ActivityIdFormat"]);
+            if (a.IdFormat == ActivityIdFormat.W3C)
+            {
+                Assert.Equal(a.TraceId.ToString(), e.Arguments["ActivityTraceId"]);
+                Assert.Equal(a.SpanId.ToString(), e.Arguments["ActivitySpanId"]);
+                Assert.Equal(a.TraceStateString, e.Arguments["ActivityTraceStateString"]);
+                if(a.ParentSpanId != default)
+                {
+                    Assert.Equal(a.ParentSpanId.ToString(), e.Arguments["ActivityParentSpanId"]);
+                }
+            }
+            Assert.Equal(string.Join(',', a.Tags), e.Arguments["ActivityTags"]);
+        }
     }
 
     /****************************************************************************/


### PR DESCRIPTION
1) There is no existing mechanism for DiagnosticSourceEventSource to fetch the current activity object. By convention it is not passed as an event argument, but rather stored in the async-local property Activity.Current. This was fixed by adding a well-known "*Activity" property that returns the result of Activity.Current regardless what object it is applied to.

2) DiagnosticSourceEventSource fails to evaluate properties on value types, such as DateTime.Ticks. Calling MethodInfo.CreateDelegate
needs to use a different signature for ref and value type properties and previously the code always used the ref-style signature. Fixed by adding ValueTypedFetchProperty that does the proper CreateDelegate and delegate invocation for structs.

3) There is no mechanism for DiagnosticSourceEventSource to enumerate the tags on an activity. This change adds the *Enumerate well-known property which will iterate any IEnumerable`1, invoke ToString() on each element, then join it as a string.


cc @stephentoub @josalem @lmolkova @sywhang  - I don't know if it will make it, but I am interested in this for 3.1 so I am trying to move it along quickly to find out.