### PR TITLE
Update SDL validation to use values from corefx-sdl-validation variable group

### DIFF
--- a/.azure-ci.yml
+++ b/.azure-ci.yml
@@ -111,12 +111,12 @@ stages:
         SDLValidationParameters:
           enable: true
           params: ' -SourceToolsList @("policheck","credscan")
-          -TsaInstanceURL "https://devdiv.visualstudio.com/"
-          -TsaProjectName "DEVDIV"
+          -TsaInstanceURL "$(TsaInstanceURL)"
+          -TsaProjectName "$(TsaProjectName)"
           -TsaNotificationEmail "$(TsaNotificationEmail)"
           -TsaCodebaseAdmin "$(TsaCodebaseAdmin)"
-          -TsaBugAreaPath "DevDiv\NET Core"
-          -TsaIterationPath "DevDiv"
+          -TsaBugAreaPath "$(TsaBugAreaPath)"
+          -TsaIterationPath "$(TsaIterationPath)"
           -TsaRepositoryName "CoreFX"
           -TsaCodebaseName "CoreFX"
           -TsaPublish $True'


### PR DESCRIPTION
We already had a variable group created for corefx for the email and codebase admin. 

With updating all parameters to use variable groups as the paths are changing frequently in the past days, instead of having to put a PR on every branch we would just update the variable group in azure devops and builds would be fixed.

Will port to 3.0 and 3.1