### PR TITLE
use background thread to wait for address changes on OSX (#41768)

### DIFF
--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.OSX.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.OSX.cs
@@ -181,6 +181,7 @@ namespace System.Net.NetworkInformation
                 }
             }
             s_runLoopThread = new Thread(RunLoopThreadStart);
+            s_runLoopThread.IsBackground = true;
             s_runLoopThread.Start();
             s_runLoopStartedEvent.WaitOne(); // Wait for the new thread to finish initialization.
         }

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkAvailabilityChangedTests.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkAvailabilityChangedTests.cs
@@ -29,6 +29,20 @@ namespace System.Net.NetworkInformation.Tests
 
         [Fact]
         [ActiveIssue(33530, TestPlatforms.FreeBSD)]
+        public void NetworkAddressChanged_Add_DoesNotBlock()
+        {
+            // Register without unregistering.
+            // This should not block process exit. If it does, this test will pass
+            // but we would fail to exit test run at the end.
+            // We cannot test this via RemoteInvoke() as that calls Environment.Exit()
+            // and forces quit even when foreground threads are running.
+            NetworkChange.NetworkAddressChanged += _addressHandler;
+            {
+            };
+        }
+
+        [Fact]
+        [ActiveIssue(33530, TestPlatforms.FreeBSD)]
         public void NetworkAddressChanged_AddAndRemove_NetworkAvailabilityChanged_JustRemove_Success()
         {
             NetworkChange.NetworkAddressChanged += _addressHandler;


### PR DESCRIPTION
### Description

Use background thread to wait for address changes on OSX to avoid hang after:
```C#
System.Net.NetworkInformation.NetworkChange.NetworkAddressChanged += (sender, e) => {}
```

ports https://github.com/dotnet/corefx/pull/41768
fixes #41740

### Customer Impact:

Requested by @davidfowl : "We found this when we noticed that applications which use AppInsights don't close when they would normally exit on a Mac. This isn't noticed normally because the normal workflow for AspNetCore apps is that when you want the server to exit you send Ctrl-C."

### Regression? 

No.

### Risk

Very low. The fix is just changing a thread to Background, and the only effect of that is to prevent the runtime joining on it before terminating.

### Tests run / added

Test added.