### PR TITLE
[release/3.1] Add tests for deserializing multi-level subclasses of native collections

### DIFF
--- a/src/System.Text.Json/tests/Serialization/TestClasses.GenericCollections.cs
+++ b/src/System.Text.Json/tests/Serialization/TestClasses.GenericCollections.cs
@@ -782,6 +782,8 @@ namespace System.Text.Json.Serialization.Tests
         }
     }
 
+    public class WrapperForStringToStringIDictionaryWrapper : StringToStringIDictionaryWrapper { };
+
     public class ReadOnlyStringToStringIDictionaryWrapper : StringToStringIDictionaryWrapper
     {
         public override bool IsReadOnly => true;
@@ -976,6 +978,10 @@ namespace System.Text.Json.Serialization.Tests
 
     public class StringListWrapper : List<string> { }
 
+    public class WrapperForGenericListWrapper<T> : GenericListWrapper<T> { }
+
+    public class WrapperForGenericListWrapper : GenericListWrapper<string> { }
+
     public class GenericListWrapper<T> : List<T> { }
 
     public class StringStackWrapper : Stack<string>
@@ -1005,6 +1011,8 @@ namespace System.Text.Json.Serialization.Tests
             }
         }
     }
+
+    public class WrapperForGenericStackWrapper<T> : GenericStackWrapper<T> { }
 
     public class StringQueueWrapper : Queue<string>
     {

--- a/src/System.Text.Json/tests/Serialization/TestClasses.NonGenericCollections.cs
+++ b/src/System.Text.Json/tests/Serialization/TestClasses.NonGenericCollections.cs
@@ -231,6 +231,8 @@ namespace System.Text.Json.Serialization.Tests
         }
     }
 
+    public class WrapperForWrapperForIList : WrapperForIList { }
+
     public class WrapperForIDictionary : IDictionary
     {
         private readonly Dictionary<string, object> _dictionary = new Dictionary<string, object>();
@@ -286,6 +288,8 @@ namespace System.Text.Json.Serialization.Tests
             return ((IDictionary)_dictionary).GetEnumerator();
         }
     }
+
+    public class WrapperForWrapperForIDictionary : WrapperForIDictionary { }
 
     public class StackWrapper : Stack
     {

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
@@ -1161,22 +1161,22 @@ namespace System.Text.Json.Serialization.Tests
         {
             static void RunTest<T>(T instance)
             {
-                string JSON;
+                string expectedJson;
 
                 if (instance is IEnumerable<string> || instance is IList)
                 {
-                    JSON = @"[""item""]";
+                    expectedJson = @"[""item""]";
                 }
                 else
                 {
-                    JSON = @"{""key"":""item""}";
+                    expectedJson = @"{""key"":""item""}";
                 }
 
-                string json = JsonSerializer.Serialize(instance);
-                Assert.Equal(JSON, json);
+                string outputJson = JsonSerializer.Serialize(instance);
+                Assert.Equal(expectedJson, outputJson);
 
-                T result = JsonSerializer.Deserialize<T>(json);
-                IEnumerator enumerator = ((IEnumerable)result).GetEnumerator();
+                T deserializedObject = JsonSerializer.Deserialize<T>(outputJson);
+                IEnumerator enumerator = ((IEnumerable)deserializedObject).GetEnumerator();
                 enumerator.MoveNext();
 
                 if (enumerator.Current is KeyValuePair<string, string> pair)
@@ -1199,7 +1199,7 @@ namespace System.Text.Json.Serialization.Tests
                 }
 
                 // Ensure roundtrip.
-                Assert.Equal(json, JsonSerializer.Serialize(result));
+                Assert.Equal(outputJson, JsonSerializer.Serialize(deserializedObject));
             }
 
             // List<string>
@@ -1228,7 +1228,7 @@ namespace System.Text.Json.Serialization.Tests
             // Type that implements a type that implements IDictionary<string, string>
             RunTest(new WrapperForStringToStringIDictionaryWrapper { ["key"] = "item" });
 
-            // Type that implements a type that implements IDictionary<string, string>
+            // Type that implements a type that implements IDictionary
             RunTest(new WrapperForWrapperForIDictionary { ["key"] = "item" });
         }
     }

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
@@ -1153,6 +1154,82 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ReadOnlyStringIListWrapper>(@"[""1"", ""2""]"));
             Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ReadOnlyStringICollectionWrapper>(@"[""1"", ""2""]"));
             Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ReadOnlyStringToStringIDictionaryWrapper>(@"{""Key"":""key"",""Value"":""value""}"));
+        }
+
+        [Fact]
+        public static void HigherOrderCollectionInheritance_Works()
+        {
+            static void RunTest<T>(T instance)
+            {
+                string JSON;
+
+                if (instance is IEnumerable<string> || instance is IList)
+                {
+                    JSON = @"[""item""]";
+                }
+                else
+                {
+                    JSON = @"{""key"":""item""}";
+                }
+
+                string json = JsonSerializer.Serialize(instance);
+                Assert.Equal(JSON, json);
+
+                T result = JsonSerializer.Deserialize<T>(json);
+                IEnumerator enumerator = ((IEnumerable)result).GetEnumerator();
+                enumerator.MoveNext();
+
+                if (enumerator.Current is KeyValuePair<string, string> pair)
+                {
+                    Assert.Equal("key", pair.Key);
+                    Assert.Equal("item", pair.Value);
+                }
+                else if (enumerator.Current is DictionaryEntry entry)
+                {
+                    Assert.Equal("key", (string)entry.Key);
+                    Assert.Equal("item", ((JsonElement)entry.Value).GetString());
+                }
+                else if (enumerator.Current is JsonElement element)
+                {
+                    Assert.Equal("item", element.GetString());
+                }
+                else
+                {
+                    Assert.Equal("item", (string)enumerator.Current);
+                }
+
+                // Ensure roundtrip.
+                Assert.Equal(json, JsonSerializer.Serialize(result));
+            }
+
+            // List<string>
+            RunTest(new List<string> { "item" });
+
+            // Type that implements List<string>
+            RunTest(new StringListWrapper { "item" });
+
+            // Type that implements List<T>
+            RunTest(new GenericListWrapper<string> { "item" });
+
+            // Type that implements a type that implements List<T>
+            RunTest(new WrapperForGenericListWrapper<string> { "item" });
+
+            // Type that implements a type that implements List<string>
+            RunTest(new WrapperForGenericListWrapper { "item" });
+
+            // Type that implements a type that implements Stack<T>
+            WrapperForGenericStackWrapper<string> stack = new WrapperForGenericStackWrapper<string>();
+            stack.Push("item");
+            RunTest(stack);
+
+            // Type that implements a type that implements IList
+            RunTest(new WrapperForWrapperForIList { "item" });
+
+            // Type that implements a type that implements IDictionary<string, string>
+            RunTest(new WrapperForStringToStringIDictionaryWrapper { ["key"] = "item" });
+
+            // Type that implements a type that implements IDictionary<string, string>
+            RunTest(new WrapperForWrapperForIDictionary { ["key"] = "item" });
         }
     }
 }


### PR DESCRIPTION
Verifies https://github.com/dotnet/corefx/issues/41427 is fixed for 3.1.

## Description
This PR adds tests to ensure that the serializer supports (de)serialization of multi-level subclasses of native collections. The fix was added in https://github.com/dotnet/corefx/pull/41523.
These tests will be included in master as part of https://github.com/dotnet/corefx/pull/41977.

## Customer Impact

Validation that https://github.com/dotnet/corefx/issues/41427 is fixed for 3.1. 

## Regression?

No.

## Risk

Tests only.