### PR TITLE
[release/3.1] Ensure serializer throws JsonException when deserializing incompatible JSON into collections

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
@@ -346,6 +346,9 @@ namespace System.Text.Json
             // No cached item was found. Try the main list which has all of the properties.
 
             string stringPropertyName = JsonHelpers.Utf8GetString(propertyName);
+
+            Debug.Assert(PropertyCache != null);
+
             if (!PropertyCache.TryGetValue(stringPropertyName, out info))
             {
                 info = JsonPropertyInfo.s_missingProperty;

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
@@ -421,6 +421,11 @@ namespace System.Text.Json
             JsonClassInfo elementClassInfo = ElementClassInfo;
             if (elementClassInfo != null && (propertyInfo = elementClassInfo.PolicyProperty) != null)
             {
+                if (!state.Current.CollectionPropertyInitialized)
+                {
+                    ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(propertyInfo.RuntimePropertyType);
+                }
+
                 // Forward the setter to the value-based JsonPropertyInfo.
                 propertyInfo.ReadEnumerable(tokenType, ref state, ref reader);
             }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleObject.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleObject.cs
@@ -45,10 +45,16 @@ namespace System.Text.Json
             if (state.Current.IsProcessingIDictionaryConstructible())
             {
                 state.Current.TempDictionaryValues = (IDictionary)classInfo.CreateConcreteDictionary();
+                state.Current.CollectionPropertyInitialized = true;
             }
             else
             {
                 state.Current.ReturnValue = classInfo.CreateObject();
+
+                if (state.Current.IsProcessingDictionary())
+                {
+                    state.Current.CollectionPropertyInitialized = true;
+                }
             }
         }
 
@@ -58,6 +64,12 @@ namespace System.Text.Json
             Debug.Assert(
                 (!state.Current.IsProcessingDictionary() || state.Current.JsonClassInfo.DataExtensionProperty == state.Current.JsonPropertyInfo) &&
                 !state.Current.IsProcessingIDictionaryConstructible());
+
+            if (state.Current.JsonClassInfo.ClassType == ClassType.Value)
+            {
+                // We should be in a converter, thus we must have bad JSON.
+                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(state.Current.JsonPropertyInfo.RuntimePropertyType);
+            }
 
             // Check if we are trying to build the sorted cache.
             if (state.Current.PropertyRefCache != null)

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -37,6 +37,11 @@ namespace System.Text.Json
 
                 state.Current.KeyName = reader.GetString();
             }
+            else if (state.Current.JsonClassInfo.ClassType == ClassType.Value)
+            {
+                // We should be in a converter, thus we must have bad JSON.
+                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(state.Current.JsonPropertyInfo.RuntimePropertyType);
+            }
             else
             {
                 state.Current.EndProperty();

--- a/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
+++ b/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
@@ -320,23 +320,78 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize(json, type));
         }
 
+        public class ClassWithArray
+        {
+            public int[] MyArray { get; set; }
+        }
+
+        public class ClassWithDictionary
+        {
+            public Dictionary<string, int[]> MyDictionary { get; set; }
+        }
+
         [Theory]
         [InlineData(typeof(int[]), @"""test""")]
         [InlineData(typeof(int[]), @"1")]
         [InlineData(typeof(int[]), @"false")]
         [InlineData(typeof(int[]), @"{}")]
+        [InlineData(typeof(int[]), @"{""test"": 1}")]
         [InlineData(typeof(int[]), @"[""test""")]
+        [InlineData(typeof(int[]), @"[""test""]")]
         [InlineData(typeof(int[]), @"[true]")]
         [InlineData(typeof(int[]), @"[{}]")]
         [InlineData(typeof(int[]), @"[[]]")]
+        [InlineData(typeof(int[]), @"[{""test"": 1}]")]
+        [InlineData(typeof(int[]), @"[[true]]")]
         [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": {}}")]
+        [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": {""test"": 1}}")]
         [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": ""test""}")]
         [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": 1}")]
         [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": true}")]
+        [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": [""test""}")]
         [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": [""test""]}")]
         [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": [[]]}")]
+        [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": [true]}")]
         [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": [{}]}")]
-        public static void InvalidJsonForArrayShouldFail(Type type, string json)
+        [InlineData(typeof(ClassWithArray), @"{""MyArray"": ""test""}")]
+        [InlineData(typeof(ClassWithArray), @"{""MyArray"": 1}")]
+        [InlineData(typeof(ClassWithArray), @"{""MyArray"": false}")]
+        [InlineData(typeof(ClassWithArray), @"{""MyArray"": {}}")]
+        [InlineData(typeof(ClassWithArray), @"{""MyArray"": {""test"": 1}}")]
+        [InlineData(typeof(ClassWithArray), @"{""MyArray"": [""test""}")]
+        [InlineData(typeof(ClassWithArray), @"{""MyArray"": [""test""]}")]
+        [InlineData(typeof(ClassWithArray), @"{""MyArray"": [true]}")]
+        [InlineData(typeof(ClassWithArray), @"{""MyArray"": [{}]}")]
+        [InlineData(typeof(ClassWithArray), @"{""MyArray"": [[]]}")]
+        [InlineData(typeof(ClassWithArray), @"{""MyArray"": [{""test"": 1}]}")]
+        [InlineData(typeof(ClassWithArray), @"{""MyArray"": [[true]]}")]
+        [InlineData(typeof(Dictionary<string, string>), @"""test""")]
+        [InlineData(typeof(Dictionary<string, string>), @"1")]
+        [InlineData(typeof(Dictionary<string, string>), @"false")]
+        [InlineData(typeof(Dictionary<string, string>), @"{"""": 1}")]
+        [InlineData(typeof(Dictionary<string, string>), @"{"""": {}}")]
+        [InlineData(typeof(Dictionary<string, string>), @"{"""": {"""":""""}}")]
+        [InlineData(typeof(Dictionary<string, string>), @"[""test""")]
+        [InlineData(typeof(Dictionary<string, string>), @"[""test""]")]
+        [InlineData(typeof(Dictionary<string, string>), @"[true]")]
+        [InlineData(typeof(Dictionary<string, string>), @"[{}]")]
+        [InlineData(typeof(Dictionary<string, string>), @"[[]]")]
+        [InlineData(typeof(Dictionary<string, string>), @"[{""test"": 1}]")]
+        [InlineData(typeof(Dictionary<string, string>), @"[[true]]")]
+        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":""test""}")]
+        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":1}")]
+        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":false}")]
+        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":{"""": 1}}")]
+        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":{"""": {}}}")]
+        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":{"""": {"""":""""}}}")]
+        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":[""test""}")]
+        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":[""test""]}")]
+        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":[true]}")]
+        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":[{}]}")]
+        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":[[]]}")]
+        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":[{""test"": 1}]}")]
+        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":[[true]]}")]
+        public static void InvalidJsonForTypeShouldFail(Type type, string json)
         {
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize(json, type));
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/41839 for 3.1.

## Description
This PR changes the exception thrown by the serializer when an attempt to deserialize incompatible  JSON into a collection from `NullReferenceException` to `JsonException`.

## Customer Impact

Instead of leaking an uncaught null ref, the correct exception is thrown for this scenario.

Fixes https://github.com/dotnet/corefx/issues/41839 for 3.1.

## Regression?

No.

## Risk

This PR introduces validation checks. This is unlikely to break current functionality. Relevant test cases added.