### PR TITLE
Guard against attempting to creating out-of-range spans in macOS FileSystemWatcher

### DIFF
--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
@@ -422,7 +422,9 @@ namespace System.IO
                         // The base FileSystemWatcher does a match check against the relative path before combining with
                         // the root dir; however, null is special cased to signify the root dir, so check if we should use that.
                         ReadOnlySpan<char> relativePath = ReadOnlySpan<char>.Empty;
-                        if (!path.Equals(_fullDirectory, StringComparison.OrdinalIgnoreCase))
+                        if (!path.Equals(_fullDirectory, StringComparison.OrdinalIgnoreCase)
+                            && path.Length >= _fullDirectory.Length
+                            && _fullDirectory.AsSpan().Equals(path.Slice(0, _fullDirectory.Length), StringComparison.OrdinalIgnoreCase))
                         {
                             // Remove the root directory to get the relative path
                             relativePath = path.Slice(_fullDirectory.Length);
@@ -467,8 +469,17 @@ namespace System.IO
                             {
                                 // Remove the base directory prefix and add the paired event to the list of
                                 // events to skip and notify the user of the rename
-                                ReadOnlySpan<char> newPathRelativeName = events[pairedId].Span.Slice(_fullDirectory.Length);
-                                watcher.NotifyRenameEventArgs(WatcherChangeTypes.Renamed, newPathRelativeName, relativePath);
+                                if (events[pairedId].Span.Length >= _fullDirectory.Length
+                                    && _fullDirectory.AsSpan().Equals(events[pairedId].Span.Slice(0, _fullDirectory.Length), StringComparison.OrdinalIgnoreCase)
+                                {
+                                    ReadOnlySpan<char> newPathRelativeName = events[pairedId].Span.Slice(_fullDirectory.Length);
+                                    watcher.NotifyRenameEventArgs(WatcherChangeTypes.Renamed, newPathRelativeName, relativePath);
+                                }
+                                else
+                                {
+                                    //if the base directory prefix isn't there, just use the full absolute path
+                                    watcher.NotifyRenameEventArgs(WatcherChangeTypes.Renamed, events[pairedId].Span, relativePath);
+                                }
 
                                 // Create a new list, if necessary, and add the event
                                 if (handledRenameEvents == null)


### PR DESCRIPTION
Addresses PR feedback in https://github.com/dotnet/corefx/pull/40957 (I don't have push rights to that branch)
Replaces https://github.com/dotnet/corefx/pull/40957
Fixes https://github.com/dotnet/corefx/issues/40054
cc: @alexischr 