### PR TITLE
Fix several Socket tests to not dispose an event on failure

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/DnsEndPointTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DnsEndPointTest.cs
@@ -195,17 +195,19 @@ namespace System.Net.Sockets.Tests
             int port;
             using (SocketTestServer server = SocketTestServer.SocketTestServerFactory(type, IPAddress.Loopback, out port))
             using (Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
-            using (ManualResetEvent complete = new ManualResetEvent(false))
             {
                 SocketAsyncEventArgs args = new SocketAsyncEventArgs();
                 args.RemoteEndPoint = new DnsEndPoint("localhost", port);
                 args.Completed += OnConnectAsyncCompleted;
+
+                ManualResetEvent complete = new ManualResetEvent(false);
                 args.UserToken = complete;
 
                 bool willRaiseEvent = sock.ConnectAsync(args);
                 if (willRaiseEvent)
                 {
                     Assert.True(complete.WaitOne(TestSettings.PassingTestTimeout), "Timed out while waiting for connection");
+                    complete.Dispose(); // only dispose on success as we know we're done with the instance
                 }
 
                 Assert.Equal(SocketError.Success, args.SocketError);
@@ -225,7 +227,6 @@ namespace System.Net.Sockets.Tests
             int port;
             using (SocketTestServer server = SocketTestServer.SocketTestServerFactory(type, IPAddress.Loopback, out port))
             using (Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
-            using (ManualResetEvent complete = new ManualResetEvent(false))
             {
                 sock.LingerState = new LingerOption(false, 0);
                 sock.NoDelay = true;
@@ -237,12 +238,15 @@ namespace System.Net.Sockets.Tests
                 SocketAsyncEventArgs args = new SocketAsyncEventArgs();
                 args.RemoteEndPoint = new DnsEndPoint("localhost", port);
                 args.Completed += OnConnectAsyncCompleted;
+
+                ManualResetEvent complete = new ManualResetEvent(false);
                 args.UserToken = complete;
 
                 bool willRaiseEvent = sock.ConnectAsync(args);
                 if (willRaiseEvent)
                 {
                     Assert.True(complete.WaitOne(TestSettings.PassingTestTimeout), "Timed out while waiting for connection");
+                    complete.Dispose(); // only dispose on success as we know we're done with the instance
                 }
 
                 Assert.Equal(SocketError.Success, args.SocketError);
@@ -262,13 +266,15 @@ namespace System.Net.Sockets.Tests
             args.Completed += OnConnectAsyncCompleted;
 
             using (Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
-            using (ManualResetEvent complete = new ManualResetEvent(false))
             {
+                ManualResetEvent complete = new ManualResetEvent(false);
                 args.UserToken = complete;
+
                 bool willRaiseEvent = sock.ConnectAsync(args);
                 if (willRaiseEvent)
                 {
                     Assert.True(complete.WaitOne(TestSettings.PassingTestTimeout), "Timed out while waiting for connection");
+                    complete.Dispose(); // only dispose on success as we know we're done with the instance
                 }
 
                 AssertHostNotFoundOrNoData(args);
@@ -287,14 +293,15 @@ namespace System.Net.Sockets.Tests
             args.Completed += OnConnectAsyncCompleted;
 
             using (Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
-            using (ManualResetEvent complete = new ManualResetEvent(false))
             {
+                ManualResetEvent complete = new ManualResetEvent(false);
                 args.UserToken = complete;
 
                 bool willRaiseEvent = sock.ConnectAsync(args);
                 if (willRaiseEvent)
                 {
                     Assert.True(complete.WaitOne(TestSettings.PassingTestTimeout), "Timed out while waiting for connection");
+                    complete.Dispose(); // only dispose on success as we know we're done with the instance
                 }
 
                 Assert.Equal(SocketError.ConnectionRefused, args.SocketError);
@@ -342,6 +349,7 @@ namespace System.Net.Sockets.Tests
                 Assert.True(Socket.ConnectAsync(SocketType.Stream, ProtocolType.Tcp, args));
 
                 Assert.True(complete.WaitOne(TestSettings.PassingTestTimeout), "Timed out while waiting for connection");
+                complete.Dispose(); // only dispose on success as we know we're done with the instance
 
                 Assert.Equal(SocketError.Success, args.SocketError);
                 Assert.Null(args.ConnectByNameError);
@@ -371,6 +379,7 @@ namespace System.Net.Sockets.Tests
             }
 
             Assert.True(complete.WaitOne(TestSettings.PassingTestTimeout), "Timed out while waiting for connection");
+            complete.Dispose(); // only dispose on success as we know we're done with the instance
 
             AssertHostNotFoundOrNoData(args);
 
@@ -397,6 +406,7 @@ namespace System.Net.Sockets.Tests
             }
 
             Assert.True(complete.WaitOne(TestSettings.PassingTestTimeout), "Timed out while waiting for connection");
+            complete.Dispose(); // only dispose on success as we know we're done with the instance
 
             Assert.Equal(SocketError.ConnectionRefused, args.SocketError);
             Assert.True(args.ConnectByNameError is SocketException);


### PR DESCRIPTION
When I run these tests locally, due to my network configuration they sometimes fail.  If they fail and the test is disposing of the ManualResetEvent, the async callback may try to set the event after it's already been disposed, which throws an exception that crashes the test process.  The easy fix is to just dispose of these MRE instances on success and let their finalizers clean up for them if the tests fail.