### PR TITLE
[release/3.1] Update SDL validation to use values from corefx-sdl-validation variable group

### DIFF
--- a/.azure-ci.yml
+++ b/.azure-ci.yml
@@ -100,12 +100,12 @@ stages:
         SDLValidationParameters:
           enable: false
           params: ' -SourceToolsList @("policheck","credscan")
-          -TsaInstanceURL "https://devdiv.visualstudio.com/"
-          -TsaProjectName "DEVDIV"
+          -TsaInstanceURL "$(TsaInstanceURL)"
+          -TsaProjectName "$(TsaProjectName)"
           -TsaNotificationEmail "$(TsaNotificationEmail)"
           -TsaCodebaseAdmin "$(TsaCodebaseAdmin)"
-          -TsaBugAreaPath "DevDiv\NET Core"
-          -TsaIterationPath "DevDiv"
+          -TsaBugAreaPath "$(TsaBugAreaPath)"
+          -TsaIterationPath "$(TsaIterationPath)"
           -TsaRepositoryName "CoreFX"
           -TsaCodebaseName "CoreFX"
           -TsaPublish $True'


### PR DESCRIPTION
Port for: https://github.com/dotnet/corefx/pull/42098

This changes SDL validation to use group variables so if a bug area path changes, we just update it directly in Azure DevOps and don't have to keep updating code and porting to all branches.

cc: @danmosemsft @ViktorHofer 