### PR TITLE
[release/3.1] DiagnosticSourceEventSource fixes for distributed tracing

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/src/ILLinkTrim.xml
+++ b/src/System.Diagnostics.DiagnosticSource/src/ILLinkTrim.xml
@@ -1,7 +1,15 @@
 <linker>
   <assembly fullname="System.Diagnostics.DiagnosticSource">
     <type fullname="System.Diagnostics.DiagnosticSourceEventSource" />
-    <type fullname="System.Diagnostics.DiagnosticSourceEventSource/TransformSpec/PropertySpec/PropertyFetch/TypedFetchProperty`2">
+    <type fullname="System.Diagnostics.DiagnosticSourceEventSource/TransformSpec/PropertySpec/PropertyFetch/RefTypedFetchProperty`2">
+      <!-- Instantiated via reflection -->
+      <method name=".ctor" />
+    </type>
+    <type fullname="System.Diagnostics.DiagnosticSourceEventSource/TransformSpec/PropertySpec/PropertyFetch/ValueTypedFetchProperty`2">
+      <!-- Instantiated via reflection -->
+      <method name=".ctor" />
+    </type>
+    <type fullname="System.Diagnostics.DiagnosticSourceEventSource/TransformSpec/PropertySpec/PropertyFetch/EnumeratePropertyFetch`1">
       <!-- Instantiated via reflection -->
       <method name=".ctor" />
     </type>

--- a/src/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
@@ -19,6 +19,12 @@
   <PropertyGroup Condition="'$(TargetGroup)' == 'net45' OR '$(TargetGroup)' == 'net46' OR '$(TargetGroup)' == 'netfx'">
     <DefineConstants>$(DefineConstants);ALLOW_PARTIALLY_TRUSTED_CALLERS;ENABLE_HTTP_HANDLER</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetGroup)' != 'netstandard1.1'">
+    <DefineConstants>$(DefineConstants);EVENTSOURCE_ACTIVITY_SUPPORT</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetGroup)' != 'netstandard1.1' AND '$(TargetGroup)' != 'netstandard1.3'">
+    <DefineConstants>$(DefineConstants);EVENTSOURCE_ENUMERATE_SUPPORT</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Diagnostics\DiagnosticSource.cs" />
     <Compile Include="System\Diagnostics\DiagnosticListener.cs" />

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
@@ -60,8 +60,11 @@ namespace System.Diagnostics
     ///       * PROPERTY_SPEC                  - This is a shortcut where VARIABLE_NAME is the LAST property name
     ///   * a PROPERTY_SPEC is basically a list of names separated by '.'  
     ///       * PROPERTY_NAME                  - fetches a property from the DiagnosticSource payload object
-    ///       * PROPERTY_NAME . PROPERTY NAME  - fetches a sub-property of the object. 
-    /// 
+    ///       * PROPERTY_NAME . PROPERTY NAME  - fetches a sub-property of the object.
+    ///
+    ///       * *Activity                      - fetches Activity.Current
+    ///       * *Enumerate                     - enumerates all the items in an IEnumerable, calls ToString() on them, and joins the
+    ///                                          strings in a comma separated list.
     /// Example1:
     /// 
     ///    "BridgeTestSource1/TestEvent1:cls_Point_X=cls.Point.X;cls_Point_Y=cls.Point.Y\r\n" + 
@@ -807,7 +810,7 @@ namespace System.Diagnostics
             {
                 for (PropertySpec cur = _fetches; cur != null; cur = cur.Next)
                 {
-                    if (obj != null)
+                    if (obj != null || cur.IsStatic)
                         obj = cur.Fetch(obj);
                 }
 
@@ -827,28 +830,41 @@ namespace System.Diagnostics
             /// </summary>
             internal class PropertySpec
             {
+                private const string CurrentActivityPropertyName = "*Activity";
+                private const string EnumeratePropertyName = "*Enumerate";
+
                 /// <summary>
                 /// Make a new PropertySpec for a property named 'propertyName'. 
                 /// For convenience you can set he 'next' field to form a linked
                 /// list of PropertySpecs. 
                 /// </summary>
-                public PropertySpec(string propertyName, PropertySpec next = null)
+                public PropertySpec(string propertyName, PropertySpec? next)
                 {
                     Next = next;
                     _propertyName = propertyName;
+
+                    // detect well-known names that are static functions
+                    if (_propertyName == CurrentActivityPropertyName)
+                    {
+                        IsStatic = true;
+                    }
                 }
 
+                public bool IsStatic { get; private set; }
+
                 /// <summary>
-                /// Given an object fetch the property that this PropertySpec represents.  
+                /// Given an object fetch the property that this PropertySpec represents.
+                /// obj may be null when IsStatic is true, otherwise it must be non-null.
                 /// </summary>
-                public object Fetch(object obj)
+                public object? Fetch(object? obj)
                 {
-                    Type objType = obj.GetType();
-                    PropertyFetch fetch = _fetchForExpectedType;
+                    PropertyFetch? fetch = _fetchForExpectedType;
+                    Debug.Assert(obj != null || IsStatic);
+                    Type? objType = obj?.GetType();
                     if (fetch == null || fetch.Type != objType)
                     {
                         _fetchForExpectedType = fetch = PropertyFetch.FetcherForProperty(
-                            objType, objType.GetTypeInfo().GetDeclaredProperty(_propertyName));
+                            objType, _propertyName);
                     }
                     return fetch.Fetch(obj);
                 }
@@ -866,47 +882,152 @@ namespace System.Diagnostics
                 /// </summary>
                 private class PropertyFetch
                 {
-                    protected PropertyFetch(Type type)
+                    public PropertyFetch(Type? type)
                     {
-                        Debug.Assert(type != null);
                         Type = type;
                     }
 
-                    internal Type Type { get; }
+                    /// <summary>
+                    /// The type of the object that the property is fetched from. For well-known static methods that
+                    /// aren't actually property getters this will return null.
+                    /// </summary>
+                    internal Type? Type { get; }
 
                     /// <summary>
-                    /// Create a property fetcher from a .NET Reflection PropertyInfo class that
-                    /// represents a property of a particular type.  
+                    /// Create a property fetcher for a propertyName
                     /// </summary>
-                    public static PropertyFetch FetcherForProperty(Type type, PropertyInfo propertyInfo)
+                    public static PropertyFetch FetcherForProperty(Type? type, string propertyName)
                     {
-                        if (propertyInfo == null)
+                        if (propertyName == null)
                             return new PropertyFetch(type);     // returns null on any fetch.
+                        if (propertyName == CurrentActivityPropertyName)
+                        {
+#if EVENTSOURCE_ACTIVITY_SUPPORT
+                            return new CurrentActivityPropertyFetch();
+#else
+                            // In netstandard1.1 the Activity.Current API doesn't exist
+                            Logger.Message($"{CurrentActivityPropertyName} not supported for this TFM");
+                            return new PropertyFetch(type);
+#endif
+                        }
 
-                        var typedPropertyFetcher = typeof(TypedFetchProperty<,>);
-                        var instantiatedTypedPropertyFetcher = typedPropertyFetcher.GetTypeInfo().MakeGenericType(
-                            propertyInfo.DeclaringType, propertyInfo.PropertyType);
-                        return (PropertyFetch)Activator.CreateInstance(instantiatedTypedPropertyFetcher, type, propertyInfo);
+                        Debug.Assert(type != null, "Type should only be null for the well-known static fetchers already checked");
+                        TypeInfo typeInfo = type.GetTypeInfo();
+                        if (propertyName == EnumeratePropertyName)
+                        {
+#if !EVENTSOURCE_ENUMERATE_SUPPORT
+                            // In netstandard1.1 and 1.3 the reflection APIs needed to implement Enumerate support aren't
+                            // available
+                            Logger.Message($"{EnumeratePropertyName} not supported for this TFM");
+                            return new PropertyFetch(type);
+#else
+                            // If there are multiple implementations of IEnumerable<T>, this arbitrarily uses the first one
+                            foreach (Type iFaceType in typeInfo.GetInterfaces())
+                            {
+                                TypeInfo iFaceTypeInfo = iFaceType.GetTypeInfo();
+                                if (!iFaceTypeInfo.IsGenericType ||
+                                    iFaceTypeInfo.GetGenericTypeDefinition() != typeof(IEnumerable<>))
+                                {
+                                    continue;
+                                }
+
+                                Type elemType = iFaceTypeInfo.GetGenericArguments()[0];
+                                Type instantiatedTypedPropertyFetcher = typeof(EnumeratePropertyFetch<>)
+                                    .GetTypeInfo().MakeGenericType(elemType);
+                                return (PropertyFetch)Activator.CreateInstance(instantiatedTypedPropertyFetcher, type)!;
+                            }
+
+                            // no implemenation of IEnumerable<T> found, return a null fetcher
+                            Logger.Message($"*Enumerate applied to non-enumerable type {type}");
+                            return new PropertyFetch(type);
+#endif
+                        }
+                        else
+                        {
+                            PropertyInfo? propertyInfo = typeInfo.GetDeclaredProperty(propertyName);
+                            if (propertyInfo == null)
+                            {
+                                Logger.Message($"Property {propertyName} not found on {type}");
+                                return new PropertyFetch(type);
+                            }
+                            Type typedPropertyFetcher = typeInfo.IsValueType ?
+                                typeof(ValueTypedFetchProperty<,>) : typeof(RefTypedFetchProperty<,>);
+                            Type instantiatedTypedPropertyFetcher = typedPropertyFetcher.GetTypeInfo().MakeGenericType(
+                                propertyInfo.DeclaringType!, propertyInfo.PropertyType);
+                            return (PropertyFetch)Activator.CreateInstance(instantiatedTypedPropertyFetcher, type, propertyInfo)!;
+                        }
                     }
 
                     /// <summary>
                     /// Given an object, fetch the property that this propertyFech represents. 
                     /// </summary>
-                    public virtual object Fetch(object obj) { return null; }
+                    public virtual object? Fetch(object? obj) { return null; }
 
                     #region private 
 
-                    private sealed class TypedFetchProperty<TObject, TProperty> : PropertyFetch
+                    private sealed class RefTypedFetchProperty<TObject, TProperty> : PropertyFetch
                     {
-                        public TypedFetchProperty(Type type, PropertyInfo property) : base(type)
+                        public RefTypedFetchProperty(Type type, PropertyInfo property) : base(type)
                         {
-                            _propertyFetch = (Func<TObject, TProperty>)property.GetMethod.CreateDelegate(typeof(Func<TObject, TProperty>));
+                            Debug.Assert(typeof(TObject).GetTypeInfo().IsAssignableFrom(type.GetTypeInfo()));
+                            _propertyFetch = (Func<TObject, TProperty>)property.GetMethod!.CreateDelegate(typeof(Func<TObject, TProperty>));
                         }
-                        public override object Fetch(object obj)
+                        public override object? Fetch(object? obj)
                         {
+                            Debug.Assert(obj is TObject);
                             return _propertyFetch((TObject)obj);
                         }
                         private readonly Func<TObject, TProperty> _propertyFetch;
+                    }
+
+                    private delegate TProperty StructFunc<TStruct, TProperty>(ref TStruct thisArg);
+
+                    // Value types methods require that the first argument is passed by reference. This requires a different delegate signature
+                    // from the reference type case.
+                    private sealed class ValueTypedFetchProperty<TStruct, TProperty> : PropertyFetch
+                    {
+                        public ValueTypedFetchProperty(Type type, PropertyInfo property) : base(type)
+                        {
+                            Debug.Assert(typeof(TStruct) == type);
+                            _propertyFetch = (StructFunc<TStruct, TProperty>)property.GetMethod!.CreateDelegate(typeof(StructFunc<TStruct, TProperty>));
+                        }
+                        public override object? Fetch(object? obj)
+                        {
+                            Debug.Assert(obj is TStruct);
+                            // It is uncommon for property getters to mutate the struct, but if they do the change will be lost.
+                            // We are calling the getter on an unboxed copy
+                            TStruct structObj = (TStruct)obj;
+                            return _propertyFetch(ref structObj);
+                        }
+                        private readonly StructFunc<TStruct, TProperty> _propertyFetch;
+                    }
+
+
+#if EVENTSOURCE_ACTIVITY_SUPPORT
+                    /// <summary>
+                    /// A fetcher that returns the result of Activity.Current
+                    /// </summary>
+                    private sealed class CurrentActivityPropertyFetch : PropertyFetch
+                    {
+                        public CurrentActivityPropertyFetch() : base(null) { }
+                        public override object? Fetch(object? obj)
+                        {
+                            return Activity.Current;
+                        }
+                    }
+#endif
+
+                    /// <summary>
+                    /// A fetcher that enumerates and formats an IEnumerable
+                    /// </summary>
+                    private sealed class EnumeratePropertyFetch<ElementType> : PropertyFetch
+                    {
+                        public EnumeratePropertyFetch(Type type) : base(type) { }
+                        public override object? Fetch(object? obj)
+                        {
+                            Debug.Assert(obj is IEnumerable<ElementType>);
+                            return string.Join(",", (IEnumerable<ElementType>)obj);
+                        }
                     }
                     #endregion
                 }

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
@@ -838,7 +838,7 @@ namespace System.Diagnostics
                 /// For convenience you can set he 'next' field to form a linked
                 /// list of PropertySpecs. 
                 /// </summary>
-                public PropertySpec(string propertyName, PropertySpec? next)
+                public PropertySpec(string propertyName, PropertySpec next)
                 {
                     Next = next;
                     _propertyName = propertyName;
@@ -856,11 +856,11 @@ namespace System.Diagnostics
                 /// Given an object fetch the property that this PropertySpec represents.
                 /// obj may be null when IsStatic is true, otherwise it must be non-null.
                 /// </summary>
-                public object? Fetch(object? obj)
+                public object Fetch(object obj)
                 {
-                    PropertyFetch? fetch = _fetchForExpectedType;
+                    PropertyFetch fetch = _fetchForExpectedType;
                     Debug.Assert(obj != null || IsStatic);
-                    Type? objType = obj?.GetType();
+                    Type objType = obj.GetType();
                     if (fetch == null || fetch.Type != objType)
                     {
                         _fetchForExpectedType = fetch = PropertyFetch.FetcherForProperty(
@@ -882,7 +882,7 @@ namespace System.Diagnostics
                 /// </summary>
                 private class PropertyFetch
                 {
-                    public PropertyFetch(Type? type)
+                    public PropertyFetch(Type type)
                     {
                         Type = type;
                     }
@@ -891,12 +891,12 @@ namespace System.Diagnostics
                     /// The type of the object that the property is fetched from. For well-known static methods that
                     /// aren't actually property getters this will return null.
                     /// </summary>
-                    internal Type? Type { get; }
+                    internal Type Type { get; }
 
                     /// <summary>
                     /// Create a property fetcher for a propertyName
                     /// </summary>
-                    public static PropertyFetch FetcherForProperty(Type? type, string propertyName)
+                    public static PropertyFetch FetcherForProperty(Type type, string propertyName)
                     {
                         if (propertyName == null)
                             return new PropertyFetch(type);     // returns null on any fetch.
@@ -944,7 +944,7 @@ namespace System.Diagnostics
                         }
                         else
                         {
-                            PropertyInfo? propertyInfo = typeInfo.GetDeclaredProperty(propertyName);
+                            PropertyInfo propertyInfo = typeInfo.GetDeclaredProperty(propertyName);
                             if (propertyInfo == null)
                             {
                                 Logger.Message($"Property {propertyName} not found on {type}");
@@ -961,7 +961,7 @@ namespace System.Diagnostics
                     /// <summary>
                     /// Given an object, fetch the property that this propertyFech represents. 
                     /// </summary>
-                    public virtual object? Fetch(object? obj) { return null; }
+                    public virtual object Fetch(object obj) { return null; }
 
                     #region private 
 
@@ -972,7 +972,7 @@ namespace System.Diagnostics
                             Debug.Assert(typeof(TObject).GetTypeInfo().IsAssignableFrom(type.GetTypeInfo()));
                             _propertyFetch = (Func<TObject, TProperty>)property.GetMethod!.CreateDelegate(typeof(Func<TObject, TProperty>));
                         }
-                        public override object? Fetch(object? obj)
+                        public override object Fetch(object obj)
                         {
                             Debug.Assert(obj is TObject);
                             return _propertyFetch((TObject)obj);
@@ -991,7 +991,7 @@ namespace System.Diagnostics
                             Debug.Assert(typeof(TStruct) == type);
                             _propertyFetch = (StructFunc<TStruct, TProperty>)property.GetMethod!.CreateDelegate(typeof(StructFunc<TStruct, TProperty>));
                         }
-                        public override object? Fetch(object? obj)
+                        public override object Fetch(object obj)
                         {
                             Debug.Assert(obj is TStruct);
                             // It is uncommon for property getters to mutate the struct, but if they do the change will be lost.
@@ -1010,7 +1010,7 @@ namespace System.Diagnostics
                     private sealed class CurrentActivityPropertyFetch : PropertyFetch
                     {
                         public CurrentActivityPropertyFetch() : base(null) { }
-                        public override object? Fetch(object? obj)
+                        public override object Fetch(object obj)
                         {
                             return Activity.Current;
                         }
@@ -1023,7 +1023,7 @@ namespace System.Diagnostics
                     private sealed class EnumeratePropertyFetch<ElementType> : PropertyFetch
                     {
                         public EnumeratePropertyFetch(Type type) : base(type) { }
-                        public override object? Fetch(object? obj)
+                        public override object Fetch(object obj)
                         {
                             Debug.Assert(obj is IEnumerable<ElementType>);
                             return string.Join(",", (IEnumerable<ElementType>)obj);


### PR DESCRIPTION
Ported change: #41943
Approved API Proposal: NA - no new APIs
## Description
We are trying to aid Azure scenarios to light up distributed tracing in a painless way. This set of changes provides additional functionality out-of-the box for any customer running .Net Core. There are three elements within the fix:

1) There is no existing mechanism for DiagnosticSourceEventSource to fetch the
current activity object. By convention it is not passed as an event argument,
but rather stored in the async-local property Activity.Current. This was fixed
by adding a well-known "*Activity" property that returns the result of
Activity.Current regardless what object it is applied to.

2) DiagnosticSourceEventSource fails to evaluate properties on value types, such
as DateTime.Ticks. Calling MethodInfo.CreateDelegate needs to use a different
signature for ref and value type properties and previously the code always used
the ref-style signature. Fixed by adding ValueTypedFetchProperty that does the
proper CreateDelegate and delegate invocation for structs.

3) There is no mechanism for DiagnosticSourceEventSource to enumerate the tags
on an activity. This change adds the *Enumerate well-known property which will
iterate any IEnumerable`1, invoke ToString() on each element, then join it as a
string.

## Customer impact
Currently the standard solution for distributed tracing requires the developer to pre-req a NuGet package for ApplicationInsights (or other telemetry provider). Many customers don't do this, or include versions that are overly old. For the developer tasked with diagnosing a production issue later, solutions that require an application to be redployed or dependencies changed is high friction, if not impossible. The solution here allows a telemetry agent deployed automatically as part of an Azure PaaS solution to connect to the .Net Core app and extract the relevant distributed tracing telemetry with no effort from the app developer. This in turn makes it much more likely that the telemetry data is available when production issues need to be diagnosed.

## Regression
This change will not cause a regression.

## Risk
Small to Medium:
There is a bit of code churn introduced by the changes with a proportional opportunity for bugs to lurk. A few factors mitigate this:
a) I've added a test that hits all the new cases and debugged through it
b) DiagnosticSourceEventSource has only a niche set of tooling that consumes it
c) The two new feature options need the telemetry tool to opt-in before they are engaged. If it turned out they were broken tools could leave them off and be no worse than now. 


Testing
Added unit test which covers the new code. Not included here I also have an E2E scenario prototype which I confirmed worked