### PR TITLE
Fix getting readonly column metadata

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserHelperClasses.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserHelperClasses.cs
@@ -341,7 +341,7 @@ namespace System.Data.SqlClient
             IsIdentity = 1 << 6,
             IsColumnSet = 1 << 7,
 
-            IsReadOnlyMask = (Updatable | UpdateableUnknown) // two bit field (0 is read only, 1 is updatable, 2 is updatability unknown)
+            IsUpdatableMask = (Updatable | UpdateableUnknown) // two bit field (0 is read only, 1 is updatable, 2 is updatability unknown)
         }
 
         internal string column;
@@ -391,13 +391,13 @@ namespace System.Data.SqlClient
 
         public byte Updatability
         {
-            get => (byte)(flags & _SqlMetadataFlags.IsReadOnlyMask);
+            get => (byte)(flags & _SqlMetadataFlags.IsUpdatableMask);
             set => flags = (_SqlMetadataFlags)((value & 0x3) | ((int)flags & ~0x03));
         }
 
         public bool IsReadOnly
         {
-            get => flags.HasFlag(_SqlMetadataFlags.IsReadOnlyMask);
+            get => (flags & _SqlMetadataFlags.IsUpdatableMask) == 0;
         }
 
         public bool IsDifferentName

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/AdapterTest/AdapterTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/AdapterTest/AdapterTest.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Text;
 using System.Reflection;
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using Xunit;
 
@@ -1240,6 +1241,52 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             finally
             {
                 ExecuteNonQueryCommand(dropSpEmployeeSales);
+            }
+        }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        public void TestReadOnlyColumnMetadata()
+        {
+            using (SqlConnection connection = new SqlConnection(DataTestUtility.TcpConnStr))
+            {
+                connection.Open();
+                using (SqlCommand command = connection.CreateCommand())
+                {
+                    command.CommandText = "Create table #t (ID int identity(1,1), sText varchar(12), sMemo as (convert(varchar,ID) + ' ' + sText))";
+                    command.ExecuteNonQuery();
+                }
+                using (SqlDataAdapter dataAdapter = new SqlDataAdapter("Select * from #t", connection))
+                {
+                    using (SqlCommandBuilder commandBuilder = new SqlCommandBuilder(dataAdapter))
+                    {
+                        using (SqlCommand cmd = commandBuilder.GetInsertCommand())
+                        {
+                            DataTestUtility.AssertEqualsWithDescription("INSERT INTO [#t] ([sText]) VALUES (@p1)", cmd.CommandText, "Unexpected insert command.");
+                        }
+                    }
+
+                    using (DataTable dataTable = new DataTable())
+                    {
+                        dataAdapter.FillSchema(dataTable, SchemaType.Mapped);
+                        Dictionary<string, bool> expAutoIncrement = new Dictionary<string, bool>()
+                        {
+                            {"ID", true},
+                            {"sText", false},
+                            {"sMemo", false}
+                        };
+                        Dictionary<string, bool> expReadOnly = new Dictionary<string, bool>()
+                        {
+                            {"ID", true},
+                            {"sText", false},
+                            {"sMemo", true}
+                        };
+                        foreach (DataColumn dataColumn in dataTable.Columns)
+                        {
+                            DataTestUtility.AssertEqualsWithDescription(dataColumn.AutoIncrement, expAutoIncrement[dataColumn.ColumnName], "Unexpected AutoIncrement metadata.");
+                            DataTestUtility.AssertEqualsWithDescription(dataColumn.ReadOnly, expReadOnly[dataColumn.ColumnName], "Unexpected ReadOnly metadata.");
+                        }
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Port fix in getting readonly column metadata from SqlClient repo [PR#286](https://github.com/dotnet/SqlClient/pull/286)