### PR TITLE
[release/3.1] Fix CharSet to Unicode for Gdip.DrawString

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
@@ -215,7 +215,7 @@ namespace System.Drawing
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipFillRectanglesI(IntPtr graphics, IntPtr brush, Rectangle[] rects, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Unicode)]
             internal static extern int GdipDrawString(IntPtr graphics, string text, int len, IntPtr font, ref RectangleF rc, IntPtr format, IntPtr brush);
 
             [DllImport(LibraryName, ExactSpelling = true)]


### PR DESCRIPTION
### Summary

`Graphics.DrawString` takes a `string` and draws it into a graphics object which then can be saved into a file. However in https://github.com/dotnet/corefx/commit/b75421a0035bf3a44e1f68447255470d57074dbb#diff-8eda13b1268284d720355f95667dea21R218 we changed the way that we did `PInvokes` in System.Drawing to improve winforms performance. This parameter needed to be marshaled as a `LPWStr` which represents a pointer to a 16 bit Unicode string, so we need to set the CharSet to Unicode in order for the output image to be rendered correctly.

### Customer Impact

User can not draw a string into an image on Unix.

Expected:
![dotnetcore22](https://user-images.githubusercontent.com/22223342/65538811-70665d80-df08-11e9-9a4e-90301233206f.png)

Output:
![dotnetcore30](https://user-images.githubusercontent.com/22223342/65538813-72302100-df08-11e9-9732-5a98379a9a43.png)

### Risk

Medium as changing marshaling can always have other fall-backs. However this should match what we had previously: https://github.com/dotnet/corefx/commit/b75421a0035bf3a44e1f68447255470d57074dbb#diff-8eda13b1268284d720355f95667dea21L457

Contributes to: https://github.com/dotnet/corefx/issues/41292