### PR TITLE
Revert license renaming

### DIFF
--- a/.azure-ci.yml
+++ b/.azure-ci.yml
@@ -13,7 +13,7 @@ trigger:
     - Documentation/*
     - CODE-OF-CONDUCT.md
     - CONTRIBUTING.md
-    - LICENSE
+    - LICENSE.TXT
     - PATENTS.TXT
     - README.md
     - SECURITY.md
@@ -29,7 +29,7 @@ pr:
     - Documentation/*
     - CODE-OF-CONDUCT.md
     - CONTRIBUTING.md
-    - LICENSE
+    - LICENSE.TXT
     - PATENTS.TXT
     - README.md
     - SECURITY.md

--- a/Documentation/building/unix-instructions.md
+++ b/Documentation/building/unix-instructions.md
@@ -78,7 +78,7 @@ There is one caveat: you must set the LANG in your shell to something other than
 ```sh
 export LANG=en_US.UTF-8
 ```
-Otherwise you may get errors like `PackagingException: File not found: '/home/dan/git/corefx/LICENSE'`. More info in [this issue](https://github.com/dotnet/corefx/issues/38608). It is possible this may occur on other distros, if LANG is set as above.
+Otherwise you may get errors like `PackagingException: File not found: '/home/dan/git/corefx/LICENSE.TXT'`. More info in [this issue](https://github.com/dotnet/corefx/issues/38608). It is possible this may occur on other distros, if LANG is set as above.
 
 We have not tested on WSL2 yet. If you try it out, we'd welcome an update.
 

--- a/eng/Packaging.props
+++ b/eng/Packaging.props
@@ -1,12 +1,12 @@
 <Project>
   <PropertyGroup>
     <PackageDescriptionFile>$(RepoRoot)pkg/descriptions.json</PackageDescriptionFile>
-    <PackageLicenseFile>$(RepoRoot)LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>$(RepoRoot)LICENSE.TXT</PackageLicenseFile>
     <PackageThirdPartyNoticesFile>$(RepoRoot)THIRD-PARTY-NOTICES.TXT</PackageThirdPartyNoticesFile>
     <RuntimeIdGraphDefinitionFile>$(RepoRoot)pkg/Microsoft.NETCore.Platforms/runtime.json</RuntimeIdGraphDefinitionFile>
     <ReleaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</ReleaseNotes>
     <ProjectUrl>https://github.com/dotnet/corefx</ProjectUrl>
-    <LicenseUrl>https://github.com/dotnet/corefx/blob/master/LICENSE</LicenseUrl>
+    <LicenseUrl>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</LicenseUrl>
     <!-- defined in buildtools packaging.targets, but we need this before targets are imported -->
     <PackagePlatform Condition="'$(PackagePlatform)' == ''">$(Platform)</PackagePlatform>
     <PackagePlatform Condition="'$(PackagePlatform)' == 'amd64'">x64</PackagePlatform>


### PR DESCRIPTION
This is the follow-up fix of https://github.com/dotnet/corefx/commit/23f5ecd6a1231d286257d9cc2efda549efed949b. Updating the remaining places.