### PR TITLE
[Release 3.1][Winforms] Adding EditorAttribute to Font.Name for FontNameEditor in .NET Core

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/Font.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Font.cs
@@ -77,8 +77,8 @@ namespace System.Drawing
         /// Gets the face name of this <see cref='Font'/> .
         /// </summary>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-#if !NETCORE
         [Editor ("System.Drawing.Design.FontNameEditor, " + Consts.AssemblySystem_Drawing_Design, typeof (System.Drawing.Design.UITypeEditor))]
+#if !NETCORE
         [TypeConverter (typeof (FontConverter.FontNameConverter))]
 #endif
         public string Name => FontFamily.Name;


### PR DESCRIPTION
Moving EditorAttribute outside of the ```#if !NETCORE``` so it gets compiled into .NET Core version of Winforms. 

 There is no straightforward solution to add this without implementing a new feature in TypeDescriptor, so we decided to with the safer and quicker solution.