### PR TITLE
[release/3.1] Compression fixes for 3.1

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -71,7 +71,7 @@
     <NewtonsoftJsonPackageVersion>12.0.1</NewtonsoftJsonPackageVersion>
     <MicrosoftDotNetPlatformAbstractionsPackageVersion>3.0.0-preview6-27804-01</MicrosoftDotNetPlatformAbstractionsPackageVersion>
     <!-- Test data -->
-    <SystemIOCompressionTestDataPackageVersion>1.0.14</SystemIOCompressionTestDataPackageVersion>
+    <SystemIOCompressionTestDataPackageVersion>1.0.16</SystemIOCompressionTestDataPackageVersion>
     <SystemIOPackagingTestDataPackageVersion>1.0.4</SystemIOPackagingTestDataPackageVersion>
     <SystemSecurityCryptographyX509CertificatesTestDataPackageVersion>1.0.7</SystemSecurityCryptographyX509CertificatesTestDataPackageVersion>
     <SystemNetTestDataPackageVersion>1.0.6</SystemNetTestDataPackageVersion>

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
@@ -530,9 +530,15 @@ namespace System.IO.Compression
         {
             try
             {
-                // this seeks to the start of the end of central directory record
+                // This seeks backwards almost to the beginning of the EOCD, one byte after where the signature would be
+                // located if the EOCD had the minimum possible size (no file zip comment)
                 _archiveStream.Seek(-ZipEndOfCentralDirectoryBlock.SizeOfBlockWithoutSignature, SeekOrigin.End);
-                if (!ZipHelper.SeekBackwardsToSignature(_archiveStream, ZipEndOfCentralDirectoryBlock.SignatureConstant))
+
+                // If the EOCD has the minimum possible size (no zip file comment), then exactly the previous 4 bytes will contain the signature
+                // But if the EOCD has max possible size, the signature should be found somewhere in the previous 64K + 4 bytes
+                if (!ZipHelper.SeekBackwardsToSignature(_archiveStream,
+                        ZipEndOfCentralDirectoryBlock.SignatureConstant,
+                        ZipEndOfCentralDirectoryBlock.ZipFileCommentMaxLength + ZipEndOfCentralDirectoryBlock.SignatureSize))
                     throw new InvalidDataException(SR.EOCDNotFound);
 
                 long eocdStart = _archiveStream.Position;
@@ -547,56 +553,17 @@ namespace System.IO.Compression
 
                 _numberOfThisDisk = eocd.NumberOfThisDisk;
                 _centralDirectoryStart = eocd.OffsetOfStartOfCentralDirectoryWithRespectToTheStartingDiskNumber;
+
                 if (eocd.NumberOfEntriesInTheCentralDirectory != eocd.NumberOfEntriesInTheCentralDirectoryOnThisDisk)
                     throw new InvalidDataException(SR.SplitSpanned);
+
                 _expectedNumberOfEntries = eocd.NumberOfEntriesInTheCentralDirectory;
 
                 // only bother saving the comment if we are in update mode
                 if (_mode == ZipArchiveMode.Update)
                     _archiveComment = eocd.ArchiveComment;
 
-                // only bother looking for zip64 EOCD stuff if we suspect it is needed because some value is FFFFFFFFF
-                // because these are the only two values we need, we only worry about these
-                // if we don't find the zip64 EOCD, we just give up and try to use the original values
-                if (eocd.NumberOfThisDisk == ZipHelper.Mask16Bit ||
-                    eocd.OffsetOfStartOfCentralDirectoryWithRespectToTheStartingDiskNumber == ZipHelper.Mask32Bit ||
-                    eocd.NumberOfEntriesInTheCentralDirectory == ZipHelper.Mask16Bit)
-                {
-                    // we need to look for zip 64 EOCD stuff
-                    // seek to the zip 64 EOCD locator
-                    _archiveStream.Seek(eocdStart - Zip64EndOfCentralDirectoryLocator.SizeOfBlockWithoutSignature, SeekOrigin.Begin);
-                    // if we don't find it, assume it doesn't exist and use data from normal eocd
-                    if (ZipHelper.SeekBackwardsToSignature(_archiveStream, Zip64EndOfCentralDirectoryLocator.SignatureConstant))
-                    {
-                        // use locator to get to Zip64EOCD
-                        Zip64EndOfCentralDirectoryLocator locator;
-                        bool zip64eocdLocatorProper = Zip64EndOfCentralDirectoryLocator.TryReadBlock(_archiveReader, out locator);
-                        Debug.Assert(zip64eocdLocatorProper); // we just found this using the signature finder, so it should be okay
-
-                        if (locator.OffsetOfZip64EOCD > long.MaxValue)
-                            throw new InvalidDataException(SR.FieldTooBigOffsetToZip64EOCD);
-                        long zip64EOCDOffset = (long)locator.OffsetOfZip64EOCD;
-
-                        _archiveStream.Seek(zip64EOCDOffset, SeekOrigin.Begin);
-
-                        // read Zip64EOCD
-                        Zip64EndOfCentralDirectoryRecord record;
-                        if (!Zip64EndOfCentralDirectoryRecord.TryReadBlock(_archiveReader, out record))
-                            throw new InvalidDataException(SR.Zip64EOCDNotWhereExpected);
-
-                        _numberOfThisDisk = record.NumberOfThisDisk;
-
-                        if (record.NumberOfEntriesTotal > long.MaxValue)
-                            throw new InvalidDataException(SR.FieldTooBigNumEntries);
-                        if (record.OffsetOfCentralDirectory > long.MaxValue)
-                            throw new InvalidDataException(SR.FieldTooBigOffsetToCD);
-                        if (record.NumberOfEntriesTotal != record.NumberOfEntriesOnThisDisk)
-                            throw new InvalidDataException(SR.SplitSpanned);
-
-                        _expectedNumberOfEntries = (long)record.NumberOfEntriesTotal;
-                        _centralDirectoryStart = (long)record.OffsetOfCentralDirectory;
-                    }
-                }
+                TryReadZip64EndOfCentralDirectory(eocd, eocdStart);
 
                 if (_centralDirectoryStart > _archiveStream.Length)
                 {
@@ -610,6 +577,65 @@ namespace System.IO.Compression
             catch (IOException ex)
             {
                 throw new InvalidDataException(SR.CDCorrupt, ex);
+            }
+        }
+
+        // Tries to find the Zip64 End of Central Directory Locator, then the Zip64 End of Central Directory, assuming the
+        // End of Central Directory block has already been found, as well as the location in the stream where the EOCD starts.
+        private void TryReadZip64EndOfCentralDirectory(ZipEndOfCentralDirectoryBlock eocd, long eocdStart)
+        {
+            // Only bother looking for the Zip64-EOCD stuff if we suspect it is needed because some value is FFFFFFFFF
+            // because these are the only two values we need, we only worry about these
+            // if we don't find the Zip64-EOCD, we just give up and try to use the original values
+            if (eocd.NumberOfThisDisk == ZipHelper.Mask16Bit ||
+                eocd.OffsetOfStartOfCentralDirectoryWithRespectToTheStartingDiskNumber == ZipHelper.Mask32Bit ||
+                eocd.NumberOfEntriesInTheCentralDirectory == ZipHelper.Mask16Bit)
+            {
+                // Read Zip64 End of Central Directory Locator
+
+                // This seeks forwards almost to the beginning of the Zip64-EOCDL, one byte after where the signature would be located
+                _archiveStream.Seek(eocdStart - Zip64EndOfCentralDirectoryLocator.SizeOfBlockWithoutSignature, SeekOrigin.Begin);
+
+                // Exactly the previous 4 bytes should contain the Zip64-EOCDL signature
+                // if we don't find it, assume it doesn't exist and use data from normal EOCD
+                if (ZipHelper.SeekBackwardsToSignature(_archiveStream,
+                        Zip64EndOfCentralDirectoryLocator.SignatureConstant,
+                        Zip64EndOfCentralDirectoryLocator.SignatureSize))
+                {
+                    Debug.Assert(_archiveReader != null);
+
+                    // use locator to get to Zip64-EOCD
+                    Zip64EndOfCentralDirectoryLocator locator;
+                    bool zip64eocdLocatorProper = Zip64EndOfCentralDirectoryLocator.TryReadBlock(_archiveReader, out locator);
+                    Debug.Assert(zip64eocdLocatorProper); // we just found this using the signature finder, so it should be okay
+
+                    if (locator.OffsetOfZip64EOCD > long.MaxValue)
+                        throw new InvalidDataException(SR.FieldTooBigOffsetToZip64EOCD);
+
+                    long zip64EOCDOffset = (long)locator.OffsetOfZip64EOCD;
+
+                    _archiveStream.Seek(zip64EOCDOffset, SeekOrigin.Begin);
+
+                    // Read Zip64 End of Central Directory Record
+
+                    Zip64EndOfCentralDirectoryRecord record;
+                    if (!Zip64EndOfCentralDirectoryRecord.TryReadBlock(_archiveReader, out record))
+                        throw new InvalidDataException(SR.Zip64EOCDNotWhereExpected);
+
+                    _numberOfThisDisk = record.NumberOfThisDisk;
+
+                    if (record.NumberOfEntriesTotal > long.MaxValue)
+                        throw new InvalidDataException(SR.FieldTooBigNumEntries);
+
+                    if (record.OffsetOfCentralDirectory > long.MaxValue)
+                        throw new InvalidDataException(SR.FieldTooBigOffsetToCD);
+
+                    if (record.NumberOfEntriesTotal != record.NumberOfEntriesOnThisDisk)
+                        throw new InvalidDataException(SR.SplitSpanned);
+
+                    _expectedNumberOfEntries = (long)record.NumberOfEntriesTotal;
+                    _centralDirectoryStart = (long)record.OffsetOfCentralDirectory;
+                }
             }
         }
 

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
@@ -289,6 +289,8 @@ namespace System.IO.Compression
     internal struct Zip64EndOfCentralDirectoryLocator
     {
         public const uint SignatureConstant = 0x07064B50;
+        public const int SignatureSize = sizeof(uint);
+
         public const int SizeOfBlockWithoutSignature = 16;
 
         public uint NumberOfDiskWithZip64EOCD;
@@ -643,7 +645,16 @@ namespace System.IO.Compression
     internal struct ZipEndOfCentralDirectoryBlock
     {
         public const uint SignatureConstant = 0x06054B50;
+        public const int SignatureSize = sizeof(uint);
+
+        // This is the minimum possible size, assuming the zip file comments variable section is empty
         public const int SizeOfBlockWithoutSignature = 18;
+
+        // The end of central directory can have a variable size zip file comment at the end, but its max length can be 64K
+        // The Zip File Format Specification does not explicitly mention a max size for this field, but we are assuming this
+        // max size because that is the maximum value an ushort can hold.
+        public const int ZipFileCommentMaxLength = ushort.MaxValue;
+
         public uint Signature;
         public ushort NumberOfThisDisk;
         public ushort NumberOfTheDiskWithTheStartOfTheCentralDirectory;
@@ -673,7 +684,7 @@ namespace System.IO.Compression
             writer.Write(startOfCentralDirectoryTruncated);
 
             // Should be valid because of how we read archiveComment in TryReadBlock:
-            Debug.Assert((archiveComment == null) || (archiveComment.Length < ushort.MaxValue));
+            Debug.Assert((archiveComment == null) || (archiveComment.Length <= ZipFileCommentMaxLength));
 
             writer.Write(archiveComment != null ? (ushort)archiveComment.Length : (ushort)0); // zip file comment length
             if (archiveComment != null)

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipHelper.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipHelper.cs
@@ -102,11 +102,15 @@ namespace System.IO.Compression
             return (uint)ret;
         }
 
-        // assumes all bytes of signatureToFind are non zero, looks backwards from current position in stream,
+        // Assumes all bytes of signatureToFind are non zero, looks backwards from current position in stream,
+        // assumes maxBytesToRead is positive, ensures to not read beyond the provided max number of bytes,
         // if the signature is found then returns true and positions stream at first byte of signature
         // if the signature is not found, returns false
-        internal static bool SeekBackwardsToSignature(Stream stream, uint signatureToFind)
+        internal static bool SeekBackwardsToSignature(Stream stream, uint signatureToFind, int maxBytesToRead)
         {
+            Debug.Assert(signatureToFind != 0);
+            Debug.Assert(maxBytesToRead > 0);
+
             int bufferPointer = 0;
             uint currentSignature = 0;
             byte[] buffer = new byte[BackwardsSeekingBufferSize];
@@ -114,7 +118,8 @@ namespace System.IO.Compression
             bool outOfBytes = false;
             bool signatureFound = false;
 
-            while (!signatureFound && !outOfBytes)
+            int bytesRead = 0;
+            while (!signatureFound && !outOfBytes && bytesRead <= maxBytesToRead)
             {
                 outOfBytes = SeekBackwardsAndRead(stream, buffer, out bufferPointer);
 
@@ -132,6 +137,8 @@ namespace System.IO.Compression
                         bufferPointer--;
                     }
                 }
+
+                bytesRead += buffer.Length;
             }
 
             if (!signatureFound)

--- a/src/System.IO.Compression/tests/CompressionStreamUnitTests.Gzip.cs
+++ b/src/System.IO.Compression/tests/CompressionStreamUnitTests.Gzip.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -58,40 +59,133 @@ namespace System.IO.Compression
             }
         }
 
-        [Theory]
-        [InlineData(1000, false, false, 1000, 1)]
-        [InlineData(1000, false, true, 0, 1)]
-        [InlineData(1000, true, false, 1000, 1)]
-        [InlineData(1000, false, false, 1, 1)]
-        [InlineData(1000, true, false, 1, 1)]
-        [InlineData(1000, false, false, 1001 * 24, 1)]
-        [InlineData(1000, true, false, 1001 * 24, 1)]
-        public async Task ManyConcatenatedGzipStreams(int streamCount, bool useAsync, bool useReadByte, int bufferSize, int bytesPerStream)
+        /// <summary>
+        /// A derived MemoryStream that avoids MemoryStream's fast path in CopyTo
+        /// that bypasses buffering.
+        /// </summary>
+        private class DerivedMemoryStream : MemoryStream
+        { }
+
+        [Fact]
+        public async Task ConcatenatedEmptyGzipStreams()
         {
-            await TestConcatenatedGzipStreams(streamCount, useAsync, useReadByte, bufferSize, bytesPerStream);
+            const int copyToBufferSizeRequested = 0x8000;
+
+            // we'll request a specific size buffer, but we cannot guarantee that's the size
+            // that will be used since CopyTo will rent from the array pool
+            // take advantage of this knowledge to find out what size it will actually use
+            var rentedBuffer = ArrayPool<byte>.Shared.Rent(copyToBufferSizeRequested);
+            int actualBufferSize = rentedBuffer.Length;
+            ArrayPool<byte>.Shared.Return(rentedBuffer);
+
+            // use 3 buffers-full so that we can prime the stream with the first buffer-full,
+            // test that CopyTo successfully flushes this at the beginning of the operation, 
+            // then populates the second buffer-full and reads its entirety despite every
+            // payload being 0 length before it reads the final buffer-full.
+            int minCompressedSize = 3 * actualBufferSize;
+
+            using (Stream compressedStream = new DerivedMemoryStream())
+            {
+                using (var gz = new GZipStream(compressedStream, CompressionLevel.NoCompression, leaveOpen: true))
+                {
+                    // write one byte in order to allow us to prime the inflater buffer
+                    gz.WriteByte(3);
+                }
+
+                while (compressedStream.Length < minCompressedSize)
+                {
+                    using (var gz = new GZipStream(compressedStream, CompressionLevel.NoCompression, leaveOpen: true))
+                    {
+                        gz.Write(Array.Empty<byte>());
+                    }
+                }
+
+                compressedStream.Seek(0, SeekOrigin.Begin);
+                using (Stream gz = new GZipStream(compressedStream, CompressionMode.Decompress, leaveOpen: true))
+                using (Stream decompressedData = new DerivedMemoryStream())
+                {
+                    // read one byte in order to fill the inflater bufffer before copy
+                    Assert.Equal(3, gz.ReadByte());
+
+                    gz.CopyTo(decompressedData, copyToBufferSizeRequested);
+                    Assert.Equal(0, decompressedData.Length);
+                }
+
+                compressedStream.Seek(0, SeekOrigin.Begin);
+                using (Stream gz = new GZipStream(compressedStream, CompressionMode.Decompress, leaveOpen: true))
+                using (Stream decompressedData = new DerivedMemoryStream())
+                {
+                    // read one byte in order to fill the inflater bufffer before copy
+                    Assert.Equal(3, gz.ReadByte());
+
+                    await gz.CopyToAsync(decompressedData, copyToBufferSizeRequested);
+                    Assert.Equal(0, decompressedData.Length);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(1000, TestScenario.Read, 1000, 1)]
+        [InlineData(1000, TestScenario.ReadByte, 0, 1)]
+        [InlineData(1000, TestScenario.ReadAsync, 1000, 1)]
+        [InlineData(1000, TestScenario.Copy, 1000, 1)]
+        [InlineData(1000, TestScenario.CopyAsync, 1000, 1)]
+        [InlineData(10, TestScenario.Read, 1000, 2000)]
+        [InlineData(10, TestScenario.ReadByte, 0, 2000)]
+        [InlineData(10, TestScenario.ReadAsync, 1000, 2000)]
+        [InlineData(10, TestScenario.Copy, 1000, 2000)]
+        [InlineData(10, TestScenario.CopyAsync, 1000, 2000)]
+        [InlineData(2, TestScenario.Copy, 1000, 0x2000-30)]
+        [InlineData(2, TestScenario.CopyAsync, 1000, 0x2000 - 30)]
+        [InlineData(1000, TestScenario.Read, 1, 1)]
+        [InlineData(1000, TestScenario.ReadAsync, 1, 1)]
+        [InlineData(1000, TestScenario.Read, 1001 * 24, 1)]
+        [InlineData(1000, TestScenario.ReadAsync, 1001 * 24, 1)]
+        [InlineData(1000, TestScenario.Copy, 1001 * 24, 1)]
+        [InlineData(1000, TestScenario.CopyAsync, 1001 * 24, 1)]
+        public async Task ManyConcatenatedGzipStreams(int streamCount, TestScenario scenario, int bufferSize, int bytesPerStream)
+        {
+            await TestConcatenatedGzipStreams(streamCount, scenario, bufferSize, bytesPerStream);
         }
 
         [Theory]
         [OuterLoop("Tests take a very long time to complete")]
-        [InlineData(400000, false, false, 1000, 1)]
-        [InlineData(400000, true, false, 1000, 1)]
-        [InlineData(1000, false, false, 1000, 20000)]
-        [InlineData(1000, false, true, 0, 20000)]
-        [InlineData(1000, true, false, 1000, 9000)]
-        [InlineData(1000, false, false, 1, 9000)]
-        [InlineData(1000, true, false, 1, 9000)]
-        [InlineData(1000, false, false, 1001 * 24, 9000)]
-        [InlineData(1000, true, false, 1001 * 24, 9000)]
-        public async Task ManyManyConcatenatedGzipStreams(int streamCount, bool useAsync, bool useReadByte, int bufferSize, int bytesPerStream)
+        [InlineData(400000, TestScenario.Read, 1000, 1)]
+        [InlineData(400000, TestScenario.ReadAsync, 1000, 1)]
+        [InlineData(400000, TestScenario.Copy, 1000, 1)]
+        [InlineData(400000, TestScenario.CopyAsync, 1000, 1)]
+        [InlineData(1000, TestScenario.Read, 1000, 20000)]
+        [InlineData(1000, TestScenario.ReadByte, 0, 20000)]
+        [InlineData(1000, TestScenario.ReadAsync, 1000, 9000)]
+        [InlineData(1000, TestScenario.Read, 1, 9000)]
+        [InlineData(1000, TestScenario.ReadAsync, 1, 9000)]
+        [InlineData(1000, TestScenario.Read, 1001 * 24, 9000)]
+        [InlineData(1000, TestScenario.ReadAsync, 1001 * 24, 9000)]
+        [InlineData(1000, TestScenario.Copy, 1001 * 24, 9000)]
+        [InlineData(1000, TestScenario.CopyAsync, 1001 * 24, 9000)]
+        public async Task ManyManyConcatenatedGzipStreams(int streamCount, TestScenario scenario, int bufferSize, int bytesPerStream)
         {
-            await TestConcatenatedGzipStreams(streamCount, useAsync, useReadByte, bufferSize, bytesPerStream);
+            await TestConcatenatedGzipStreams(streamCount, scenario, bufferSize, bytesPerStream);
         }
 
-        private async Task TestConcatenatedGzipStreams(int streamCount, bool useAsync, bool useReadByte, int bufferSize, int bytesPerStream = 1)
+        public enum TestScenario
         {
-            using (var correctDecompressedOutput = new MemoryStream())
-            using (var compressedStream = new MemoryStream())
-            using (var decompressorOutput = new MemoryStream())
+            ReadByte,
+            Read,
+            ReadAsync,
+            Copy,
+            CopyAsync
+        }
+
+        private async Task TestConcatenatedGzipStreams(int streamCount, TestScenario scenario, int bufferSize, int bytesPerStream = 1)
+        {
+            bool isCopy = scenario == TestScenario.Copy || scenario == TestScenario.CopyAsync;
+
+            using (MemoryStream correctDecompressedOutput = new MemoryStream())
+            // For copy scenarios use a derived MemoryStream to avoid MemoryStream's Copy optimization 
+            // that turns the Copy into a single Write passing the backing buffer
+            using (MemoryStream compressedStream = isCopy ? new DerivedMemoryStream() : new MemoryStream())  
+            using (MemoryStream decompressorOutput = new MemoryStream())
             {
                 for (int i = 0; i < streamCount; i++)
                 {
@@ -100,7 +194,7 @@ namespace System.IO.Compression
                         for (int j = 0; j < bytesPerStream; j++)
                         {
                             byte b = (byte)((i * j) % 256);
-                            gz.WriteByte( b);
+                            gz.WriteByte(b);
                             correctDecompressedOutput.WriteByte(b);
                         }
                     }
@@ -108,46 +202,55 @@ namespace System.IO.Compression
                 compressedStream.Seek(0, SeekOrigin.Begin);
 
                 var decompressor = CreateStream(compressedStream, CompressionMode.Decompress);
-                //Thread.Sleep(10000);
 
                 var bytes = new byte[bufferSize];
                 bool finished = false;
                 int retCount = 0, totalRead = 0;
                 while (!finished)
                 {
-                    if (useAsync)
+                    switch (scenario)
                     {
-                        try
-                        {
-                            retCount = await decompressor.ReadAsync(bytes, 0, bufferSize);
-                            totalRead += retCount;
-                            if (retCount != 0)
-                                await decompressorOutput.WriteAsync(bytes, 0, retCount);
+                        case TestScenario.ReadAsync:
+                            try
+                            {
+                                retCount = await decompressor.ReadAsync(bytes, 0, bufferSize);
+                                totalRead += retCount;
+                                if (retCount != 0)
+                                    await decompressorOutput.WriteAsync(bytes, 0, retCount);
+                                else
+                                    finished = true;
+                            }
+                            catch (Exception)
+                            {
+                                throw new Exception(retCount + " " + totalRead);
+                            }
+                            break;
+                        case TestScenario.ReadByte:
+                            int b = decompressor.ReadByte();
+
+                            if (b != -1)
+                                decompressorOutput.WriteByte((byte)b);
                             else
                                 finished = true;
-                        }
-                        catch (Exception)
-                        {
-                            throw new Exception(retCount + " " + totalRead);
-                        }
-                    }
-                    else if (useReadByte)
-                    {
-                        int b = decompressor.ReadByte();
 
-                        if (b != -1)
-                            decompressorOutput.WriteByte((byte)b);
-                        else
-                            finished = true;
-                    }
-                    else
-                    {
-                        retCount = decompressor.Read(bytes, 0, bufferSize);
+                            break;
+                        case TestScenario.Read:
+                            retCount = decompressor.Read(bytes, 0, bufferSize);
 
-                        if (retCount != 0)
-                            decompressorOutput.Write(bytes, 0, retCount);
-                        else
+                            if (retCount != 0)
+                                decompressorOutput.Write(bytes, 0, retCount);
+                            else
+                                finished = true;
+
+                            break;
+                        case TestScenario.Copy:
+                            decompressor.CopyTo(decompressorOutput, bufferSize);
                             finished = true;
+                            break;
+                        case TestScenario.CopyAsync:
+                            await decompressor.CopyToAsync(decompressorOutput, bufferSize);
+                            finished = true;
+                            break;
                     }
                 }
                 decompressor.Dispose();


### PR DESCRIPTION
Ports the following to release/3.1
https://github.com/dotnet/corefx/pull/41190
https://github.com/dotnet/corefx/pull/41451

Issues:
System.IO.Compression.ZipArchive reads entire input stream before failing when non-Zip specified (#34892)
InvalidDataException when decompressing concatenated GZIP payloads with CopyTo (#40710)


## Description
- When examining a stream to see if it is a valid zip we search the entire stream for the end of central directory.  For large streams that aren't zips this can take a very long time.  We can assume that the end of central directory is within a certain distance from the end of the stream, which results in a smaller amount of seeking/reading and a faster failure.
- When reading a concatenated GZip payload and the footer of a payload is at the start of a block we will skip the rest of the block and try to consume a header at the start of the next block.

## Customer Impact

- Slow failure is a perf issue for customers, some users perceive this as a deadlock.
- Concat bug is a correctness / data corruption issue.  Customer is blocked when copying from a stream that has a concatenated payload on a particular boundary.  In the case of an (un)lucky payload this can result in silently omitting data.

## Regression?

No (concat issue broken only in new behavior, since it was introduced)

## Risk

Low. 
Someone reading a zip from a stream with other data may have previously succeeded but will now fail.  We've mitigated this by testing lots of permutations of zips with padding and confirmed that our new behavior is similar to most other zip implementations.  
There is a small risk that the concat fix will result in a case that was failing now producing a lot more data, but this is the purpose of the fix.
Both fixes have added tests for the specific scenario they address.