### PR TITLE
Handle non blittable LOGFONT structs

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/Font.Windows.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Font.Windows.cs
@@ -319,11 +319,12 @@ namespace System.Drawing
             }
             catch (ArgumentException)
             {
-                // If the type wasn't blittable it won't be able to be pinned with GCHandle. Try
+                // If the type isn't blittable it won't be able to be pinned with GCHandle. Try
                 // to use the marshaller to copy the "native" representation instead.
                 //
-                // This happens for classes or structs that have objects non fixed arrays in them,
-                // it will *not* work with blittable structs (which are handled in the try).
+                // This happens for classes or structs that have reference types as members.
+                // Marshal.StructureToPtr() will *not* work with blittable structs (which are
+                // handled in the try block above).
                 Marshal.StructureToPtr(lf, new IntPtr(&logFont), fDeleteOld: false);
             }
 

--- a/src/System.Drawing.Common/tests/FontTests.cs
+++ b/src/System.Drawing.Common/tests/FontTests.cs
@@ -711,6 +711,56 @@ namespace System.Drawing.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ConditionalFact(Helpers.IsDrawingSupported)]
+        public void FromLogFont_UnblittableStruct()
+        {
+            const byte OUT_TT_ONLY_PRECIS = 7;
+            using (var image = new Bitmap(10, 10))
+            using (Graphics graphics = Graphics.FromImage(image))
+            {
+                IntPtr hdc = graphics.GetHdc();
+                try
+                {
+                    var logFont = new UnblittableLOGFONT
+                    {
+                        lfOutPrecision = OUT_TT_ONLY_PRECIS
+                    };
+
+                    using (Font font = Font.FromLogFont(logFont))
+                    {
+                        Assert.NotNull(font);
+                        Assert.NotEmpty(font.Name);
+                    }
+                }
+                finally
+                {
+                    graphics.ReleaseHdc();
+                }
+            }
+        }
+
+        [Serializable()]
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+        public struct UnblittableLOGFONT
+        {
+            public int lfHeight;
+            public int lfWidth;
+            public int lfEscapement;
+            public int lfOrientation;
+            public int lfWeight;
+            public byte lfItalic;
+            public byte lfUnderline;
+            public byte lfStrikeOut;
+            public byte lfCharSet;
+            public byte lfOutPrecision;
+            public byte lfClipPrecision;
+            public byte lfQuality;
+            public byte lfPitchAndFamily;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
+            public string lfFaceName;
+        }
+
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(GraphicsUnit.Document)]
         [InlineData(GraphicsUnit.Inch)]


### PR DESCRIPTION
Adding support for blittable structs broke non-blittable structs passed to `Font.FromLogFont`. Try to blit and fall through to the marshaller for non blittable types.

Fixes: https://github.com/dotnet/winforms/issues/2136

We should consider for 3.1 as this has been reported by a customer.