### PR TITLE
Fix a rare GetAwaiter().GetResult() on a ValueTask in System.Net.Http

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpBaseStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpBaseStream.cs
@@ -103,7 +103,7 @@ namespace System.Net.Http
             // situations.  Either a derived stream overrides this anyway, so the implementation won't be used,
             // or it's being called as part of HttpContent.SerializeToStreamAsync, which means custom
             // content is explicitly choosing to make a synchronous call as part of an asynchronous method.
-            WriteAsync(buffer, offset, count, default).GetAwaiter().GetResult();
+            WriteAsync(buffer, offset, count, CancellationToken.None).GetAwaiter().GetResult();
         }
 
         public sealed override void WriteByte(byte value) =>

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpBaseStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpBaseStream.cs
@@ -103,8 +103,7 @@ namespace System.Net.Http
             // situations.  Either a derived stream overrides this anyway, so the implementation won't be used,
             // or it's being called as part of HttpContent.SerializeToStreamAsync, which means custom
             // content is explicitly choosing to make a synchronous call as part of an asynchronous method.
-            ValidateBufferArgs(buffer, offset, count);
-            WriteAsync(new Memory<byte>(buffer, offset, count), CancellationToken.None).GetAwaiter().GetResult();
+            WriteAsync(buffer, offset, count, default).GetAwaiter().GetResult();
         }
 
         public sealed override void WriteByte(byte value) =>


### PR DESCRIPTION
If someone's custom HttpContent-derived type is implementing their async SerializeToStreamAsync with synchronous Write calls on the destination stream, and if that WriteAsync method returns an IValueTaskSource-based ValueTask that's not yet completed, this could throw an exception.   This is unlikely to actually negative impact anyone right now, but it's worth fixing.  This is one of the patterns an analyzer around ValueTasks will help find and fix.