### PR TITLE
Tests for BIFE containing path

### DIFF
--- a/src/Common/tests/CoreFx.Private.TestUtilities/System/AssertExtensions.cs
+++ b/src/Common/tests/CoreFx.Private.TestUtilities/System/AssertExtensions.cs
@@ -21,6 +21,12 @@ namespace System
             Assert.Equal(expectedMessage, Assert.Throws<T>(action).Message);
         }
 
+        public static void ThrowsContains<T>(Action action, string expectedMessageContent)
+            where T : Exception
+        {
+            Assert.Contains(expectedMessageContent, Assert.Throws<T>(action).Message);
+        }
+
         public static void Throws<T>(string netCoreParamName, string netFxParamName, Action action)
             where T : ArgumentException
         {

--- a/src/System.Reflection/tests/AssemblyTests.cs
+++ b/src/System.Reflection/tests/AssemblyTests.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Reflection.Tests;
 using System.Runtime.CompilerServices;
 using System.Security;
+using System.Text;
 using Xunit;
 
 [assembly:
@@ -321,6 +322,38 @@ namespace System.Reflection.Tests
         public void LoadFile_NoSuchPath_ThrowsArgumentException()
         {
             AssertExtensions.Throws<ArgumentException>("path", null, () => Assembly.LoadFile("System.Runtime.Tests.dll"));
+        }
+
+        // This test should apply equally to Unix, but this reliably hits a particular one of the
+        // myriad ways that assembly load can fail
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]
+        public void LoadFile_ValidPEBadIL_ThrowsBadImageFormatExceptionWithPath()
+        {
+            string path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "kernelbase.dll");
+            if (!File.Exists(path))
+                return;
+
+            AssertExtensions.ThrowsContains<BadImageFormatException>(() => Assembly.LoadFile(path), path);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(5)]
+        [InlineData(50)]
+        [InlineData(100)]
+        // Higher numbers hit some codepaths that currently don't include the path in the exception message
+        public void LoadFile_ValidPEBadIL_ThrowsBadImageFormatExceptionWithPath(int seek)
+        {
+            ReadOnlySpan<byte> garbage = Encoding.UTF8.GetBytes(new string('X', 500));
+            string path = GetTestFilePath();
+            File.Copy(SourceTestAssemblyPath, path);
+            using (var fs = new FileStream(path, FileMode.Open))
+            {
+                fs.Seek(seek, SeekOrigin.Begin);
+                fs.Write(garbage);
+            }
+
+            AssertExtensions.ThrowsContains<BadImageFormatException>(() => Assembly.LoadFile(path), path);
         }
 
         [Fact]

--- a/src/System.Reflection/tests/AssemblyTests.cs
+++ b/src/System.Reflection/tests/AssemblyTests.cs
@@ -350,7 +350,7 @@ namespace System.Reflection.Tests
             File.Copy(SourceTestAssemblyPath, path);
             using (var fs = new FileStream(path, FileMode.Open))
             {
-                fs.Seek(seek, SeekOrigin.Begin);
+                fs.Position = seek;
                 fs.Write(garbage);
             }
 

--- a/src/System.Reflection/tests/AssemblyTests.cs
+++ b/src/System.Reflection/tests/AssemblyTests.cs
@@ -326,7 +326,8 @@ namespace System.Reflection.Tests
 
         // This test should apply equally to Unix, but this reliably hits a particular one of the
         // myriad ways that assembly load can fail
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))]
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
         public void LoadFile_ValidPEBadIL_ThrowsBadImageFormatExceptionWithPath()
         {
             string path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "kernelbase.dll");


### PR DESCRIPTION
Test for https://github.com/dotnet/coreclr/pull/27469

The first one tests the change above. The other tests some other paths, not including that path. I could remove it.