### PR TITLE
Remove ILLinkTrim.xml from System.Net.Http

### DIFF
--- a/src/System.Net.Http/src/ILLinkTrim.xml
+++ b/src/System.Net.Http/src/ILLinkTrim.xml
@@ -1,6 +1,0 @@
-<linker>
-  <assembly fullname="System.Net.Http">
-    <!-- Anonymous types are used with DiagnosticSource logging and subscribers reflect over those, calling their public getters. -->
-    <type fullname="*f__AnonymousType*" />
-  </assembly>
-</linker>


### PR DESCRIPTION
The file was there to keep anonymous types used by DiagnosticsHandler from having their getters removed.  But a) it was relying on the implementation detail name generated by Roslyn, and b) it was keeping alive other state from other anonymous types in the assembly.  I changed it to use concrete types instead.  This also happens to result in less code, because we don't need the generated Equals/GetHashCode methods generated for anonymous types.

cc: @lmolkova, @noahfalk 