### PR TITLE
Test for null FNFE.FusionLog

### DIFF
--- a/src/System.Reflection/tests/AssemblyNameTests.cs
+++ b/src/System.Reflection/tests/AssemblyNameTests.cs
@@ -312,7 +312,7 @@ namespace System.Reflection.Tests
         [Fact]
         public void EmptyFusionLog()
         {
-            FileNotFoundException fnfe = Assert.Throws<FileNotFoundException>(() => Assembly.LoadFrom(@"c:\non\existent\file.dll"));
+            FileNotFoundException fnfe = Assert.Throws<FileNotFoundException>(() => Assembly.LoadFrom(@"\non\existent\file.dll"));
             Assert.Null(fnfe.FusionLog);
         }
 

--- a/src/System.Reflection/tests/AssemblyNameTests.cs
+++ b/src/System.Reflection/tests/AssemblyNameTests.cs
@@ -309,6 +309,13 @@ namespace System.Reflection.Tests
             Assert.Equal(assemblyName.Name.Length, assemblyName.FullName.IndexOf(','));
         }
 
+        [Fact]
+        public void EmptyFusionLog()
+        {
+            FileNotFoundException fnfe = Assert.Throws<FileNotFoundException>(() => Assembly.LoadFrom(@"c:\non\existent\file.dll"));
+            Assert.Null(fnfe.FusionLog);
+        }
+
         public static IEnumerable<object[]> SetPublicKey_TestData()
         {
             yield return new object[] { null };


### PR DESCRIPTION
Test for https://github.com/dotnet/coreclr/pull/27471

Note that although change above was in EEFileLoadException, that wraps FileNotFoundException in some cases. 
https://github.com/dotnet/coreclr/blob/d815d217f1930c4443834db41f172474953ede9b/src/vm/clrex.cpp#L1778