### PR TITLE
QUIC: Remove ConnectAsync on QuicStream

### DIFF
--- a/src/System.Net.Quic/ref/System.Net.Quic.cs
+++ b/src/System.Net.Quic/ref/System.Net.Quic.cs
@@ -43,7 +43,6 @@ namespace System.Net.Quic
         public override void Flush() => throw null;
         public override int Read(byte[] buffer, int offset, int count) => throw null;
         public override void Write(byte[] buffer, int offset, int count) => throw null;
-        public bool Connected => throw null;
         public int StreamId => throw null;
         public void ShutdownRead() => throw null;
         public void ShutdownWrite() => throw null;

--- a/src/System.Net.Quic/ref/System.Net.Quic.cs
+++ b/src/System.Net.Quic/ref/System.Net.Quic.cs
@@ -43,7 +43,7 @@ namespace System.Net.Quic
         public override void Flush() => throw null;
         public override int Read(byte[] buffer, int offset, int count) => throw null;
         public override void Write(byte[] buffer, int offset, int count) => throw null;
-        public int StreamId => throw null;
+        public long StreamId => throw null;
         public void ShutdownRead() => throw null;
         public void ShutdownWrite() => throw null;
     }

--- a/src/System.Net.Quic/ref/System.Net.Quic.cs
+++ b/src/System.Net.Quic/ref/System.Net.Quic.cs
@@ -43,7 +43,6 @@ namespace System.Net.Quic
         public override void Flush() => throw null;
         public override int Read(byte[] buffer, int offset, int count) => throw null;
         public override void Write(byte[] buffer, int offset, int count) => throw null;
-        public System.Threading.Tasks.ValueTask ConnectAsync(System.Threading.CancellationToken cancellationToken = default) => throw null;
         public bool Connected => throw null;
         public int StreamId => throw null;
         public void ShutdownRead() => throw null;

--- a/src/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -24,8 +24,8 @@ namespace System.Net.Quic
         private Socket _socket = null;
         private IPEndPoint _peerListenEndPoint = null;
         private TcpListener _inboundListener = null;
-        private int _nextOutboundBidirectionalStream;
-        private int _nextOutboundUnidirectionalStream;
+        private long _nextOutboundBidirectionalStream;
+        private long _nextOutboundUnidirectionalStream;
 
         /// <summary>
         /// Create an outbound QUIC connection.
@@ -148,7 +148,7 @@ namespace System.Net.Quic
         {
             if (_mock)
             {
-                int streamId;
+                long streamId;
                 lock (_syncObject)
                 {
                     streamId = _nextOutboundUnidirectionalStream;
@@ -171,7 +171,7 @@ namespace System.Net.Quic
         {
             if (_mock)
             {
-                int streamId;
+                long streamId;
                 lock (_syncObject)
                 {
                     streamId = _nextOutboundBidirectionalStream;

--- a/src/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -155,7 +155,7 @@ namespace System.Net.Quic
                     _nextOutboundUnidirectionalStream += 4;
                 }
 
-                return new QuicStream(this, streamId, false);
+                return new QuicStream(this, streamId, bidirectional: false);
             }
             else
             {
@@ -178,7 +178,7 @@ namespace System.Net.Quic
                     _nextOutboundBidirectionalStream += 4;
                 }
 
-                return new QuicStream(this, streamId, true);
+                return new QuicStream(this, streamId, bidirectional: true);
             }
             else
             {
@@ -231,7 +231,7 @@ namespace System.Net.Quic
                 }
 
                 bool bidirectional = ((streamId & 0b10) == 0);
-                return new QuicStream(socket, streamId, canWrite: bidirectional);
+                return new QuicStream(socket, streamId, bidirectional: bidirectional);
             }
             else
             {

--- a/src/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
+++ b/src/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
@@ -126,7 +126,8 @@ namespace System.Net.Quic
             {
                 if (disposing)
                 {
-                    // TODO: dispose managed state (managed objects).
+                    _tcpListener?.Stop();
+                    _tcpListener = null;
                 }
 
                 // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.

--- a/src/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
+++ b/src/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
@@ -25,24 +25,24 @@ namespace System.Net.Quic
 
         // Constructor for outbound streams
         // !!! TEMPORARY FOR QUIC MOCK SUPPORT
-        internal QuicStream(QuicConnection connection, long streamId, bool canRead)
+        internal QuicStream(QuicConnection connection, long streamId, bool bidirectional)
         {
             _mock = true;
             _connection = connection;
             _streamId = streamId;
-            _canRead = canRead;
+            _canRead = bidirectional;
             _canWrite = true;
         }
 
         // Constructor for inbound streams
         // !!! TEMPORARY FOR QUIC MOCK SUPPORT
-        internal QuicStream(Socket socket, long streamId, bool canWrite)
+        internal QuicStream(Socket socket, long streamId, bool bidirectional)
         {
             _mock = true;
             _socket = socket;
             _streamId = streamId;
             _canRead = true;
-            _canWrite = canWrite;
+            _canWrite = bidirectional;
         }
 
         public override bool CanSeek => false;

--- a/src/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
+++ b/src/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
@@ -14,7 +14,7 @@ namespace System.Net.Quic
     public sealed class QuicStream : Stream
     {
         private bool _disposed = false;
-        private readonly int _streamId;
+        private readonly long _streamId;
         private bool _canRead;
         private bool _canWrite;
         private QuicConnection _connection;
@@ -25,7 +25,7 @@ namespace System.Net.Quic
 
         // Constructor for outbound streams
         // !!! TEMPORARY FOR QUIC MOCK SUPPORT
-        internal QuicStream(QuicConnection connection, int streamId, bool canRead)
+        internal QuicStream(QuicConnection connection, long streamId, bool canRead)
         {
             _mock = true;
             _connection = connection;
@@ -36,7 +36,7 @@ namespace System.Net.Quic
 
         // Constructor for inbound streams
         // !!! TEMPORARY FOR QUIC MOCK SUPPORT
-        internal QuicStream(Socket socket, int streamId, bool canWrite)
+        internal QuicStream(Socket socket, long streamId, bool canWrite)
         {
             _mock = true;
             _socket = socket;
@@ -119,7 +119,7 @@ namespace System.Net.Quic
         /// <summary>
         /// QUIC stream ID.
         /// </summary>
-        public int StreamId
+        public long StreamId
         {
             get
             {

--- a/src/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
+++ b/src/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
@@ -117,26 +117,6 @@ namespace System.Net.Quic
         }
 
         /// <summary>
-        /// Indicates whether the stream has been connected.
-        /// </summary>
-        public bool Connected
-        {
-            get
-            {
-                CheckDisposed();
-
-                if (_mock)
-                {
-                    return _socket != null;
-                }
-                else
-                {
-                    throw new NotImplementedException();
-                }
-            }
-        }
-
-        /// <summary>
         /// QUIC stream ID.
         /// </summary>
         public int StreamId
@@ -180,7 +160,7 @@ namespace System.Net.Quic
 
             if (_mock)
             {
-                if (!Connected)
+                if (_socket == null)
                 {
                     await ConnectAsync(cancellationToken).ConfigureAwait(false);
                 }
@@ -225,7 +205,7 @@ namespace System.Net.Quic
 
             if (_mock)
             {
-                if (!Connected)
+                if (_socket == null)
                 {
                     await ConnectAsync(cancellationToken).ConfigureAwait(false);
                 }

--- a/src/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
+++ b/src/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
@@ -52,10 +52,8 @@ namespace System.Net.Quic.Tests
             }
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task TestStreams(bool explicitConnect)
+        [Fact]
+        public async Task TestStreams()
         {
             using (QuicListener listener = new QuicListener(new IPEndPoint(IPAddress.Loopback, 0), sslServerAuthenticationOptions: null, mock: true))
             {
@@ -76,70 +74,46 @@ namespace System.Net.Quic.Tests
                     Assert.Equal(listenEndPoint, clientConnection.RemoteEndPoint);
                     Assert.Equal(clientConnection.LocalEndPoint, serverConnection.RemoteEndPoint);
 
-                    await CreateAndTestBidirectionalStream(clientConnection, serverConnection, explicitConnect);
-                    await CreateAndTestBidirectionalStream(serverConnection, clientConnection, explicitConnect);
-                    await CreateAndTestUnidirectionalStream(serverConnection, clientConnection, explicitConnect);
-                    await CreateAndTestUnidirectionalStream(clientConnection, serverConnection, explicitConnect);
+                    await CreateAndTestBidirectionalStream(clientConnection, serverConnection);
+                    await CreateAndTestBidirectionalStream(serverConnection, clientConnection);
+                    await CreateAndTestUnidirectionalStream(serverConnection, clientConnection);
+                    await CreateAndTestUnidirectionalStream(clientConnection, serverConnection);
                 }
             }
         }
 
-        private static async Task CreateAndTestBidirectionalStream(QuicConnection c1, QuicConnection c2, bool explicitConnect)
+        private static async Task CreateAndTestBidirectionalStream(QuicConnection c1, QuicConnection c2)
         {
             using (QuicStream s1 = c1.CreateBidirectionalStream())
             {
                 Assert.True(s1.CanRead);
                 Assert.True(s1.CanWrite);
                 Assert.False(s1.Connected);
-                Assert.Equal(s1.StreamId, -1);
 
-                if (explicitConnect)
+                ValueTask writeTask = s1.WriteAsync(s_data);
+                using (QuicStream s2 = await c2.AcceptStreamAsync())
                 {
-                    await s1.ConnectAsync();
-                    using (QuicStream s2 = await c2.AcceptStreamAsync())
-                    {
-                        await TestBidirectionalStream(s1, s2);
-                    }
-                }
-                else
-                {
-                    ValueTask writeTask = s1.WriteAsync(s_data);
-                    using (QuicStream s2 = await c2.AcceptStreamAsync())
-                    {
-                        await ReceiveDataAsync(s_data, s2);
-                        await writeTask;
-                        await TestBidirectionalStream(s1, s2);
-                    }
+                    await ReceiveDataAsync(s_data, s2);
+                    await writeTask;
+                    await TestBidirectionalStream(s1, s2);
                 }
             }
         }
 
-        private static async Task CreateAndTestUnidirectionalStream(QuicConnection c1, QuicConnection c2, bool explicitConnect)
+        private static async Task CreateAndTestUnidirectionalStream(QuicConnection c1, QuicConnection c2)
         {
             using (QuicStream s1 = c1.CreateUnidirectionalStream())
             {
                 Assert.False(s1.CanRead);
                 Assert.True(s1.CanWrite);
                 Assert.False(s1.Connected);
-                Assert.Equal(s1.StreamId, -1);
 
-                if (explicitConnect)
+                ValueTask writeTask = s1.WriteAsync(s_data);
+                using (QuicStream s2 = await c2.AcceptStreamAsync())
                 {
-                    await s1.ConnectAsync();
-                    using (QuicStream s2 = await c2.AcceptStreamAsync())
-                    {
-                        await TestUnidirectionalStream(s1, s2);
-                    }
-                }
-                else
-                {
-                    ValueTask writeTask = s1.WriteAsync(s_data);
-                    using (QuicStream s2 = await c2.AcceptStreamAsync())
-                    {
-                        await ReceiveDataAsync(s_data, s2);
-                        await writeTask;
-                        await TestUnidirectionalStream(s1, s2);
-                    }
+                    await ReceiveDataAsync(s_data, s2);
+                    await writeTask;
+                    await TestUnidirectionalStream(s1, s2);
                 }
             }
         }

--- a/src/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
+++ b/src/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
@@ -88,7 +88,6 @@ namespace System.Net.Quic.Tests
             {
                 Assert.True(s1.CanRead);
                 Assert.True(s1.CanWrite);
-                Assert.False(s1.Connected);
 
                 ValueTask writeTask = s1.WriteAsync(s_data);
                 using (QuicStream s2 = await c2.AcceptStreamAsync())
@@ -106,7 +105,6 @@ namespace System.Net.Quic.Tests
             {
                 Assert.False(s1.CanRead);
                 Assert.True(s1.CanWrite);
-                Assert.False(s1.Connected);
 
                 ValueTask writeTask = s1.WriteAsync(s_data);
                 using (QuicStream s2 = await c2.AcceptStreamAsync())
@@ -124,8 +122,6 @@ namespace System.Net.Quic.Tests
             Assert.True(s1.CanWrite);
             Assert.True(s2.CanRead);
             Assert.True(s2.CanWrite);
-            Assert.True(s1.Connected);
-            Assert.True(s2.Connected);
             Assert.Equal(s1.StreamId, s2.StreamId);
 
             await SendAndReceiveDataAsync(s_data, s1, s2);
@@ -143,8 +139,6 @@ namespace System.Net.Quic.Tests
             Assert.True(s1.CanWrite);
             Assert.True(s2.CanRead);
             Assert.False(s2.CanWrite);
-            Assert.True(s1.Connected);
-            Assert.True(s2.Connected);
             Assert.Equal(s1.StreamId, s2.StreamId);
 
             await SendAndReceiveDataAsync(s_data, s1, s2);


### PR DESCRIPTION
We don't need/want to expose this capability. Just ensure the stream ID is assigned when the QuicStream is created, and then create the stream on the wire on first use.

@scalablecory @jkotalik 