### PR TITLE
Fix clean switch

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -11,7 +11,6 @@ Param(
   [switch]$coverage,
   [string]$testscope,
   [string]$arch,
-  [switch]$clean,
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )
 


### PR DESCRIPTION
When I moved the clean switch to Arcade I forgot to remove the switch in our script. With the switch present here the clean switch would be encoded as an msbuild property /p:clean=true instead of the expected script argument `-clean`.