### PR TITLE
[release/3.1] Use Sse2 instrinsics to optimize NeedsEscaping/FindFirstCharToEncode for all built-in JavaScriptEncoders

### DIFF
--- a/src/System.Text.Encodings.Web/src/Configurations.props
+++ b/src/System.Text.Encodings.Web/src/Configurations.props
@@ -1,6 +1,7 @@
 ﻿<Project DefaultTargets="Build">
   <PropertyGroup>
     <BuildConfigurations>
+      netcoreapp;
       netstandard2.1;
       netstandard;
       uap-Windows_NT;

--- a/src/System.Text.Encodings.Web/src/Configurations.props
+++ b/src/System.Text.Encodings.Web/src/Configurations.props
@@ -1,7 +1,7 @@
 ﻿<Project DefaultTargets="Build">
   <PropertyGroup>
     <BuildConfigurations>
-      netcoreapp;
+      netcoreapp3.0;
       netstandard2.1;
       netstandard;
       uap-Windows_NT;

--- a/src/System.Text.Encodings.Web/src/System.Text.Encodings.Web.csproj
+++ b/src/System.Text.Encodings.Web/src/System.Text.Encodings.Web.csproj
@@ -3,12 +3,15 @@
     <ProjectGuid>{B7EDBF00-765A-48E8-B593-CD668288E274}</ProjectGuid>
     <RootNamespace>System.Text.Encodings.Web</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Configurations>netstandard-Debug;netstandard-Release;netstandard2.1-Debug;netstandard2.1-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release;netstandard2.1-Debug;netstandard2.1-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="System\Text\Encodings\Web\DefaultJavaScriptEncoder.cs" />
+    <Compile Include="System\Text\Encodings\Web\DefaultJavaScriptEncoderBasicLatin.cs" />
     <Compile Include="System\Text\Encodings\Web\HexUtil.cs" />
     <Compile Include="System\Text\Encodings\Web\HtmlEncoder.cs" />
     <Compile Include="System\Text\Encodings\Web\JavaScriptEncoder.cs" />
+    <Compile Include="System\Text\Encodings\Web\JavaScriptEncoderHelper.cs" />
     <Compile Include="System\Text\Encodings\Web\TextEncoder.cs" />
     <Compile Include="System\Text\Encodings\Web\TextEncoderSettings.cs" />
     <Compile Include="System\Text\Encodings\Web\UnsafeRelaxedJavaScriptEncoder.cs" />
@@ -19,6 +22,9 @@
     <Compile Include="System\Text\Unicode\UnicodeRange.cs" />
     <Compile Include="System\Text\Unicode\UnicodeRanges.cs" />
     <Compile Include="System\Text\Unicode\UnicodeRanges.generated.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetCoreApp)' == 'true'">
+    <Compile Include="System\Text\Encodings\Web\Sse2Helper.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(CommonPath)\CoreLib\System\Text\UnicodeDebug.cs">
@@ -36,5 +42,8 @@
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Threading" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetCoreApp)' == 'true'">
+    <Reference Include="System.Runtime.Intrinsics" />
   </ItemGroup>
 </Project>

--- a/src/System.Text.Encodings.Web/src/System.Text.Encodings.Web.csproj
+++ b/src/System.Text.Encodings.Web/src/System.Text.Encodings.Web.csproj
@@ -4,6 +4,7 @@
     <RootNamespace>System.Text.Encodings.Web</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release;netstandard2.1-Debug;netstandard2.1-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
+    <DefineConstants Condition="'$(TargetsNetCoreApp)' == 'true'">$(DefineConstants);BUILDING_INBOX_LIBRARY</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Text\Encodings\Web\DefaultJavaScriptEncoder.cs" />

--- a/src/System.Text.Encodings.Web/src/System.Text.Encodings.Web.csproj
+++ b/src/System.Text.Encodings.Web/src/System.Text.Encodings.Web.csproj
@@ -3,7 +3,7 @@
     <ProjectGuid>{B7EDBF00-765A-48E8-B593-CD668288E274}</ProjectGuid>
     <RootNamespace>System.Text.Encodings.Web</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release;netstandard2.1-Debug;netstandard2.1-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
+    <Configurations>netcoreapp3.0-Debug;netcoreapp3.0-Release;netstandard-Debug;netstandard-Release;netstandard2.1-Debug;netstandard2.1-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
     <DefineConstants Condition="'$(TargetsNetCoreApp)' == 'true'">$(DefineConstants);BUILDING_INBOX_LIBRARY</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/DefaultJavaScriptEncoder.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/DefaultJavaScriptEncoder.cs
@@ -9,22 +9,24 @@ using System.Text.Internal;
 using System.Text.Unicode;
 
 #if NETCOREAPP
-using System.Numerics;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 #endif
 
 namespace System.Text.Encodings.Web
 {
-    internal sealed class UnsafeRelaxedJavaScriptEncoder : JavaScriptEncoder
+    internal sealed class DefaultJavaScriptEncoder : JavaScriptEncoder
     {
         private readonly AllowedCharactersBitmap _allowedCharacters;
 
-        internal static readonly UnsafeRelaxedJavaScriptEncoder s_singleton = new UnsafeRelaxedJavaScriptEncoder();
+        private readonly int[] _asciiNeedsEscaping = new int[0x80];
 
-        private UnsafeRelaxedJavaScriptEncoder()
+        public DefaultJavaScriptEncoder(TextEncoderSettings filter)
         {
-            var filter = new TextEncoderSettings(UnicodeRanges.All);
+            if (filter == null)
+            {
+                throw new ArgumentNullException(nameof(filter));
+            }
 
             _allowedCharacters = filter.GetAllowedCharacters();
 
@@ -32,13 +34,28 @@ namespace System.Text.Encodings.Web
             // (includes categories Cc, Cs, Co, Cn, Zs [except U+0020 SPACE], Zl, Zp)
             _allowedCharacters.ForbidUndefinedCharacters();
 
-            // '"' (U+0022 QUOTATION MARK) must always be escaped in Javascript / ECMAScript / JSON.
-            _allowedCharacters.ForbidCharacter('\"'); // can be used to escape attributes
+            // Forbid characters that are special in HTML.
+            // Even though this is a not HTML encoder,
+            // it's unfortunately common for developers to
+            // forget to HTML-encode a string once it has been JS-encoded,
+            // so this offers extra protection.
+            DefaultHtmlEncoder.ForbidHtmlCharacters(_allowedCharacters);
 
             // '\' (U+005C REVERSE SOLIDUS) must always be escaped in Javascript / ECMAScript / JSON.
             // '/' (U+002F SOLIDUS) is not Javascript / ECMAScript / JSON-sensitive so doesn't need to be escaped.
             _allowedCharacters.ForbidCharacter('\\');
+
+            // '`' (U+0060 GRAVE ACCENT) is ECMAScript-sensitive (see ECMA-262).
+            _allowedCharacters.ForbidCharacter('`');
+
+            for (int i = 0; i < _asciiNeedsEscaping.Length; i++)
+            {
+                _asciiNeedsEscaping[i] = WillEncode(i) ? 1 : -1;
+            }
         }
+
+        public DefaultJavaScriptEncoder(params UnicodeRange[] allowedRanges) : this(new TextEncoderSettings(allowedRanges))
+        { }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override bool WillEncode(int unicodeScalar)
@@ -61,81 +78,9 @@ namespace System.Text.Encodings.Web
                 throw new ArgumentNullException(nameof(text));
             }
 
-            int idx = 0;
-
-#if NETCOREAPP
-            if (Sse2.IsSupported)
-            {
-                short* startingAddress = (short*)text;
-                while (textLength - 8 >= idx)
-                {
-                    Debug.Assert(startingAddress >= text && startingAddress <= (text + textLength - 8));
-
-                    // Load the next 8 characters.
-                    Vector128<short> sourceValue = Sse2.LoadVector128(startingAddress);
-
-                    Vector128<short> mask = Sse2Helper.CreateAsciiMask(sourceValue);
-                    int index = Sse2.MoveMask(mask.AsByte());
-
-                    if (index != 0)
-                    {
-                        // At least one of the following 8 characters is non-ASCII.
-                        int processNextEight = idx + 8;
-                        Debug.Assert(processNextEight <= textLength);
-                        for (; idx < processNextEight; idx++)
-                        {
-                            Debug.Assert((text + idx) <= (text + textLength));
-                            if (!_allowedCharacters.IsCharacterAllowed(*(text + idx)))
-                            {
-                                goto Return;
-                            }
-                        }
-                        startingAddress += 8;
-                    }
-                    else
-                    {
-                        // Check if any of the 8 characters need to be escaped.
-                        mask = Sse2Helper.CreateEscapingMask_UnsafeRelaxedJavaScriptEncoder(sourceValue);
-
-                        index = Sse2.MoveMask(mask.AsByte());
-                        // If index == 0, that means none of the 8 characters needed to be escaped.
-                        // TrailingZeroCount is relatively expensive, avoid it if possible.
-                        if (index != 0)
-                        {
-                            // Found at least one character that needs to be escaped, figure out the index of
-                            // the first one found that needed to be escaped within the 8 characters.
-                            Debug.Assert(index > 0 && index <= 65_535);
-                            int tzc = BitOperations.TrailingZeroCount(index);
-                            Debug.Assert(tzc % 2 == 0 && tzc >= 0 && tzc <= 16);
-                            idx += tzc >> 1;
-                            goto Return;
-                        }
-                        idx += 8;
-                        startingAddress += 8;
-                    }
-                }
-
-                // Process the remaining characters.
-                Debug.Assert(textLength - idx < 8);
-            }
-#endif
-
-            for (; idx < textLength; idx++)
-            {
-                Debug.Assert((text + idx) <= (text + textLength));
-                if (!_allowedCharacters.IsCharacterAllowed(*(text + idx)))
-                {
-                    goto Return;
-                }
-            }
-
-            idx = -1; // All characters are allowed.
-
-        Return:
-            return idx;
+            return _allowedCharacters.FindFirstCharacterToEncode(text, textLength);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override unsafe int FindFirstCharacterToEncodeUtf8(ReadOnlySpan<byte> utf8Text)
         {
             fixed (byte* ptr = utf8Text)
@@ -169,7 +114,7 @@ namespace System.Text.Encodings.Web
 
                                 if (UnicodeUtility.IsAsciiCodePoint(ptr[idx]))
                                 {
-                                    if (!_allowedCharacters.IsUnicodeScalarAllowed(ptr[idx]))
+                                    if (DoesAsciiNeedEncoding(ptr[idx]) == 1)
                                     {
                                         goto Return;
                                     }
@@ -189,29 +134,35 @@ namespace System.Text.Encodings.Web
                                     idx += utf8BytesConsumedForScalar;
                                 }
                             }
-                            startingAddress = (sbyte*)ptr + idx;
                         }
                         else
                         {
-                            // Check if any of the 16 bytes need to be escaped.
-                            mask = Sse2Helper.CreateEscapingMask_UnsafeRelaxedJavaScriptEncoder(sourceValue);
+                            if (DoesAsciiNeedEncoding(ptr[idx]) == 1
 
-                            index = Sse2.MoveMask(mask);
-                            // If index == 0, that means none of the 16 bytes needed to be escaped.
-                            // TrailingZeroCount is relatively expensive, avoid it if possible.
-                            if (index != 0)
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1)
                             {
-                                // Found at least one byte that needs to be escaped, figure out the index of
-                                // the first one found that needed to be escaped within the 16 bytes.
-                                Debug.Assert(index > 0 && index <= 65_535);
-                                int tzc = BitOperations.TrailingZeroCount(index);
-                                Debug.Assert(tzc >= 0 && tzc <= 16);
-                                idx += tzc;
                                 goto Return;
                             }
-                            idx += 16;
-                            startingAddress += 16;
+                            idx++;
                         }
+                        startingAddress = (sbyte*)ptr + idx;
                     }
 
                     // Process the remaining bytes.
@@ -225,7 +176,7 @@ namespace System.Text.Encodings.Web
 
                     if (UnicodeUtility.IsAsciiCodePoint(ptr[idx]))
                     {
-                        if (!_allowedCharacters.IsUnicodeScalarAllowed(ptr[idx]))
+                        if (DoesAsciiNeedEncoding(ptr[idx]) == 1)
                         {
                             goto Return;
                         }
@@ -253,10 +204,22 @@ namespace System.Text.Encodings.Web
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private int DoesAsciiNeedEncoding(byte value)
+        {
+            Debug.Assert(value <= 0x7F);
+
+            int needsEscaping = _asciiNeedsEscaping[value];
+
+            Debug.Assert(needsEscaping == 1 || needsEscaping == -1);
+
+            return needsEscaping;
+        }
+
         // The worst case encoding is 6 output chars per input char: [input] U+FFFF -> [output] "\uFFFF"
         // We don't need to worry about astral code points since they're represented as encoded
         // surrogate pairs in the output.
-        public override int MaxOutputCharactersPerInputCharacter => 12; // "\uFFFF\uFFFF" is the longest encoded form 
+        public override int MaxOutputCharactersPerInputCharacter => 12; // "\uFFFF\uFFFF" is the longest encoded form
 
         private static readonly char[] s_b = new char[] { '\\', 'b' };
         private static readonly char[] s_t = new char[] { '\\', 't' };
@@ -264,7 +227,6 @@ namespace System.Text.Encodings.Web
         private static readonly char[] s_f = new char[] { '\\', 'f' };
         private static readonly char[] s_r = new char[] { '\\', 'r' };
         private static readonly char[] s_back = new char[] { '\\', '\\' };
-        private static readonly char[] s_doubleQuote = new char[] { '\\', '"' };
 
         // Writes a scalar value as a JavaScript-escaped character (or sequence of characters).
         // See ECMA-262, Sec. 7.8.4, and ECMA-404, Sec. 9
@@ -295,29 +257,13 @@ namespace System.Text.Encodings.Web
             char[] toCopy;
             switch (unicodeScalar)
             {
-                case '\"':
-                    toCopy = s_doubleQuote;
-                    break;
-                case '\b':
-                    toCopy = s_b;
-                    break;
-                case '\t':
-                    toCopy = s_t;
-                    break;
-                case '\n':
-                    toCopy = s_n;
-                    break;
-                case '\f':
-                    toCopy = s_f;
-                    break;
-                case '\r':
-                    toCopy = s_r;
-                    break;
-                case '\\':
-                    toCopy = s_back;
-                    break;
-                default:
-                    return JavaScriptEncoderHelper.TryWriteEncodedScalarAsNumericEntity(unicodeScalar, buffer, bufferLength, out numberOfCharactersWritten);
+                case '\b': toCopy = s_b; break;
+                case '\t': toCopy = s_t; break;
+                case '\n': toCopy = s_n; break;
+                case '\f': toCopy = s_f; break;
+                case '\r': toCopy = s_r; break;
+                case '\\': toCopy = s_back; break;
+                default: return JavaScriptEncoderHelper.TryWriteEncodedScalarAsNumericEntity(unicodeScalar, buffer, bufferLength, out numberOfCharactersWritten);
             }
             return TryCopyCharacters(toCopy, buffer, bufferLength, out numberOfCharactersWritten);
         }

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/DefaultJavaScriptEncoder.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/DefaultJavaScriptEncoder.cs
@@ -8,7 +8,7 @@ using System.Runtime.CompilerServices;
 using System.Text.Internal;
 using System.Text.Unicode;
 
-#if NETCOREAPP
+#if BUILDING_INBOX_LIBRARY
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 #endif
@@ -87,7 +87,7 @@ namespace System.Text.Encodings.Web
             {
                 int idx = 0;
 
-#if NETCOREAPP
+#if BUILDING_INBOX_LIBRARY
                 if (Sse2.IsSupported)
                 {
                     sbyte* startingAddress = (sbyte*)ptr;

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/DefaultJavaScriptEncoderBasicLatin.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/DefaultJavaScriptEncoderBasicLatin.cs
@@ -1,0 +1,289 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Text.Internal;
+using System.Text.Unicode;
+
+#if NETCOREAPP
+using System.Numerics;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+#endif
+
+namespace System.Text.Encodings.Web
+{
+    internal sealed class DefaultJavaScriptEncoderBasicLatin : JavaScriptEncoder
+    {
+        internal static readonly DefaultJavaScriptEncoderBasicLatin s_singleton = new DefaultJavaScriptEncoderBasicLatin();
+
+        private DefaultJavaScriptEncoderBasicLatin()
+        {
+            var filter = new TextEncoderSettings(UnicodeRanges.BasicLatin);
+
+            AllowedCharactersBitmap allowedCharacters = filter.GetAllowedCharacters();
+
+            // Forbid codepoints which aren't mapped to characters or which are otherwise always disallowed
+            // (includes categories Cc, Cs, Co, Cn, Zs [except U+0020 SPACE], Zl, Zp)
+            allowedCharacters.ForbidUndefinedCharacters();
+
+            // Forbid characters that are special in HTML.
+            // Even though this is a not HTML encoder,
+            // it's unfortunately common for developers to
+            // forget to HTML-encode a string once it has been JS-encoded,
+            // so this offers extra protection.
+            DefaultHtmlEncoder.ForbidHtmlCharacters(allowedCharacters);
+
+            // '\' (U+005C REVERSE SOLIDUS) must always be escaped in Javascript / ECMAScript / JSON.
+            // '/' (U+002F SOLIDUS) is not Javascript / ECMAScript / JSON-sensitive so doesn't need to be escaped.
+            allowedCharacters.ForbidCharacter('\\');
+
+            // '`' (U+0060 GRAVE ACCENT) is ECMAScript-sensitive (see ECMA-262).
+            allowedCharacters.ForbidCharacter('`');
+
+#if DEBUG
+            // Verify and ensure that the AllowList bit map matches the set of allowed characters using AllowedCharactersBitmap
+            for (int i = 0; i < AllowList.Length; i++)
+            {
+                char ch = (char)i;
+                Debug.Assert((allowedCharacters.IsCharacterAllowed(ch) ? 1 : 0) == AllowList[ch]);
+                Debug.Assert(allowedCharacters.IsCharacterAllowed(ch) == !NeedsEscaping(ch));
+            }
+            for (int i = AllowList.Length; i <= char.MaxValue; i++)
+            {
+                char ch = (char)i;
+                Debug.Assert(!allowedCharacters.IsCharacterAllowed(ch));
+                Debug.Assert(NeedsEscaping(ch));
+            }
+#endif
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public override bool WillEncode(int unicodeScalar)
+        {
+            if (UnicodeHelpers.IsSupplementaryCodePoint(unicodeScalar))
+            {
+                return true;
+            }
+
+            Debug.Assert(unicodeScalar >= char.MinValue && unicodeScalar <= char.MaxValue);
+
+            return NeedsEscaping((char)unicodeScalar);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public override unsafe int FindFirstCharacterToEncode(char* text, int textLength)
+        {
+            if (text == null)
+            {
+                throw new ArgumentNullException(nameof(text));
+            }
+
+            int idx = 0;
+
+#if NETCOREAPP
+            if (Sse2.IsSupported)
+            {
+                short* startingAddress = (short*)text;
+                while (textLength - 8 >= idx)
+                {
+                    Debug.Assert(startingAddress >= text && startingAddress <= (text + textLength - 8));
+
+                    // Load the next 8 characters.
+                    Vector128<short> sourceValue = Sse2.LoadVector128(startingAddress);
+
+                    // Check if any of the 8 characters need to be escaped.
+                    Vector128<short> mask = Sse2Helper.CreateEscapingMask_DefaultJavaScriptEncoderBasicLatin(sourceValue);
+
+                    int index = Sse2.MoveMask(mask.AsByte());
+                    // If index == 0, that means none of the 8 characters needed to be escaped.
+                    // TrailingZeroCount is relatively expensive, avoid it if possible.
+                    if (index != 0)
+                    {
+                        // Found at least one character that needs to be escaped, figure out the index of
+                        // the first one found that needed to be escaped within the 8 characters.
+                        Debug.Assert(index > 0 && index <= 65_535);
+                        int tzc = BitOperations.TrailingZeroCount(index);
+                        Debug.Assert(tzc % 2 == 0 && tzc >= 0 && tzc <= 16);
+                        idx += tzc >> 1;
+                        goto Return;
+                    }
+                    idx += 8;
+                    startingAddress += 8;
+                }
+
+                // Process the remaining characters.
+                Debug.Assert(textLength - idx < 8);
+            }
+#endif
+
+            for (; idx < textLength; idx++)
+            {
+                Debug.Assert((text + idx) <= (text + textLength));
+                if (NeedsEscaping(*(text + idx)))
+                {
+                    goto Return;
+                }
+            }
+
+            idx = -1; // All characters are allowed.
+
+        Return:
+            return idx;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public override unsafe int FindFirstCharacterToEncodeUtf8(ReadOnlySpan<byte> utf8Text)
+        {
+            fixed (byte* ptr = utf8Text)
+            {
+                int idx = 0;
+
+#if NETCOREAPP
+                if (Sse2.IsSupported)
+                {
+                    sbyte* startingAddress = (sbyte*)ptr;
+                    while (utf8Text.Length - 16 >= idx)
+                    {
+                        Debug.Assert(startingAddress >= ptr && startingAddress <= (ptr + utf8Text.Length - 16));
+
+                        // Load the next 16 bytes.
+                        Vector128<sbyte> sourceValue = Sse2.LoadVector128(startingAddress);
+
+                        // Check if any of the 16 bytes need to be escaped.
+                        Vector128<sbyte> mask = Sse2Helper.CreateEscapingMask_DefaultJavaScriptEncoderBasicLatin(sourceValue);
+
+                        int index = Sse2.MoveMask(mask);
+                        // If index == 0, that means none of the 16 bytes needed to be escaped.
+                        // TrailingZeroCount is relatively expensive, avoid it if possible.
+                        if (index != 0)
+                        {
+                            // Found at least one byte that needs to be escaped, figure out the index of
+                            // the first one found that needed to be escaped within the 16 bytes.
+                            int tzc = BitOperations.TrailingZeroCount(index);
+                            Debug.Assert(tzc >= 0 && tzc <= 16);
+                            idx += tzc;
+                            goto Return;
+                        }
+                        idx += 16;
+                        startingAddress += 16;
+                    }
+
+                    // Process the remaining bytes.
+                    Debug.Assert(utf8Text.Length - idx < 16);
+                }
+#endif
+
+                for (; idx < utf8Text.Length; idx++)
+                {
+                    Debug.Assert((ptr + idx) <= (ptr + utf8Text.Length));
+                    if (NeedsEscaping(*(ptr + idx)))
+                    {
+                        goto Return;
+                    }
+                }
+
+                idx = -1; // All bytes are allowed.
+
+            Return:
+                return idx;
+            }
+        }
+
+        // The worst case encoding is 6 output chars per input char: [input] U+FFFF -> [output] "\uFFFF"
+        // We don't need to worry about astral code points since they're represented as encoded
+        // surrogate pairs in the output.
+        public override int MaxOutputCharactersPerInputCharacter => 12; // "\uFFFF\uFFFF" is the longest encoded form
+
+        private static readonly char[] s_b = new char[] { '\\', 'b' };
+        private static readonly char[] s_t = new char[] { '\\', 't' };
+        private static readonly char[] s_n = new char[] { '\\', 'n' };
+        private static readonly char[] s_f = new char[] { '\\', 'f' };
+        private static readonly char[] s_r = new char[] { '\\', 'r' };
+        private static readonly char[] s_back = new char[] { '\\', '\\' };
+
+        // Writes a scalar value as a JavaScript-escaped character (or sequence of characters).
+        // See ECMA-262, Sec. 7.8.4, and ECMA-404, Sec. 9
+        // http://www.ecma-international.org/ecma-262/5.1/#sec-7.8.4
+        // http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf
+        public override unsafe bool TryEncodeUnicodeScalar(int unicodeScalar, char* buffer, int bufferLength, out int numberOfCharactersWritten)
+        {
+            if (buffer == null)
+            {
+                throw new ArgumentNullException(nameof(buffer));
+            }
+            // ECMA-262 allows encoding U+000B as "\v", but ECMA-404 does not.
+            // Both ECMA-262 and ECMA-404 allow encoding U+002F SOLIDUS as "\/"
+            // (in ECMA-262 this character is a NonEscape character); however, we
+            // don't encode SOLIDUS by default unless the caller has provided an
+            // explicit bitmap which does not contain it. In this case we'll assume
+            // that the caller didn't want a SOLIDUS written to the output at all,
+            // so it should be written using "\u002F" encoding.
+            // HTML-specific characters (including apostrophe and quotes) will
+            // be written out as numeric entities for defense-in-depth.
+            // See UnicodeEncoderBase ctor comments for more info.
+
+            if (!WillEncode(unicodeScalar))
+            {
+                return TryWriteScalarAsChar(unicodeScalar, buffer, bufferLength, out numberOfCharactersWritten);
+            }
+
+            char[] toCopy;
+            switch (unicodeScalar)
+            {
+                case '\b':
+                    toCopy = s_b;
+                    break;
+                case '\t':
+                    toCopy = s_t;
+                    break;
+                case '\n':
+                    toCopy = s_n;
+                    break;
+                case '\f':
+                    toCopy = s_f;
+                    break;
+                case '\r':
+                    toCopy = s_r;
+                    break;
+                case '\\':
+                    toCopy = s_back;
+                    break;
+                default:
+                    return JavaScriptEncoderHelper.TryWriteEncodedScalarAsNumericEntity(unicodeScalar, buffer, bufferLength, out numberOfCharactersWritten);
+            }
+            return TryCopyCharacters(toCopy, buffer, bufferLength, out numberOfCharactersWritten);
+        }
+
+        private static ReadOnlySpan<byte> AllowList => new byte[byte.MaxValue + 1]
+        {
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // U+0000..U+000F
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // U+0010..U+001F
+            1, 1, 0, 1, 1, 1, 0, 0, 1, 1, 1, 0, 1, 1, 1, 1, // U+0020..U+002F
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 1, // U+0030..U+003F
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // U+0040..U+004F
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, // U+0050..U+005F
+            0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // U+0060..U+006F
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, // U+0070..U+007F
+
+            // Also include the ranges from U+0080 to U+00FF for performance to avoid UTF8 code from checking boundary.
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // U+00F0..U+00FF
+        };
+
+        public const int LastAsciiCharacter = 0x7F;
+
+        private static bool NeedsEscaping(byte value) => AllowList[value] == 0;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool NeedsEscaping(char value) => value > LastAsciiCharacter || AllowList[value] == 0;
+    }
+}

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/DefaultJavaScriptEncoderBasicLatin.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/DefaultJavaScriptEncoderBasicLatin.cs
@@ -7,7 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Text.Internal;
 using System.Text.Unicode;
 
-#if NETCOREAPP
+#if BUILDING_INBOX_LIBRARY
 using System.Numerics;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
@@ -83,7 +83,7 @@ namespace System.Text.Encodings.Web
 
             int idx = 0;
 
-#if NETCOREAPP
+#if BUILDING_INBOX_LIBRARY
             if (Sse2.IsSupported)
             {
                 short* startingAddress = (short*)text;
@@ -141,7 +141,7 @@ namespace System.Text.Encodings.Web
             {
                 int idx = 0;
 
-#if NETCOREAPP
+#if BUILDING_INBOX_LIBRARY
                 if (Sse2.IsSupported)
                 {
                     sbyte* startingAddress = (sbyte*)ptr;

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/JavaScriptEncoder.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/JavaScriptEncoder.cs
@@ -2,10 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.ComponentModel;
-using System.Diagnostics;
-using System.Runtime.CompilerServices;
-using System.Text.Internal;
 using System.Text.Unicode;
 
 namespace System.Text.Encodings.Web
@@ -18,10 +14,7 @@ namespace System.Text.Encodings.Web
         /// <summary>
         /// Returns a default built-in instance of <see cref="JavaScriptEncoder"/>.
         /// </summary>
-        public static JavaScriptEncoder Default
-        {
-            get { return DefaultJavaScriptEncoder.Singleton; }
-        }
+        public static JavaScriptEncoder Default => DefaultJavaScriptEncoderBasicLatin.s_singleton;
 
         /// <summary>
         /// Returns a built-in instance of <see cref="JavaScriptEncoder"/> that is less strict about what gets encoded.
@@ -40,11 +33,8 @@ namespace System.Text.Encodings.Web
         /// <para>
         /// Unlike the <see cref="Default"/>, this encoder instance allows some other characters to go through unescaped (for example, '+'), and hence must be used cautiously.
         /// </para>
-        /// </remarks> 
-        public static JavaScriptEncoder UnsafeRelaxedJsonEscaping
-        {
-            get { return UnsafeRelaxedJavaScriptEncoder.s_singleton; }
-        }
+        /// </remarks>
+        public static JavaScriptEncoder UnsafeRelaxedJsonEscaping => UnsafeRelaxedJavaScriptEncoder.s_singleton;
 
         /// <summary>
         /// Creates a new instance of JavaScriptEncoder with provided settings.
@@ -65,168 +55,6 @@ namespace System.Text.Encodings.Web
         public static JavaScriptEncoder Create(params UnicodeRange[] allowedRanges)
         {
             return new DefaultJavaScriptEncoder(allowedRanges);
-        }
-    }
-
-    internal sealed class DefaultJavaScriptEncoder : JavaScriptEncoder
-    {
-        private AllowedCharactersBitmap _allowedCharacters;
-
-        internal static readonly DefaultJavaScriptEncoder Singleton = new DefaultJavaScriptEncoder(new TextEncoderSettings(UnicodeRanges.BasicLatin));
-
-        public DefaultJavaScriptEncoder(TextEncoderSettings filter)
-        {
-            if (filter == null)
-            {
-                throw new ArgumentNullException(nameof(filter));
-            }
-
-            _allowedCharacters = filter.GetAllowedCharacters();
-
-            // Forbid codepoints which aren't mapped to characters or which are otherwise always disallowed
-            // (includes categories Cc, Cs, Co, Cn, Zs [except U+0020 SPACE], Zl, Zp)
-            _allowedCharacters.ForbidUndefinedCharacters();
-
-            // Forbid characters that are special in HTML.
-            // Even though this is a not HTML encoder, 
-            // it's unfortunately common for developers to
-            // forget to HTML-encode a string once it has been JS-encoded,
-            // so this offers extra protection.
-            DefaultHtmlEncoder.ForbidHtmlCharacters(_allowedCharacters);
-
-            // '\' (U+005C REVERSE SOLIDUS) must always be escaped in Javascript / ECMAScript / JSON.
-            // '/' (U+002F SOLIDUS) is not Javascript / ECMAScript / JSON-sensitive so doesn't need to be escaped.
-            _allowedCharacters.ForbidCharacter('\\');
-            
-            // '`' (U+0060 GRAVE ACCENT) is ECMAScript-sensitive (see ECMA-262).
-            _allowedCharacters.ForbidCharacter('`'); 
-        }
-
-        public DefaultJavaScriptEncoder(params UnicodeRange[] allowedRanges) : this(new TextEncoderSettings(allowedRanges))
-        { }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override bool WillEncode(int unicodeScalar)
-        {
-            if (UnicodeHelpers.IsSupplementaryCodePoint(unicodeScalar)) return true;
-            return !_allowedCharacters.IsUnicodeScalarAllowed(unicodeScalar);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe override int FindFirstCharacterToEncode(char* text, int textLength)
-        {
-            if (text == null)
-            {
-                throw new ArgumentNullException(nameof(text));
-            }
-
-            return _allowedCharacters.FindFirstCharacterToEncode(text, textLength);
-        }
-
-        // The worst case encoding is 6 output chars per input char: [input] U+FFFF -> [output] "\uFFFF"
-        // We don't need to worry about astral code points since they're represented as encoded
-        // surrogate pairs in the output.
-        public override int MaxOutputCharactersPerInputCharacter
-        {
-            get { return 12; } // "\uFFFF\uFFFF" is the longest encoded form 
-        }
-
-        static readonly char[] s_b = new char[] { '\\', 'b' };
-        static readonly char[] s_t = new char[] { '\\', 't' };
-        static readonly char[] s_n = new char[] { '\\', 'n' };
-        static readonly char[] s_f = new char[] { '\\', 'f' };
-        static readonly char[] s_r = new char[] { '\\', 'r' };
-        static readonly char[] s_back = new char[] { '\\', '\\' };
-
-        // Writes a scalar value as a JavaScript-escaped character (or sequence of characters).
-        // See ECMA-262, Sec. 7.8.4, and ECMA-404, Sec. 9
-        // http://www.ecma-international.org/ecma-262/5.1/#sec-7.8.4
-        // http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf
-        public unsafe override bool TryEncodeUnicodeScalar(int unicodeScalar, char* buffer, int bufferLength, out int numberOfCharactersWritten)
-        {
-            if (buffer == null)
-            {
-                throw new ArgumentNullException(nameof(buffer));
-            }
-            // ECMA-262 allows encoding U+000B as "\v", but ECMA-404 does not.
-            // Both ECMA-262 and ECMA-404 allow encoding U+002F SOLIDUS as "\/"
-            // (in ECMA-262 this character is a NonEscape character); however, we
-            // don't encode SOLIDUS by default unless the caller has provided an
-            // explicit bitmap which does not contain it. In this case we'll assume
-            // that the caller didn't want a SOLIDUS written to the output at all,
-            // so it should be written using "\u002F" encoding.
-            // HTML-specific characters (including apostrophe and quotes) will
-            // be written out as numeric entities for defense-in-depth.
-            // See UnicodeEncoderBase ctor comments for more info.
-
-            if (!WillEncode(unicodeScalar)) { return TryWriteScalarAsChar(unicodeScalar, buffer, bufferLength, out numberOfCharactersWritten); }
-
-            char[] toCopy;
-            switch (unicodeScalar)
-            {
-                case '\b': toCopy = s_b; break;
-                case '\t': toCopy = s_t; break;
-                case '\n': toCopy = s_n; break;
-                case '\f': toCopy = s_f; break;
-                case '\r': toCopy = s_r; break;
-                case '\\': toCopy = s_back; break;
-                default: return TryWriteEncodedScalarAsNumericEntity(unicodeScalar, buffer, bufferLength, out numberOfCharactersWritten); 
-            }
-            return TryCopyCharacters(toCopy, buffer, bufferLength, out numberOfCharactersWritten);
-        }
-
-        private static unsafe bool TryWriteEncodedScalarAsNumericEntity(int unicodeScalar, char* buffer, int length, out int numberOfCharactersWritten)
-        {
-            Debug.Assert(buffer != null && length >= 0);
-
-            if (UnicodeHelpers.IsSupplementaryCodePoint(unicodeScalar))
-            {
-                // Convert this back to UTF-16 and write out both characters.
-                char leadingSurrogate, trailingSurrogate;
-                UnicodeHelpers.GetUtf16SurrogatePairFromAstralScalarValue(unicodeScalar, out leadingSurrogate, out trailingSurrogate);
-                int leadingSurrogateCharactersWritten;
-                if (TryWriteEncodedSingleCharacter(leadingSurrogate, buffer, length, out leadingSurrogateCharactersWritten) &&
-                    TryWriteEncodedSingleCharacter(trailingSurrogate, buffer + leadingSurrogateCharactersWritten, length - leadingSurrogateCharactersWritten, out numberOfCharactersWritten)
-                )
-                {
-                    numberOfCharactersWritten += leadingSurrogateCharactersWritten;
-                    return true;
-                }
-                else
-                {
-                    numberOfCharactersWritten = 0;
-                    return false;
-                }
-            }
-            else
-            {
-                // This is only a single character.
-                return TryWriteEncodedSingleCharacter(unicodeScalar, buffer, length, out numberOfCharactersWritten);
-            }
-        }
-
-        // Writes an encoded scalar value (in the BMP) as a JavaScript-escaped character.
-        private static unsafe bool TryWriteEncodedSingleCharacter(int unicodeScalar, char* buffer, int length, out int numberOfCharactersWritten)
-        {
-            Debug.Assert(buffer != null && length >= 0);
-            Debug.Assert(!UnicodeHelpers.IsSupplementaryCodePoint(unicodeScalar), "The incoming value should've been in the BMP.");
-
-            if (length < 6)
-            {
-                numberOfCharactersWritten = 0;
-                return false;
-            }
-
-            // Encode this as 6 chars "\uFFFF".
-            *buffer = '\\'; buffer++;
-            *buffer = 'u'; buffer++;
-            *buffer = HexUtil.Int32LsbToHexDigit(unicodeScalar >> 12); buffer++;
-            *buffer = HexUtil.Int32LsbToHexDigit((int)((unicodeScalar >> 8) & 0xFU)); buffer++;
-            *buffer = HexUtil.Int32LsbToHexDigit((int)((unicodeScalar >> 4) & 0xFU)); buffer++;
-            *buffer = HexUtil.Int32LsbToHexDigit((int)(unicodeScalar & 0xFU)); buffer++;
-
-            numberOfCharactersWritten = 6;
-            return true;
         }
     }
 }

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/JavaScriptEncoderHelper.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/JavaScriptEncoderHelper.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Text.Unicode;
+
+namespace System.Text.Encodings.Web
+{
+    internal static class JavaScriptEncoderHelper
+    {
+        public static unsafe bool TryWriteEncodedScalarAsNumericEntity(int unicodeScalar, char* buffer, int length, out int numberOfCharactersWritten)
+        {
+            Debug.Assert(buffer != null && length >= 0);
+
+            if (UnicodeHelpers.IsSupplementaryCodePoint(unicodeScalar))
+            {
+                // Convert this back to UTF-16 and write out both characters.
+                UnicodeHelpers.GetUtf16SurrogatePairFromAstralScalarValue(unicodeScalar, out char leadingSurrogate, out char trailingSurrogate);
+                if (TryWriteEncodedSingleCharacter(leadingSurrogate, buffer, length, out int leadingSurrogateCharactersWritten) &&
+                    TryWriteEncodedSingleCharacter(trailingSurrogate, buffer + leadingSurrogateCharactersWritten, length - leadingSurrogateCharactersWritten, out numberOfCharactersWritten)
+                )
+                {
+                    numberOfCharactersWritten += leadingSurrogateCharactersWritten;
+                    return true;
+                }
+                else
+                {
+                    numberOfCharactersWritten = 0;
+                    return false;
+                }
+            }
+            else
+            {
+                // This is only a single character.
+                return TryWriteEncodedSingleCharacter(unicodeScalar, buffer, length, out numberOfCharactersWritten);
+            }
+        }
+
+        // Writes an encoded scalar value (in the BMP) as a JavaScript-escaped character.
+        private static unsafe bool TryWriteEncodedSingleCharacter(int unicodeScalar, char* buffer, int length, out int numberOfCharactersWritten)
+        {
+            Debug.Assert(buffer != null && length >= 0);
+            Debug.Assert(!UnicodeHelpers.IsSupplementaryCodePoint(unicodeScalar), "The incoming value should've been in the BMP.");
+
+            if (length < 6)
+            {
+                numberOfCharactersWritten = 0;
+                return false;
+            }
+
+            // Encode this as 6 chars "\uFFFF".
+            *buffer = '\\';
+            buffer++;
+            *buffer = 'u';
+            buffer++;
+            *buffer = HexUtil.Int32LsbToHexDigit(unicodeScalar >> 12);
+            buffer++;
+            *buffer = HexUtil.Int32LsbToHexDigit((int)((unicodeScalar >> 8) & 0xFU));
+            buffer++;
+            *buffer = HexUtil.Int32LsbToHexDigit((int)((unicodeScalar >> 4) & 0xFU));
+            buffer++;
+            *buffer = HexUtil.Int32LsbToHexDigit((int)(unicodeScalar & 0xFU));
+
+            numberOfCharactersWritten = 6;
+            return true;
+        }
+    }
+}

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/Sse2Helper.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/Sse2Helper.cs
@@ -1,0 +1,127 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Numerics;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+
+namespace System.Text.Encodings.Web
+{
+    internal static class Sse2Helper
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector128<short> CreateEscapingMask_UnsafeRelaxedJavaScriptEncoder(Vector128<short> sourceValue)
+        {
+            Debug.Assert(Sse2.IsSupported);
+
+            // Space ' ', anything in the control characters range, and anything above short.MaxValue but less than or equal char.MaxValue
+            Vector128<short> mask = Sse2.CompareLessThan(sourceValue, s_mask_UInt16_0x20);
+
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_UInt16_0x22)); // Quotation Mark '"'
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_UInt16_0x5C)); // Reverse Solidus '\'
+
+            return mask;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector128<sbyte> CreateEscapingMask_UnsafeRelaxedJavaScriptEncoder(Vector128<sbyte> sourceValue)
+        {
+            Debug.Assert(Sse2.IsSupported);
+
+            Vector128<sbyte> mask = Sse2.CompareLessThan(sourceValue, s_mask_SByte_0x20); // Control characters, and anything above 0x7E since sbyte.MaxValue is 0x7E
+
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_SByte_0x22)); // Quotation Mark "
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_SByte_0x5C)); // Reverse Solidus \
+
+            return mask;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector128<short> CreateEscapingMask_DefaultJavaScriptEncoderBasicLatin(Vector128<short> sourceValue)
+        {
+            Debug.Assert(Sse2.IsSupported);
+
+            Vector128<short> mask = CreateEscapingMask_UnsafeRelaxedJavaScriptEncoder(sourceValue);
+
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_UInt16_0x26)); // Ampersand '&'
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_UInt16_0x27)); // Apostrophe '''
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_UInt16_0x2B)); // Plus sign '+'
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_UInt16_0x3C)); // Less Than Sign '<'
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_UInt16_0x3E)); // Greater Than Sign '>'
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_UInt16_0x60)); // Grave Access '`'
+
+            mask = Sse2.Or(mask, Sse2.CompareGreaterThan(sourceValue, s_mask_UInt16_0x7E)); // Tilde '~', anything above the ASCII range
+
+            return mask;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector128<sbyte> CreateEscapingMask_DefaultJavaScriptEncoderBasicLatin(Vector128<sbyte> sourceValue)
+        {
+            Debug.Assert(Sse2.IsSupported);
+
+            Vector128<sbyte> mask = CreateEscapingMask_UnsafeRelaxedJavaScriptEncoder(sourceValue);
+
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_SByte_0x26)); // Ampersand &
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_SByte_0x27)); // Apostrophe '
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_SByte_0x2B)); // Plus sign +
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_SByte_0x3C)); // Less Than Sign <
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_SByte_0x3E)); // Greater Than Sign >
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_SByte_0x60)); // Grave Access `
+
+            return mask;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector128<short> CreateAsciiMask(Vector128<short> sourceValue)
+        {
+            Debug.Assert(Sse2.IsSupported);
+
+            Vector128<short> mask = Sse2.CompareLessThan(sourceValue, s_mask_UInt16_0x00); // Null, anything above short.MaxValue but less than or equal char.MaxValue
+            mask = Sse2.Or(mask, Sse2.CompareGreaterThan(sourceValue, s_mask_UInt16_0x7E)); // Tilde '~', anything above the ASCII range
+
+            return mask;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector128<sbyte> CreateAsciiMask(Vector128<sbyte> sourceValue)
+        {
+            Debug.Assert(Sse2.IsSupported);
+
+            // Null, anything above sbyte.MaxValue but less than or equal byte.MaxValue (i.e. anything above the ASCII range)
+            Vector128<sbyte> mask = Sse2.CompareLessThan(sourceValue, s_mask_SByte_0x00);
+            return mask;
+        }
+
+        private static readonly Vector128<short> s_mask_UInt16_0x00 = Vector128<short>.Zero; // Null
+
+        private static readonly Vector128<short> s_mask_UInt16_0x20 = Vector128.Create((short)0x20); // Space ' '
+
+        private static readonly Vector128<short> s_mask_UInt16_0x22 = Vector128.Create((short)0x22); // Quotation Mark '"'
+        private static readonly Vector128<short> s_mask_UInt16_0x26 = Vector128.Create((short)0x26); // Ampersand '&'
+        private static readonly Vector128<short> s_mask_UInt16_0x27 = Vector128.Create((short)0x27); // Apostrophe '''
+        private static readonly Vector128<short> s_mask_UInt16_0x2B = Vector128.Create((short)0x2B); // Plus sign '+'
+        private static readonly Vector128<short> s_mask_UInt16_0x3C = Vector128.Create((short)0x3C); // Less Than Sign '<'
+        private static readonly Vector128<short> s_mask_UInt16_0x3E = Vector128.Create((short)0x3E); // Greater Than Sign '>'
+        private static readonly Vector128<short> s_mask_UInt16_0x5C = Vector128.Create((short)0x5C); // Reverse Solidus '\'
+        private static readonly Vector128<short> s_mask_UInt16_0x60 = Vector128.Create((short)0x60); // Grave Access '`'
+
+        private static readonly Vector128<short> s_mask_UInt16_0x7E = Vector128.Create((short)0x7E); // Tilde '~'
+
+        private static readonly Vector128<sbyte> s_mask_SByte_0x00 = Vector128<sbyte>.Zero; // Null
+
+        private static readonly Vector128<sbyte> s_mask_SByte_0x20 = Vector128.Create((sbyte)0x20); // Space ' '
+
+        private static readonly Vector128<sbyte> s_mask_SByte_0x22 = Vector128.Create((sbyte)0x22); // Quotation Mark '"'
+        private static readonly Vector128<sbyte> s_mask_SByte_0x26 = Vector128.Create((sbyte)0x26); // Ampersand '&'
+        private static readonly Vector128<sbyte> s_mask_SByte_0x27 = Vector128.Create((sbyte)0x27); // Apostrophe '''
+        private static readonly Vector128<sbyte> s_mask_SByte_0x2B = Vector128.Create((sbyte)0x2B); // Plus sign '+'
+        private static readonly Vector128<sbyte> s_mask_SByte_0x3C = Vector128.Create((sbyte)0x3C); // Less Than Sign '<'
+        private static readonly Vector128<sbyte> s_mask_SByte_0x3E = Vector128.Create((sbyte)0x3E); // Greater Than Sign '>'
+        private static readonly Vector128<sbyte> s_mask_SByte_0x5C = Vector128.Create((sbyte)0x5C); // Reverse Solidus '\'
+        private static readonly Vector128<sbyte> s_mask_SByte_0x60 = Vector128.Create((sbyte)0x60); // Grave Access '`'
+    }
+}

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/TextEncoder.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/TextEncoder.cs
@@ -10,7 +10,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text.Unicode;
 
-#if NETCOREAPP
+#if BUILDING_INBOX_LIBRARY
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 #endif
@@ -711,7 +711,7 @@ namespace System.Text.Encodings.Web
             {
                 int idx = 0;
 
-#if NETCOREAPP
+#if BUILDING_INBOX_LIBRARY
                 if (Sse2.IsSupported)
                 {
                     sbyte* startingAddress = (sbyte*)ptr;

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/TextEncoder.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/TextEncoder.cs
@@ -10,6 +10,11 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text.Unicode;
 
+#if NETCOREAPP
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+#endif
+
 namespace System.Text.Encodings.Web
 {
     /// <summary>
@@ -23,6 +28,8 @@ namespace System.Text.Encodings.Web
     {
         // Fast cache for Ascii
         private byte[][] _asciiEscape = new byte[0x80][];
+
+        private readonly int[] _asciiNeedsEscaping = new int[0x80];
 
         // Keep a reference to Array.Empty<byte> as this is used as a singleton for comparisons
         // and there is no guarantee that Array.Empty<byte>() will always be the same instance.
@@ -693,46 +700,132 @@ namespace System.Text.Encodings.Web
         /// current encoder instance, or -1 if no data in <paramref name="utf8Text"/> requires escaping.
         /// </returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual int FindFirstCharacterToEncodeUtf8(ReadOnlySpan<byte> utf8Text)
+        public virtual unsafe int FindFirstCharacterToEncodeUtf8(ReadOnlySpan<byte> utf8Text)
         {
-            int originalUtf8TextLength = utf8Text.Length;
-
             // Loop through the input text, terminating when we see ill-formed UTF-8 or when we decode a scalar value
             // that must be encoded. If we see either of these things then we'll return its index in the original
             // input sequence. If we consume the entire text without seeing either of these, return -1 to indicate
             // that the text can be copied as-is without escaping.
 
-            int i = 0;
-            while (i < utf8Text.Length)
+            fixed (byte* ptr = utf8Text)
             {
-                byte value = utf8Text[i];
-                if (UnicodeUtility.IsAsciiCodePoint(value))
+                int idx = 0;
+
+#if NETCOREAPP
+                if (Sse2.IsSupported)
                 {
-                    if (!ReferenceEquals(GetAsciiEncoding(value), s_noEscape))
+                    sbyte* startingAddress = (sbyte*)ptr;
+                    while (utf8Text.Length - 16 >= idx)
                     {
-                        return originalUtf8TextLength - utf8Text.Length + i;
+                        Debug.Assert(startingAddress >= ptr && startingAddress <= (ptr + utf8Text.Length - 16));
+
+                        // Load the next 16 bytes.
+                        Vector128<sbyte> sourceValue = Sse2.LoadVector128(startingAddress);
+
+                        Vector128<sbyte> mask = Sse2Helper.CreateAsciiMask(sourceValue);
+                        int index = Sse2.MoveMask(mask);
+
+                        if (index != 0)
+                        {
+                            // At least one of the following 16 bytes is non-ASCII.
+
+                            int processNextSixteen = idx + 16;
+                            Debug.Assert(processNextSixteen <= utf8Text.Length);
+
+                            while (idx < processNextSixteen)
+                            {
+                                Debug.Assert((ptr + idx) <= (ptr + utf8Text.Length));
+
+                                if (UnicodeUtility.IsAsciiCodePoint(ptr[idx]))
+                                {
+                                    if (DoesAsciiNeedEncoding(ptr[idx]) == 1)
+                                    {
+                                        goto Return;
+                                    }
+                                    idx++;
+                                }
+                                else
+                                {
+                                    OperationStatus opStatus = UnicodeHelpers.DecodeScalarValueFromUtf8(utf8Text.Slice(idx), out uint nextScalarValue, out int utf8BytesConsumedForScalar);
+
+                                    Debug.Assert(nextScalarValue <= int.MaxValue);
+                                    if (opStatus != OperationStatus.Done || WillEncode((int)nextScalarValue))
+                                    {
+                                        goto Return;
+                                    }
+
+                                    Debug.Assert(opStatus == OperationStatus.Done);
+                                    idx += utf8BytesConsumedForScalar;
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (DoesAsciiNeedEncoding(ptr[idx]) == 1
+
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1
+                                || DoesAsciiNeedEncoding(ptr[++idx]) == 1)
+                            {
+                                goto Return;
+                            }
+                            idx++;
+                        }
+                        startingAddress = (sbyte*)ptr + idx;
                     }
 
-                    i++;
+                    // Process the remaining bytes.
+                    Debug.Assert(utf8Text.Length - idx < 16);
                 }
-                else
+#endif
+
+                while (idx < utf8Text.Length)
                 {
-                    if (i > 0)
-                    {
-                        utf8Text = utf8Text.Slice(i);
-                    }
+                    Debug.Assert((ptr + idx) <= (ptr + utf8Text.Length));
 
-                    if (UnicodeHelpers.DecodeScalarValueFromUtf8(utf8Text, out uint nextScalarValue, out int bytesConsumedThisIteration) != OperationStatus.Done
-                      || WillEncode((int)nextScalarValue))
+                    if (UnicodeUtility.IsAsciiCodePoint(ptr[idx]))
                     {
-                        return originalUtf8TextLength - utf8Text.Length;
+                        if (DoesAsciiNeedEncoding(ptr[idx]) == 1)
+                        {
+                            goto Return;
+                        }
+                        idx++;
                     }
+                    else
+                    {
+                        OperationStatus opStatus = UnicodeHelpers.DecodeScalarValueFromUtf8(utf8Text.Slice(idx), out uint nextScalarValue, out int utf8BytesConsumedForScalar);
 
-                    i = bytesConsumedThisIteration;
+                        Debug.Assert(nextScalarValue <= int.MaxValue);
+                        if (opStatus != OperationStatus.Done || WillEncode((int)nextScalarValue))
+                        {
+                            goto Return;
+                        }
+
+                        Debug.Assert(opStatus == OperationStatus.Done);
+                        idx += utf8BytesConsumedForScalar;
+                    }
                 }
+
+                idx = -1; // All bytes are allowed.
+
+            Return:
+                return idx;
             }
-
-            return -1; // no input data needs to be escaped
         }
 
         /// <summary>
@@ -813,8 +906,24 @@ namespace System.Text.Encodings.Web
                     _asciiEscape[value] = encoding;
                 }
             }
-
             return encoding;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private int DoesAsciiNeedEncoding(byte value)
+        {
+            Debug.Assert(value <= 0x7F);
+
+            int needsEscaping = _asciiNeedsEscaping[value];
+
+            Debug.Assert(needsEscaping == 0 || needsEscaping == 1 || needsEscaping == -1);
+
+            if (needsEscaping == 0)
+            {
+                needsEscaping = WillEncode(value) ? 1 : -1;
+                _asciiNeedsEscaping[value] = needsEscaping;
+            }
+            return needsEscaping;
         }
 
         private static void ThrowArgumentException_MaxOutputCharsPerInputChar()

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/UnsafeRelaxedJavaScriptEncoder.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/UnsafeRelaxedJavaScriptEncoder.cs
@@ -8,7 +8,7 @@ using System.Runtime.CompilerServices;
 using System.Text.Internal;
 using System.Text.Unicode;
 
-#if NETCOREAPP
+#if BUILDING_INBOX_LIBRARY
 using System.Numerics;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
@@ -63,7 +63,7 @@ namespace System.Text.Encodings.Web
 
             int idx = 0;
 
-#if NETCOREAPP
+#if BUILDING_INBOX_LIBRARY
             if (Sse2.IsSupported)
             {
                 short* startingAddress = (short*)text;
@@ -142,7 +142,7 @@ namespace System.Text.Encodings.Web
             {
                 int idx = 0;
 
-#if NETCOREAPP
+#if BUILDING_INBOX_LIBRARY
                 if (Sse2.IsSupported)
                 {
                     sbyte* startingAddress = (sbyte*)ptr;

--- a/src/System.Text.Encodings.Web/tests/JavaScriptStringEncoderTests.cs
+++ b/src/System.Text.Encodings.Web/tests/JavaScriptStringEncoderTests.cs
@@ -5,11 +5,14 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Encodings.Web;
+using System.Text.Internal;
 using System.Text.Unicode;
 using Xunit;
 
@@ -158,6 +161,22 @@ namespace Microsoft.Framework.WebEncoders
                     new object[] { '\'', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
                     new object[] { '+', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
                     new object[] { '\uFFFD', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+
+                    new object[] { 'a', new MyCustomEncoder(UnicodeRanges.All), false },
+                    new object[] { '\u001F', new MyCustomEncoder(UnicodeRanges.All), true },
+                    new object[] { '\u2000', new MyCustomEncoder(UnicodeRanges.All), true },
+                    new object[] { '\u00A2', new MyCustomEncoder(UnicodeRanges.All), false },
+                    new object[] { '\uA686', new MyCustomEncoder(UnicodeRanges.All), false },
+                    new object[] { '\u6C49', new MyCustomEncoder(UnicodeRanges.All), false },
+                    new object[] { '"', new MyCustomEncoder(UnicodeRanges.All), true },
+                    new object[] { '\\', new MyCustomEncoder(UnicodeRanges.All), true },
+                    new object[] { '<', new MyCustomEncoder(UnicodeRanges.All), true },
+                    new object[] { '>', new MyCustomEncoder(UnicodeRanges.All), true },
+                    new object[] { '&', new MyCustomEncoder(UnicodeRanges.All), true },
+                    new object[] { '`', new MyCustomEncoder(UnicodeRanges.All), true },
+                    new object[] { '\'', new MyCustomEncoder(UnicodeRanges.All), true },
+                    new object[] { '+', new MyCustomEncoder(UnicodeRanges.All), true },
+                    new object[] { '\uFFFD', new MyCustomEncoder(UnicodeRanges.All), false },
                 };
             }
         }
@@ -234,6 +253,22 @@ namespace Microsoft.Framework.WebEncoders
                     new object[] { '\'', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
                     new object[] { '+', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
                     new object[] { '\uFFFD', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+
+                    new object[] { 'a', new MyCustomEncoder(UnicodeRanges.All), false },
+                    new object[] { '\u001F', new MyCustomEncoder(UnicodeRanges.All), true },
+                    new object[] { '\u2000', new MyCustomEncoder(UnicodeRanges.All), true },
+                    new object[] { '\u00A2', new MyCustomEncoder(UnicodeRanges.All), false },
+                    new object[] { '\uA686', new MyCustomEncoder(UnicodeRanges.All), false },
+                    new object[] { '\u6C49', new MyCustomEncoder(UnicodeRanges.All), false },
+                    new object[] { '"', new MyCustomEncoder(UnicodeRanges.All), true },
+                    new object[] { '\\', new MyCustomEncoder(UnicodeRanges.All), true },
+                    new object[] { '<', new MyCustomEncoder(UnicodeRanges.All), true },
+                    new object[] { '>', new MyCustomEncoder(UnicodeRanges.All), true },
+                    new object[] { '&', new MyCustomEncoder(UnicodeRanges.All), true },
+                    new object[] { '`', new MyCustomEncoder(UnicodeRanges.All), true },
+                    new object[] { '\'', new MyCustomEncoder(UnicodeRanges.All), true },
+                    new object[] { '+', new MyCustomEncoder(UnicodeRanges.All), true },
+                    new object[] { '\uFFFD', new MyCustomEncoder(UnicodeRanges.All), false },
                 };
             }
         }
@@ -307,6 +342,7 @@ namespace Microsoft.Framework.WebEncoders
                     new object[] { JavaScriptEncoder.Create(UnicodeRanges.BasicLatin) },
                     new object[] { JavaScriptEncoder.Create(UnicodeRanges.All) },
                     new object[] { JavaScriptEncoder.UnsafeRelaxedJsonEscaping },
+                    new object[] { new MyCustomEncoder(UnicodeRanges.BasicLatin) },
                 };
             }
         }
@@ -361,7 +397,86 @@ namespace Microsoft.Framework.WebEncoders
 
                     new object[] { '\uD801', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin) },
                     new object[] { '\uDC01', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin) },
+
+                    new object[] { '\uD801', new MyCustomEncoder(UnicodeRanges.BasicLatin) },
+                    new object[] { '\uDC01', new MyCustomEncoder(UnicodeRanges.BasicLatin) },
                 };
+            }
+        }
+
+        internal sealed class MyCustomEncoder : JavaScriptEncoder
+        {
+            private readonly AllowedCharactersBitmap _allowedCharacters;
+
+            public MyCustomEncoder(TextEncoderSettings filter)
+            {
+                if (filter == null)
+                {
+                    throw new ArgumentNullException(nameof(filter));
+                }
+
+                _allowedCharacters = filter.GetAllowedCharacters();
+
+                // Forbid codepoints which aren't mapped to characters or which are otherwise always disallowed
+                // (includes categories Cc, Cs, Co, Cn, Zs [except U+0020 SPACE], Zl, Zp)
+                _allowedCharacters.ForbidUndefinedCharacters();
+
+                // Forbid characters that are special in HTML.
+                // Even though this is a not HTML encoder,
+                // it's unfortunately common for developers to
+                // forget to HTML-encode a string once it has been JS-encoded,
+                // so this offers extra protection.
+                ForbidHtmlCharacters(_allowedCharacters);
+
+                // '\' (U+005C REVERSE SOLIDUS) must always be escaped in Javascript / ECMAScript / JSON.
+                // '/' (U+002F SOLIDUS) is not Javascript / ECMAScript / JSON-sensitive so doesn't need to be escaped.
+                _allowedCharacters.ForbidCharacter('\\');
+
+                // '`' (U+0060 GRAVE ACCENT) is ECMAScript-sensitive (see ECMA-262).
+                _allowedCharacters.ForbidCharacter('`');
+            }
+
+            internal static void ForbidHtmlCharacters(AllowedCharactersBitmap allowedCharacters)
+            {
+                allowedCharacters.ForbidCharacter('<');
+                allowedCharacters.ForbidCharacter('>');
+                allowedCharacters.ForbidCharacter('&');
+                allowedCharacters.ForbidCharacter('\''); // can be used to escape attributes
+                allowedCharacters.ForbidCharacter('\"'); // can be used to escape attributes
+                allowedCharacters.ForbidCharacter('+'); // technically not HTML-specific, but can be used to perform UTF7-based attacks
+            }
+
+            public MyCustomEncoder(params UnicodeRange[] allowedRanges) : this(new TextEncoderSettings(allowedRanges))
+            { }
+
+            public override int MaxOutputCharactersPerInputCharacter => 12; // "\uFFFF\uFFFF" is the longest encoded form
+
+            public override unsafe bool TryEncodeUnicodeScalar(int unicodeScalar, char* buffer, int bufferLength, out int numberOfCharactersWritten)
+            {
+                throw new NotImplementedException();
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public override unsafe int FindFirstCharacterToEncode(char* text, int textLength)
+            {
+                if (text == null)
+                {
+                    throw new ArgumentNullException(nameof(text));
+                }
+
+                return _allowedCharacters.FindFirstCharacterToEncode(text, textLength);
+            }
+
+            public override bool WillEncode(int unicodeScalar)
+            {
+                if (UnicodeHelpers.IsSupplementaryCodePoint(unicodeScalar))
+                {
+                    return true;
+                }
+
+                Debug.Assert(unicodeScalar >= char.MinValue && unicodeScalar <= char.MaxValue);
+
+                return !_allowedCharacters.IsUnicodeScalarAllowed(unicodeScalar);
             }
         }
 

--- a/src/System.Text.Encodings.Web/tests/JavaScriptStringEncoderTests.cs
+++ b/src/System.Text.Encodings.Web/tests/JavaScriptStringEncoderTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Unicode;
 using Xunit;

--- a/src/System.Text.Encodings.Web/tests/JavaScriptStringEncoderTests.cs
+++ b/src/System.Text.Encodings.Web/tests/JavaScriptStringEncoderTests.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Buffers;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -15,6 +16,354 @@ namespace Microsoft.Framework.WebEncoders
 {
     public partial class JavaScriptStringEncoderTests
     {
+        [Fact]
+        public unsafe void NullPtrThrows()
+        {
+            Assert.Throws<ArgumentNullException>(() => JavaScriptEncoder.Default.FindFirstCharacterToEncode(null, 0));
+            Assert.Throws<ArgumentNullException>(() => JavaScriptEncoder.UnsafeRelaxedJsonEscaping.FindFirstCharacterToEncode(null, 0));
+            Assert.Throws<ArgumentNullException>(() => JavaScriptEncoder.Create(UnicodeRanges.All).FindFirstCharacterToEncode(null, 0));
+
+            Assert.Throws<ArgumentNullException>(() => JavaScriptEncoder.Default.TryEncodeUnicodeScalar('a', null, 0, out _));
+            Assert.Throws<ArgumentNullException>(() => JavaScriptEncoder.UnsafeRelaxedJsonEscaping.TryEncodeUnicodeScalar('a', null, 0, out _));
+            Assert.Throws<ArgumentNullException>(() => JavaScriptEncoder.Create(UnicodeRanges.All).TryEncodeUnicodeScalar('a', null, 0, out _));
+
+            Assert.Throws<ArgumentNullException>(() => JavaScriptEncoder.Create((TextEncoderSettings)null));
+            Assert.Throws<ArgumentNullException>(() => JavaScriptEncoder.Create((UnicodeRange)null));
+        }
+
+        [Theory]
+        [MemberData(nameof(EscapingTestData))]
+        public unsafe void FindFirstCharacterToEncode(char replacementChar, JavaScriptEncoder encoder, bool requiresEscaping)
+        {
+            Assert.Equal(-1, encoder.FindFirstCharacterToEncodeUtf8(default));
+            fixed (char* ptr = string.Empty)
+            {
+                Assert.Equal(-1, encoder.FindFirstCharacterToEncode(ptr, 0));
+            }
+
+            var random = new Random(42);
+            for (int dataLength = 0; dataLength < 50; dataLength++)
+            {
+                char[] str = new char[dataLength];
+                for (int i = 0; i < dataLength; i++)
+                {
+                    str[i] = (char)random.Next(97, 123);
+                }
+                string baseStr = new string(str);
+                byte[] sourceUtf8 = Encoding.UTF8.GetBytes(baseStr);
+
+                Assert.Equal(-1, encoder.FindFirstCharacterToEncodeUtf8(sourceUtf8));
+                fixed (char* ptr = baseStr)
+                {
+                    Assert.Equal(-1, encoder.FindFirstCharacterToEncode(ptr, baseStr.Length));
+                }
+
+                for (int i = 0; i < dataLength; i++)
+                {
+                    char[] changed = baseStr.ToCharArray();
+                    changed[i] = replacementChar;
+                    string source = new string(changed);
+                    sourceUtf8 = Encoding.UTF8.GetBytes(source);
+
+                    Assert.Equal(requiresEscaping ? i : -1, encoder.FindFirstCharacterToEncodeUtf8(sourceUtf8));
+                    fixed (char* ptr = source)
+                    {
+                        Assert.Equal(requiresEscaping ? i : -1, encoder.FindFirstCharacterToEncode(ptr, source.Length));
+                    }
+                }
+
+                if (dataLength != 0)
+                {
+                    char[] changed = baseStr.ToCharArray();
+                    changed.AsSpan().Fill(replacementChar);
+                    string source = new string(changed);
+                    sourceUtf8 = Encoding.UTF8.GetBytes(source);
+
+                    Assert.Equal(requiresEscaping ? 0 : -1, encoder.FindFirstCharacterToEncodeUtf8(sourceUtf8));
+                    fixed (char* ptr = source)
+                    {
+                        Assert.Equal(requiresEscaping ? 0 : -1, encoder.FindFirstCharacterToEncode(ptr, source.Length));
+                    }
+                }
+            }
+        }
+
+        public static IEnumerable<object[]> EscapingTestData
+        {
+            get
+            {
+                return new List<object[]>
+                {
+                    new object[] { 'a', JavaScriptEncoder.Default, false },              // ASCII not escaped
+                    new object[] { '\u001F', JavaScriptEncoder.Default, true },          // control character within single byte range
+                    new object[] { '\u2000', JavaScriptEncoder.Default, true },          // space character outside single byte range
+                    new object[] { '\u00A2', JavaScriptEncoder.Default, true },          // non-ASCII but < 255
+                    new object[] { '\uA686', JavaScriptEncoder.Default, true },          // non-ASCII above short.MaxValue
+                    new object[] { '\u6C49', JavaScriptEncoder.Default, true },          // non-ASCII from chinese alphabet - multibyte
+                    new object[] { '"', JavaScriptEncoder.Default, true },               // ASCII but must always be escaped in JSON
+                    new object[] { '\\', JavaScriptEncoder.Default, true },              // ASCII but must always be escaped in JSON
+                    new object[] { '<', JavaScriptEncoder.Default, true },               // ASCII but escaped by default
+                    new object[] { '>', JavaScriptEncoder.Default, true },               // ASCII but escaped by default
+                    new object[] { '&', JavaScriptEncoder.Default, true },               // ASCII but escaped by default
+                    new object[] { '`', JavaScriptEncoder.Default, true },               // ASCII but escaped by default
+                    new object[] { '\'', JavaScriptEncoder.Default, true },              // ASCII but escaped by default
+                    new object[] { '+', JavaScriptEncoder.Default, true },               // ASCII but escaped by default
+                    new object[] { '\uFFFD', JavaScriptEncoder.Default, true },          // Default replacement character
+
+                    new object[] { 'a', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin), false },
+                    new object[] { '\u001F', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin), true },
+                    new object[] { '\u2000', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin), true },
+                    new object[] { '\u00A2', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin), true },
+                    new object[] { '\uA686', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin), true },
+                    new object[] { '\u6C49', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin), true },
+                    new object[] { '"', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin), true },
+                    new object[] { '\\', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin), true },
+                    new object[] { '<', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin), true },
+                    new object[] { '>', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin), true },
+                    new object[] { '&', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin), true },
+                    new object[] { '`', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin), true },
+                    new object[] { '\'', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin), true },
+                    new object[] { '+', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin), true },
+                    new object[] { '\uFFFD', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin), true },
+
+                    new object[] { 'a', JavaScriptEncoder.Create(UnicodeRanges.All), false },
+                    new object[] { '\u001F', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '\u2000', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '\u00A2', JavaScriptEncoder.Create(UnicodeRanges.All), false },
+                    new object[] { '\uA686', JavaScriptEncoder.Create(UnicodeRanges.All), false },
+                    new object[] { '\u6C49', JavaScriptEncoder.Create(UnicodeRanges.All), false },
+                    new object[] { '"', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '\\', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '<', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '>', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '&', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '`', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '\'', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '+', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '\uFFFD', JavaScriptEncoder.Create(UnicodeRanges.All), false },
+
+                    new object[] { 'a', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '\u001F', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, true },
+                    new object[] { '\u2000', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, true },
+                    new object[] { '\u00A2', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '\uA686', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '\u6C49', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '"', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, true },
+                    new object[] { '\\', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, true },
+                    new object[] { '<', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '>', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '&', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '`', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '\'', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '+', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '\uFFFD', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(EscapingTestData_NonAscii))]
+        public unsafe void FindFirstCharacterToEncode_NonAscii(char replacementChar, JavaScriptEncoder encoder, bool requiresEscaping)
+        {
+            var random = new Random(42);
+            for (int dataLength = 1; dataLength < 50; dataLength++)
+            {
+                char[] str = new char[dataLength];
+                for (int i = 0; i < dataLength; i++)
+                {
+                    str[i] = (char)random.Next(0x2E9B, 0x2EF4); // CJK Radicals Supplement characters
+                }
+                string baseStr = new string(str);
+                byte[] sourceUtf8 = Encoding.UTF8.GetBytes(baseStr);
+
+                Assert.Equal(-1, encoder.FindFirstCharacterToEncodeUtf8(sourceUtf8));
+                fixed (char* ptr = baseStr)
+                {
+                    Assert.Equal(-1, encoder.FindFirstCharacterToEncode(ptr, baseStr.Length));
+                }
+
+                for (int i = 0; i < dataLength; i++)
+                {
+                    string source = baseStr.Insert(i, new string(replacementChar, 1));
+                    sourceUtf8 = Encoding.UTF8.GetBytes(source);
+
+                    Assert.Equal(requiresEscaping ? i * 3 : -1, encoder.FindFirstCharacterToEncodeUtf8(sourceUtf8)); // Each CJK character expands to 3 utf-8 bytes.
+                    fixed (char* ptr = source)
+                    {
+                        Assert.Equal(requiresEscaping ? i : -1, encoder.FindFirstCharacterToEncode(ptr, source.Length));
+                    }
+                }
+            }
+        }
+
+        public static IEnumerable<object[]> EscapingTestData_NonAscii
+        {
+            get
+            {
+                return new List<object[]>
+                {
+                    new object[] { 'a', JavaScriptEncoder.Create(UnicodeRanges.All), false },
+                    new object[] { '\u001F', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '\u2000', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '\u00A2', JavaScriptEncoder.Create(UnicodeRanges.All), false },
+                    new object[] { '\uA686', JavaScriptEncoder.Create(UnicodeRanges.All), false },
+                    new object[] { '\u6C49', JavaScriptEncoder.Create(UnicodeRanges.All), false },
+                    new object[] { '"', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '\\', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '<', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '>', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '&', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '`', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '\'', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '+', JavaScriptEncoder.Create(UnicodeRanges.All), true },
+                    new object[] { '\uFFFD', JavaScriptEncoder.Create(UnicodeRanges.All), false },
+
+                    new object[] { 'a', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '\u001F', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, true },
+                    new object[] { '\u2000', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, true },
+                    new object[] { '\u00A2', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '\uA686', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '\u6C49', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '"', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, true },
+                    new object[] { '\\', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, true },
+                    new object[] { '<', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '>', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '&', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '`', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '\'', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '+', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                    new object[] { '\uFFFD', JavaScriptEncoder.UnsafeRelaxedJsonEscaping, false },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(JavaScriptEncoders))]
+        public unsafe void EscapingTestWhileWritingSurrogate(JavaScriptEncoder encoder)
+        {
+            char highSurrogate = '\uD801';
+            char lowSurrogate = '\uDC37';
+            var random = new Random(42);
+            for (int dataLength = 2; dataLength < 50; dataLength++)
+            {
+                char[] str = new char[dataLength];
+                for (int i = 0; i < dataLength; i++)
+                {
+                    str[i] = (char)random.Next(97, 123);
+                }
+                string baseStr = new string(str);
+                byte[] sourceUtf8 = Encoding.UTF8.GetBytes(baseStr);
+
+                Assert.Equal(-1, encoder.FindFirstCharacterToEncodeUtf8(sourceUtf8));
+                fixed (char* ptr = baseStr)
+                {
+                    Assert.Equal(-1, encoder.FindFirstCharacterToEncode(ptr, baseStr.Length));
+                }
+
+                for (int i = 0; i < dataLength - 1; i++)
+                {
+                    char[] changed = baseStr.ToCharArray();
+                    changed[i] = highSurrogate;
+                    changed[i + 1] = lowSurrogate;
+                    string newStr = new string(changed);
+                    sourceUtf8 = Encoding.UTF8.GetBytes(newStr);
+
+                    Assert.Equal(i, encoder.FindFirstCharacterToEncodeUtf8(sourceUtf8));
+                    fixed (char* ptr = newStr)
+                    {
+                        Assert.Equal(i, encoder.FindFirstCharacterToEncode(ptr, newStr.Length));
+                    }
+                }
+
+                {
+                    char[] changed = baseStr.ToCharArray();
+
+                    for (int i = 0; i < changed.Length - 1; i += 2)
+                    {
+                        changed[i] = highSurrogate;
+                        changed[i + 1] = lowSurrogate;
+                    }
+
+                    string newStr = new string(changed);
+                    sourceUtf8 = Encoding.UTF8.GetBytes(newStr);
+
+                    Assert.Equal(0, encoder.FindFirstCharacterToEncodeUtf8(sourceUtf8));
+                    fixed (char* ptr = newStr)
+                    {
+                        Assert.Equal(0, encoder.FindFirstCharacterToEncode(ptr, newStr.Length));
+                    }
+                }
+            }
+        }
+
+        public static IEnumerable<object[]> JavaScriptEncoders
+        {
+            get
+            {
+                return new List<object[]>
+                {
+                    new object[] { JavaScriptEncoder.Default },
+                    new object[] { JavaScriptEncoder.Create(UnicodeRanges.BasicLatin) },
+                    new object[] { JavaScriptEncoder.Create(UnicodeRanges.All) },
+                    new object[] { JavaScriptEncoder.UnsafeRelaxedJsonEscaping },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidEscapingTestData))]
+        public unsafe void InvalidFindFirstCharacterToEncode(char replacementChar, JavaScriptEncoder encoder)
+        {
+            var random = new Random(42);
+            for (int dataLength = 0; dataLength < 47; dataLength++)
+            {
+                char[] str = new char[dataLength];
+                for (int i = 0; i < dataLength; i++)
+                {
+                    str[i] = (char)random.Next(97, 123);
+                }
+                string baseStr = new string(str);
+                byte[] baseStrUtf8 = Encoding.UTF8.GetBytes(baseStr);
+
+                for (int i = 0; i < dataLength; i++)
+                {
+                    char[] changed = baseStr.ToCharArray();
+                    changed[i] = replacementChar;
+                    string source = new string(changed);
+                    byte[] sourceUtf8 = new byte[baseStrUtf8.Length];
+                    baseStrUtf8.AsSpan().CopyTo(sourceUtf8);
+                    sourceUtf8[i] = 0xC3;   // Invalid, first byte of a 2-byte utf-8 character
+
+                    Assert.Equal(i, encoder.FindFirstCharacterToEncodeUtf8(sourceUtf8));
+                    fixed (char* ptr = source)
+                    {
+                        Assert.Equal(i, encoder.FindFirstCharacterToEncode(ptr, source.Length));
+                    }
+                }
+            }
+        }
+
+        public static IEnumerable<object[]> InvalidEscapingTestData
+        {
+            get
+            {
+                return new List<object[]>
+                {
+                    new object[] { '\uD801', JavaScriptEncoder.Default },         // Invalid, high surrogate alone
+                    new object[] { '\uDC01', JavaScriptEncoder.Default },         // Invalid, low surrogate alone
+
+                    new object[] { '\uD801', JavaScriptEncoder.UnsafeRelaxedJsonEscaping },
+                    new object[] { '\uDC01', JavaScriptEncoder.UnsafeRelaxedJsonEscaping },
+
+                    new object[] { '\uD801', JavaScriptEncoder.Create(UnicodeRanges.All) },
+                    new object[] { '\uDC01', JavaScriptEncoder.Create(UnicodeRanges.All) },
+
+                    new object[] { '\uD801', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin) },
+                    new object[] { '\uDC01', JavaScriptEncoder.Create(UnicodeRanges.BasicLatin) },
+                };
+            }
+        }
+
         [Fact]
         public void TestSurrogate()
         {
@@ -198,7 +547,8 @@ namespace Microsoft.Framework.WebEncoders
         }
 
         [Fact]
-        public void JavaScriptStringEncode_AllRangesAllowed_StillEncodesForbiddenChars_Simple_Escaping() {
+        public void JavaScriptStringEncode_AllRangesAllowed_StillEncodesForbiddenChars_Simple_Escaping()
+        {
             // The following two calls could be simply InlineData to the Theory below
             // Unfortunately, the xUnit logger fails to escape the inputs when logging the test results,
             // and so the suite fails despite all tests passing. 

--- a/src/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/System.Text.Json/src/System.Text.Json.csproj
@@ -195,7 +195,6 @@
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />
-    <Reference Include="System.Runtime.Intrinsics" />
     <Reference Include="System.Text.Encoding.Extensions" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/System.Text.Json/src/System.Text.Json.csproj
@@ -195,6 +195,7 @@
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />
+    <Reference Include="System.Runtime.Intrinsics" />
     <Reference Include="System.Text.Encoding.Extensions" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Escaping.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Escaping.cs
@@ -5,9 +5,15 @@
 using System.Buffers;
 using System.Buffers.Text;
 using System.Diagnostics;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text.Encodings.Web;
+
+#if BUILDING_INBOX_LIBRARY
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+#endif
 
 namespace System.Text.Json
 {
@@ -55,57 +61,202 @@ namespace System.Text.Json
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool NeedsEscaping(char value) => value > LastAsciiCharacter || AllowList[value] == 0;
 
-        public static int NeedsEscaping(ReadOnlySpan<byte> value, JavaScriptEncoder encoder)
+#if BUILDING_INBOX_LIBRARY
+        private static readonly Vector128<short> s_mask_UInt16_0x20 = Vector128.Create((short)0x20); // Space ' '
+
+        private static readonly Vector128<short> s_mask_UInt16_0x22 = Vector128.Create((short)0x22); // Quotation Mark '"'
+        private static readonly Vector128<short> s_mask_UInt16_0x26 = Vector128.Create((short)0x26); // Ampersand '&'
+        private static readonly Vector128<short> s_mask_UInt16_0x27 = Vector128.Create((short)0x27); // Apostrophe '''
+        private static readonly Vector128<short> s_mask_UInt16_0x2B = Vector128.Create((short)0x2B); // Plus sign '+'
+        private static readonly Vector128<short> s_mask_UInt16_0x3C = Vector128.Create((short)0x3C); // Less Than Sign '<'
+        private static readonly Vector128<short> s_mask_UInt16_0x3E = Vector128.Create((short)0x3E); // Greater Than Sign '>'
+        private static readonly Vector128<short> s_mask_UInt16_0x5C = Vector128.Create((short)0x5C); // Reverse Solidus '\'
+        private static readonly Vector128<short> s_mask_UInt16_0x60 = Vector128.Create((short)0x60); // Grave Access '`'
+
+        private static readonly Vector128<short> s_mask_UInt16_0x7E = Vector128.Create((short)0x7E); // Tilde '~'
+
+        private static readonly Vector128<sbyte> s_mask_SByte_0x20 = Vector128.Create((sbyte)0x20); // Space ' '
+
+        private static readonly Vector128<sbyte> s_mask_SByte_0x22 = Vector128.Create((sbyte)0x22); // Quotation Mark '"'
+        private static readonly Vector128<sbyte> s_mask_SByte_0x26 = Vector128.Create((sbyte)0x26); // Ampersand '&'
+        private static readonly Vector128<sbyte> s_mask_SByte_0x27 = Vector128.Create((sbyte)0x27); // Apostrophe '''
+        private static readonly Vector128<sbyte> s_mask_SByte_0x2B = Vector128.Create((sbyte)0x2B); // Plus sign '+'
+        private static readonly Vector128<sbyte> s_mask_SByte_0x3C = Vector128.Create((sbyte)0x3C); // Less Than Sign '<'
+        private static readonly Vector128<sbyte> s_mask_SByte_0x3E = Vector128.Create((sbyte)0x3E); // Greater Than Sign '>'
+        private static readonly Vector128<sbyte> s_mask_SByte_0x5C = Vector128.Create((sbyte)0x5C); // Reverse Solidus '\'
+        private static readonly Vector128<sbyte> s_mask_SByte_0x60 = Vector128.Create((sbyte)0x60); // Grave Access '`'
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Vector128<short> CreateEscapingMask(Vector128<short> sourceValue)
         {
-            int idx;
+            Debug.Assert(Sse2.IsSupported);
 
-            if (encoder != null)
-            {
-                idx = encoder.FindFirstCharacterToEncodeUtf8(value);
-                goto Return;
-            }
+            Vector128<short> mask = Sse2.CompareLessThan(sourceValue, s_mask_UInt16_0x20); // Space ' ', anything in the control characters range
 
-            for (idx = 0; idx < value.Length; idx++)
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_UInt16_0x22)); // Quotation Mark '"'
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_UInt16_0x26)); // Ampersand '&'
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_UInt16_0x27)); // Apostrophe '''
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_UInt16_0x2B)); // Plus sign '+'
+
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_UInt16_0x3C)); // Less Than Sign '<'
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_UInt16_0x3E)); // Greater Than Sign '>'
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_UInt16_0x5C)); // Reverse Solidus '\'
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_UInt16_0x60)); // Grave Access '`'
+
+            mask = Sse2.Or(mask, Sse2.CompareGreaterThan(sourceValue, s_mask_UInt16_0x7E)); // Tilde '~', anything above the ASCII range
+
+            return mask;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Vector128<sbyte> CreateEscapingMask(Vector128<sbyte> sourceValue)
+        {
+            Debug.Assert(Sse2.IsSupported);
+
+            Vector128<sbyte> mask = Sse2.CompareLessThan(sourceValue, s_mask_SByte_0x20); // Control characters, and anything above 0x7E since sbyte.MaxValue is 0x7E
+
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_SByte_0x22)); // Quotation Mark "
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_SByte_0x26)); // Ampersand &
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_SByte_0x27)); // Apostrophe '
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_SByte_0x2B)); // Plus sign +
+
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_SByte_0x3C)); // Less Than Sign <
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_SByte_0x3E)); // Greater Than Sign >
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_SByte_0x5C)); // Reverse Solidus \
+            mask = Sse2.Or(mask, Sse2.CompareEqual(sourceValue, s_mask_SByte_0x60)); // Grave Access `
+
+            return mask;
+        }
+#endif
+
+        public static unsafe int NeedsEscaping(ReadOnlySpan<byte> value, JavaScriptEncoder encoder)
+        {
+            fixed (byte* ptr = value)
             {
-                if (NeedsEscaping(value[idx]))
+                int idx = 0;
+
+                if (encoder != null)
                 {
+                    idx = encoder.FindFirstCharacterToEncodeUtf8(value);
                     goto Return;
                 }
+
+#if BUILDING_INBOX_LIBRARY
+                if (Sse2.IsSupported)
+                {
+                    sbyte* startingAddress = (sbyte*)ptr;
+                    while (value.Length - 16 >= idx)
+                    {
+                        Debug.Assert(startingAddress >= ptr && startingAddress <= (ptr + value.Length - 16));
+
+                        // Load the next 16 bytes.
+                        Vector128<sbyte> sourceValue = Sse2.LoadVector128(startingAddress);
+
+                        // Check if any of the 16 bytes need to be escaped.
+                        Vector128<sbyte> mask = CreateEscapingMask(sourceValue);
+
+                        int index = Sse2.MoveMask(mask.AsByte());
+                        // If index == 0, that means none of the 16 bytes needed to be escaped.
+                        // TrailingZeroCount is relatively expensive, avoid it if possible.
+                        if (index != 0)
+                        {
+                            // Found at least one byte that needs to be escaped, figure out the index of
+                            // the first one found that needed to be escaped within the 16 bytes.
+                            Debug.Assert(index > 0 && index <= 65_535);
+                            int tzc = BitOperations.TrailingZeroCount(index);
+                            Debug.Assert(tzc >= 0 && tzc <= 16);
+                            idx += tzc;
+                            goto Return;
+                        }
+                        idx += 16;
+                        startingAddress += 16;
+                    }
+
+                    // Process the remaining characters.
+                    Debug.Assert(value.Length - idx < 16);
+                }
+#endif
+
+                for (; idx < value.Length; idx++)
+                {
+                    Debug.Assert((ptr + idx) <= (ptr + value.Length));
+                    if (NeedsEscaping(*(ptr + idx)))
+                    {
+                        goto Return;
+                    }
+                }
+
+                idx = -1; // all characters allowed
+
+            Return:
+                return idx;
             }
-
-            idx = -1; // all characters allowed
-
-        Return:
-            return idx;
         }
 
         public static unsafe int NeedsEscaping(ReadOnlySpan<char> value, JavaScriptEncoder encoder)
         {
-            int idx;
-
-            // Some implementations of JavascriptEncoder.FindFirstCharacterToEncode may not accept
-            // null pointers and gaurd against that. Hence, check up-front and fall down to return -1.
-            if (encoder != null && !value.IsEmpty)
+            fixed (char* ptr = value)
             {
-                fixed (char* ptr = value)
+                int idx = 0;
+
+                // Some implementations of JavascriptEncoder.FindFirstCharacterToEncode may not accept
+                // null pointers and gaurd against that. Hence, check up-front and fall down to return -1.
+                if (encoder != null && !value.IsEmpty)
                 {
                     idx = encoder.FindFirstCharacterToEncode(ptr, value.Length);
-                }
-                goto Return;
-            }
-
-            for (idx = 0; idx < value.Length; idx++)
-            {
-                if (NeedsEscaping(value[idx]))
-                {
                     goto Return;
                 }
+
+#if BUILDING_INBOX_LIBRARY
+                if (Sse2.IsSupported)
+                {
+                    short* startingAddress = (short*)ptr;
+                    while (value.Length - 8 >= idx)
+                    {
+                        Debug.Assert(startingAddress >= ptr && startingAddress <= (ptr + value.Length - 8));
+
+                        // Load the next 8 characters.
+                        Vector128<short> sourceValue = Sse2.LoadVector128(startingAddress);
+
+                        // Check if any of the 8 characters need to be escaped.
+                        Vector128<short> mask = CreateEscapingMask(sourceValue);
+
+                        int index = Sse2.MoveMask(mask.AsByte());
+                        // If index == 0, that means none of the 8 characters needed to be escaped.
+                        // TrailingZeroCount is relatively expensive, avoid it if possible.
+                        if (index != 0)
+                        {
+                            // Found at least one character that needs to be escaped, figure out the index of
+                            // the first one found that needed to be escaped within the 8 characters.
+                            Debug.Assert(index > 0 && index <= 65_535);
+                            int tzc = BitOperations.TrailingZeroCount(index);
+                            Debug.Assert(tzc % 2 == 0 && tzc >= 0 && tzc <= 16);
+                            idx += tzc >> 1;
+                            goto Return;
+                        }
+                        idx += 8;
+                        startingAddress += 8;
+                    }
+
+                    // Process the remaining characters.
+                    Debug.Assert(value.Length - idx < 8);
+                }
+#endif
+
+                for (; idx < value.Length; idx++)
+                {
+                    Debug.Assert((ptr + idx) <= (ptr + value.Length));
+                    if (NeedsEscaping(*(ptr + idx)))
+                    {
+                        goto Return;
+                    }
+                }
+
+                idx = -1; // All characters are allowed.
+
+            Return:
+                return idx;
             }
-
-            idx = -1; // all characters allowed
-
-        Return:
-            return idx;
         }
 
         public static int GetMaxEscapedLength(int textLength, int firstIndexToEscape)

--- a/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Escaping.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Escaping.cs
@@ -5,8 +5,11 @@
 using System.Buffers;
 using System.Buffers.Text;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;  // Do not remove. Needed for Int32LsbToHexDigit when !BUILDING_INBOX_LIBRARY
 using System.Text.Encodings.Web;
+
+#if !BUILDING_INBOX_LIBRARY
+using System.Runtime.CompilerServices;
+#endif
 
 namespace System.Text.Json
 {

--- a/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Escaping.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Escaping.cs
@@ -62,7 +62,7 @@ namespace System.Text.Json
         public static unsafe int NeedsEscaping(ReadOnlySpan<char> value, JavaScriptEncoder encoder)
         {
             // Some implementations of JavaScriptEncoder.FindFirstCharacterToEncode may not accept
-            // null pointers and gaurd against that. Hence, check up-front to return -1.
+            // null pointers and guard against that. Hence, check up-front to return -1.
             if (value.IsEmpty)
             {
                 return -1;


### PR DESCRIPTION
Port the set of performance optimizations related to escaping checks: https://github.com/dotnet/corefx/pull/41845, https://github.com/dotnet/corefx/pull/41933, https://github.com/dotnet/corefx/pull/42023 and add necessary fixes that are dependent on the release/3.1 branch (such as use of TFM based constants instead of the SDK one)

The PR descriptions highlight the performance improvements. Here's a gist with the analysis:
https://gist.github.com/ahsonkhan/c566f5e7d65c1fde5a83a67be290c4ee

### Description

No functional/behavioral change is intended by this change, other than perf optimizations.

Here are the key improvements:
- Use Sse2 intrinsics to process 8 characters at a time, otherwise fall back to the sequential code path
- Use a int[] cache to store the ASCII characters as they get processed for better caching perf
- Loop unrolling in areas where perf matters and it was feasible

This set of optimizations was applied to all the built-in concrete encoders (`Default`, `UnsafeRelaxedJsonEscaping`, ones created from the `Create` factory method, and the `TextEncoder` virtual methods), and since it was applied on multiple types, some of this change involves refactoring out the common code into helpers/separate files.

### Customer Impact:

Callers of the S.T.Json `JsonSerializer` and `Utf8JsonWriter` get faster when using any encoder options, particularly for writing strings that are large (>= 16 characters). This change also targets improving users of ASP.NET since they set the `JsonSerializerOption` to use the non-default `JavaScriptEncoder` by default (`UnsafeRelaxedJsonEscaping`).

Here's a summary of the results (regardless of whether folks use the default encoder or pass in the custom built-in encoders via the `JsonSerializerOptions` or `JsonWriterOptions`).
1) For end-to-end scenario (such as serializing commonly found objects/payloads), there is a 10-15% improvement. This is particularly noticeable for an object model/payload used by the NuGet client team (`SearchResult`).
2) Writing relatively large JSON strings using the writer got ~30% faster (i.e. greater than 16 characters).
3) Checking to escape UTF-16 (for strings of length >= 16)
   - using Default improved 2x
   - using Relaxed improved 3x
   - using Custom improved 15-20%
   - small regression for lengths <= 4.
4) Checking to escape UTF-8 (for strings of length >= 16)
   - using Default improved 2-5x
   - using Relaxed improved 6-10x
   - using Custom improved 2-3x
   - small regression for lengths <= 2.

By moving the "NeedsEscaping" logic to its correct location - S.T.E.Web and removing duplicate code from S.T.Json leads to better separation of concerns/single responsibility and helps with maintenance by mitigating potential bugs that could occur when we have duplicate logic.

### Regression? 

No

### Risk

The primary risk with this change is the escaping check breaks for some edge case/length. This is mitigated by code review from multiple folks and exhaustive tests (test coverage of the added code is ~100%). The code was also written defensively using Debug.Asserts aggressively to reason about the invariant. Given the performance gains is substantial, and moving the logic into S.T.E.W follows better encapsulation, I think the risk is justified.

### Tests run / added

A big part of this change includes adding tests for various encoders and input strings to validate that the right index is being returned for which character needs to be escaped. This includes surrogate pairs, invalid strings, empty strings, etc.

cc @GrabYourPitchforks, @steveharter, @ericstj, @danmosemsft 