### PR TITLE
Normalize Linux and Windows X.509 Revocation Statuses

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Crypto.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Crypto.cs
@@ -80,6 +80,10 @@ internal static partial class Interop
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool PushX509StackField(SafeX509StackHandle stack, SafeX509Handle x509);
 
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_PushX509StackField")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool PushX509StackField(SafeSharedX509StackHandle stack, SafeX509Handle x509);
+
         internal static string GetX509RootStorePath()
         {
             return Marshal.PtrToStringAnsi(GetX509RootStorePath_private());

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OCSP.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OCSP.cs
@@ -35,13 +35,15 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_OcspResponseDestroy")]
         internal static extern void OcspResponseDestroy(IntPtr ocspReq);
 
-
         [DllImport(Libraries.CryptoNative)]
-        private static extern X509VerifyStatusCode CryptoNative_X509ChainGetCachedOcspStatus(SafeX509StoreCtxHandle ctx, string cachePath);
+        private static extern X509VerifyStatusCode CryptoNative_X509ChainGetCachedOcspStatus(
+            SafeX509StoreCtxHandle ctx,
+            string cachePath,
+            int chainDepth);
 
-        internal static X509VerifyStatusCode X509ChainGetCachedOcspStatus(SafeX509StoreCtxHandle ctx, string cachePath)
+        internal static X509VerifyStatusCode X509ChainGetCachedOcspStatus(SafeX509StoreCtxHandle ctx, string cachePath, int chainDepth)
         {
-            X509VerifyStatusCode response = CryptoNative_X509ChainGetCachedOcspStatus(ctx, cachePath);
+            X509VerifyStatusCode response = CryptoNative_X509ChainGetCachedOcspStatus(ctx, cachePath, chainDepth);
 
             if (response < 0)
             {
@@ -57,15 +59,17 @@ internal static partial class Interop
             SafeX509StoreCtxHandle ctx,
             SafeOcspRequestHandle req,
             SafeOcspResponseHandle resp,
-            string cachePath);
+            string cachePath,
+            int chainDepth);
 
         internal static X509VerifyStatusCode X509ChainVerifyOcsp(
             SafeX509StoreCtxHandle ctx,
             SafeOcspRequestHandle req,
             SafeOcspResponseHandle resp,
-            string cachePath)
+            string cachePath,
+            int chainDepth)
         {
-            X509VerifyStatusCode response = CryptoNative_X509ChainVerifyOcsp(ctx, req, resp, cachePath);
+            X509VerifyStatusCode response = CryptoNative_X509ChainVerifyOcsp(ctx, req, resp, cachePath, chainDepth);
 
             if (response < 0)
             {
@@ -77,11 +81,13 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.CryptoNative)]
-        private static extern SafeOcspRequestHandle CryptoNative_X509ChainBuildOcspRequest(SafeX509StoreCtxHandle storeCtx);
+        private static extern SafeOcspRequestHandle CryptoNative_X509ChainBuildOcspRequest(
+            SafeX509StoreCtxHandle storeCtx,
+            int chainDepth);
 
-        internal static SafeOcspRequestHandle X509ChainBuildOcspRequest(SafeX509StoreCtxHandle storeCtx)
+        internal static SafeOcspRequestHandle X509ChainBuildOcspRequest(SafeX509StoreCtxHandle storeCtx, int chainDepth)
         {
-            SafeOcspRequestHandle req = CryptoNative_X509ChainBuildOcspRequest(storeCtx);
+            SafeOcspRequestHandle req = CryptoNative_X509ChainBuildOcspRequest(storeCtx, chainDepth);
 
             if (req.IsInvalid)
             {

--- a/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -563,6 +563,8 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     FALLBACK_FUNCTION(X509_up_ref) \
     REQUIRED_FUNCTION(X509_verify_cert) \
     REQUIRED_FUNCTION(X509_verify_cert_error_string) \
+    REQUIRED_FUNCTION(X509_VERIFY_PARAM_clear_flags) \
+    REQUIRED_FUNCTION(X509_VERIFY_PARAM_get_flags) \
     REQUIRED_FUNCTION(X509_VERIFY_PARAM_set_time) \
     LIGHTUP_FUNCTION(EC_GF2m_simple_method) \
     LIGHTUP_FUNCTION(EC_GROUP_get_curve_GF2m) \
@@ -956,6 +958,8 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define X509_up_ref X509_up_ref_ptr
 #define X509_verify_cert X509_verify_cert_ptr
 #define X509_verify_cert_error_string X509_verify_cert_error_string_ptr
+#define X509_VERIFY_PARAM_clear_flags X509_VERIFY_PARAM_clear_flags_ptr
+#define X509_VERIFY_PARAM_get_flags X509_VERIFY_PARAM_get_flags_ptr
 #define X509_VERIFY_PARAM_set_time X509_VERIFY_PARAM_set_time_ptr
 #define EC_GF2m_simple_method EC_GF2m_simple_method_ptr
 #define EC_GROUP_get_curve_GF2m EC_GROUP_get_curve_GF2m_ptr

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.c
@@ -841,7 +841,7 @@ static X509VerifyStatusCode CheckOcsp(OCSP_REQUEST* req,
     if (basicResp != NULL)
     {
         X509_STORE* store = X509_STORE_CTX_get0_store(storeCtx);
-        X509_VERIFY_PARAM* param = store->param;
+        X509_VERIFY_PARAM* param = X509_STORE_get0_param(store);
         unsigned long currentFlags = X509_VERIFY_PARAM_get_flags(param);
         // Reset the flags so the OCSP_basic_verify doesn't do a CRL lookup
         X509_VERIFY_PARAM_clear_flags(param, currentFlags);

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.c
@@ -841,6 +841,10 @@ static X509VerifyStatusCode CheckOcsp(OCSP_REQUEST* req,
     if (basicResp != NULL)
     {
         X509_STORE* store = X509_STORE_CTX_get0_store(storeCtx);
+        X509_VERIFY_PARAM* param = store->param;
+        unsigned long currentFlags = X509_VERIFY_PARAM_get_flags(param);
+        // Reset the flags so the OCSP_basic_verify doesn't do a CRL lookup
+        X509_VERIFY_PARAM_clear_flags(param, currentFlags);
         X509Stack* untrusted = X509_STORE_CTX_get0_untrusted(storeCtx);
 
         // From the documentation:
@@ -858,7 +862,7 @@ static X509VerifyStatusCode CheckOcsp(OCSP_REQUEST* req,
             nonceCheck = 1;
         }
 
-        if (nonceCheck == 1 && OCSP_basic_verify(basicResp, untrusted, store, 0))
+        if (nonceCheck == 1 && OCSP_basic_verify(basicResp, untrusted, store, OCSP_TRUSTOTHER))
         {
             ASN1_GENERALIZEDTIME* thisupd = NULL;
             ASN1_GENERALIZEDTIME* nextupd = NULL;
@@ -886,6 +890,9 @@ static X509VerifyStatusCode CheckOcsp(OCSP_REQUEST* req,
             }
         }
 
+        // Restore the flags
+        X509_STORE_set_flags(store, currentFlags);
+
         OCSP_BASICRESP_free(basicResp);
         basicResp = NULL;
     }
@@ -894,7 +901,7 @@ static X509VerifyStatusCode CheckOcsp(OCSP_REQUEST* req,
     return ret;
 }
 
-static int Get0CertAndIssuer(X509_STORE_CTX* storeCtx, X509** subject, X509** issuer)
+static int Get0CertAndIssuer(X509_STORE_CTX* storeCtx, int chainDepth, X509** subject, X509** issuer)
 {
     assert(storeCtx != NULL);
     assert(subject != NULL);
@@ -904,13 +911,13 @@ static int Get0CertAndIssuer(X509_STORE_CTX* storeCtx, X509** subject, X509** is
     X509Stack* chain = X509_STORE_CTX_get0_chain(storeCtx);
     int chainSize = chain == NULL ? 0 : sk_X509_num(chain);
 
-    if (chainSize < 1)
+    if (chainSize <= chainDepth)
     {
         return 0;
     }
 
-    *subject = sk_X509_value(chain, 0);
-    *issuer = sk_X509_value(chain, chainSize == 1 ? 0 : 1);
+    *subject = sk_X509_value(chain, chainDepth);
+    *issuer = sk_X509_value(chain, chainSize == chainDepth + 1 ? chainDepth : chainDepth + 1);
     return 1;
 }
 
@@ -924,7 +931,7 @@ static time_t GetIssuanceWindowStart()
     return t;
 }
 
-X509VerifyStatusCode CryptoNative_X509ChainGetCachedOcspStatus(X509_STORE_CTX* storeCtx, char* cachePath)
+X509VerifyStatusCode CryptoNative_X509ChainGetCachedOcspStatus(X509_STORE_CTX* storeCtx, char* cachePath, int chainDepth)
 {
     if (storeCtx == NULL || cachePath == NULL)
     {
@@ -934,7 +941,7 @@ X509VerifyStatusCode CryptoNative_X509ChainGetCachedOcspStatus(X509_STORE_CTX* s
     X509* subject;
     X509* issuer;
 
-    if (!Get0CertAndIssuer(storeCtx, &subject, &issuer))
+    if (!Get0CertAndIssuer(storeCtx, chainDepth, &subject, &issuer))
     {
         return (X509VerifyStatusCode)-2;
     }
@@ -1009,7 +1016,7 @@ X509VerifyStatusCode CryptoNative_X509ChainGetCachedOcspStatus(X509_STORE_CTX* s
     return ret;
 }
 
-OCSP_REQUEST* CryptoNative_X509ChainBuildOcspRequest(X509_STORE_CTX* storeCtx)
+OCSP_REQUEST* CryptoNative_X509ChainBuildOcspRequest(X509_STORE_CTX* storeCtx, int chainDepth)
 {
     if (storeCtx == NULL)
     {
@@ -1019,7 +1026,7 @@ OCSP_REQUEST* CryptoNative_X509ChainBuildOcspRequest(X509_STORE_CTX* storeCtx)
     X509* subject;
     X509* issuer;
 
-    if (!Get0CertAndIssuer(storeCtx, &subject, &issuer))
+    if (!Get0CertAndIssuer(storeCtx, chainDepth, &subject, &issuer))
     {
         return NULL;
     }
@@ -1055,7 +1062,7 @@ OCSP_REQUEST* CryptoNative_X509ChainBuildOcspRequest(X509_STORE_CTX* storeCtx)
 }
 
 X509VerifyStatusCode
-CryptoNative_X509ChainVerifyOcsp(X509_STORE_CTX* storeCtx, OCSP_REQUEST* req, OCSP_RESPONSE* resp, char* cachePath)
+CryptoNative_X509ChainVerifyOcsp(X509_STORE_CTX* storeCtx, OCSP_REQUEST* req, OCSP_RESPONSE* resp, char* cachePath, int chainDepth)
 {
     if (storeCtx == NULL || req == NULL || resp == NULL)
     {
@@ -1065,7 +1072,7 @@ CryptoNative_X509ChainVerifyOcsp(X509_STORE_CTX* storeCtx, OCSP_REQUEST* req, OC
     X509* subject;
     X509* issuer;
 
-    if (!Get0CertAndIssuer(storeCtx, &subject, &issuer))
+    if (!Get0CertAndIssuer(storeCtx, chainDepth, &subject, &issuer))
     {
         return (X509VerifyStatusCode)-2;
     }

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.h
@@ -354,13 +354,13 @@ DLLEXPORT int32_t CryptoNative_X509StoreCtxResetForSignatureError(X509_STORE_CTX
 Look for a cached OCSP response appropriate to the end-entity certificate using the issuer as
 determined by the chain in storeCtx.
 */
-DLLEXPORT X509VerifyStatusCode CryptoNative_X509ChainGetCachedOcspStatus(X509_STORE_CTX* storeCtx, char* cachePath);
+DLLEXPORT X509VerifyStatusCode CryptoNative_X509ChainGetCachedOcspStatus(X509_STORE_CTX* storeCtx, char* cachePath, int chainDepth);
 
 /*
 Build an OCSP request appropriate for the end-entity certificate using the issuer (and trust) as
 determined by the chain in storeCtx.
 */
-DLLEXPORT OCSP_REQUEST* CryptoNative_X509ChainBuildOcspRequest(X509_STORE_CTX* storeCtx);
+DLLEXPORT OCSP_REQUEST* CryptoNative_X509ChainBuildOcspRequest(X509_STORE_CTX* storeCtx, int chainDepth);
 
 /*
 Determine if the OCSP response is acceptable, and if acceptable report the status and
@@ -369,4 +369,5 @@ cache the result (if appropriate)
 DLLEXPORT X509VerifyStatusCode CryptoNative_X509ChainVerifyOcsp(X509_STORE_CTX* storeCtx,
                                                                 OCSP_REQUEST* req,
                                                                 OCSP_RESPONSE* resp,
-                                                                char* cachePath);
+                                                                char* cachePath,
+                                                                int chainDepth);

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CertificateAssetDownloader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CertificateAssetDownloader.cs
@@ -100,12 +100,14 @@ namespace Internal.Cryptography.Pal
         {
             if (s_downloadBytes != null && remainingDownloadTime > TimeSpan.Zero)
             {
+                long totalMillis = (long)remainingDownloadTime.TotalMilliseconds;
                 Stopwatch stopwatch = Stopwatch.StartNew();
+
                 try
                 {
                     Task<byte[]> task = s_downloadBytes(uri);
 
-                    if (task.Wait(remainingDownloadTime))
+                    if (totalMillis > int.MaxValue || task.Wait((int)totalMillis))
                     {
                         return task.GetAwaiter().GetResult();
                     }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ChainPal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ChainPal.cs
@@ -85,19 +85,16 @@ namespace Internal.Cryptography.Pal
                 }
             }
 
-            if (revocationMode == X509RevocationMode.Online &&
-                status != Interop.Crypto.X509VerifyStatusCode.X509_V_OK)
-            {
-                revocationMode = X509RevocationMode.Offline;
-            }
-
             // In NoCheck+OK then we don't need to build the chain any more, we already
             // know it's error-free.  So skip straight to finish.
             if (status != Interop.Crypto.X509VerifyStatusCode.X509_V_OK ||
                 revocationMode != X509RevocationMode.NoCheck)
             {
-                chainPal.CommitToChain();
-                chainPal.ProcessRevocation(revocationMode, revocationFlag);
+                if (OpenSslX509ChainProcessor.IsCompleteChain(status))
+                {
+                    chainPal.CommitToChain();
+                    chainPal.ProcessRevocation(revocationMode, revocationFlag);
+                }
             }
 
             chainPal.Finish(applicationPolicy, certificatePolicy);

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ChainVerifier.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ChainVerifier.cs
@@ -63,6 +63,11 @@ namespace Internal.Cryptography.Pal
                         suppressionFlag = X509VerificationFlags.IgnoreCertificateAuthorityRevocationUnknown;
                     }
                 }
+                else if (status.Status == X509ChainStatusFlags.OfflineRevocation)
+                {
+                    // This is mainly a warning code, it's redundant to RevocationStatusUnknown
+                    continue;
+                }
                 else
                 {
                     suppressionFlag = GetSuppressionFlag(status.Status);

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
@@ -373,13 +373,9 @@ namespace Internal.Cryptography.Pal
 
             // If anything is wrong, move see if we need to try OCSP,
             // or clearing an unwanted root revocation flag.
-            if (Interop.Crypto.X509StoreCtxGetError(_storeCtx) !=
-                Interop.Crypto.X509VerifyStatusCode.X509_V_OK)
+            if (Interop.Crypto.X509StoreCtxGetError(_storeCtx) != Interop.Crypto.X509VerifyStatusCode.X509_V_OK)
             {
-                FinishRevocation(
-                    revocationMode,
-                    revocationFlag,
-                    chainSize);
+                FinishRevocation(revocationMode, revocationFlag, chainSize);
             }
         }
 
@@ -607,13 +603,9 @@ namespace Internal.Cryptography.Pal
 
             // If the chain had any errors during the previous build we need to walk it again with
             // the error collector running.
-            if (Interop.Crypto.X509StoreCtxGetError(_storeCtx) !=
-                Interop.Crypto.X509VerifyStatusCode.X509_V_OK)
+            if (Interop.Crypto.X509StoreCtxGetError(_storeCtx) != Interop.Crypto.X509VerifyStatusCode.X509_V_OK)
             {
-                if (workingChain == null)
-                {
-                    workingChain = _workingChain = BuildWorkingChain();
-                }
+                workingChain ??= BuildWorkingChain();
             }
 
             X509ChainElement[] elements = BuildChainElements(
@@ -1264,20 +1256,6 @@ namespace Internal.Cryptography.Pal
                                 ArrayPool<ErrorCollection>.Shared.Return(toReturn);
                             }
 
-                            //if (MapVerifyErrorToChainStatus(errorCode) == X509ChainStatusFlags.RevocationStatusUnknown)
-                            //{
-                            //    LastUnknownRevocation = Math.Max(LastUnknownRevocation, errorDepth);
-                            //}
-                            //else if (errorCode == Interop.Crypto.X509VerifyStatusCode.X509_V_ERR_CERT_REVOKED)
-                            //{
-                            //    LastRevoked = Math.Max(LastUnknownRevocation, errorDepth);
-                            //}
-                            //else if (errorCode == Interop.Crypto.X509VerifyStatusCode.X509_V_ERR_CRL_HAS_EXPIRED)
-                            //{
-                            //    // Co-assert no CRL with CRL expired.
-                            //    _errors[errorDepth].Add(Interop.Crypto.X509VerifyStatusCode.X509_V_ERR_UNABLE_TO_GET_CRL);
-                            //}
-
                             LastError = Math.Max(errorDepth, LastError);
                             _errors[errorDepth].Add(errorCode);
                         }
@@ -1322,7 +1300,6 @@ namespace Internal.Cryptography.Pal
                 int bucket = FindBucket(statusCode, out int bitValue);
                 return (_codes[bucket] & bitValue) != 0;
             }
-
 
             internal void ClearRevoked()
             {

--- a/src/System.Security.Cryptography.X509Certificates/tests/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.X509Certificates/tests/Resources/Strings.resx
@@ -63,4 +63,94 @@
   <data name="Cryptography_Unmapped_System_Typed_Error" xml:space="preserve">
     <value>The system cryptographic library returned error '{0}' of type '{1}'</value>
   </data>
+  <data name="Argument_EncodeDestinationTooSmall" xml:space="preserve">
+    <value>The destination is too small to hold the encoded value.</value>
+  </data>
+  <data name="Argument_InvalidOidValue" xml:space="preserve">
+    <value>The OID value was invalid.</value>
+  </data>
+  <data name="Cryptography_Asn_EnumeratedValueRequiresNonFlagsEnum" xml:space="preserve">
+    <value>ASN.1 Enumerated values only apply to enum types without the [Flags] attribute.</value>
+  </data>
+  <data name="Cryptography_Asn_NamedBitListRequiresFlagsEnum" xml:space="preserve">
+    <value>Named bit list operations require an enum with the [Flags] attribute.</value>
+  </data>
+  <data name="Cryptography_Asn_NamedBitListValueTooBig" xml:space="preserve">
+    <value>The encoded named bit list value is larger than the value size of the '{0}' enum.</value>
+  </data>
+  <data name="Cryptography_Asn_UniversalValueIsFixed" xml:space="preserve">
+    <value>Tags with TagClass Universal must have the appropriate TagValue value for the data type being read or written.</value>
+  </data>
+  <data name="Cryptography_Asn_UnusedBitCountRange" xml:space="preserve">
+    <value>Unused bit count must be between 0 and 7, inclusive.</value>
+  </data>
+  <data name="Cryptography_AsnSerializer_AmbiguousFieldType" xml:space="preserve">
+    <value>Field '{0}' of type '{1}' has ambiguous type '{2}', an attribute derived from AsnTypeAttribute is required.</value>
+  </data>
+  <data name="Cryptography_AsnSerializer_Choice_AllowNullNonNullable" xml:space="preserve">
+    <value>[Choice].AllowNull=true is not valid because type '{0}' cannot have a null value.</value>
+  </data>
+  <data name="Cryptography_AsnSerializer_Choice_ConflictingTagMapping" xml:space="preserve">
+    <value>The tag ({0} {1}) for field '{2}' on type '{3}' already is associated in this context with field '{4}' on type '{5}'.</value>
+  </data>
+  <data name="Cryptography_AsnSerializer_Choice_DefaultValueDisallowed" xml:space="preserve">
+    <value>Field '{0}' on [Choice] type '{1}' has a default value, which is not permitted.</value>
+  </data>
+  <data name="Cryptography_AsnSerializer_Choice_NoChoiceWasMade" xml:space="preserve">
+    <value>An instance of [Choice] type '{0}' has no non-null fields.</value>
+  </data>
+  <data name="Cryptography_AsnSerializer_Choice_NonNullableField" xml:space="preserve">
+    <value>Field '{0}' on [Choice] type '{1}' can not be assigned a null value.</value>
+  </data>
+  <data name="Cryptography_AsnSerializer_Choice_TooManyValues" xml:space="preserve">
+    <value>Fields '{0}' and '{1}' on type '{2}' are both non-null when only one value is permitted.</value>
+  </data>
+  <data name="Cryptography_AsnSerializer_Choice_TypeCycle" xml:space="preserve">
+    <value>Field '{0}' on [Choice] type '{1}' has introduced a type chain cycle.</value>
+  </data>
+  <data name="Cryptography_AsnSerializer_MultipleAsnTypeAttributes" xml:space="preserve">
+    <value>Field '{0}' on type '{1}' has multiple attributes deriving from '{2}' when at most one is permitted.</value>
+  </data>
+  <data name="Cryptography_AsnSerializer_NoJaggedArrays" xml:space="preserve">
+    <value>Type '{0}' cannot be serialized or deserialized because it is an array of arrays.</value>
+  </data>
+  <data name="Cryptography_AsnSerializer_NoMultiDimensionalArrays" xml:space="preserve">
+    <value>Type '{0}' cannot be serialized or deserialized because it is a multi-dimensional array.</value>
+  </data>
+  <data name="Cryptography_AsnSerializer_NoOpenTypes" xml:space="preserve">
+    <value>Type '{0}' cannot be serialized or deserialized because it is not sealed or has unbound generic parameters.</value>
+  </data>
+  <data name="Cryptography_AsnSerializer_Optional_NonNullableField" xml:space="preserve">
+    <value>Field '{0}' on type '{1}' is declared [OptionalValue], but it can not be assigned a null value.</value>
+  </data>
+  <data name="Cryptography_AsnSerializer_SetValueException" xml:space="preserve">
+    <value>Unable to set field {0} on type {1}.</value>
+  </data>
+  <data name="Cryptography_AsnSerializer_SpecificTagChoice" xml:space="preserve">
+    <value>Field '{0}' on type '{1}' has specified an implicit tag value via [ExpectedTag] for [Choice] type '{2}'. ExplicitTag must be true, or the [ExpectedTag] attribute removed.</value>
+  </data>
+  <data name="Cryptography_AsnSerializer_UnexpectedTypeForAttribute" xml:space="preserve">
+    <value>Field '{0}' of type '{1}' has an effective type of '{2}' when one of ({3}) was expected.</value>
+  </data>
+  <data name="Cryptography_AsnSerializer_UtcTimeTwoDigitYearMaxTooSmall" xml:space="preserve">
+    <value>Field '{0}' on type '{1}' has a [UtcTime] TwoDigitYearMax value ({2}) smaller than the minimum (99).</value>
+  </data>
+  <data name="Cryptography_AsnSerializer_UnhandledType" xml:space="preserve">
+    <value>Could not determine how to serialize or deserialize type '{0}'.</value>
+  </data>
+  <data name="Cryptography_AsnWriter_EncodeUnbalancedStack" xml:space="preserve">
+    <value>Encode cannot be called while a Sequence or SetOf is still open.</value>
+  </data>
+  <data name="Cryptography_AsnWriter_PopWrongTag" xml:space="preserve">
+    <value>Cannot pop the requested tag as it is not currently in progress.</value>
+  </data>
+  <data name="Cryptography_Der_Invalid_Encoding" xml:space="preserve">
+    <value>ASN1 corrupted data.</value>
+  </data>
+  <data name="Cryptography_Invalid_IA5String" xml:space="preserve">
+    <value>The string contains a character not in the 7 bit ASCII character set.</value>
+  </data>
+  <data name="Cryptography_WriteEncodedValue_OneValueAtATime" xml:space="preserve">
+    <value>The input to WriteEncodedValue must represent a single encoded value with no trailing data.</value>
+  </data>
 </root>

--- a/src/System.Security.Cryptography.X509Certificates/tests/RevocationTests/CertificateAuthority.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/RevocationTests/CertificateAuthority.cs
@@ -301,7 +301,14 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
                     writer.WriteEncodedValue(signatureAlgId);
 
                     // issuer
-                    writer.WriteEncodedValue(_cert.SubjectName.RawData);
+                    if (CorruptRevocationIssuerName)
+                    {
+                        writer.WriteEncodedValue(s_nonParticipatingName.RawData);
+                    }
+                    else
+                    {
+                        writer.WriteEncodedValue(_cert.SubjectName.RawData);
+                    }
 
                     if (RevocationExpiration.HasValue)
                     {
@@ -462,7 +469,15 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
 
                     writer.PushSequence(s_context1);
                     {
-                        writer.WriteEncodedValue(responder.SubjectName.RawData);
+                        if (CorruptRevocationIssuerName)
+                        {
+                            writer.WriteEncodedValue(s_nonParticipatingName.RawData);
+                        }
+                        else
+                        {
+                            writer.WriteEncodedValue(responder.SubjectName.RawData);
+                        }
+
                         writer.PopSequence(s_context1);
                     }
 

--- a/src/System.Security.Cryptography.X509Certificates/tests/RevocationTests/CertificateAuthority.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/RevocationTests/CertificateAuthority.cs
@@ -1,0 +1,536 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using System.Security.Cryptography.Asn1;
+
+namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
+{
+    // This class represents only a portion of what is required to be a proper Certificate Authority.
+    //
+    // Please do not use it as the basis for any real Public/Private Key Infrastructure (PKI) system
+    // without understanding all of the portions of proper CA management that you're skipping.
+    //
+    // At minimum, read the current baseline requirements of the CA/Browser Forum.
+    internal sealed class CertificateAuthority : IDisposable
+    {
+        private static readonly Asn1Tag s_context0 = new Asn1Tag(TagClass.ContextSpecific, 0);
+        private static readonly Asn1Tag s_context1 = new Asn1Tag(TagClass.ContextSpecific, 1);
+        private static readonly Asn1Tag s_context2 = new Asn1Tag(TagClass.ContextSpecific, 2);
+        private static readonly Asn1Tag s_context4 = new Asn1Tag(TagClass.ContextSpecific, 4);
+
+        private static readonly X509BasicConstraintsExtension s_eeConstraints =
+            new X509BasicConstraintsExtension(false, false, 0, false);
+
+        private static readonly X509KeyUsageExtension s_caKeyUsage =
+            new X509KeyUsageExtension(
+                X509KeyUsageFlags.KeyCertSign | X509KeyUsageFlags.CrlSign,
+                critical: false);
+
+        private static readonly X509KeyUsageExtension s_eeKeyUsage =
+            new X509KeyUsageExtension(
+                X509KeyUsageFlags.DigitalSignature,
+                critical: false);
+
+        private static readonly X509EnhancedKeyUsageExtension s_ocspResponderEku =
+            new X509EnhancedKeyUsageExtension(
+                new OidCollection()
+                {
+                    new Oid("1.3.6.1.5.5.7.3.9", null),
+                },
+                critical: false);
+
+        private readonly X509Certificate2 _cert;
+        private X509Extension _cdpExtension;
+        private X509Extension _aiaExtension;
+        private X509Extension _akidExtension;
+
+        private byte[] _crl;
+
+        internal string CdpUri { get; }
+        internal string OcspUri { get; }
+
+        internal CertificateAuthority(X509Certificate2 cert, string cdpUrl, string ocspUrl)
+        {
+            _cert = cert;
+            CdpUri = cdpUrl;
+            OcspUri = ocspUrl;
+        }
+
+        public void Dispose()
+        {
+            _cert.Dispose();
+        }
+
+        internal object SubjectName => _cert.Subject;
+
+        internal X509Certificate2 CloneIssuerCert()
+        {
+            return new X509Certificate2(_cert.RawData);
+        }
+
+        internal X509Certificate2 CreateSubordinateCA(
+            string subject,
+            RSA publicKey,
+            int? depthLimit = null)
+        {
+            return CreateCertificate(
+                subject,
+                publicKey,
+                TimeSpan.FromMinutes(1),
+                new X509BasicConstraintsExtension(
+                    certificateAuthority: true,
+                    depthLimit.HasValue,
+                    depthLimit.GetValueOrDefault(),
+                    critical: true),
+                s_caKeyUsage,
+                ekuExtension: null);
+        }
+
+        internal X509Certificate2 CreateEndEntity(string subject, RSA publicKey)
+        {
+            return CreateCertificate(
+                subject,
+                publicKey,
+                TimeSpan.FromSeconds(2),
+                s_eeConstraints,
+                s_eeKeyUsage,
+                ekuExtension: null);
+        }
+
+        internal X509Certificate2 CreateOcspSigner(string subject, RSA publicKey)
+        {
+            return CreateCertificate(
+                subject,
+                publicKey,
+                TimeSpan.FromSeconds(1),
+                s_eeConstraints,
+                s_eeKeyUsage,
+                s_ocspResponderEku);
+        }
+
+        private X509Certificate2 CreateCertificate(
+            string subject,
+            RSA publicKey,
+            TimeSpan nestingBuffer,
+            X509BasicConstraintsExtension basicConstraints,
+            X509KeyUsageExtension keyUsage,
+            X509EnhancedKeyUsageExtension ekuExtension)
+        {
+            if (_cdpExtension == null && CdpUri != null)
+            {
+                _cdpExtension = CreateCdpExtension(CdpUri);
+            }
+
+            if (_aiaExtension == null && OcspUri != null)
+            {
+                _aiaExtension = CreateAiaExtension(OcspUri);
+            }
+
+            if (_akidExtension == null)
+            {
+                _akidExtension = CreateAkidExtension();
+            }
+
+            CertificateRequest request = new CertificateRequest(
+                subject,
+                publicKey,
+                HashAlgorithmName.SHA256,
+                RSASignaturePadding.Pkcs1);
+
+            request.CertificateExtensions.Add(basicConstraints);
+            request.CertificateExtensions.Add(keyUsage);
+            request.CertificateExtensions.Add(_cdpExtension);
+            request.CertificateExtensions.Add(_aiaExtension);
+            request.CertificateExtensions.Add(_akidExtension);
+            request.CertificateExtensions.Add(
+                new X509SubjectKeyIdentifierExtension(request.PublicKey, false));
+
+            if (ekuExtension != null)
+            {
+                request.CertificateExtensions.Add(ekuExtension);
+            }
+
+            byte[] serial = new byte[sizeof(long)];
+            RandomNumberGenerator.Fill(serial);
+
+            return request.Create(
+                _cert,
+                _cert.NotBefore.Add(nestingBuffer),
+                _cert.NotAfter.Subtract(nestingBuffer),
+                serial);
+        }
+
+        internal byte[] GetCrl()
+        {
+            byte[] crl = _crl;
+
+            if (crl != null)
+            {
+                return crl;
+            }
+
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.DER))
+            {
+                writer.PushSequence();
+                {
+                    writer.WriteObjectIdentifier("1.2.840.113549.1.1.11");
+                    writer.WriteNull();
+
+                    writer.PopSequence();
+                }
+
+                byte[] signatureAlgId = writer.Encode();
+                writer.Reset();
+
+                // TBSCertList
+                writer.PushSequence();
+                {
+                    // version v2(1)
+                    writer.WriteInteger(1);
+
+                    // signature (AlgorithmIdentifier)
+                    writer.WriteEncodedValue(signatureAlgId);
+
+                    // issuer
+                    writer.WriteEncodedValue(_cert.SubjectName.RawData);
+
+                    // thisUpdate
+                    writer.WriteUtcTime(DateTimeOffset.UtcNow);
+
+                    // nextUpdate (skip)
+                    // writer.WriteUtcTime(issuer.NotAfter.AddSeconds(-1));
+
+                    // revokedCertificates (none, don't write down)
+
+                    // extensions [0] EXPLICIT Extensions
+                    writer.PushSequence(s_context0);
+                    {
+                        // Extensions (SEQUENCE OF)
+                        writer.PushSequence();
+                        {
+                            if (_akidExtension == null)
+                            {
+                                _akidExtension = CreateAkidExtension();
+                            }
+
+                            // Authority Key Identifier Extension
+                            writer.PushSequence();
+                            {
+                                writer.WriteObjectIdentifier(_akidExtension.Oid.Value);
+
+                                if (_akidExtension.Critical)
+                                {
+                                    writer.WriteBoolean(true);
+                                }
+
+                                writer.WriteOctetString(_akidExtension.RawData);
+                                writer.PopSequence();
+                            }
+
+                            // CRL Number Extension
+                            writer.PushSequence();
+                            {
+                                writer.WriteObjectIdentifier("2.5.29.20");
+
+                                using (AsnWriter nested = new AsnWriter(AsnEncodingRules.DER))
+                                {
+                                    nested.WriteInteger(0);
+                                    writer.WriteOctetString(nested.Encode());
+                                }
+
+                                writer.PopSequence();
+                            }
+
+                            writer.PopSequence();
+                        }
+
+                        writer.PopSequence(s_context0);
+                    }
+
+                    writer.PopSequence();
+                }
+
+                byte[] tbsCertList = writer.Encode();
+                writer.Reset();
+
+                byte[] signature;
+
+                using (RSA key = _cert.GetRSAPrivateKey())
+                {
+                    signature =
+                        key.SignData(tbsCertList, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+                }
+
+                // CertificateList
+                writer.PushSequence();
+                {
+                    writer.WriteEncodedValue(tbsCertList);
+                    writer.WriteEncodedValue(signatureAlgId);
+                    writer.WriteBitString(signature);
+
+                    writer.PopSequence();
+                }
+
+                _crl = writer.Encode();
+            }
+
+            return _crl;
+        }
+
+        internal byte[] BuildOcspResponse(
+            ReadOnlyMemory<byte> certId,
+            ReadOnlyMemory<byte> nonceExtension)
+        {
+            Asn1Tag context0 = new Asn1Tag(TagClass.ContextSpecific, 0);
+            Asn1Tag context1 = new Asn1Tag(TagClass.ContextSpecific, 1);
+            DateTimeOffset now = DateTimeOffset.UtcNow;
+
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.DER))
+            {
+                /*
+                 
+   ResponseData ::= SEQUENCE {
+      version              [0] EXPLICIT Version DEFAULT v1,
+      responderID              ResponderID,
+      producedAt               GeneralizedTime,
+      responses                SEQUENCE OF SingleResponse,
+      responseExtensions   [1] EXPLICIT Extensions OPTIONAL }
+                 */
+                writer.PushSequence();
+                {
+                    // Skip version (v1)
+
+                    /*
+   ResponderID ::= CHOICE {
+      byName               [1] Name,
+      byKey                [2] KeyHash }
+                     */
+
+                    writer.PushSequence(context1);
+                    {
+                        writer.WriteEncodedValue(_cert.SubjectName.RawData);
+                        writer.PopSequence(context1);
+                    }
+
+                    writer.WriteGeneralizedTime(now);
+
+                    writer.PushSequence();
+                    {
+                        /*
+   SingleResponse ::= SEQUENCE {
+      certID                       CertID,
+      certStatus                   CertStatus,
+      thisUpdate                   GeneralizedTime,
+      nextUpdate         [0]       EXPLICIT GeneralizedTime OPTIONAL,
+      singleExtensions   [1]       EXPLICIT Extensions OPTIONAL }
+                         */
+                        writer.PushSequence();
+                        {
+                            writer.WriteEncodedValue(certId.Span);
+                            writer.WriteNull(context0);
+                            writer.WriteGeneralizedTime(now, omitFractionalSeconds: true);
+
+                            writer.PopSequence();
+                        }
+
+                        writer.PopSequence();
+                    }
+
+                    if (!nonceExtension.IsEmpty)
+                    {
+                        writer.PushSequence(context1);
+                        {
+                            writer.PushSequence();
+                            writer.WriteEncodedValue(nonceExtension.Span);
+                            writer.PopSequence();
+                            writer.PopSequence(context1);
+                        }
+                    }
+
+                    writer.PopSequence();
+                }
+
+                byte[] tbsResponseData = writer.Encode();
+                writer.Reset();
+
+                /*
+                    BasicOCSPResponse       ::= SEQUENCE {
+      tbsResponseData      ResponseData,
+      signatureAlgorithm   AlgorithmIdentifier,
+      signature            BIT STRING,
+      certs            [0] EXPLICIT SEQUENCE OF Certificate OPTIONAL }
+                 */
+                writer.PushSequence();
+                {
+                    writer.WriteEncodedValue(tbsResponseData);
+                    writer.PushSequence();
+                    writer.WriteObjectIdentifier("1.2.840.113549.1.1.11");
+                    writer.WriteNull();
+                    writer.PopSequence();
+
+                    using (RSA rsa = _cert.GetRSAPrivateKey())
+                    {
+                        writer.WriteBitString(
+                            rsa.SignData(
+                                tbsResponseData,
+                                HashAlgorithmName.SHA256,
+                                RSASignaturePadding.Pkcs1));
+                    }
+
+                    writer.PopSequence();
+                }
+
+                byte[] responseBytes = writer.Encode();
+                writer.Reset();
+
+                writer.PushSequence();
+                {
+                    writer.WriteEnumeratedValue(OcspResponseStatus.Successful);
+
+                    writer.PushSequence(context0);
+                    {
+                        writer.PushSequence();
+                        {
+                            writer.WriteObjectIdentifier("1.3.6.1.5.5.7.48.1.1");
+                            writer.WriteOctetString(responseBytes);
+                            writer.PopSequence();
+                        }
+
+                        writer.PopSequence(context0);
+                    }
+
+                    writer.PopSequence();
+                }
+
+                return writer.Encode();
+            }
+        }
+
+        private static X509Extension CreateAiaExtension(string ocspStem)
+        {
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.DER))
+            {
+                // AuthorityInfoAccessSyntax (SEQUENCE OF)
+                writer.PushSequence();
+                {
+                    // AccessDescription
+                    writer.PushSequence();
+                    {
+                        writer.WriteObjectIdentifier("1.3.6.1.5.5.7.48.1");
+                        writer.WriteCharacterString(
+                            new Asn1Tag(TagClass.ContextSpecific, 6),
+                            UniversalTagNumber.IA5String,
+                            ocspStem);
+
+                        writer.PopSequence();
+                    }
+
+                    writer.PopSequence();
+                }
+
+                return new X509Extension("1.3.6.1.5.5.7.1.1", writer.Encode(), false);
+            }
+        }
+
+        private static X509Extension CreateCdpExtension(string cdp)
+        {
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.DER))
+            {
+                // SEQUENCE OF
+                writer.PushSequence();
+                {
+                    // DistributionPoint
+                    writer.PushSequence();
+                    {
+                        // Because DistributionPointName is a CHOICE type this tag is explicit.
+                        // (ITU-T REC X.680-201508 C.3.2.2(g)(3rd bullet))
+                        // distributionPoint [0] DistributionPointName
+                        writer.PushSequence(s_context0);
+                        {
+                            // [0] DistributionPointName (GeneralNames (SEQUENCE OF))
+                            writer.PushSequence(s_context0);
+                            {
+                                // GeneralName ([6]  IA5String)
+                                writer.WriteCharacterString(
+                                    new Asn1Tag(TagClass.ContextSpecific, 6),
+                                    UniversalTagNumber.IA5String,
+                                    cdp);
+
+                                writer.PopSequence(s_context0);
+                            }
+
+                            writer.PopSequence(s_context0);
+                        }
+
+                        writer.PopSequence();
+                    }
+
+                    writer.PopSequence();
+                }
+
+                return new X509Extension("2.5.29.31", writer.Encode(), false);
+            }
+        }
+
+        private X509Extension CreateAkidExtension()
+        {
+            X509SubjectKeyIdentifierExtension skid =
+                _cert.Extensions.OfType<X509SubjectKeyIdentifierExtension>().SingleOrDefault();
+
+            using (AsnWriter writer = new AsnWriter(AsnEncodingRules.DER))
+            {
+                // AuthorityKeyIdentifier
+                writer.PushSequence();
+                {
+                    if (skid == null)
+                    {
+                        // authorityCertIssuer [1] GeneralNames (SEQUENCE OF)
+                        writer.PushSequence(s_context1);
+                        {
+                            // directoryName [4] Name
+                            byte[] dn = _cert.SubjectName.RawData;
+
+                            if (!s_context4.TryEncode(dn, out int written) || written != 1)
+                            {
+                                throw new InvalidOperationException();
+                            }
+
+                            writer.WriteEncodedValue(dn);
+                            writer.PopSequence(s_context1);
+                        }
+
+                        // authorityCertSerialNumber [2] CertificateSerialNumber (INTEGER)
+                        byte[] serial = _cert.GetSerialNumber();
+                        Array.Reverse(serial);
+                        writer.WriteInteger(s_context2, serial);
+                    }
+                    else
+                    {
+                        // keyIdentifier [0] KeyIdentifier (OCTET STRING)
+                        AsnReader reader = new AsnReader(skid.RawData, AsnEncodingRules.BER);
+                        ReadOnlyMemory<byte> contents;
+
+                        if (!reader.TryReadPrimitiveOctetStringBytes(out contents))
+                        {
+                            throw new InvalidOperationException();
+                        }
+
+                        reader.ThrowIfNotEmpty();
+                        writer.WriteOctetString(s_context0, contents.Span);
+                    }
+
+                    writer.PopSequence();
+                }
+
+                return new X509Extension("2.5.29.35", writer.Encode(), false);
+            }
+        }
+
+        private enum OcspResponseStatus
+        {
+            Successful,
+        }
+    }
+}

--- a/src/System.Security.Cryptography.X509Certificates/tests/RevocationTests/CertificateAuthority.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/RevocationTests/CertificateAuthority.cs
@@ -153,7 +153,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
                 ocspResponder: true);
         }
 
-
         internal void RebuildRootWithRevocation()
         {
             if (_cdpExtension == null && CdpUri != null)
@@ -639,6 +638,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
             reader.ThrowIfNotEmpty();
 
             AsnReader algIdReader = idReader.ReadSequence();
+
             if (algIdReader.ReadObjectIdentifierAsString() != "1.3.14.3.2.26")
             {
                 return CertStatus.Unknown;
@@ -708,6 +708,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
                     writer.PushSequence();
                     {
                         writer.WriteObjectIdentifier("1.3.6.1.5.5.7.48.1");
+
                         writer.WriteCharacterString(
                             new Asn1Tag(TagClass.ContextSpecific, 6),
                             UniversalTagNumber.IA5String,

--- a/src/System.Security.Cryptography.X509Certificates/tests/RevocationTests/DynamicRevocationTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/RevocationTests/DynamicRevocationTests.cs
@@ -1,0 +1,133 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using Xunit;
+
+namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
+{
+    public static class DynamicRevocationTests
+    {
+        [Fact]
+        public static void CrlCrlRevokeIntermediate()
+        {
+            BuildPrivatePki(
+                issuerRevocationViaCrl: true,
+                issuerRevocationViaOcsp: false,
+                endEntityRevocationViaCrl: true,
+                endEntityRevocationViaOcsp: false,
+                out RevocationResponder responder,
+                out CertificateAuthority root,
+                out CertificateAuthority intermediate,
+                out X509Certificate2 endEntity);
+
+            using (responder)
+            using (root)
+            using (intermediate)
+            using (endEntity)
+            using (ChainHolder holder = new ChainHolder())
+            {
+                X509Chain chain = holder.Chain;
+                chain.ChainPolicy.CustomTrustStore.Add(root.CloneIssuerCert());
+                chain.ChainPolicy.ExtraStore.Add(intermediate.CloneIssuerCert());
+                chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+                chain.ChainPolicy.VerificationTime = endEntity.NotBefore.AddMinutes(1);
+
+                bool chainBuilt = chain.Build(endEntity);
+                Assert.Equal(3, chain.ChainElements.Count);
+                Assert.Equal(X509ChainStatusFlags.NoError, chain.AllStatusFlags());
+                Assert.True(chainBuilt, "Chain built with nothing revoked.");
+            }
+        }
+
+        private static void BuildPrivatePki(
+            bool issuerRevocationViaCrl,
+            bool issuerRevocationViaOcsp,
+            bool endEntityRevocationViaCrl,
+            bool endEntityRevocationViaOcsp,
+            out RevocationResponder responder,
+            out CertificateAuthority rootAuthority,
+            out CertificateAuthority intermediateAuthority,
+            out X509Certificate2 endEntityCert,
+            bool registerAuthorities = true)
+        {
+            Assert.True(
+                issuerRevocationViaCrl || issuerRevocationViaOcsp ||
+                    endEntityRevocationViaCrl || endEntityRevocationViaOcsp,
+                "At least one revocation mode is enabled");
+
+            // All keys created in this method are smaller than recommended,
+            // but they only live for a few seconds (at most),
+            // and never communicate out of process.
+            const int KeySize = 1024;
+
+            using (RSA rootKey = RSA.Create(KeySize))
+            using (RSA intermedKey = RSA.Create(KeySize))
+            using (RSA eeKey = RSA.Create(KeySize))
+            {
+                var rootReq = new CertificateRequest(
+                    "CN=A Revocation Test Root",
+                    rootKey,
+                    HashAlgorithmName.SHA256,
+                    RSASignaturePadding.Pkcs1);
+
+                X509BasicConstraintsExtension caConstraints =
+                    new X509BasicConstraintsExtension(true, false, 0, true);
+
+                rootReq.CertificateExtensions.Add(caConstraints);
+                var rootSkid = new X509SubjectKeyIdentifierExtension(rootReq.PublicKey, false);
+                rootReq.CertificateExtensions.Add(
+                    rootSkid);
+
+                DateTimeOffset start = DateTimeOffset.UtcNow;
+                DateTimeOffset end = start.AddMonths(3);
+
+                // Don't dispose this, it's being transferred to the CertificateAuthority
+                X509Certificate2 rootCert = rootReq.CreateSelfSigned(start.AddDays(-2), end.AddDays(2));
+                responder = RevocationResponder.CreateAndListen();
+
+                string cdpUrl = $"{responder.UriPrefix}crl/{rootSkid.SubjectKeyIdentifier}.crl";
+                string ocspUrl = $"{responder.UriPrefix}ocsp/{rootSkid.SubjectKeyIdentifier}";
+
+                rootAuthority = new CertificateAuthority(
+                    rootCert,
+                    issuerRevocationViaCrl ? cdpUrl : null,
+                    issuerRevocationViaOcsp ? ocspUrl : null);
+
+                // Don't dispose this, it's being transferred to the CertificateAuthority
+                X509Certificate2 intermedCert;
+
+                {
+                    X509Certificate2 intermedPub = rootAuthority.CreateSubordinateCA(
+                        "CN=A Revocation Test CA",
+                        intermedKey);
+
+                    intermedCert = intermedPub.CopyWithPrivateKey(intermedKey);
+                    intermedPub.Dispose();
+                }
+
+                X509SubjectKeyIdentifierExtension intermedSkid =
+                    intermedCert.Extensions.OfType<X509SubjectKeyIdentifierExtension>().Single();
+
+                cdpUrl = $"{responder.UriPrefix}crl/{intermedSkid.SubjectKeyIdentifier}.crl";
+                ocspUrl = $"{responder.UriPrefix}ocsp/{intermedSkid.SubjectKeyIdentifier}";
+
+                intermediateAuthority = new CertificateAuthority(
+                    intermedCert,
+                    endEntityRevocationViaCrl ? cdpUrl : null,
+                    endEntityRevocationViaOcsp ? ocspUrl : null);
+
+                endEntityCert = intermediateAuthority.CreateEndEntity(
+                    "CN=A Revocation Test Cert",
+                    eeKey);
+            }
+
+            if (registerAuthorities)
+            {
+                responder.AddCertificateAuthority(rootAuthority);
+                responder.AddCertificateAuthority(intermediateAuthority);
+            }
+        }
+    }
+}

--- a/src/System.Security.Cryptography.X509Certificates/tests/RevocationTests/DynamicRevocationTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/RevocationTests/DynamicRevocationTests.cs
@@ -19,6 +19,11 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
         private static readonly X509ChainStatusFlags ThisOsRevocationStatusUnknown =
                 X509ChainStatusFlags.RevocationStatusUnknown | X509ChainStatusFlags.OfflineRevocation;
 
+        // RHEL6 uses a version of OpenSSL that (empirically) doesn't support designated responders.
+        // (There's a chance that we should be passing in extra stuff, but RHEL6 is the only platform
+        // still on OpenSSL 1.0.0/1.0.1 in 2019, so it seems OpenSSL-related)
+        private static readonly bool s_supportsDesignatedResponder = PlatformDetection.IsNotRedHatFamily6;
+
         [Flags]
         public enum PkiOptions
         {
@@ -49,7 +54,9 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
         {
             get
             {
-                for (int designation = 0; designation < 4; designation++)
+                int designationLimit = s_supportsDesignatedResponder ? 4 : 1;
+
+                for (int designation = 0; designation < designationLimit; designation++)
                 {
                     PkiOptions designationOptions = (PkiOptions)(designation << 16);
 

--- a/src/System.Security.Cryptography.X509Certificates/tests/RevocationTests/DynamicRevocationTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/RevocationTests/DynamicRevocationTests.cs
@@ -13,7 +13,9 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
     [ActiveIssue(41974, TestPlatforms.OSX)]
     public static class DynamicRevocationTests
     {
-        private static readonly TimeSpan s_urlRetrievalLimit = TimeSpan.FromSeconds(5);
+        // The CI machines are doing an awful lot of things at once, be generous with the timeout;
+        private static readonly TimeSpan s_urlRetrievalLimit = TimeSpan.FromSeconds(15);
+
         private static readonly Oid s_tlsServerOid = new Oid("1.3.6.1.5.5.7.3.1", null);
 
         private static readonly X509ChainStatusFlags ThisOsRevocationStatusUnknown =
@@ -22,11 +24,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
         // RHEL6 uses a version of OpenSSL that (empirically) doesn't support designated responders.
         // (There's a chance that we should be passing in extra stuff, but RHEL6 is the only platform
         // still on OpenSSL 1.0.0/1.0.1 in 2019, so it seems OpenSSL-related)
-        //
-        // Windows 7 seems to only support designated responders for the target certificate,
-        // rather than complicate the generator too much just don't run the desginated-responder tests there.
-        private static readonly bool s_supportsDesignatedResponder =
-            PlatformDetection.IsNotRedHatFamily6 && PlatformDetection.IsNotWindows7;
+        private static readonly bool s_supportsDesignatedResponder = PlatformDetection.IsNotRedHatFamily6;
 
         [Flags]
         public enum PkiOptions

--- a/src/System.Security.Cryptography.X509Certificates/tests/RevocationTests/DynamicRevocationTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/RevocationTests/DynamicRevocationTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
 {
+    [OuterLoop("These tests run serially at about 1 second each, and the code shouldn't change that often.")]
     [ActiveIssue(41974, TestPlatforms.OSX)]
     public static class DynamicRevocationTests
     {

--- a/src/System.Security.Cryptography.X509Certificates/tests/RevocationTests/DynamicRevocationTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/RevocationTests/DynamicRevocationTests.cs
@@ -22,7 +22,11 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
         // RHEL6 uses a version of OpenSSL that (empirically) doesn't support designated responders.
         // (There's a chance that we should be passing in extra stuff, but RHEL6 is the only platform
         // still on OpenSSL 1.0.0/1.0.1 in 2019, so it seems OpenSSL-related)
-        private static readonly bool s_supportsDesignatedResponder = PlatformDetection.IsNotRedHatFamily6;
+        //
+        // Windows 7 seems to only support designated responders for the target certificate,
+        // rather than complicate the generator too much just don't run the desginated-responder tests there.
+        private static readonly bool s_supportsDesignatedResponder =
+            PlatformDetection.IsNotRedHatFamily6 && PlatformDetection.IsNotWindows7;
 
         [Flags]
         public enum PkiOptions

--- a/src/System.Security.Cryptography.X509Certificates/tests/RevocationTests/DynamicRevocationTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/RevocationTests/DynamicRevocationTests.cs
@@ -3,55 +3,194 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Xunit;
 
 namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
 {
     public static class DynamicRevocationTests
     {
-        [Fact]
-        public static void CrlCrlRevokeIntermediate()
+        [Flags]
+        public enum PkiOptions
+        {
+            None = 0,
+
+            IssuerRevocationViaCrl = 1 << 0,
+            IssuerRevocationViaOcsp = 1 << 1,
+            EndEntityRevocationViaCrl = 1 << 2,
+            EndEntityRevocationViaOcsp = 1 << 3,
+
+            CrlEverywhere = IssuerRevocationViaCrl | EndEntityRevocationViaCrl,
+            OcspEverywhere = IssuerRevocationViaOcsp | EndEntityRevocationViaOcsp,
+            AllRevocation = CrlEverywhere | OcspEverywhere,
+        }
+
+        private delegate void RunSimpleTest(
+            CertificateAuthority root,
+            CertificateAuthority intermediate,
+            X509Certificate2 endEntity,
+            ChainHolder chainHolder);
+
+
+        [Theory]
+        [InlineData(PkiOptions.CrlEverywhere)]
+        [InlineData(PkiOptions.OcspEverywhere)]
+        [InlineData(PkiOptions.IssuerRevocationViaCrl | PkiOptions.EndEntityRevocationViaOcsp)]
+        [InlineData(PkiOptions.IssuerRevocationViaOcsp | PkiOptions.EndEntityRevocationViaCrl)]
+        [InlineData(PkiOptions.AllRevocation)]
+        public static void NothingRevoked(PkiOptions pkiOptions)
+        {
+            SimpleTest(
+                pkiOptions,
+                (root, intermediate, endEntity, holder) =>
+                {
+                    X509Chain chain = holder.Chain;
+                    chain.ChainPolicy.VerificationTime = endEntity.NotBefore.AddMinutes(1);
+
+                    bool chainBuilt = chain.Build(endEntity);
+                    Assert.Equal(3, chain.ChainElements.Count);
+                    Assert.Equal(X509ChainStatusFlags.NoError, chain.AllStatusFlags());
+                    Assert.True(chainBuilt, "Chain built with ExcludeRoot");
+                    holder.DisposeChainElements();
+
+                    chain.ChainPolicy.RevocationFlag = X509RevocationFlag.EndCertificateOnly;
+
+                    chainBuilt = chain.Build(endEntity);
+                    Assert.Equal(3, chain.ChainElements.Count);
+                    Assert.Equal(X509ChainStatusFlags.NoError, chain.AllStatusFlags());
+                    Assert.True(chainBuilt, "Chain built with EndCertificateOnly");
+                },
+                $"NothingRevoked - {pkiOptions}");
+        }
+
+        [Theory]
+        [InlineData(PkiOptions.CrlEverywhere)]
+        [InlineData(PkiOptions.OcspEverywhere)]
+        [InlineData(PkiOptions.IssuerRevocationViaCrl | PkiOptions.EndEntityRevocationViaOcsp)]
+        [InlineData(PkiOptions.IssuerRevocationViaOcsp | PkiOptions.EndEntityRevocationViaCrl)]
+        [InlineData(PkiOptions.AllRevocation)]
+        public static void RevokeIntermediate(PkiOptions pkiOptions)
+        {
+            SimpleTest(
+                pkiOptions,
+                (root, intermediate, endEntity, holder) =>
+                {
+                    using (X509Certificate2 intermediateCert = intermediate.CloneIssuerCert())
+                    {
+                        X509Chain chain = holder.Chain;
+                        DateTimeOffset now = DateTimeOffset.UtcNow;
+                        root.Revoke(intermediateCert, now);
+                        chain.ChainPolicy.VerificationTime = now.AddSeconds(1).UtcDateTime;
+
+                        bool chainBuilt = chain.Build(endEntity);
+                        Assert.Equal(3, chain.ChainElements.Count);
+
+                        Assert.True(
+                            chain.AllStatusFlags().HasFlag(X509ChainStatusFlags.Revoked),
+                            "Revoked flag is asserted at the chain");
+
+                        Assert.Equal(X509ChainStatusFlags.NoError, chain.ChainElements[2].AllStatusFlags());
+                        Assert.Equal(X509ChainStatusFlags.Revoked, chain.ChainElements[1].AllStatusFlags());
+                        Assert.False(chainBuilt, "Chain built with ExcludeRoot.");
+                        holder.DisposeChainElements();
+
+                        chain.ChainPolicy.RevocationFlag = X509RevocationFlag.EndCertificateOnly;
+
+                        chainBuilt = chain.Build(endEntity);
+                        Assert.Equal(3, chain.ChainElements.Count);
+                        Assert.Equal(X509ChainStatusFlags.NoError, chain.AllStatusFlags());
+                        Assert.True(chainBuilt, "Chain built with EndCertificateOnly");
+                    }
+                },
+                $"RevokeIntermediate - {pkiOptions}");
+        }
+
+        [Theory]
+        [InlineData(PkiOptions.CrlEverywhere)]
+        [InlineData(PkiOptions.OcspEverywhere)]
+        [InlineData(PkiOptions.IssuerRevocationViaCrl | PkiOptions.EndEntityRevocationViaOcsp)]
+        [InlineData(PkiOptions.IssuerRevocationViaOcsp | PkiOptions.EndEntityRevocationViaCrl)]
+        [InlineData(PkiOptions.AllRevocation)]
+        public static void RevokeEndEntity(PkiOptions pkiOptions)
+        {
+            SimpleTest(
+                pkiOptions,
+                (root, intermediate, endEntity, holder) =>
+                {
+                    DateTimeOffset now = DateTimeOffset.UtcNow;
+                    intermediate.Revoke(endEntity, now);
+
+                    X509Chain chain = holder.Chain;
+                    chain.ChainPolicy.VerificationTime = now.AddSeconds(1).UtcDateTime;
+
+                    bool chainBuilt = chain.Build(endEntity);
+                    Assert.Equal(3, chain.ChainElements.Count);
+
+                    Assert.Equal(X509ChainStatusFlags.Revoked, chain.AllStatusFlags());
+                    Assert.Equal(X509ChainStatusFlags.NoError, chain.ChainElements[2].AllStatusFlags());
+                    Assert.Equal(X509ChainStatusFlags.NoError, chain.ChainElements[1].AllStatusFlags());
+                    Assert.Equal(X509ChainStatusFlags.Revoked, chain.ChainElements[0].AllStatusFlags());
+                    Assert.False(chainBuilt, "Chain built with ExcludeRoot.");
+                    holder.DisposeChainElements();
+
+                    chain.ChainPolicy.RevocationFlag = X509RevocationFlag.EndCertificateOnly;
+
+                    chainBuilt = chain.Build(endEntity);
+                    Assert.Equal(3, chain.ChainElements.Count);
+                    Assert.Equal(X509ChainStatusFlags.Revoked, chain.AllStatusFlags());
+                    Assert.Equal(X509ChainStatusFlags.NoError, chain.ChainElements[2].AllStatusFlags());
+                    Assert.Equal(X509ChainStatusFlags.NoError, chain.ChainElements[1].AllStatusFlags());
+                    Assert.Equal(X509ChainStatusFlags.Revoked, chain.ChainElements[0].AllStatusFlags());
+                    Assert.False(chainBuilt, "Chain built with EndCertificateOnly");
+                },
+                $"RevokeEndEntity - {pkiOptions}");
+        }
+
+        private static void SimpleTest(
+            PkiOptions pkiOptions,
+            RunSimpleTest callback,
+            [CallerMemberName]string callerName = null)
         {
             BuildPrivatePki(
-                issuerRevocationViaCrl: true,
-                issuerRevocationViaOcsp: false,
-                endEntityRevocationViaCrl: true,
-                endEntityRevocationViaOcsp: false,
+                pkiOptions,
                 out RevocationResponder responder,
                 out CertificateAuthority root,
                 out CertificateAuthority intermediate,
-                out X509Certificate2 endEntity);
+                out X509Certificate2 endEntity,
+                callerName);
 
             using (responder)
             using (root)
             using (intermediate)
             using (endEntity)
             using (ChainHolder holder = new ChainHolder())
+            using (X509Certificate2 rootCert = root.CloneIssuerCert())
+            using (X509Certificate2 intermediateCert = intermediate.CloneIssuerCert())
             {
                 X509Chain chain = holder.Chain;
-                chain.ChainPolicy.CustomTrustStore.Add(root.CloneIssuerCert());
-                chain.ChainPolicy.ExtraStore.Add(intermediate.CloneIssuerCert());
+                chain.ChainPolicy.CustomTrustStore.Add(rootCert);
+                chain.ChainPolicy.ExtraStore.Add(intermediateCert);
                 chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
                 chain.ChainPolicy.VerificationTime = endEntity.NotBefore.AddMinutes(1);
 
-                bool chainBuilt = chain.Build(endEntity);
-                Assert.Equal(3, chain.ChainElements.Count);
-                Assert.Equal(X509ChainStatusFlags.NoError, chain.AllStatusFlags());
-                Assert.True(chainBuilt, "Chain built with nothing revoked.");
+                callback(root, intermediate, endEntity, holder);
             }
         }
 
         private static void BuildPrivatePki(
-            bool issuerRevocationViaCrl,
-            bool issuerRevocationViaOcsp,
-            bool endEntityRevocationViaCrl,
-            bool endEntityRevocationViaOcsp,
+            PkiOptions pkiOptions,
             out RevocationResponder responder,
             out CertificateAuthority rootAuthority,
             out CertificateAuthority intermediateAuthority,
             out X509Certificate2 endEntityCert,
+            [CallerMemberName] string callerName = null,
             bool registerAuthorities = true)
         {
+            bool issuerRevocationViaCrl = pkiOptions.HasFlag(PkiOptions.IssuerRevocationViaCrl);
+            bool issuerRevocationViaOcsp = pkiOptions.HasFlag(PkiOptions.IssuerRevocationViaOcsp);
+            bool endEntityRevocationViaCrl = pkiOptions.HasFlag(PkiOptions.EndEntityRevocationViaCrl);
+            bool endEntityRevocationViaOcsp = pkiOptions.HasFlag(PkiOptions.EndEntityRevocationViaOcsp);
+
             Assert.True(
                 issuerRevocationViaCrl || issuerRevocationViaOcsp ||
                     endEntityRevocationViaCrl || endEntityRevocationViaOcsp,
@@ -67,7 +206,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
             using (RSA eeKey = RSA.Create(KeySize))
             {
                 var rootReq = new CertificateRequest(
-                    "CN=A Revocation Test Root",
+                    $"CN=\"A Revocation Test Root ({callerName})\"",
                     rootKey,
                     HashAlgorithmName.SHA256,
                     RSASignaturePadding.Pkcs1);
@@ -100,7 +239,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
 
                 {
                     X509Certificate2 intermedPub = rootAuthority.CreateSubordinateCA(
-                        "CN=A Revocation Test CA",
+                        $"CN=\"A Revocation Test CA ({callerName})\"",
                         intermedKey);
 
                     intermedCert = intermedPub.CopyWithPrivateKey(intermedKey);
@@ -119,7 +258,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
                     endEntityRevocationViaOcsp ? ocspUrl : null);
 
                 endEntityCert = intermediateAuthority.CreateEndEntity(
-                    "CN=A Revocation Test Cert",
+                    $"CN=\"A Revocation Test Cert ({callerName})\"",
                     eeKey);
             }
 

--- a/src/System.Security.Cryptography.X509Certificates/tests/RevocationTests/DynamicRevocationTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/RevocationTests/DynamicRevocationTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
 {
+    [ActiveIssue(41974, TestPlatforms.OSX)]
     public static class DynamicRevocationTests
     {
         private static readonly TimeSpan s_urlRetrievalLimit = TimeSpan.FromSeconds(5);

--- a/src/System.Security.Cryptography.X509Certificates/tests/RevocationTests/RevocationResponder.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/RevocationTests/RevocationResponder.cs
@@ -195,7 +195,17 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
                         context.Response.StatusDescription = "OK";
                         context.Response.ContentType = "application/ocsp-response";
                         context.Response.Close(ocspResponse, willBlock: false);
-                        Trace($"OCSP Response: {ocspResponse.Length} bytes from {authority.SubjectName}");
+
+                        if (authority.HasOcspDelegation)
+                        {
+                            Trace($"OCSP Response: {ocspResponse.Length} bytes from {authority.SubjectName} delegated to {authority.OcspResponderSubjectName}");
+
+                        }
+                        else
+                        {
+                            Trace($"OCSP Response: {ocspResponse.Length} bytes from {authority.SubjectName}");
+                        }
+
                         return;
                     }
                 }
@@ -220,6 +230,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
 
                 HttpListener listener = new HttpListener();
                 listener.Prefixes.Add(uriPrefix);
+                listener.IgnoreWriteExceptions = true;
 
                 try
                 {

--- a/src/System.Security.Cryptography.X509Certificates/tests/RevocationTests/RevocationResponder.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/RevocationTests/RevocationResponder.cs
@@ -216,7 +216,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
             while (true)
             {
                 int port = RandomNumberGenerator.GetInt32(41000, 42000);
-                uriPrefix = $"http://localhost:{port}/";
+                uriPrefix = $"http://127.0.0.1:{port}/";
 
                 HttpListener listener = new HttpListener();
                 listener.Prefixes.Add(uriPrefix);

--- a/src/System.Security.Cryptography.X509Certificates/tests/RevocationTests/RevocationResponder.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/RevocationTests/RevocationResponder.cs
@@ -1,0 +1,269 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Net;
+using System.Security.Cryptography.Asn1;
+using System.Threading.Tasks;
+using System.Web;
+
+namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
+{
+    internal sealed class RevocationResponder : IDisposable
+    {
+        private static readonly bool s_traceEnabled =
+            Environment.GetEnvironmentVariable("TRACE_REVOCATION_RESPONSE") != null;
+
+        private readonly HttpListener _listener;
+
+        private readonly Dictionary<string, CertificateAuthority> _crlPaths
+            = new Dictionary<string, CertificateAuthority>();
+
+        private readonly List<(string, CertificateAuthority)> _ocspAuthorities =
+            new List<(string, CertificateAuthority)>();
+
+        public string UriPrefix { get; }
+
+        private RevocationResponder(HttpListener listener, string uriPrefix)
+        {
+            _listener = listener;
+            UriPrefix = uriPrefix;
+        }
+
+        public void Dispose()
+        {
+            _listener.Close();
+        }
+
+        internal void AddCertificateAuthority(CertificateAuthority authority)
+        {
+            if (authority.CdpUri != null && authority.CdpUri.StartsWith(UriPrefix))
+            {
+                _crlPaths.Add(authority.CdpUri.Substring(UriPrefix.Length - 1), authority);
+            }
+
+            if (authority.OcspUri != null && authority.OcspUri.StartsWith(UriPrefix))
+            {
+                _ocspAuthorities.Add((authority.OcspUri.Substring(UriPrefix.Length - 1), authority));
+            }
+        }
+
+        private async void HandleRequests()
+        {
+            while (_listener.IsListening)
+            {
+                await HandleRequestAsync();
+            }
+        }
+
+        private async Task HandleRequestAsync()
+        {
+            HttpListenerContext context = null;
+
+            bool responded = false;
+            try
+            {
+                context = await _listener.GetContextAsync();
+                HandleRequest(context, ref responded);
+            }
+            catch (Exception e)
+            {
+                try
+                {
+                    if (!responded && context != null)
+                    {
+                        context.Response.StatusCode = 500;
+                        context.Response.StatusDescription = "Internal Server Error";
+                        context.Response.Close();
+
+                        Trace($"Sent 500 due to exception on {context.Request.HttpMethod} {context.Request.RawUrl}");
+                        Trace(e.ToString());
+                    }
+                }
+                catch (Exception)
+                {
+                }
+                
+                return;
+            }
+
+            if (!responded)
+            {
+                Trace($"404 for {context.Request.HttpMethod} {context.Request.RawUrl}");
+
+                try
+                {
+                    context.Response.StatusCode = 404;
+                    context.Response.Close();
+                }
+                catch (Exception)
+                {
+                }
+            }
+        }
+
+        private void HandleRequest(HttpListenerContext context, ref bool responded)
+        {
+            CertificateAuthority authority;
+            string url = context.Request.RawUrl;
+
+            if (_crlPaths.TryGetValue(url, out authority))
+            {
+                byte[] crl = authority.GetCrl();
+
+                responded = true;
+                context.Response.StatusCode = 200;
+                context.Response.ContentType = "application/pkix-crl";
+                context.Response.Close(crl, willBlock: false);
+                Trace($"Responded with {crl.Length}-byte CRL from {authority.SubjectName}.");
+                return;
+            }
+
+            string prefix;
+
+            foreach (var tuple in _ocspAuthorities)
+            {
+                (prefix, authority) = tuple;
+
+                if (url.StartsWith(prefix))
+                {
+                    if (context.Request.HttpMethod == "GET")
+                    {
+                        ReadOnlyMemory<byte> certId;
+                        ReadOnlyMemory<byte> nonce;
+
+                        try
+                        {
+                            string base64 = HttpUtility.UrlDecode(url.Substring(prefix.Length + 1));
+                            byte[] reqBytes = Convert.FromBase64String(base64);
+                            DecodeOcspRequest(reqBytes, out certId, out nonce);
+                        }
+                        catch (Exception)
+                        {
+                            Trace($"OcspRequest Decode failed ({url})");
+                            context.Response.StatusCode = 400;
+                            context.Response.Close();
+                            return;
+                        }
+
+                        byte[] ocspResponse = authority.BuildOcspResponse(certId, nonce);
+
+                        responded = true;
+                        context.Response.StatusCode = 200;
+                        context.Response.StatusDescription = "OK";
+                        context.Response.ContentType = "application/ocsp-response";
+                        context.Response.Close(ocspResponse, willBlock: false);
+                        Trace($"OCSP Response: {ocspResponse.Length} bytes from {authority.SubjectName}");
+                        return;
+                    }
+                }
+            }
+        }
+
+        internal static RevocationResponder CreateAndListen()
+        {
+            HttpListener listener = OpenListener(out string uriPrefix);
+            
+            RevocationResponder responder = new RevocationResponder(listener, uriPrefix);
+            responder.HandleRequests();
+            return responder;
+        }
+
+        private static HttpListener OpenListener(out string uriPrefix)
+        {
+            while (true)
+            {
+                int port = RandomNumberGenerator.GetInt32(41000, 42000);
+                uriPrefix = $"http://localhost:{port}/";
+
+                HttpListener listener = new HttpListener();
+                listener.Prefixes.Add(uriPrefix);
+
+                try
+                {
+                    listener.Start();
+                    Trace($"Listening at {uriPrefix}");
+                    return listener;
+                }
+                catch
+                {
+                }
+            }
+        }
+
+        private static void DecodeOcspRequest(
+            byte[] requestBytes,
+            out ReadOnlyMemory<byte> certId,
+            out ReadOnlyMemory<byte> nonceExtension)
+        {
+            AsnReader reader = new AsnReader(requestBytes, AsnEncodingRules.DER);
+            AsnReader request = reader.ReadSequence();
+            reader.ThrowIfNotEmpty();
+
+            AsnReader tbsRequest = request.ReadSequence();
+
+            if (request.HasData)
+            {
+                // Optional signature
+                request.ReadEncodedValue();
+                request.ThrowIfNotEmpty();
+            }
+
+            // Only v1(0) is supported, and it shouldn't be written. So just don't read it.
+
+            if (tbsRequest.PeekTag() == new Asn1Tag(TagClass.ContextSpecific, 1))
+            {
+                tbsRequest.ReadEncodedValue();
+            }
+
+            AsnReader requestList = tbsRequest.ReadSequence();
+            AsnReader requestExtensions = null;
+
+            if (tbsRequest.HasData)
+            {
+                AsnReader requestExtensionsWrapper = tbsRequest.ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 2));
+                requestExtensions = requestExtensionsWrapper.ReadSequence();
+                requestExtensionsWrapper.ThrowIfNotEmpty();
+            }
+
+            tbsRequest.ThrowIfNotEmpty();
+
+            AsnReader firstRequest = requestList.ReadSequence();
+            requestList.ThrowIfNotEmpty();
+
+            certId = firstRequest.ReadEncodedValue();
+
+            if (firstRequest.HasData)
+            {
+                firstRequest.ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 0));
+            }
+
+            firstRequest.ThrowIfNotEmpty();
+
+            nonceExtension = default;
+
+            if (requestExtensions != null)
+            {
+                while (requestExtensions.HasData)
+                {
+                    ReadOnlyMemory<byte> wholeExtension = requestExtensions.PeekEncodedValue();
+                    AsnReader extension = requestExtensions.ReadSequence();
+
+                    if (extension.ReadObjectIdentifierAsString() == "1.3.6.1.5.5.7.48.1.2")
+                    {
+                        nonceExtension = wholeExtension;
+                    }
+                }
+            }
+        }
+
+        private static void Trace(string trace)
+        {
+            if (s_traceEnabled)
+            {
+                Console.WriteLine(trace);
+            }
+        }
+    }
+}

--- a/src/System.Security.Cryptography.X509Certificates/tests/RevocationTests/RevocationResponder.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/RevocationTests/RevocationResponder.cs
@@ -199,7 +199,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
                         if (authority.HasOcspDelegation)
                         {
                             Trace($"OCSP Response: {ocspResponse.Length} bytes from {authority.SubjectName} delegated to {authority.OcspResponderSubjectName}");
-
                         }
                         else
                         {

--- a/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
@@ -10,7 +10,14 @@
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <Configurations>netcoreapp-OSX-Debug;netcoreapp-OSX-Release;netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
   </PropertyGroup>
+  <Import Project="$(CommonPath)\System\Security\Cryptography\Asn1Reader\System.Security.Cryptography.Asn1Reader.Shared.projitems" />
   <ItemGroup>
+    <Compile Include="$(CommonPath)\System\Memory\PointerMemoryManager.cs">
+      <Link>Common\System\Memory\PointerMemoryManager.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Security\Cryptography\CryptoPool.cs">
+      <Link>Common\System\Security\Cryptography\CryptoPool.cs</Link>
+    </Compile>
     <Compile Include="Cert.cs" />
     <Compile Include="CertTests.cs" />
     <Compile Include="ChainHolder.cs" />
@@ -49,6 +56,9 @@
     <Compile Include="CertificateCreation\RSAPkcs1X509SignatureGeneratorTests.cs" />
     <Compile Include="CertificateCreation\RSAPssX509SignatureGeneratorTests.cs" />
     <Compile Include="CertificateCreation\SubjectAltNameBuilderTests.cs" />
+    <Compile Include="RevocationTests\CertificateAuthority.cs" />
+    <Compile Include="RevocationTests\DynamicRevocationTests.cs" />
+    <Compile Include="RevocationTests\RevocationResponder.cs" />
     <Compile Include="DSAOther.cs" />
     <Compile Include="DynamicChainTests.cs" />
     <Compile Include="ECDsaOther.cs" />


### PR DESCRIPTION
* Add a bunch of tests for X.509 Revocation using an HttpListener-based responder
* Add Linux support for OCSP at multiple levels (not just the leaf)
* Fix up some inconsistencies in chain element statuses

Fixes #41738.
Fixes #41475.

After CR signoff I'll flip the entire DynamicRevocationTests class to OuterLoop, and possibly look into finding out ways to get some/better parallelization out of it.  (I tried using a rotating pool of RSA keys for the test, but that didn't measurably move the needle in the runs on my machine... it's dominated by serial execution of serial loopback HTTP)
