### PR TITLE
Delete ILLinkTrim.xml from System.Net.Primitives

### DIFF
--- a/eng/illink.targets
+++ b/eng/illink.targets
@@ -82,8 +82,8 @@
       <ILLinkArgs>$(ILLinkArgs) --skip-unresolved true</ILLinkArgs>
       <!-- keep interface implementations -->
       <ILLinkArgs>$(ILLinkArgs) --disable-opt unusedinterfaces</ILLinkArgs>
-      <!-- keep PreserveDependencyAttribute -->
-      <ILLinkArgs>$(ILLinkArgs) --keep-dep-attributes true</ILLinkArgs>
+      <!-- keep PreserveDependencyAttribute unless a project explicitly disables it -->
+      <ILLinkArgs Condition="'$(ILLinkKeepDepAttributes)' != 'false'">$(ILLinkArgs) --keep-dep-attributes true</ILLinkArgs>
     </PropertyGroup>
 
     <MakeDir Directories="$(ILLinkTrimInputPath)" />

--- a/src/System.Net.HttpListener/src/System.Net.HttpListener.csproj
+++ b/src/System.Net.HttpListener/src/System.Net.HttpListener.csproj
@@ -100,6 +100,9 @@
       <Link>Common\System\Net\WebSockets\WebSocketValidate.cs</Link>
     </Compile>
     <Compile Include="System\Net\Windows\CookieExtensions.cs" />
+    <Compile Include="$(CommonPath)\CoreLib\System\Runtime\CompilerServices\PreserveDependencyAttribute.cs">
+      <Link>Common\System\Runtime\CompilerServices\PreserveDependencyAttribute.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true' AND '$(ForceManagedImplementation)' != 'true'">
     <Compile Include="System\Net\Windows\HttpListener.Windows.cs" />

--- a/src/System.Net.HttpListener/src/System/Net/Windows/CookieExtensions.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/CookieExtensions.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace System.Net
 {
@@ -12,26 +13,20 @@ namespace System.Net
     {
         private static Func<Cookie, string> s_toServerStringFunc;
 
+        [PreserveDependency("ToServerString", "System.Net.Cookie", "System.Net.Primitives")]
         public static string ToServerString(this Cookie cookie)
         {
-            if (s_toServerStringFunc == null)
-            {
-                s_toServerStringFunc = (Func<Cookie, string>)typeof(Cookie).GetMethod("ToServerString", BindingFlags.Instance | BindingFlags.NonPublic).CreateDelegate(typeof(Func<Cookie, string>));
-            }
-
+            s_toServerStringFunc ??= (Func<Cookie, string>)typeof(Cookie).GetMethod("ToServerString", BindingFlags.Instance | BindingFlags.NonPublic).CreateDelegate(typeof(Func<Cookie, string>));
             Debug.Assert(s_toServerStringFunc != null, "Reflection failed for Cookie.ToServerString().");
             return s_toServerStringFunc(cookie);
         }
 
         private static Func<Cookie, Cookie> s_cloneFunc;
 
+        [PreserveDependency("Clone", "System.Net.Cookie", "System.Net.Primitives")]
         public static Cookie Clone(this Cookie cookie)
         {
-            if (s_cloneFunc == null)
-            {
-                s_cloneFunc = (Func<Cookie, Cookie>)typeof(Cookie).GetMethod("Clone", BindingFlags.Instance | BindingFlags.NonPublic).CreateDelegate(typeof(Func<Cookie, Cookie>));
-            }
-
+            s_cloneFunc ??= (Func<Cookie, Cookie>)typeof(Cookie).GetMethod("Clone", BindingFlags.Instance | BindingFlags.NonPublic).CreateDelegate(typeof(Func<Cookie, Cookie>));
             Debug.Assert(s_cloneFunc != null, "Reflection failed for Cookie.Clone().");
             return s_cloneFunc(cookie);
         }
@@ -47,17 +42,12 @@ namespace System.Net
 
         private static Func<Cookie, CookieVariant> s_getVariantFunc;
 
+        [PreserveDependency("get_Variant", "System.Net.Cookie", "System.Net.Primitives")]
         public static bool IsRfc2965Variant(this Cookie cookie)
         {
-            if (s_getVariantFunc == null)
-            {
-                s_getVariantFunc = (Func<Cookie, CookieVariant>)typeof(Cookie).GetProperty("Variant", BindingFlags.Instance | BindingFlags.NonPublic).GetGetMethod(true).CreateDelegate(typeof(Func<Cookie, CookieVariant>));
-            }
-
+            s_getVariantFunc ??= (Func<Cookie, CookieVariant>)typeof(Cookie).GetProperty("Variant", BindingFlags.Instance | BindingFlags.NonPublic).GetGetMethod(true).CreateDelegate(typeof(Func<Cookie, CookieVariant>));
             Debug.Assert(s_getVariantFunc != null, "Reflection failed for Cookie.Variant.");
-            CookieVariant variant = s_getVariantFunc(cookie);
-
-            return variant == CookieVariant.Rfc2965;
+            return s_getVariantFunc(cookie) == CookieVariant.Rfc2965;
         }
     }
 
@@ -65,13 +55,10 @@ namespace System.Net
     {
         private static Func<CookieCollection, Cookie, bool, int> s_internalAddFunc;
 
+        [PreserveDependency("InternalAdd", "System.Net.CookieCollection", "System.Net.Primitives")]
         public static int InternalAdd(this CookieCollection cookieCollection, Cookie cookie, bool isStrict)
         {
-            if (s_internalAddFunc == null)
-            {
-                s_internalAddFunc = (Func<CookieCollection, Cookie, bool, int>)typeof(CookieCollection).GetMethod("InternalAdd", BindingFlags.Instance | BindingFlags.NonPublic).CreateDelegate(typeof(Func<CookieCollection, Cookie, bool, int>));
-            }
-
+            s_internalAddFunc ??= (Func<CookieCollection, Cookie, bool, int>)typeof(CookieCollection).GetMethod("InternalAdd", BindingFlags.Instance | BindingFlags.NonPublic).CreateDelegate(typeof(Func<CookieCollection, Cookie, bool, int>));
             Debug.Assert(s_internalAddFunc != null, "Reflection failed for CookieCollection.InternalAdd().");
             return s_internalAddFunc(cookieCollection, cookie, isStrict);
         }

--- a/src/System.Net.Primitives/src/ILLinkTrim.xml
+++ b/src/System.Net.Primitives/src/ILLinkTrim.xml
@@ -1,9 +1,0 @@
-<linker>
-  <assembly fullname="System.Net.Primitives">
-    <type fullname="System.Net.Cookie">
-      <!-- Workarounds for https://github.com/dotnet/corefx/issues/13607 -->
-      <method name="set_Variant" />
-      <method name="ToServerString" />
-    </type>
-  </assembly>
-</linker>

--- a/src/System.Net.Primitives/src/System.Net.Primitives.csproj
+++ b/src/System.Net.Primitives/src/System.Net.Primitives.csproj
@@ -3,6 +3,7 @@
     <AssemblyName>System.Net.Primitives</AssemblyName>
     <OutputType>Library</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ILLinkKeepDepAttributes>false</ILLinkKeepDepAttributes> <!-- See comments in Cookie.cs -->
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <PropertyGroup>
@@ -89,6 +90,9 @@
     </Compile>
     <Compile Include="$(CommonPath)\CoreLib\System\Text\StringBuilderCache.cs">
       <Link>Common\System\Text\StringBuilderCache.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\CoreLib\System\Runtime\CompilerServices\PreserveDependencyAttribute.cs">
+      <Link>Common\System\Runtime\CompilerServices\PreserveDependencyAttribute.cs</Link>
     </Compile>
     <!-- Logging -->
     <Compile Include="$(CommonPath)\System\Net\Logging\NetEventSource.Common.cs">

--- a/src/System.Net.Primitives/tests/UnitTests/System.Net.Primitives.UnitTests.Tests.csproj
+++ b/src/System.Net.Primitives/tests/UnitTests/System.Net.Primitives.UnitTests.Tests.csproj
@@ -59,6 +59,9 @@
     <Compile Include="..\..\src\System\Net\IPAddressParser.cs">
       <Link>ProductionCode\System\Net\IPAddressParser.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\CoreLib\System\Runtime\CompilerServices\PreserveDependencyAttribute.cs">
+      <Link>Common\System\Runtime\CompilerServices\PreserveDependencyAttribute.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CookieCollectionTest.cs" />


### PR DESCRIPTION
This existed because HttpListener is using a few internal members via reflection (boo).  One of the methods listed in this file isn't used by anyone, however, so it's not clear why it's here; probably a typo.  The other (ToServerString) has no internal usage and exists only to support HttpListener, which means we'd really like it to survive the initial assembly-level trimming, but then only be kept around for the app-level trimming if this functionality from HttpListener is used.

Given our current limitations, I've added the ability for an assembly to opt-out of keeping around PreserveDependency attributes, I've so opted-out in Primitives, and then I've used PreserveDependency on the two public ctors of Cookie that will always be hit if a cookie is created, such that ToServerString will survive the assembly build, but then these attributes evaporate.

I've also added PreserveDependency attributes into HttpListener, to codify its dependency on the various internals (most of which survive into the assembly initially because they're used by something reachable from public API).

There is still an issue tracking these reflection-based internals dependencies into Cookie from HttpListener.

cc: @marek-safar, @davidsh