### PR TITLE
[release/3.1] Support dictionaries that don't implement non-generic IDictionary

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNotNullable.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNotNullable.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -125,6 +126,22 @@ namespace System.Text.Json
         public override Type GetDictionaryConcreteType()
         {
             return typeof(Dictionary<string, TRuntimeProperty>);
+        }
+
+        public override void GetDictionaryKeyAndValueFromGenericDictionary(ref WriteStackFrame writeStackFrame, out string key, out object value)
+        {
+            if (writeStackFrame.CollectionEnumerator is IEnumerator<KeyValuePair<string, TRuntimeProperty>> genericEnumerator)
+            {
+                key = genericEnumerator.Current.Key;
+                value = genericEnumerator.Current.Value;
+            }
+            else
+            {
+                throw ThrowHelper.GetNotSupportedException_SerializationNotSupportedCollection(
+                    writeStackFrame.JsonPropertyInfo.DeclaredPropertyType,
+                    writeStackFrame.JsonPropertyInfo.ParentClassType,
+                    writeStackFrame.JsonPropertyInfo.PropertyInfo);
+            }
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNotNullableContravariant.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNotNullableContravariant.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -127,6 +128,22 @@ namespace System.Text.Json.Serialization
         public override Type GetDictionaryConcreteType()
         {
             return typeof(Dictionary<string, TRuntimeProperty>);
+        }
+
+        public override void GetDictionaryKeyAndValueFromGenericDictionary(ref WriteStackFrame writeStackFrame, out string key, out object value)
+        {
+            if (writeStackFrame.CollectionEnumerator is IEnumerator<KeyValuePair<string, TRuntimeProperty>> genericEnumerator)
+            {
+                key = genericEnumerator.Current.Key;
+                value = genericEnumerator.Current.Value;
+            }
+            else
+            {
+                throw ThrowHelper.GetNotSupportedException_SerializationNotSupportedCollection(
+                    writeStackFrame.JsonPropertyInfo.DeclaredPropertyType,
+                    writeStackFrame.JsonPropertyInfo.ParentClassType,
+                    writeStackFrame.JsonPropertyInfo.PropertyInfo);
+            }
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNullable.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNullable.cs
@@ -152,5 +152,21 @@ namespace System.Text.Json
         {
             return typeof(Dictionary<string, TProperty?>);
         }
+
+        public override void GetDictionaryKeyAndValueFromGenericDictionary(ref WriteStackFrame writeStackFrame, out string key, out object value)
+        {
+            if (writeStackFrame.CollectionEnumerator is IEnumerator<KeyValuePair<string, TProperty?>> genericEnumerator)
+            {
+                key = genericEnumerator.Current.Key;
+                value = genericEnumerator.Current.Value;
+            }
+            else
+            {
+                throw ThrowHelper.GetNotSupportedException_SerializationNotSupportedCollection(
+                    writeStackFrame.JsonPropertyInfo.DeclaredPropertyType,
+                    writeStackFrame.JsonPropertyInfo.ParentClassType,
+                    writeStackFrame.JsonPropertyInfo.PropertyInfo);
+            }
+        }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleDictionary.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleDictionary.cs
@@ -41,14 +41,11 @@ namespace System.Text.Json
                     return true;
                 }
 
-                if (enumerable is IDictionary dictionary)
-                {
-                    state.Current.CollectionEnumerator = dictionary.GetEnumerator();
-                }
-                else
-                {
-                    state.Current.CollectionEnumerator = enumerable.GetEnumerator();
-                }
+                // Let the dictionary return the default IEnumerator from its IEnumerable.GetEnumerator().
+                // For IDictionary-derived classes this is normally be IDictionaryEnumerator.
+                // For IDictionary<TKey, TVale>-derived classes this is normally IDictionaryEnumerator as well
+                // but may be IEnumerable<KeyValuePair<TKey, TValue>> if the dictionary only supports generics.
+                state.Current.CollectionEnumerator = enumerable.GetEnumerator();
 
                 if (state.Current.ExtensionDataStatus != ExtensionDataWriteStatus.Writing)
                 {
@@ -58,28 +55,35 @@ namespace System.Text.Json
 
             if (state.Current.CollectionEnumerator.MoveNext())
             {
+                // A dictionary should not have a null KeyValuePair.
+                Debug.Assert(state.Current.CollectionEnumerator.Current != null);
+
+                bool obtainedValues = false;
+                string key = default;
+                object value = default;
+
                 // Check for polymorphism.
                 if (elementClassInfo.ClassType == ClassType.Unknown)
                 {
-                    object currentValue = ((IDictionaryEnumerator)state.Current.CollectionEnumerator).Entry.Value;
-                    GetRuntimeClassInfo(currentValue, ref elementClassInfo, options);
+                    jsonPropertyInfo.GetDictionaryKeyAndValue(ref state.Current, out key, out value);
+                    GetRuntimeClassInfo(value, ref elementClassInfo, options);
+                    obtainedValues = true;
                 }
 
                 if (elementClassInfo.ClassType == ClassType.Value)
                 {
                     elementClassInfo.PolicyProperty.WriteDictionary(ref state, writer);
                 }
-                else if (state.Current.CollectionEnumerator.Current == null)
-                {
-                    writer.WriteNull(jsonPropertyInfo.Name);
-                }
                 else
                 {
+                    if (!obtainedValues)
+                    {
+                        jsonPropertyInfo.GetDictionaryKeyAndValue(ref state.Current, out key, out value);
+                    }
+
                     // An object or another enumerator requires a new stack frame.
-                    var enumerator = (IDictionaryEnumerator)state.Current.CollectionEnumerator;
-                    object value = enumerator.Value;
                     state.Push(elementClassInfo, value);
-                    state.Current.KeyName = (string)enumerator.Key;
+                    state.Current.KeyName = key;
                 }
 
                 return false;
@@ -127,15 +131,14 @@ namespace System.Text.Json
                 key = polymorphicEnumerator.Current.Key;
                 value = (TProperty)polymorphicEnumerator.Current.Value;
             }
-            else if (current.IsIDictionaryConstructible || current.IsIDictionaryConstructibleProperty)
+            else if (current.CollectionEnumerator is IDictionaryEnumerator iDictionaryEnumerator &&
+                iDictionaryEnumerator.Key is string keyAsString)
             {
-                key = (string)((DictionaryEntry)current.CollectionEnumerator.Current).Key;
-                value = (TProperty)((DictionaryEntry)current.CollectionEnumerator.Current).Value;
+                key = keyAsString;
+                value = (TProperty)iDictionaryEnumerator.Value;
             }
             else
             {
-                // Todo: support non-generic Dictionary here (IDictionaryEnumerator)
-                // https://github.com/dotnet/corefx/issues/41034
                 throw ThrowHelper.GetNotSupportedException_SerializationNotSupportedCollection(
                     current.JsonPropertyInfo.DeclaredPropertyType,
                     current.JsonPropertyInfo.ParentClassType,

--- a/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
+++ b/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
@@ -883,13 +883,23 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        public static void HashtableFail()
+        public static void Hashtable()
         {
-            {
-                IDictionary ht = new Hashtable();
-                ht.Add("Key", "Value");
-                Assert.Throws<NotSupportedException>(() => JsonSerializer.Serialize(ht));
-            }
+            const string Json = @"{""Key"":""Value""}";
+
+            IDictionary ht = new Hashtable();
+            ht.Add("Key", "Value");
+            string json = JsonSerializer.Serialize(ht);
+
+            Assert.Equal(Json, json);
+
+            ht = JsonSerializer.Deserialize<IDictionary>(json);
+            Assert.IsType<JsonElement>(ht["Key"]);
+            Assert.Equal("Value", ((JsonElement)ht["Key"]).GetString());
+
+            // Verify round-tripped JSON.
+            json = JsonSerializer.Serialize(ht);
+            Assert.Equal(Json, json);
         }
 
         [Fact]
@@ -1495,6 +1505,253 @@ namespace System.Text.Json.Serialization.Tests
             public Dictionary<string, Dictionary<string, string>> StringDictVals { get; set; }
             public Dictionary<string, Dictionary<string, object>> ObjectDictVals { get; set; }
             public Dictionary<string, SimpleClassWithDictionaries> ClassVals { get; set; }
+        }
+
+        public class DictionaryThatOnlyImplementsIDictionaryOfStringTValue<TValue> : IDictionary<string, TValue>
+        {
+            IDictionary<string, TValue> _inner = new Dictionary<string, TValue>();
+
+            public TValue this[string key]
+            {
+                get
+                {
+                    return _inner[key];
+                }
+                set
+                {
+                    _inner[key] = value;
+                }
+            }
+
+            public ICollection<string> Keys => _inner.Keys;
+
+            public ICollection<TValue> Values => _inner.Values;
+
+            public int Count => _inner.Count;
+
+            public bool IsReadOnly => _inner.IsReadOnly;
+
+            public void Add(string key, TValue value)
+            {
+                _inner.Add(key, value);
+            }
+
+            public void Add(KeyValuePair<string, TValue> item)
+            {
+                _inner.Add(item);
+            }
+
+            public void Clear()
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool Contains(KeyValuePair<string, TValue> item)
+            {
+                return _inner.Contains(item);
+            }
+
+            public bool ContainsKey(string key)
+            {
+                return _inner.ContainsKey(key);
+            }
+
+            public void CopyTo(KeyValuePair<string, TValue>[] array, int arrayIndex)
+            {
+                // CopyTo should not be called.
+                throw new NotImplementedException();
+            }
+
+            public IEnumerator<KeyValuePair<string, TValue>> GetEnumerator()
+            {
+                // Don't return results directly from _inner since that will return an enumerator that returns
+                // IDictionaryEnumerator which should not require.
+                foreach (KeyValuePair<string, TValue> keyValuePair in _inner)
+                {
+                    yield return keyValuePair;
+                }
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+
+            public bool Remove(string key)
+            {
+                // Remove should not be called.
+                throw new NotImplementedException();
+            }
+
+            public bool Remove(KeyValuePair<string, TValue> item)
+            {
+                // Remove should not be called.
+                throw new NotImplementedException();
+            }
+
+            public bool TryGetValue(string key, out TValue value)
+            {
+                return _inner.TryGetValue(key, out value);
+            }
+        }
+
+        [Fact]
+        public static void DictionaryOfTOnlyWithStringTValueAsInt()
+        {
+            const string Json = @"{""One"":1,""Two"":2}";
+
+            DictionaryThatOnlyImplementsIDictionaryOfStringTValue<int> dictionary;
+
+            dictionary = JsonSerializer.Deserialize<DictionaryThatOnlyImplementsIDictionaryOfStringTValue<int>>(Json);
+            Assert.Equal(1, dictionary["One"]);
+            Assert.Equal(2, dictionary["Two"]);
+
+            string json = JsonSerializer.Serialize(dictionary);
+            Assert.Equal(Json, json);
+        }
+
+        [Fact]
+        public static void DictionaryOfTOnlyWithStringTValueAsPoco()
+        {
+            const string Json = @"{""One"":{""Id"":1},""Two"":{""Id"":2}}";
+
+            DictionaryThatOnlyImplementsIDictionaryOfStringTValue<Poco> dictionary;
+
+            dictionary = JsonSerializer.Deserialize<DictionaryThatOnlyImplementsIDictionaryOfStringTValue<Poco>>(Json);
+            Assert.Equal(1, dictionary["One"].Id);
+            Assert.Equal(2, dictionary["Two"].Id);
+
+            string json = JsonSerializer.Serialize(dictionary);
+            Assert.Equal(Json, json);
+        }
+
+        public class DictionaryThatOnlyImplementsIDictionaryOfStringPoco : DictionaryThatOnlyImplementsIDictionaryOfStringTValue<Poco>
+        {
+        }
+
+        [Fact]
+        public static void DictionaryOfTOnlyWithStringPoco()
+        {
+            const string Json = @"{""One"":{""Id"":1},""Two"":{""Id"":2}}";
+
+            DictionaryThatOnlyImplementsIDictionaryOfStringPoco dictionary;
+
+            dictionary = JsonSerializer.Deserialize<DictionaryThatOnlyImplementsIDictionaryOfStringPoco>(Json);
+            Assert.Equal(1, dictionary["One"].Id);
+            Assert.Equal(2, dictionary["Two"].Id);
+
+            string json = JsonSerializer.Serialize(dictionary);
+            Assert.Equal(Json, json);
+        }
+
+        public class DictionaryThatHasIncomatibleEnumerator<TValue> : IDictionary<string, TValue>
+        {
+            IDictionary<string, TValue> _inner = new Dictionary<string, TValue>();
+
+            public TValue this[string key]
+            {
+                get
+                {
+                    return _inner[key];
+                }
+                set
+                {
+                    _inner[key] = value;
+                }
+            }
+
+            public ICollection<string> Keys => _inner.Keys;
+
+            public ICollection<TValue> Values => _inner.Values;
+
+            public int Count => _inner.Count;
+
+            public bool IsReadOnly => _inner.IsReadOnly;
+
+            public void Add(string key, TValue value)
+            {
+                _inner.Add(key, value);
+            }
+
+            public void Add(KeyValuePair<string, TValue> item)
+            {
+                _inner.Add(item);
+            }
+
+            public void Clear()
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool Contains(KeyValuePair<string, TValue> item)
+            {
+                return _inner.Contains(item);
+            }
+
+            public bool ContainsKey(string key)
+            {
+                return _inner.ContainsKey(key);
+            }
+
+            public void CopyTo(KeyValuePair<string, TValue>[] array, int arrayIndex)
+            {
+                // CopyTo should not be called.
+                throw new NotImplementedException();
+            }
+
+            public IEnumerator<KeyValuePair<string, TValue>> GetEnumerator()
+            {
+                // The generic GetEnumerator() should not be called for this test.
+                throw new NotImplementedException();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                // Create an incompatible converter.
+                return new int[] {100,200 }.GetEnumerator();
+            }
+
+            public bool Remove(string key)
+            {
+                // Remove should not be called.
+                throw new NotImplementedException();
+            }
+
+            public bool Remove(KeyValuePair<string, TValue> item)
+            {
+                // Remove should not be called.
+                throw new NotImplementedException();
+            }
+
+            public bool TryGetValue(string key, out TValue value)
+            {
+                return _inner.TryGetValue(key, out value);
+            }
+        }
+
+        [Fact]
+        public static void VerifyDictionaryThatHasIncomatibleEnumeratorWithInt()
+        {
+            const string Json = @"{""One"":1,""Two"":2}";
+
+            DictionaryThatHasIncomatibleEnumerator<int> dictionary;
+            dictionary = JsonSerializer.Deserialize<DictionaryThatHasIncomatibleEnumerator<int>>(Json);
+            Assert.Equal(1, dictionary["One"]);
+            Assert.Equal(2, dictionary["Two"]);
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Serialize(dictionary));
+        }
+
+
+        [Fact]
+        public static void VerifyDictionaryThatHasIncomatibleEnumeratorWithPoco()
+        {
+            const string Json = @"{""One"":{""Id"":1},""Two"":{""Id"":2}}";
+
+            DictionaryThatHasIncomatibleEnumerator<Poco> dictionary;
+            dictionary = JsonSerializer.Deserialize<DictionaryThatHasIncomatibleEnumerator<Poco>>(Json);
+            Assert.Equal(1, dictionary["One"].Id);
+            Assert.Equal(2, dictionary["Two"].Id);
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Serialize(dictionary));
         }
     }
 }


### PR DESCRIPTION
_note: this PR was created and made stand-alone since the [previous PR that included this fix](https://github.com/dotnet/corefx/pull/42008) takes a dependency on [collection PR](https://github.com/dotnet/corefx/pull/42009) that will likely not be accepted._ 

Ports https://github.com/dotnet/corefx/pull/41903

## Issue:
Support dictionaries that implement `IDictionary<TKey, TValue>` but do not implement the non-generic `IDictionary`

## Description
An assumption was made during serialization that a call to a dictionary's `GetEnumerator()` (either through the `IEnumerable` or `IDictionary` interfaces) returns an `IDictionaryEnumerable` (which is required for types that implement `IDictionary`). However, there are certain "newer" generic collection types outside of the BCL that don't implement `IDictionary` or return `IDictionaryEnumerable` from their `IEnumerable.GetEnumerator()` method (note that `IDictionary<TKey, TValue>` does not implement `IDictionary`). This caused a `InvalidCastException` at runtime. The fix is to assume `IEnumerable<KeyValuePair<TKey, TValue>>` instead of `IDictionaryEnumerable` for generic dictionaries.

## Customer Impact

Without this PR, there is no support for generic dictionaries that implement `IDictionary<TKey, TValue>` but don't support the older non-generic `IDictionary`. This is a community-reported issue and is blocking adoption.

## Regression?

No. The `InvalidCastException` is no longer encountered.

## Risk

Low. Dictionaries have good coverage already and additional tests were added. A community member [verified ](https://github.com/dotnet/corefx/issues/41329#issuecomment-545501088) a fix based on the sames changes to master.
