### PR TITLE
fix license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,4 +83,4 @@ Note: See officially supported [OS versions](https://github.com/dotnet/core/blob
 
 ## License
 
-.NET (including the runtime repo) is licensed under the [MIT](LICENSE) license.
+.NET (including the runtime repo) is licensed under the [MIT](LICENSE.TXT) license.


### PR DESCRIPTION
Link to the license in README.md was broken with https://github.com/dotnet/corefx/pull/42000 