### PR TITLE
Avoid duplicated message in WebException

### DIFF
--- a/src/System.Net.Requests/src/System/Net/WebException.cs
+++ b/src/System.Net.Requests/src/System/Net/WebException.cs
@@ -87,17 +87,12 @@ namespace System.Net
         internal static Exception CreateCompatibleException(Exception exception)
         {
             Debug.Assert(exception != null);
-            if (exception is HttpRequestException)
+            if (exception is HttpRequestException hre)
             {
-                Exception inner = exception.InnerException;
-                string message = inner != null ?
-                    exception.Message + " " + inner.Message :
-                    exception.Message;
-
                 return new WebException(
-                    message,
+                    exception.Message,
                     exception,
-                    GetStatusFromException(exception as HttpRequestException),
+                    GetStatusFromException(hre),
                     null);
             }
             else if (exception is TaskCanceledException)


### PR DESCRIPTION
In a bunch of places, including in HttpClient, when a new exception instance is created to wrap an inner exception, the inner exception's message is then used as the message for the wrapping exception.  WebRequest.CreateCompatibleException is taking such an HttpRequestException and concatenating the outer and inner exception's messages, which means it's often duplicating the exact same message twice.

Since we're including the exception as the inner exception, there's no need for such duplication... we can just follow suit and use the outer exception's message without concatenation.

Fixes https://github.com/dotnet/corefx/issues/42181