### PR TITLE
Fix deserialize issue with a large Stream containing a BOM

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
@@ -183,7 +183,7 @@ namespace System.Text.Json
                     else if (bytesInBuffer != 0)
                     {
                         // Shift the processed bytes to the beginning of buffer to make more room.
-                        Buffer.BlockCopy(buffer, bytesConsumed, buffer, 0, bytesInBuffer);
+                        Buffer.BlockCopy(buffer, bytesConsumed + start, buffer, 0, bytesInBuffer);
                     }
                 }
             }

--- a/src/System.Text.Json/tests/Serialization/Stream.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Stream.ReadTests.cs
@@ -155,29 +155,27 @@ namespace System.Text.Json.Serialization.Tests
                     byte[] objBytes = Encoding.UTF8.GetBytes(
                         @"{""Test"":{},""Test2"":[],""Test3"":{""Value"":{}},""PersonType"":0,""Id"":2}");
 
+                    byte[] utf8Bom = Encoding.UTF8.GetPreamble();
                     byte[] comma = Encoding.UTF8.GetBytes(@",");
+                    byte[] startArray = Encoding.UTF8.GetBytes(@"[");
+                    byte[] endArray = Encoding.UTF8.GetBytes(@"]");
 
                     var stream = new MemoryStream();
 
-                    // Write BOM.
-                    stream.Write(Encoding.UTF8.GetPreamble());
+                    stream.Write(utf8Bom, 0, utf8Bom.Length);
+                    stream.Write(startArray, 0, startArray.Length);
 
-                    // Write start array.
-                    stream.Write(Encoding.UTF8.GetBytes(@"["));
-
-                    // Write entries.
                     for (int i = 1; i <= count; i++)
                     {
-                        stream.Write(objBytes);
+                        stream.Write(objBytes, 0, objBytes.Length);
 
                         if (i < count)
                         {
-                            stream.Write(comma);
+                            stream.Write(comma, 0, comma.Length);
                         }
                     }
 
-                    // Write end array.
-                    stream.Write(Encoding.UTF8.GetBytes(@"]"));
+                    stream.Write(endArray, 0, endArray.Length);
 
                     stream.Position = 0;
                     return new object[] { stream, count };


### PR DESCRIPTION
Addresses https://github.com/dotnet/corefx/issues/42145 for master.

If a Stream contains a BOM and encounters the area of code where remaining bytes need to be moved to the beginning of the buffer, the `Buffer.BlockCopy()`'s `srcOffset` parameter was 3 bytes (the BOM length) too short causing the wrong bytes to be moved. This occurs only when the Stream's length is greater than the default buffer length which is 16K (unless changed in JsonSerializerOptions).

This is expected to be ported to 3.1 and perhaps 3.0.x.
