### PR TITLE
[release/3.1] Use ThrowHelper in Utf8JsonReader.GetGuid so that the deserializer can catch the exception and re-throw JsonException

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
@@ -108,7 +108,7 @@ namespace System.Text.Json
         {
             if (!TryGetBytesFromBase64(out byte[] value))
             {
-                throw ThrowHelper.GetFormatException(DateType.Base64String);
+                throw ThrowHelper.GetFormatException(DataType.Base64String);
             }
             return value;
         }
@@ -395,7 +395,7 @@ namespace System.Text.Json
         {
             if (!TryGetDateTime(out DateTime value))
             {
-                throw ThrowHelper.GetFormatException(DateType.DateTime);
+                throw ThrowHelper.GetFormatException(DataType.DateTime);
             }
 
             return value;
@@ -418,7 +418,7 @@ namespace System.Text.Json
         {
             if (!TryGetDateTimeOffset(out DateTimeOffset value))
             {
-                throw ThrowHelper.GetFormatException(DateType.DateTimeOffset);
+                throw ThrowHelper.GetFormatException(DataType.DateTimeOffset);
             }
 
             return value;
@@ -441,7 +441,7 @@ namespace System.Text.Json
         {
             if (!TryGetGuid(out Guid value))
             {
-                throw new FormatException(SR.FormatGuid);
+                throw ThrowHelper.GetFormatException(DataType.Guid);
             }
 
             return value;

--- a/src/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
+++ b/src/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
@@ -565,20 +565,23 @@ namespace System.Text.Json
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static FormatException GetFormatException(DateType dateType)
+        public static FormatException GetFormatException(DataType dateType)
         {
             string message = "";
 
             switch (dateType)
             {
-                case DateType.DateTime:
+                case DataType.DateTime:
                     message = SR.FormatDateTime;
                     break;
-                case DateType.DateTimeOffset:
+                case DataType.DateTimeOffset:
                     message = SR.FormatDateTimeOffset;
                     break;
-                case DateType.Base64String:
+                case DataType.Base64String:
                     message = SR.CannotDecodeInvalidBase64;
+                    break;
+                case DataType.Guid:
+                    message = SR.FormatGuid;
                     break;
                 default:
                     Debug.Fail($"The DateType enum value: {dateType} is not part of the switch. Add the appropriate case and exception message.");
@@ -650,10 +653,11 @@ namespace System.Text.Json
         Decimal
     }
 
-    internal enum DateType
+    internal enum DataType
     {
         DateTime,
         DateTimeOffset,
-        Base64String
+        Base64String,
+        Guid,
     }
 }

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
@@ -78,6 +78,29 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<int[]>(Encoding.UTF8.GetBytes(@"[1,a]")));
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<int>(@"null"));
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<int>(@""""""));
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<DateTime>("\"abc\""));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<DateTimeOffset>("\"abc\""));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Guid>("\"abc\""));
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<byte>("\"abc\""));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<byte>("1.1"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<sbyte>("\"abc\""));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<sbyte>("1.1"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<short>("\"abc\""));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<short>("1.1"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ushort>("\"abc\""));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ushort>("1.1"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<int>("\"abc\""));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<int>("1.1"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<uint>("\"abc\""));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<uint>("1.1"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<long>("\"abc\""));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<long>("1.1"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ulong>("\"abc\""));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ulong>("1.1"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<float>("\"abc\""));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<double>("\"abc\""));
         }
 
         [Theory]


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/41032

Porting https://github.com/dotnet/corefx/pull/40938 which addresses https://github.com/aspnet/AspNetCore/issues/13811

### Description

Use the existing ThrowHelper which sets the source of the exception correctly for the case of Guid so that the deserializer knows to re-catch that and throw the expected JsonException (like all other data types we support). Renaming the internal `DateType` to `DataType` to correctly reflect its usage.

### Customer Impact:

Customer reported issue. When processing mismatching JSON payload within an AspNetCore WebAPI that expected Guids, the user sees a 500 error (Internal Server Error) rather than the expected 400 (Bad Request Error). Asp.Net expects a JsonException in this case from the deserializer and we are leaking FormatException.

Snippet from issue - Expected behavior:
> Invalid GUID should trigger a "Bad Request" (400) response with a ProblemDetails object, not an Internal server error.

### Regression? 

No

### Risk

Low. Other than the rename and tests, the change is a one line fix and we are still throwing the same exception from the reader. We are now correctly throwing `JsonException` from the Deserializer. The only concern would be if someone was catching and relying on the previous exception rather than `JsonException` but that would be an incorrect approach anyway.

### Tests run / added

Unit tests added for "mismatching" deserialization of the supported primitive types and validated within an aspnet web api that the fix from master works as expected.

cc @pranavkm, @ericstj, @danmosemsft 
