### PR TITLE
Add windows support to build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,11 +4,11 @@ source="${BASH_SOURCE[0]}"
 
 function is_cygwin_or_mingw()
 {
-    case $(uname -s) in
-        CYGWIN*)    return 0;;
-        MINGW*)     return 0;;
-        *)          return 1;;
-    esac
+  case $(uname -s) in
+    CYGWIN*)    return 0;;
+    MINGW*)     return 0;;
+    *)          return 1;;
+  esac
 }
 
 # resolve $SOURCE until the file is no longer a symlink

--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,15 @@
 
 source="${BASH_SOURCE[0]}"
 
+function is_cygwin_or_mingw()
+{
+    case $(uname -s) in
+        CYGWIN*)    return 0;;
+        MINGW*)     return 0;;
+        *)          return 1;;
+    esac
+}
+
 # resolve $SOURCE until the file is no longer a symlink
 while [[ -h $source ]]; do
   scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
@@ -13,5 +22,14 @@ while [[ -h $source ]]; do
 done
 
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
-"$scriptroot/eng/build.sh" $@
+
+if is_cygwin_or_mingw; then
+  # if bash shell running on Windows (not WSL),
+  # pass control to powershell build script.
+  scriptroot=$(cygpath -d "$scriptroot")
+  powershell -c "$scriptroot\\build.cmd" $@
+else
+  "$scriptroot/eng/build.sh" $@
+fi
+
 exit $?


### PR DESCRIPTION
Convenience change to enable building corefx from bash shells running on windows (e.g. Cygwin, MinGW, git bash, but not WSL). This would let me save ~5 seconds of typing every time I want to build.