### PR TITLE
[release/3.1] Port cache polymorphic properties (#41753)

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.AddProperty.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.AddProperty.cs
@@ -2,9 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reflection;
 using System.Text.Json.Serialization;
+using System.Threading;
 
 namespace System.Text.Json
 {
@@ -208,19 +210,31 @@ namespace System.Text.Json
                 options: options);
         }
 
-        internal JsonPropertyInfo CreatePolymorphicProperty(JsonPropertyInfo property, Type runtimePropertyType, JsonSerializerOptions options)
+        internal JsonPropertyInfo GetOrAddPolymorphicProperty(JsonPropertyInfo property, Type runtimePropertyType, JsonSerializerOptions options)
         {
-            JsonPropertyInfo runtimeProperty = CreateProperty(
-                property.DeclaredPropertyType,
-                runtimePropertyType,
-                property.ImplementedPropertyType,
-                property.PropertyInfo,
-                parentClassType: Type,
-                converter: null,
-                options: options);
-            property.CopyRuntimeSettingsTo(runtimeProperty);
+            static JsonPropertyInfo CreateRuntimeProperty((JsonPropertyInfo property, Type runtimePropertyType) key, (JsonSerializerOptions options, Type classType) arg)
+            {
+                JsonPropertyInfo runtimeProperty = CreateProperty(
+                    key.property.DeclaredPropertyType,
+                    key.runtimePropertyType,
+                    key.property.ImplementedPropertyType,
+                    key.property.PropertyInfo,
+                    parentClassType: arg.classType,
+                    converter : null,
+                    options: arg.options);
 
-            return runtimeProperty;
+                key.property.CopyRuntimeSettingsTo(runtimeProperty);
+
+                return runtimeProperty;
+            }
+
+            ConcurrentDictionary<(JsonPropertyInfo, Type), JsonPropertyInfo> cache =
+                LazyInitializer.EnsureInitialized(ref RuntimePropertyCache, () => new ConcurrentDictionary<(JsonPropertyInfo, Type), JsonPropertyInfo>());
+#if BUILDING_INBOX_LIBRARY
+            return cache.GetOrAdd((property, runtimePropertyType), (key, arg) => CreateRuntimeProperty(key, arg), (options, Type));
+#else
+            return cache.GetOrAdd((property, runtimePropertyType), key => CreateRuntimeProperty(key, (options, Type)));
+#endif
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
@@ -26,6 +27,9 @@ namespace System.Text.Json
 
         // All of the serializable properties on a POCO (except the optional extension property) keyed on property name.
         public volatile Dictionary<string, JsonPropertyInfo> PropertyCache;
+
+        // Serializable runtime/polymorphic properties, keyed on property and runtime type.
+        public ConcurrentDictionary<(JsonPropertyInfo, Type), JsonPropertyInfo> RuntimePropertyCache;
 
         // All of the serializable properties on a POCO including the optional extension property.
         // Used for performance during serialization instead of 'PropertyCache' above.

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
@@ -31,7 +31,7 @@ namespace System.Text.Json
             }
             else if (state.Current.JsonClassInfo.ClassType == ClassType.Unknown)
             {
-                jsonPropertyInfo = state.Current.JsonClassInfo.CreatePolymorphicProperty(jsonPropertyInfo, typeof(object), options);
+                jsonPropertyInfo = state.Current.JsonClassInfo.GetOrAddPolymorphicProperty(jsonPropertyInfo, typeof(object), options);
             }
 
             // Verify that we have a valid enumerable.

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleValue.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleValue.cs
@@ -24,7 +24,7 @@ namespace System.Text.Json
             }
             else if (state.Current.JsonClassInfo.ClassType == ClassType.Unknown)
             {
-                jsonPropertyInfo = state.Current.JsonClassInfo.CreatePolymorphicProperty(jsonPropertyInfo, typeof(object), options);
+                jsonPropertyInfo = state.Current.JsonClassInfo.GetOrAddPolymorphicProperty(jsonPropertyInfo, typeof(object), options);
             }
 
             jsonPropertyInfo.Read(tokenType, ref state, ref reader);

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
@@ -31,7 +31,7 @@ namespace System.Text.Json
                 // Nothing to do for typeof(object)
                 if (runtimeType != typeof(object))
                 {
-                    jsonPropertyInfo = jsonClassInfo.CreatePolymorphicProperty(jsonPropertyInfo, runtimeType, options);
+                    jsonPropertyInfo = jsonClassInfo.GetOrAddPolymorphicProperty(jsonPropertyInfo, runtimeType, options);
                 }
             }
         }

--- a/src/System.Text.Json/tests/Serialization/Object.WriteTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Object.WriteTests.cs
@@ -75,5 +75,30 @@ namespace System.Text.Json.Serialization.Tests
 
             public string NonIndexerProp { get; set; }
         }
+
+        [Fact]
+        public static void WritePolymorhicSimple()
+        {
+            string json = JsonSerializer.Serialize(new { Prop = (object)new[] { 0 } });
+            Assert.Equal(@"{""Prop"":[0]}", json);
+        }
+
+        [Fact]
+        public static void WritePolymorphicDifferentAttributes()
+        {
+            string json = JsonSerializer.Serialize(new Polymorphic());
+            Assert.Equal(@"{""P1"":"""",""p_3"":""""}", json);
+        }
+
+        private class Polymorphic
+        {
+            public object P1 => "";
+
+            [JsonIgnore]
+            public object P2 => "";
+
+            [JsonPropertyName("p_3")]
+            public object P3 => "";
+        }
     }
 }


### PR DESCRIPTION
_note: this PR was created and made stand-alone since the [previous PR that included this fix](https://github.com/dotnet/corefx/pull/42008) takes a dependency on [collection PR](https://github.com/dotnet/corefx/pull/42009) that will likely not be accepted._ 

Ports https://github.com/dotnet/corefx/pull/41753

## Issue
With the PR there is significant performance improvement when using polymorphic serialization. The issue was created and fixed by a community member by adding a dictionary-based cache and reports real-world gains of 68x.

## Description
When a property of type of System.Object is serialized, the serializer enters a polymorphic mode where it obtains the actual run-time type to serialize. Getting the appropriate infrastructure (including looking up a converter for that type and generating IL for the setter) is expensive and was not cached. This PR caches that information. 

## Customer Impact

- Slow behavior when using polymorphic serialization.

## Regression?

No.

## Risk

Low. 
The performance issue is very specific to polymorphic serialization which was already tested. An additional test was added to verify the cache is properly keying.