### PR TITLE
Handle wrong type error when deserializing array

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleDictionary.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleDictionary.cs
@@ -31,7 +31,7 @@ namespace System.Text.Json
                 state.Current.CollectionPropertyInitialized = true;
 
                 ClassType classType = state.Current.JsonClassInfo.ClassType;
-                if (classType == ClassType.Value)
+                if (classType != ClassType.Dictionary && classType != ClassType.Object)
                 {
                     Type elementClassInfoType = jsonPropertyInfo.ElementClassInfo.Type;
                     if (elementClassInfoType != typeof(object) && elementClassInfoType != typeof(JsonElement))

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
@@ -187,6 +187,12 @@ namespace System.Text.Json
         {
             JsonPropertyInfo jsonPropertyInfo = state.Current.JsonPropertyInfo;
 
+            if (jsonPropertyInfo == null)
+            {
+                Debug.Assert(state.Current.JsonClassInfo.ClassType == ClassType.Object);
+                throw ThrowHelper.GetJsonElementWrongTypeException(JsonTokenType.StartObject, JsonTokenType.StartArray);
+            }
+
             // If the property has an EnumerableConverter, then we use tempEnumerableValues.
             if (jsonPropertyInfo.EnumerableConverter != null)
             {

--- a/src/System.Text.Json/tests/Serialization/Array.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Array.ReadTests.cs
@@ -201,6 +201,13 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<int[,]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]")));
         }
 
+        [Fact]
+        public static void ReadArrayDeclaredAsObjectFail()
+        {
+            // JSON type is Dictionary<string, List<SimpleTestClass>>
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Dictionary<string, SimpleTestClass>>(Encoding.UTF8.GetBytes(@"{""MyList"":[{""MyString"":""name""}]}")));
+        }
+
         public static IEnumerable<object[]> ReadNullJson
         {
             get

--- a/src/System.Text.Json/tests/Serialization/Array.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Array.ReadTests.cs
@@ -201,13 +201,6 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<int[,]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]")));
         }
 
-        [Fact]
-        public static void ReadArrayDeclaredAsObjectFail()
-        {
-            // JSON type is Dictionary<string, List<SimpleTestClass>>
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Dictionary<string, SimpleTestClass>>(Encoding.UTF8.GetBytes(@"{""MyList"":[{""MyString"":""name""}]}")));
-        }
-
         public static IEnumerable<object[]> ReadNullJson
         {
             get

--- a/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
+++ b/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
@@ -391,6 +391,15 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":[[]]}")]
         [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":[{""test"": 1}]}")]
         [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":[[true]]}")]
+        [InlineData(typeof(Dictionary<string, Poco>), @"{""key"":[{""Id"":3}]}")]
+        [InlineData(typeof(Dictionary<string, Poco>), @"{""key"":[""test""]}")]
+        [InlineData(typeof(Dictionary<string, Poco>), @"{""key"":[1]}")]
+        [InlineData(typeof(Dictionary<string, Poco>), @"{""key"":[false]}")]
+        [InlineData(typeof(Dictionary<string, Poco>), @"{""key"":[]}")]
+        [InlineData(typeof(Dictionary<string, Poco>), @"{""key"":1}")]
+        [InlineData(typeof(Dictionary<string, List<Poco>>), @"{""key"":{""Id"":3}}")]
+        [InlineData(typeof(Dictionary<string, List<Poco>>), @"{""key"":{}}")]
+        [InlineData(typeof(Dictionary<string, List<Poco>>), @"{""key"":[[]]}")]
         public static void InvalidJsonForTypeShouldFail(Type type, string json)
         {
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize(json, type));
@@ -906,7 +915,7 @@ namespace System.Text.Json.Serialization.Tests
         public static void CustomEscapingOnPropertyNameAndValue()
         {
             var dict = new Dictionary<string, string>();
-            dict.Add("A\u046701","Value\u0467");
+            dict.Add("A\u046701", "Value\u0467");
 
             // Baseline with no escaping.
             var json = JsonSerializer.Serialize(dict);
@@ -1763,7 +1772,7 @@ namespace System.Text.Json.Serialization.Tests
             IEnumerator IEnumerable.GetEnumerator()
             {
                 // Create an incompatible converter.
-                return new int[] {100,200 }.GetEnumerator();
+                return new int[] { 100, 200 }.GetEnumerator();
             }
 
             public bool Remove(string key)


### PR DESCRIPTION
In ReadCore, when it finds a StartArray token, but the type
declared is an object, a NRE was being thrown. It should
return an error explaining the wrong type was found.

Fixes: #42143 

When I ran the System.Text.Json tests from the master branch locally, 47 failed, so I'm not 100% confident that my change didn't break any tests (still 47 failing locally, just not sure they're the same ones)