### PR TITLE
Ensure serializer throws JsonException when deserializing incompatible JSON into collections

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
@@ -332,6 +332,9 @@ namespace System.Text.Json
             // No cached item was found. Try the main list which has all of the properties.
 
             string stringPropertyName = JsonHelpers.Utf8GetString(propertyName);
+
+            Debug.Assert(PropertyCache != null);
+
             if (!PropertyCache.TryGetValue(stringPropertyName, out info))
             {
                 info = JsonPropertyInfo.s_missingProperty;

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
@@ -366,6 +366,11 @@ namespace System.Text.Json
             JsonClassInfo elementClassInfo = ElementClassInfo;
             if (elementClassInfo != null && (propertyInfo = elementClassInfo.PolicyProperty) != null)
             {
+                if (!state.Current.CollectionPropertyInitialized)
+                {
+                    ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(propertyInfo.RuntimePropertyType);
+                }
+
                 // Forward the setter to the value-based JsonPropertyInfo.
                 propertyInfo.ReadEnumerable(tokenType, ref state, ref reader);
             }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoCommon.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoCommon.cs
@@ -97,7 +97,6 @@ namespace System.Text.Json
         public override void SetValueAsObject(object obj, object value)
         {
             Debug.Assert(HasSetter);
-
             TDeclaredProperty typedValue = (TDeclaredProperty)value;
 
             if (typedValue != null || !IgnoreNullValues)

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoCommon.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoCommon.cs
@@ -97,6 +97,7 @@ namespace System.Text.Json
         public override void SetValueAsObject(object obj, object value)
         {
             Debug.Assert(HasSetter);
+
             TDeclaredProperty typedValue = (TDeclaredProperty)value;
 
             if (typedValue != null || !IgnoreNullValues)

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleObject.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleObject.cs
@@ -52,6 +52,8 @@ namespace System.Text.Json
                     state.Current.ReturnValue = value;
                     state.Current.DetermineIfDictionaryCanBePopulated(state.Current.ReturnValue);
                 }
+
+                state.Current.CollectionPropertyInitialized = true;
             }
             else
             {
@@ -68,6 +70,12 @@ namespace System.Text.Json
             if (state.Current.PropertyRefCache != null)
             {
                 state.Current.JsonClassInfo.UpdateSortedPropertyCache(ref state.Current);
+            }
+
+            if (state.Current.JsonClassInfo.ClassType == ClassType.Value)
+            {
+                // We should be in a converter, thus we must have bad JSON.
+                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(state.Current.JsonPropertyInfo.RuntimePropertyType);
             }
 
             object value = state.Current.ReturnValue;

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleObject.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleObject.cs
@@ -66,16 +66,16 @@ namespace System.Text.Json
             // Only allow dictionaries to be processed here if this is the DataExtensionProperty.
             Debug.Assert(!state.Current.IsProcessingDictionary() || state.Current.JsonClassInfo.DataExtensionProperty == state.Current.JsonPropertyInfo);
 
-            // Check if we are trying to build the sorted cache.
-            if (state.Current.PropertyRefCache != null)
-            {
-                state.Current.JsonClassInfo.UpdateSortedPropertyCache(ref state.Current);
-            }
-
             if (state.Current.JsonClassInfo.ClassType == ClassType.Value)
             {
                 // We should be in a converter, thus we must have bad JSON.
                 ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(state.Current.JsonPropertyInfo.RuntimePropertyType);
+            }
+
+            // Check if we are trying to build the sorted cache.
+            if (state.Current.PropertyRefCache != null)
+            {
+                state.Current.JsonClassInfo.UpdateSortedPropertyCache(ref state.Current);
             }
 
             object value = state.Current.ReturnValue;

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -37,6 +37,11 @@ namespace System.Text.Json
 
                 state.Current.KeyName = reader.GetString();
             }
+            else if (state.Current.JsonClassInfo.ClassType == ClassType.Value)
+            {
+                // We should already be in a converter, thus we must have bad JSON.
+                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(state.Current.JsonPropertyInfo.RuntimePropertyType);
+            }
             else
             {
                 state.Current.EndProperty();

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -39,7 +39,7 @@ namespace System.Text.Json
             }
             else if (state.Current.JsonClassInfo.ClassType == ClassType.Value)
             {
-                // We should already be in a converter, thus we must have bad JSON.
+                // We should be in a converter, thus we must have bad JSON.
                 ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(state.Current.JsonPropertyInfo.RuntimePropertyType);
             }
             else

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
@@ -303,7 +303,11 @@ namespace System.Text.Json
 
         public void DetermineEnumerablePopulationStrategy(object targetEnumerable)
         {
-            if (JsonPropertyInfo.RuntimeClassInfo.AddItemToObject != null)
+            if (JsonPropertyInfo.ClassType != ClassType.Enumerable)
+            {
+                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(JsonPropertyInfo.RuntimePropertyType);
+            }
+            else if (JsonPropertyInfo.RuntimeClassInfo.AddItemToObject != null)
             {
                 if (!JsonPropertyInfo.TryCreateEnumerableAddMethod(targetEnumerable, out object addMethodDelegate))
                 {

--- a/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
+++ b/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
@@ -320,23 +320,78 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize(json, type));
         }
 
+        public class ClassWithArray
+        {
+            public int[] MyArray { get; set; }
+        }
+
+        public class ClassWithDictionary
+        {
+            public Dictionary<string, int[]> MyDictionary { get; set; }
+        }
+
         [Theory]
         [InlineData(typeof(int[]), @"""test""")]
         [InlineData(typeof(int[]), @"1")]
         [InlineData(typeof(int[]), @"false")]
         [InlineData(typeof(int[]), @"{}")]
+        [InlineData(typeof(int[]), @"{""test"": 1}")]
         [InlineData(typeof(int[]), @"[""test""")]
+        [InlineData(typeof(int[]), @"[""test""]")]
         [InlineData(typeof(int[]), @"[true]")]
         [InlineData(typeof(int[]), @"[{}]")]
         [InlineData(typeof(int[]), @"[[]]")]
+        [InlineData(typeof(int[]), @"[{""test"": 1}]")]
+        [InlineData(typeof(int[]), @"[[true]]")]
         [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": {}}")]
+        [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": {""test"": 1}}")]
         [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": ""test""}")]
         [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": 1}")]
         [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": true}")]
+        [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": [""test""}")]
         [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": [""test""]}")]
         [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": [[]]}")]
+        [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": [true]}")]
         [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": [{}]}")]
-        public static void InvalidJsonForArrayShouldFail(Type type, string json)
+        [InlineData(typeof(ClassWithArray), @"{""MyArray"": ""test""}")]
+        [InlineData(typeof(ClassWithArray), @"{""MyArray"": 1}")]
+        [InlineData(typeof(ClassWithArray), @"{""MyArray"": false}")]
+        [InlineData(typeof(ClassWithArray), @"{""MyArray"": {}}")]
+        [InlineData(typeof(ClassWithArray), @"{""MyArray"": {""test"": 1}}")]
+        [InlineData(typeof(ClassWithArray), @"{""MyArray"": [""test""}")]
+        [InlineData(typeof(ClassWithArray), @"{""MyArray"": [""test""]}")]
+        [InlineData(typeof(ClassWithArray), @"{""MyArray"": [true]}")]
+        [InlineData(typeof(ClassWithArray), @"{""MyArray"": [{}]}")]
+        [InlineData(typeof(ClassWithArray), @"{""MyArray"": [[]]}")]
+        [InlineData(typeof(ClassWithArray), @"{""MyArray"": [{""test"": 1}]}")]
+        [InlineData(typeof(ClassWithArray), @"{""MyArray"": [[true]]}")]
+        [InlineData(typeof(Dictionary<string, string>), @"""test""")]
+        [InlineData(typeof(Dictionary<string, string>), @"1")]
+        [InlineData(typeof(Dictionary<string, string>), @"false")]
+        [InlineData(typeof(Dictionary<string, string>), @"{"""": 1}")]
+        [InlineData(typeof(Dictionary<string, string>), @"{"""": {}}")]
+        [InlineData(typeof(Dictionary<string, string>), @"{"""": {"""":""""}}")]
+        [InlineData(typeof(Dictionary<string, string>), @"[""test""")]
+        [InlineData(typeof(Dictionary<string, string>), @"[""test""]")]
+        [InlineData(typeof(Dictionary<string, string>), @"[true]")]
+        [InlineData(typeof(Dictionary<string, string>), @"[{}]")]
+        [InlineData(typeof(Dictionary<string, string>), @"[[]]")]
+        [InlineData(typeof(Dictionary<string, string>), @"[{""test"": 1}]")]
+        [InlineData(typeof(Dictionary<string, string>), @"[[true]]")]
+        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":""test""}")]
+        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":1}")]
+        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":false}")]
+        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":{"""": 1}}")]
+        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":{"""": {}}}")]
+        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":{"""": {"""":""""}}}")]
+        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":[""test""}")]
+        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":[""test""]}")]
+        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":[true]}")]
+        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":[{}]}")]
+        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":[[]]}")]
+        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":[{""test"": 1}]}")]
+        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":[[true]]}")]
+        public static void InvalidJsonForTypeShouldFail(Type type, string json)
         {
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize(json, type));
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/41839 for 5.0. https://github.com/dotnet/corefx/pull/42071 fixes it for 3.1.