### PR TITLE
[release/3.1] Make Add/Remove UnsignedAttribute work with counter signers

### DIFF
--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SubjectIdentifier.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SubjectIdentifier.cs
@@ -127,6 +127,41 @@ namespace System.Security.Cryptography.Pkcs
                     throw new CryptographicException();
             }
         }
+
+        internal bool IsEquivalentTo(SubjectIdentifier other)
+        {
+            SubjectIdentifier currentId = other;
+
+            if (currentId.Type != Type)
+            {
+                return false;
+            }
+
+            X509IssuerSerial issuerSerial = default;
+
+            if (Type == SubjectIdentifierType.IssuerAndSerialNumber)
+            {
+                issuerSerial = (X509IssuerSerial)Value;
+            }
+
+            switch (Type)
+            {
+                case SubjectIdentifierType.IssuerAndSerialNumber:
+                    {
+                        X509IssuerSerial currentIssuerSerial = (X509IssuerSerial)currentId.Value;
+
+                        return currentIssuerSerial.IssuerName == issuerSerial.IssuerName &&
+                            currentIssuerSerial.SerialNumber == issuerSerial.SerialNumber;
+                    }
+                case SubjectIdentifierType.SubjectKeyIdentifier:
+                    return (string)Value == (string)currentId.Value;
+                case SubjectIdentifierType.NoSignature:
+                    return true;
+                default:
+                    Debug.Fail($"No match logic for SubjectIdentifierType {Type}");
+                    throw new CryptographicException();
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/41158
Ports: https://github.com/dotnet/corefx/pull/41236

### Description

This extends #25449 which has added support for adding unsigned attributes to signers to also work with counter-signers which is a valid scenario for i.e. people wanting to add a timestamp to their counter-signatures.

### Customer Impact

Customers will be able to add unsigned attributes to counter signer which unblocks certain scenarios like attaching a timestamp to a counter signature.

### Regression? 

No

### Risk

Small. Feature is relatively new and not a main scenario. There are multiple tests testing original change as well as the extended scenarios.

cc: @danmosemsft 