### PR TITLE
Handle non blittable LOGFONT structs (#41975)

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/Font.Windows.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Font.Windows.cs
@@ -311,16 +311,21 @@ namespace System.Drawing
             // Now that we know the marshalled size is the same as LOGFONT, copy in the data
             logFont = new SafeNativeMethods.LOGFONT();
 
-            if (!type.IsValueType)
-            {
-                // Only works with non value types
-                Marshal.StructureToPtr(lf, new IntPtr(&logFont), fDeleteOld: false);
-            }
-            else
+            try
             {
                 GCHandle handle = GCHandle.Alloc(lf, GCHandleType.Pinned);
                 Buffer.MemoryCopy((byte*)handle.AddrOfPinnedObject(), &logFont, nativeSize, nativeSize);
                 handle.Free();
+            }
+            catch (ArgumentException)
+            {
+                // If the type isn't blittable it won't be able to be pinned with GCHandle. Try
+                // to use the marshaller to copy the "native" representation instead.
+                //
+                // This happens for classes or structs that have reference types as members.
+                // Marshal.StructureToPtr() will *not* work with blittable structs (which are
+                // handled in the try block above).
+                Marshal.StructureToPtr(lf, new IntPtr(&logFont), fDeleteOld: false);
             }
 
             return FromLogFontInternal(ref logFont, hdc);

--- a/src/System.Drawing.Common/src/System/Drawing/Font.Windows.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Font.Windows.cs
@@ -310,23 +310,7 @@ namespace System.Drawing
 
             // Now that we know the marshalled size is the same as LOGFONT, copy in the data
             logFont = new SafeNativeMethods.LOGFONT();
-
-            try
-            {
-                GCHandle handle = GCHandle.Alloc(lf, GCHandleType.Pinned);
-                Buffer.MemoryCopy((byte*)handle.AddrOfPinnedObject(), &logFont, nativeSize, nativeSize);
-                handle.Free();
-            }
-            catch (ArgumentException)
-            {
-                // If the type isn't blittable it won't be able to be pinned with GCHandle. Try
-                // to use the marshaller to copy the "native" representation instead.
-                //
-                // This happens for classes or structs that have reference types as members.
-                // Marshal.StructureToPtr() will *not* work with blittable structs (which are
-                // handled in the try block above).
-                Marshal.StructureToPtr(lf, new IntPtr(&logFont), fDeleteOld: false);
-            }
+            Marshal.StructureToPtr(lf, new IntPtr(&logFont), fDeleteOld: false);
 
             return FromLogFontInternal(ref logFont, hdc);
         }

--- a/src/System.Drawing.Common/tests/FontTests.cs
+++ b/src/System.Drawing.Common/tests/FontTests.cs
@@ -711,6 +711,56 @@ namespace System.Drawing.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ConditionalFact(Helpers.IsDrawingSupported)]
+        public void FromLogFont_UnblittableStruct()
+        {
+            const byte OUT_TT_ONLY_PRECIS = 7;
+            using (var image = new Bitmap(10, 10))
+            using (Graphics graphics = Graphics.FromImage(image))
+            {
+                IntPtr hdc = graphics.GetHdc();
+                try
+                {
+                    var logFont = new UnblittableLOGFONT
+                    {
+                        lfOutPrecision = OUT_TT_ONLY_PRECIS
+                    };
+
+                    using (Font font = Font.FromLogFont(logFont))
+                    {
+                        Assert.NotNull(font);
+                        Assert.NotEmpty(font.Name);
+                    }
+                }
+                finally
+                {
+                    graphics.ReleaseHdc();
+                }
+            }
+        }
+
+        [Serializable()]
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+        public struct UnblittableLOGFONT
+        {
+            public int lfHeight;
+            public int lfWidth;
+            public int lfEscapement;
+            public int lfOrientation;
+            public int lfWeight;
+            public byte lfItalic;
+            public byte lfUnderline;
+            public byte lfStrikeOut;
+            public byte lfCharSet;
+            public byte lfOutPrecision;
+            public byte lfClipPrecision;
+            public byte lfQuality;
+            public byte lfPitchAndFamily;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
+            public string lfFaceName;
+        }
+
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(GraphicsUnit.Document)]
         [InlineData(GraphicsUnit.Inch)]

--- a/src/System.Drawing.Common/tests/FontTests.cs
+++ b/src/System.Drawing.Common/tests/FontTests.cs
@@ -740,6 +740,54 @@ namespace System.Drawing.Tests
             }
         }
 
+        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
+        [ConditionalFact(Helpers.IsDrawingSupported)]
+        public void FromLogFont_BlittableStruct()
+        {
+            const byte OUT_TT_ONLY_PRECIS = 7;
+            using (var image = new Bitmap(10, 10))
+            using (Graphics graphics = Graphics.FromImage(image))
+            {
+                IntPtr hdc = graphics.GetHdc();
+                try
+                {
+                    var logFont = new BlittableLOGFONT
+                    {
+                        lfOutPrecision = OUT_TT_ONLY_PRECIS
+                    };
+
+                    using (Font font = Font.FromLogFont(logFont))
+                    {
+                        Assert.NotNull(font);
+                        Assert.NotEqual(font.Name[0], '\0');
+                    }
+                }
+                finally
+                {
+                    graphics.ReleaseHdc();
+                }
+            }
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public unsafe struct BlittableLOGFONT
+        {
+            public int lfHeight;
+            public int lfWidth;
+            public int lfEscapement;
+            public int lfOrientation;
+            public int lfWeight;
+            public byte lfItalic;
+            public byte lfUnderline;
+            public byte lfStrikeOut;
+            public byte lfCharSet;
+            public byte lfOutPrecision;
+            public byte lfClipPrecision;
+            public byte lfQuality;
+            public byte lfPitchAndFamily;
+            public fixed char lfFaceName[32];
+        }
+
         [Serializable()]
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
         public struct UnblittableLOGFONT


### PR DESCRIPTION
### Summary

`System.Drawing.Font.FromLogFont(object lf)` takes a LOGFONT “structure” to create a `Font`. User defined structs that are not blittable (that have a reference type in them) no longer work with this API. This issue was found by a WinForms customer that was trying to port.

### Customer Impact

User can no longer use some existing LOGFONT wrapping types. The workaround is to convert the struct to a class or blittable struct.

### Risk

Low. I was choosing the wrong code path for non-blittable structs. Change is simple.

Fixes: https://github.com/dotnet/winforms/issues/2136
Ports https://github.com/dotnet/corefx/pull/41975 (with additional changes per @jkotas feedback)
