### PR TITLE
Clean up use of PreserveDependencyAttribute in System.Text.Json

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonConverterEnum.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonConverterEnum.cs
@@ -20,8 +20,7 @@ namespace System.Text.Json.Serialization.Converters
 
         [PreserveDependency(
             ".ctor(System.Text.Json.Serialization.Converters.EnumConverterOptions)",
-            "System.Text.Json.Serialization.Converters.JsonConverterEnum`1",
-            "System.Text.Json")]
+            "System.Text.Json.Serialization.Converters.JsonConverterEnum`1")]
         public override JsonConverter CreateConverter(Type type, JsonSerializerOptions options)
         {
             JsonConverter converter = (JsonConverter)Activator.CreateInstance(

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonKeyValuePairConverter.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonKeyValuePairConverter.cs
@@ -19,7 +19,7 @@ namespace System.Text.Json.Serialization.Converters
             return (generic == typeof(KeyValuePair<,>));
         }
 
-        [PreserveDependency(".ctor()", "System.Text.Json.Serialization.Converters.JsonKeyValuePairConverter`2", "System.Text.Json")]
+        [PreserveDependency(".ctor()", "System.Text.Json.Serialization.Converters.JsonKeyValuePairConverter`2")]
         public override JsonConverter CreateConverter(Type type, JsonSerializerOptions options)
         {
             Type keyType = type.GetGenericArguments()[0];

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.AddProperty.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.AddProperty.cs
@@ -45,8 +45,8 @@ namespace System.Text.Json
                 options);
         }
 
-        [PreserveDependency(".ctor()", "System.Text.Json.JsonPropertyInfoNullable`2", "System.Text.Json")]
-        [PreserveDependency(".ctor()", "System.Text.Json.Serialization.JsonPropertyInfoNotNullableContravariant`4", "System.Text.Json")]
+        [PreserveDependency(".ctor()", "System.Text.Json.JsonPropertyInfoNullable`2")]
+        [PreserveDependency(".ctor()", "System.Text.Json.Serialization.JsonPropertyInfoNotNullableContravariant`4")]
         internal static JsonPropertyInfo CreateProperty(
             Type declaredPropertyType,
             Type runtimePropertyType,

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonStringEnumConverter.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonStringEnumConverter.cs
@@ -56,8 +56,7 @@ namespace System.Text.Json.Serialization
         /// <inheritdoc />
         [PreserveDependency(
             ".ctor(System.Text.Json.Serialization.Converters.EnumConverterOptions, System.Text.Json.JsonNamingPolicy)",
-            "System.Text.Json.Serialization.Converters.JsonConverterEnum`1",
-            "System.Text.Json")]
+            "System.Text.Json.Serialization.Converters.JsonConverterEnum`1")]
         public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
         {
             JsonConverter converter = (JsonConverter)Activator.CreateInstance(

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/ReflectionEmitMemberAccessor.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/ReflectionEmitMemberAccessor.cs
@@ -61,7 +61,7 @@ namespace System.Text.Json
             return (Action<TProperty>)addMethod.CreateDelegate(typeof(Action<TProperty>), target);
         }
 
-        [PreserveDependency(".ctor()", "System.Text.Json.ImmutableEnumerableCreator`2", "System.Text.Json")]
+        [PreserveDependency(".ctor()", "System.Text.Json.ImmutableEnumerableCreator`2")]
         public override ImmutableCollectionCreator ImmutableCollectionCreateRange(Type constructingType, Type collectionType, Type elementType)
         {
             MethodInfo createRange = ImmutableCollectionCreateRangeMethod(constructingType, elementType);
@@ -101,7 +101,7 @@ namespace System.Text.Json
             return creator;
         }
 
-        [PreserveDependency(".ctor()", "System.Text.Json.ImmutableDictionaryCreator`2", "System.Text.Json")]
+        [PreserveDependency(".ctor()", "System.Text.Json.ImmutableDictionaryCreator`2")]
         public override ImmutableCollectionCreator ImmutableDictionaryCreateRange(Type constructingType, Type collectionType, Type elementType)
         {
             Debug.Assert(collectionType.IsGenericType);

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/ReflectionMemberAccessor.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/ReflectionMemberAccessor.cs
@@ -48,7 +48,7 @@ namespace System.Text.Json
             return (Action<TProperty>)addMethod.CreateDelegate(typeof(Action<TProperty>), target);
         }
 
-        [PreserveDependency(".ctor()", "System.Text.Json.ImmutableEnumerableCreator`2", "System.Text.Json")]
+        [PreserveDependency(".ctor()", "System.Text.Json.ImmutableEnumerableCreator`2")]
         public override ImmutableCollectionCreator ImmutableCollectionCreateRange(Type constructingType, Type collectionType, Type elementType)
         {
             MethodInfo createRange = ImmutableCollectionCreateRangeMethod(constructingType, elementType);
@@ -71,7 +71,7 @@ namespace System.Text.Json
             return creator;
         }
 
-        [PreserveDependency(".ctor()", "System.Text.Json.ImmutableDictionaryCreator`2", "System.Text.Json")]
+        [PreserveDependency(".ctor()", "System.Text.Json.ImmutableDictionaryCreator`2")]
         public override ImmutableCollectionCreator ImmutableDictionaryCreateRange(Type constructingType, Type collectionType, Type elementType)
         {
             Debug.Assert(collectionType.IsGenericType);


### PR DESCRIPTION
It's not necessary to specify the assembly name when the consumer is in the same assembly.