### PR TITLE
Event log retries

### DIFF
--- a/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogEntryCollectionTests.cs
@@ -40,7 +40,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.Retry(() => EventLog.Delete(log));
+                Helpers.RetrySilently(() => EventLog.Delete(log));
             }
         }
 
@@ -65,7 +65,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.Retry(() => EventLog.Delete(log));
+                Helpers.RetrySilently(() => EventLog.Delete(log));
             }
         }
 
@@ -95,7 +95,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.Retry(() => EventLog.Delete(log));
+                Helpers.RetrySilently(() => EventLog.Delete(log));
             }
         }
 
@@ -122,7 +122,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.Retry(() => EventLog.Delete(log));
+                Helpers.RetrySilently(() => EventLog.Delete(log));
             }
         }
     }

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogSourceCreationTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogSourceCreationTests.cs
@@ -21,7 +21,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.Retry(() => EventLog.Delete(log));
+                Helpers.Retry(() => EventLog.Delete(log));  // unlike other tests, throw if delete fails
             }
 
             Assert.False(EventLog.SourceExists(source));
@@ -155,7 +155,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.Retry(() => EventLog.Delete(log));
+                Helpers.RetrySilently(() => EventLog.Delete(log));
             }
         }
 

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
@@ -44,7 +44,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.Retry(() => EventLog.Delete(log));
+                Helpers.RetrySilently(() => EventLog.Delete(log));
             }
         }
 
@@ -71,7 +71,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.Retry(() => EventLog.Delete(log));
+                Helpers.Retry(() => EventLog.Delete(log)); // unlike other tests, throw if delete fails
                 Assert.False(EventLog.Exists(log));
             }
         }
@@ -147,7 +147,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.Retry(() => EventLog.Delete(log));
+                Helpers.RetrySilently(() => EventLog.Delete(log));
             }
         }
 
@@ -186,7 +186,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.Retry(() => EventLog.Delete(log));
+                Helpers.RetrySilently(() => EventLog.Delete(log));
             }
         }
 
@@ -213,7 +213,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.Retry(() => EventLog.Delete(log));
+                Helpers.RetrySilently(() => EventLog.Delete(log));
             }
         }
 
@@ -273,7 +273,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.Retry(() => EventLog.Delete(log));
+                Helpers.RetrySilently(() => EventLog.Delete(log));
             }
         }
 
@@ -331,7 +331,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.Retry(() => EventLog.Delete(log));
+                Helpers.RetrySilently(() => EventLog.Delete(log));
             }
         }
 

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogWriteEntryTests.cs
@@ -149,7 +149,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.Retry(() => EventLog.Delete(log));
+                Helpers.RetrySilently(() => EventLog.Delete(log));
             }
         }
 
@@ -178,7 +178,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.Retry(() => EventLog.Delete(log));
+                Helpers.RetrySilently(() => EventLog.Delete(log));
             }
         }
 
@@ -207,7 +207,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.Retry(() => EventLog.Delete(log));
+                Helpers.RetrySilently(() => EventLog.Delete(log));
             }
         }
 
@@ -242,7 +242,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.Retry(() => EventLog.Delete(log));
+                Helpers.RetrySilently(() => EventLog.Delete(log));
             }
         }
 
@@ -271,7 +271,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.Retry(() => EventLog.Delete(log));
+                Helpers.RetrySilently(() => EventLog.Delete(log));
             }
         }
 
@@ -324,7 +324,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.Retry(() => EventLog.Delete(log));
+                Helpers.RetrySilently(() => EventLog.Delete(log));
             }
         }
 
@@ -351,7 +351,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.Retry(() => EventLog.Delete(log));
+                Helpers.RetrySilently(() => EventLog.Delete(log));
             }
         }
 

--- a/src/System.Diagnostics.EventLog/tests/EventLogTraceListenerTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTraceListenerTests.cs
@@ -109,7 +109,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.Retry(() => EventLog.Delete(log));
+                Helpers.RetrySilently(() => EventLog.Delete(log));
             }
         }
 
@@ -142,7 +142,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.Retry(() => EventLog.Delete(log));
+                Helpers.RetrySilently(() => EventLog.Delete(log));
             }
         }
 
@@ -174,7 +174,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.Retry(() => EventLog.Delete(log));
+                Helpers.RetrySilently(() => EventLog.Delete(log));
             }
         }
 
@@ -247,7 +247,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.Retry(() => EventLog.Delete(log));
+                Helpers.RetrySilently(() => EventLog.Delete(log));
             }
         }
 
@@ -292,7 +292,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.Retry(() => EventLog.Delete(log));
+                Helpers.RetrySilently(() => EventLog.Delete(log));
             }
         }
 

--- a/src/System.Diagnostics.EventLog/tests/Helpers.cs
+++ b/src/System.Diagnostics.EventLog/tests/Helpers.cs
@@ -18,6 +18,17 @@ namespace System.Diagnostics.Tests
         public static bool IsElevatedAndSupportsEventLogs { get => AdminHelpers.IsProcessElevated() && SupportsEventLogs; }
         public static bool SupportsEventLogs { get => PlatformDetection.IsNotWindowsNanoServer && PlatformDetection.IsNotWindowsIoTCore; }
 
+        // Retry that eats exceptions: for "best effort cleanup"
+        public static void RetrySilently(Action func)
+        {
+            try
+            {
+                Retry(func);
+            }
+            catch
+            {}
+        }
+
         public static void Retry(Action func)
         {
             Retry<object>(() => { func(); return null; });
@@ -30,7 +41,7 @@ namespace System.Diagnostics.Tests
             RetryHelper.Execute(() =>
             {
                 result = func();
-            }, maxAttempts: 10, (iteration) => iteration * 300);
+            }, maxAttempts: 20, (iteration) => iteration * 300);
 
             return result;
         }

--- a/src/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/EventLogWatcherTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/EventLogWatcherTests.cs
@@ -90,7 +90,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.Retry(() => EventLog.Delete(log));
+                Helpers.RetrySilently(() => EventLog.Delete(log));
             }
         }
 


### PR DESCRIPTION
Attempt to work around #41150 and #41968

Closes #41968

The OS is returning `ERROR_GEN_FAILURE` from `ClearEventLogW` 10 times in a row on the same log. In one of these cases it then did it 10 times again on the next test. (Probably because that test was hoping to use the same name.)

I do not know why this is but it's clearly rare and it's only on the cleanup path. So make our calls to this from tests ignore such failures, unless they're actually testing it.

Also incremented max retries, since why not.