### PR TITLE
Improve LINQ diagnosability and startup performance

### DIFF
--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/DelegateHelpers.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/DelegateHelpers.cs
@@ -130,7 +130,11 @@ namespace System.Dynamic.Utils
             }
             catch
             {
-                return null; // If unable to instantiate thunk, fall back to dynamic method creation
+                // If unable to instantiate thunk, fall back to dynamic method creation
+                // This is expected to happen for cases such as function pointer types as arguments
+                // Or new forms of types added to the typesystem in the future that aren't compatible with
+                // generics
+                return null;
             }
         }
 

--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/DelegateHelpers.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/DelegateHelpers.cs
@@ -6,6 +6,8 @@ using System.Reflection;
 
 #if !FEATURE_DYNAMIC_DELEGATE
 using System.Reflection.Emit;
+using System.Threading;
+using System.Text;
 #endif
 
 namespace System.Dynamic.Utils
@@ -24,9 +26,60 @@ namespace System.Dynamic.Utils
 
 #if !FEATURE_DYNAMIC_DELEGATE
 
-        private static readonly CacheDict<Type, DynamicMethod> s_thunks = new CacheDict<Type, DynamicMethod>(256);
+        private static readonly CacheDict<Type, MethodInfo> s_thunks = new CacheDict<Type, MethodInfo>(256);
         private static readonly MethodInfo s_FuncInvoke = typeof(Func<object[], object>).GetMethod("Invoke");
         private static readonly MethodInfo s_ArrayEmpty = typeof(Array).GetMethod(nameof(Array.Empty)).MakeGenericMethod(typeof(object));
+
+        public static void ActionThunk(Func<object[], object> handler)
+        {
+            handler(Array.Empty<object>());
+        }
+
+        public static void ActionThunk1<T1>(Func<object[], object> handler, T1 t1)
+        {
+            handler(new object[]{t1});
+        }
+
+        public static void ActionThunk2<T1, T2>(Func<object[], object> handler, T1 t1, T2 t2)
+        {
+            handler(new object[]{t1, t2});
+        }
+
+        public static TReturn FuncThunk<TReturn>(Func<object[], object> handler)
+        {
+            return (TReturn)handler(Array.Empty<object>());
+        }
+
+        public static TReturn FuncThunk1<T1, TReturn>(Func<object[], object> handler, T1 t1)
+        {
+            return (TReturn)handler(new object[]{t1});
+        }
+
+        public static TReturn FuncThunk2<T1, T2, TReturn>(Func<object[], object> handler, T1 t1, T2 t2)
+        {
+            return (TReturn)handler(new object[]{t1, t2});
+        }
+
+        private static MethodInfo[] s_ActionThunks = GetActionThunks();
+        private static MethodInfo[] s_FuncThunks = GetFuncThunks();
+
+        private static MethodInfo[] GetActionThunks()
+        {
+            Type delHelpers = typeof(DelegateHelpers);
+            return new MethodInfo[]{delHelpers.GetMethod("ActionThunk"),
+                                    delHelpers.GetMethod("ActionThunk1"),
+                                    delHelpers.GetMethod("ActionThunk2")};
+        }
+
+        private static MethodInfo[] GetFuncThunks()
+        {
+            Type delHelpers = typeof(DelegateHelpers);
+            return new MethodInfo[]{delHelpers.GetMethod("FuncThunk"),
+                                    delHelpers.GetMethod("FuncThunk1"),
+                                    delHelpers.GetMethod("FuncThunk2")};
+        }
+
+        private static int s_thunksCreated;
 
         // We will generate the following code:
         //
@@ -43,7 +96,7 @@ namespace System.Dynamic.Utils
         // return (TRet)ret;
         private static Delegate CreateObjectArrayDelegateRefEmit(Type delegateType, Func<object[], object> handler)
         {
-            DynamicMethod thunkMethod;
+            MethodInfo thunkMethod;
 
             if (!s_thunks.TryGetValue(delegateType, out thunkMethod))
             {
@@ -53,101 +106,173 @@ namespace System.Dynamic.Utils
                 bool hasReturnValue = returnType != typeof(void);
 
                 ParameterInfo[] parameters = delegateInvokeMethod.GetParametersCached();
-                Type[] paramTypes = new Type[parameters.Length + 1];
-                paramTypes[0] = typeof(Func<object[], object>);
-                for (int i = 0; i < parameters.Length; i++)
+
+                do
                 {
-                    paramTypes[i + 1] = parameters[i].ParameterType;
-                }
-
-                thunkMethod = new DynamicMethod("Thunk", returnType, paramTypes);
-                ILGenerator ilgen = thunkMethod.GetILGenerator();
-
-                LocalBuilder argArray = ilgen.DeclareLocal(typeof(object[]));
-                LocalBuilder retValue = ilgen.DeclareLocal(typeof(object));
-
-                // create the argument array
-                if (parameters.Length == 0)
-                {
-                    ilgen.Emit(OpCodes.Call, s_ArrayEmpty);
-                }
-                else
-                {
-                    ilgen.Emit(OpCodes.Ldc_I4, parameters.Length);
-                    ilgen.Emit(OpCodes.Newarr, typeof(object));
-                }
-                ilgen.Emit(OpCodes.Stloc, argArray);
-
-                // populate object array
-                bool hasRefArgs = false;
-                for (int i = 0; i < parameters.Length; i++)
-                {
-                    bool paramIsByReference = parameters[i].ParameterType.IsByRef;
-                    Type paramType = parameters[i].ParameterType;
-                    if (paramIsByReference)
-                        paramType = paramType.GetElementType();
-
-                    hasRefArgs = hasRefArgs || paramIsByReference;
-
-                    ilgen.Emit(OpCodes.Ldloc, argArray);
-                    ilgen.Emit(OpCodes.Ldc_I4, i);
-                    ilgen.Emit(OpCodes.Ldarg, i + 1);
-
-                    if (paramIsByReference)
+                    if (parameters.Length > 2)
                     {
-                        ilgen.Emit(OpCodes.Ldobj, paramType);
+                        break; // Don't use C# thunks for more than 2 parameters
                     }
-                    Type boxType = ConvertToBoxableType(paramType);
-                    ilgen.Emit(OpCodes.Box, boxType);
-                    ilgen.Emit(OpCodes.Stelem_Ref);
-                }
 
-                if (hasRefArgs)
-                {
-                    ilgen.BeginExceptionBlock();
-                }
-
-                // load delegate
-                ilgen.Emit(OpCodes.Ldarg_0);
-
-                // load array
-                ilgen.Emit(OpCodes.Ldloc, argArray);
-
-                // invoke Invoke
-                ilgen.Emit(OpCodes.Callvirt, s_FuncInvoke);
-                ilgen.Emit(OpCodes.Stloc, retValue);
-
-                if (hasRefArgs)
-                {
-                    // copy back ref/out args
-                    ilgen.BeginFinallyBlock();
-                    for (int i = 0; i < parameters.Length; i++)
+                    if (returnType.IsByRefLike || returnType.IsByRef || returnType.IsPointer)
                     {
-                        if (parameters[i].ParameterType.IsByRef)
-                        {
-                            Type byrefToType = parameters[i].ParameterType.GetElementType();
+                        break; // Don't use C# thunks for types that cannot be generic arguments
+                    }
 
-                            // update parameter
-                            ilgen.Emit(OpCodes.Ldarg, i + 1);
-                            ilgen.Emit(OpCodes.Ldloc, argArray);
-                            ilgen.Emit(OpCodes.Ldc_I4, i);
-                            ilgen.Emit(OpCodes.Ldelem_Ref);
-                            ilgen.Emit(OpCodes.Unbox_Any, byrefToType);
-                            ilgen.Emit(OpCodes.Stobj, byrefToType);
+                    bool invalidParameter = false;
+                    foreach (ParameterInfo parameter in parameters)
+                    {
+                        Type parameterType = parameter.ParameterType;
+                        if  (parameterType.IsByRefLike || parameterType.IsByRef || parameterType.IsPointer)
+                        {
+                            invalidParameter = true;
+                            break; // Don't use C# thunks for types that cannot be generic arguments
                         }
                     }
-                    ilgen.EndExceptionBlock();
-                }
 
-                if (hasReturnValue)
+                    if (invalidParameter)
+                        break;
+
+                    int thunkTypeArgCount = parameters.Length;
+                    if (hasReturnValue)
+                        thunkTypeArgCount++;
+
+                    Type[] thunkTypeArgs = new Type[thunkTypeArgCount];
+                    for (int i = 0; i < parameters.Length; i++)
+                    {
+                        thunkTypeArgs[i] = parameters[i].ParameterType;
+                    }
+                    MethodInfo uninstantiatedMethod;
+
+                    if (hasReturnValue)
+                    {
+                        thunkTypeArgs[thunkTypeArgs.Length - 1] = returnType;
+                        uninstantiatedMethod = s_FuncThunks[parameters.Length];
+                    }
+                    else
+                    {
+                        uninstantiatedMethod = s_ActionThunks[parameters.Length];
+                    }
+
+                    if (thunkTypeArgs.Length > 0)
+                        s_thunks[delegateType] = thunkMethod = uninstantiatedMethod.MakeGenericMethod(thunkTypeArgs);
+                    else
+                        s_thunks[delegateType] = thunkMethod = uninstantiatedMethod;
+
+                } while (false);
+
+                if (thunkMethod == null)
                 {
-                    ilgen.Emit(OpCodes.Ldloc, retValue);
-                    ilgen.Emit(OpCodes.Unbox_Any, ConvertToBoxableType(returnType));
+                    int thunkIndex = Interlocked.Increment(ref s_thunksCreated);
+                    Type[] paramTypes = new Type[parameters.Length + 1];
+                    paramTypes[0] = typeof(Func<object[], object>);
+
+                    StringBuilder thunkName = new StringBuilder();
+                    thunkName.Append("Thunk");
+                    thunkName.Append(thunkIndex);
+                    if (hasReturnValue)
+                    {
+                        thunkName.Append("ret_");
+                        thunkName.Append(returnType.Name);
+                    }
+
+                    for (int i = 0; i < parameters.Length; i++)
+                    {
+                        thunkName.Append("_");
+                        thunkName.Append(parameters[i].ParameterType.Name);
+                        paramTypes[i + 1] = parameters[i].ParameterType;
+                    }
+
+                    DynamicMethod dynamicThunkMethod = new DynamicMethod(thunkName.ToString(), returnType, paramTypes);
+                    thunkMethod = dynamicThunkMethod;
+                    ILGenerator ilgen = dynamicThunkMethod.GetILGenerator();
+
+                    LocalBuilder argArray = ilgen.DeclareLocal(typeof(object[]));
+                    LocalBuilder retValue = ilgen.DeclareLocal(typeof(object));
+
+                    // create the argument array
+                    if (parameters.Length == 0)
+                    {
+                        ilgen.Emit(OpCodes.Call, s_ArrayEmpty);
+                    }
+                    else
+                    {
+                        ilgen.Emit(OpCodes.Ldc_I4, parameters.Length);
+                        ilgen.Emit(OpCodes.Newarr, typeof(object));
+                    }
+                    ilgen.Emit(OpCodes.Stloc, argArray);
+
+                    // populate object array
+                    bool hasRefArgs = false;
+                    for (int i = 0; i < parameters.Length; i++)
+                    {
+                        bool paramIsByReference = parameters[i].ParameterType.IsByRef;
+                        Type paramType = parameters[i].ParameterType;
+                        if (paramIsByReference)
+                            paramType = paramType.GetElementType();
+
+                        hasRefArgs = hasRefArgs || paramIsByReference;
+
+                        ilgen.Emit(OpCodes.Ldloc, argArray);
+                        ilgen.Emit(OpCodes.Ldc_I4, i);
+                        ilgen.Emit(OpCodes.Ldarg, i + 1);
+
+                        if (paramIsByReference)
+                        {
+                            ilgen.Emit(OpCodes.Ldobj, paramType);
+                        }
+                        Type boxType = ConvertToBoxableType(paramType);
+                        ilgen.Emit(OpCodes.Box, boxType);
+                        ilgen.Emit(OpCodes.Stelem_Ref);
+                    }
+
+                    if (hasRefArgs)
+                    {
+                        ilgen.BeginExceptionBlock();
+                    }
+
+                    // load delegate
+                    ilgen.Emit(OpCodes.Ldarg_0);
+
+                    // load array
+                    ilgen.Emit(OpCodes.Ldloc, argArray);
+
+                    // invoke Invoke
+                    ilgen.Emit(OpCodes.Callvirt, s_FuncInvoke);
+                    ilgen.Emit(OpCodes.Stloc, retValue);
+
+                    if (hasRefArgs)
+                    {
+                        // copy back ref/out args
+                        ilgen.BeginFinallyBlock();
+                        for (int i = 0; i < parameters.Length; i++)
+                        {
+                           if (parameters[i].ParameterType.IsByRef)
+                           {
+                                Type byrefToType = parameters[i].ParameterType.GetElementType();
+
+                                // update parameter
+                                ilgen.Emit(OpCodes.Ldarg, i + 1);
+                                ilgen.Emit(OpCodes.Ldloc, argArray);
+                                ilgen.Emit(OpCodes.Ldc_I4, i);
+                                ilgen.Emit(OpCodes.Ldelem_Ref);
+                                ilgen.Emit(OpCodes.Unbox_Any, byrefToType);
+                                ilgen.Emit(OpCodes.Stobj, byrefToType);
+                            }
+                        }
+                        ilgen.EndExceptionBlock();
+                    }
+
+                    if (hasReturnValue)
+                    {
+                        ilgen.Emit(OpCodes.Ldloc, retValue);
+                        ilgen.Emit(OpCodes.Unbox_Any, ConvertToBoxableType(returnType));
+                    }
+
+                    ilgen.Emit(OpCodes.Ret);
+
+                    s_thunks[delegateType] = thunkMethod;
                 }
-
-                ilgen.Emit(OpCodes.Ret);
-
-                s_thunks[delegateType] = thunkMethod;
             }
 
             return thunkMethod.CreateDelegate(delegateType, handler);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.cs
@@ -26,6 +26,8 @@ namespace System.Linq.Expressions.Compiler
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling")]
     internal sealed partial class LambdaCompiler : ILocalCache
     {
+        private static int s_lambdaMethodIndex;
+
         private delegate void WriteBack(LambdaCompiler compiler);
 
         // Information on the entire lambda tree currently being compiled
@@ -67,7 +69,7 @@ namespace System.Linq.Expressions.Compiler
         {
             Type[] parameterTypes = GetParameterTypes(lambda, typeof(Closure));
 
-            var method = new DynamicMethod(lambda.Name ?? "lambda_method", lambda.ReturnType, parameterTypes, true);
+            var method = new DynamicMethod(lambda.Name ?? ("lambda_method" + s_lambdaMethodIndex.ToString()), lambda.ReturnType, parameterTypes, true);
 
             _tree = tree;
             _lambda = lambda;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.cs
@@ -8,6 +8,7 @@ using System.Dynamic.Utils;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
+using System.Threading;
 
 namespace System.Linq.Expressions.Compiler
 {
@@ -69,7 +70,8 @@ namespace System.Linq.Expressions.Compiler
         {
             Type[] parameterTypes = GetParameterTypes(lambda, typeof(Closure));
 
-            var method = new DynamicMethod(lambda.Name ?? ("lambda_method" + s_lambdaMethodIndex.ToString()), lambda.ReturnType, parameterTypes, true);
+            int lambdaMethodIndex = Interlocked.Increment(ref s_lambdaMethodIndex);
+            var method = new DynamicMethod(lambda.Name ?? ("lambda_method" + lambdaMethodIndex.ToString()), lambda.ReturnType, parameterTypes, true);
 
             _tree = tree;
             _lambda = lambda;

--- a/src/System.Linq.Expressions/tests/CompilerTests.cs
+++ b/src/System.Linq.Expressions/tests/CompilerTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 using System.Threading;
 using Xunit;
 
@@ -411,7 +412,8 @@ namespace System.Linq.Expressions.Tests
                 .Select(line => line.Trim())
                 .Where(line => line != "" && !line.StartsWith("//"));
 
-            return string.Join("\n", lines);
+            string beforeLambdaUniquifierRemoval = string.Join("\n", lines);
+            return Regex.Replace(beforeLambdaUniquifierRemoval, "lambda_method[0-9]*", "lambda_method");
         }
 
         private static void VerifyEmitConstantsToIL<T>(T value)

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
@@ -946,5 +946,34 @@ namespace System.Linq.Expressions.Tests
 
 #endif
 
+        [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.Netcoreapp, "Optimization in .NET Core")]
+        public void ValidateThatInterpreterWithSimpleTypeUsesNonDynamicThunk()
+        {
+            Expression<Action> action = () => Console.WriteLine("");
+            Assert.True(action.Compile(preferInterpretation:true).Method.GetType().Name == "RuntimeMethodInfo");
+            Expression<Action<int>> action1 = (int x) => Console.WriteLine(x.ToString());
+            Assert.True(action1.Compile(preferInterpretation:true).Method.GetType().Name == "RuntimeMethodInfo");
+            Expression<Action<int, object>> action2 = (int x, object y) => Console.WriteLine(y);
+            Assert.True(action2.Compile(preferInterpretation:true).Method.GetType().Name == "RuntimeMethodInfo");
+
+            Expression<Func<object>> func = () => null;
+            Assert.True(func.Compile(preferInterpretation:true).Method.GetType().Name == "RuntimeMethodInfo");
+            Expression<Func<object, object>> func1 = (object o) => null;
+            Assert.True(func1.Compile(preferInterpretation:true).Method.GetType().Name == "RuntimeMethodInfo");
+            Expression<Func<object, object, object>> func2 = (object o, object o2) => null;
+            Assert.True(func2.Compile(preferInterpretation:true).Method.GetType().Name == "RuntimeMethodInfo");
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.Netcoreapp, "Optimization in .NET Core")]
+        public void ValidateThatInterpreterWithSimpleTypeUsesDynamicThunk()
+        {
+            Expression<Action<object,object,object>> complexaction = (object o1, object o2, object o3) => Console.WriteLine("");
+            Assert.True(complexaction.Compile(preferInterpretation:true).Method.GetType().Name == "RTDynamicMethod");
+
+            Expression<Func<object, object, object,object>> complexfunc = (object o1, object o2, object o3) => null;
+            Assert.True(complexfunc.Compile(preferInterpretation:true).Method.GetType().Name == "RTDynamicMethod");
+        }
     }
 }


### PR DESCRIPTION
- Give unique numbered names to LINQ lambdas which are not named
- Generate LINQ interpreter thunks with unique names that are descriptive of the delegate in use
- For interpreter thunk cases where the delegate type is simple corresponding to simple parameter passing to functions taking up to 2 parameters, use precompiled C# generics instead. 
  - This results in using generic sharing for many instead of requiring exact compiled code