### PR TITLE
[release/3.1] JsonSerializer.Serialize should check whether the passed-in Utf8JsonWriter is null.

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
@@ -97,6 +97,11 @@ namespace System.Text.Json
                 options = JsonSerializerOptions.s_defaultOptions;
             }
 
+            if (writer == null)
+            {
+                throw new ArgumentNullException(nameof(writer));
+            }
+
             WriteCore(writer, value, type, options);
         }
 
@@ -111,6 +116,7 @@ namespace System.Text.Json
         private static void WriteCore(Utf8JsonWriter writer, object value, Type type, JsonSerializerOptions options)
         {
             Debug.Assert(type != null || value == null);
+            Debug.Assert(writer != null);
 
             if (value == null)
             {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Utf8JsonWriter.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Utf8JsonWriter.cs
@@ -12,6 +12,9 @@ namespace System.Text.Json
         /// <param name="writer">The writer to write.</param>
         /// <param name="value">The value to convert and write.</param>
         /// <param name="options">Options to control the behavior.</param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="writer"/> is null.
+        /// </exception>
         public static void Serialize<TValue>(Utf8JsonWriter writer, TValue value, JsonSerializerOptions options = null)
         {
             WriteValueCore(writer, value, typeof(TValue), options);
@@ -24,6 +27,9 @@ namespace System.Text.Json
         /// <param name="value">The value to convert and write.</param>
         /// <param name="inputType">The type of the <paramref name="value"/> to convert.</param>
         /// <param name="options">Options to control the behavior.</param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="writer"/> is null.
+        /// </exception>
         public static void Serialize(Utf8JsonWriter writer, object value, Type inputType, JsonSerializerOptions options = null)
         {
             VerifyValueAndType(value, inputType);

--- a/src/System.Text.Json/tests/Serialization/WriteValueTests.cs
+++ b/src/System.Text.Json/tests/Serialization/WriteValueTests.cs
@@ -10,6 +10,13 @@ namespace System.Text.Json.Serialization.Tests
     public static partial class WriteValueTests
     {
         [Fact]
+        public static void NullWriterThrows()
+        {
+            Assert.Throws<ArgumentNullException>(() => JsonSerializer.Serialize(null, 1));
+            Assert.Throws<ArgumentNullException>(() => JsonSerializer.Serialize(null, 1, typeof(int)));
+        }
+
+        [Fact]
         public static void CanWriteValueToJsonArray()
         {
             using MemoryStream memoryStream = new MemoryStream();


### PR DESCRIPTION
Porting https://github.com/dotnet/corefx/pull/42026

### Description

Add null checks for the `Utf8JsonWriter` argument being passed in to the JsonSerializer.Serialize overloads.

### Customer Impact:

Instead of user potentially seeing a `NullReferenceException`, they now get a more friendly `ArgumentNullException`. I'd put this type of fix in general reliability improvement.

### Regression? 

No

### Risk

Low. The change is really straight forward (basic argument validation and moving to a user-friendly exception). No one should be depending on `NullReferenceException`.

### Tests run / added

Basic test added.

cc @steveharter, @ericstj, @danmosemsft 
