### PR TITLE
Fix System.Net.WebUtility.HtmlDecode issue

### DIFF
--- a/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
@@ -264,8 +264,8 @@ namespace System.Net
                     // if we find another '&' before finding a ';', then this is not an entity,
                     // and the next '&' might start a real entity (VSWhidbey 275184)
                     ReadOnlySpan<char> inputSlice = input.Slice(i + 1);
-                    int entityLength = inputSlice.IndexOf(';');
-                    if (entityLength >= 0)
+                    int entityLength = inputSlice.IndexOfAny(";&");
+                    if (entityLength >= 0 && inputSlice[entityLength] == ';')
                     {
                         int entityEndPosition = (i + 1) + entityLength;
                         if (entityLength > 1 && inputSlice[0] == '#')

--- a/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
@@ -264,7 +264,7 @@ namespace System.Net
                     // if we find another '&' before finding a ';', then this is not an entity,
                     // and the next '&' might start a real entity (VSWhidbey 275184)
                     ReadOnlySpan<char> inputSlice = input.Slice(i + 1);
-                    int entityLength = inputSlice.IndexOfAny(";&");
+                    int entityLength = inputSlice.IndexOfAny(';', '&');
                     if (entityLength >= 0 && inputSlice[entityLength] == ';')
                     {
                         int entityEndPosition = (i + 1) + entityLength;

--- a/src/System.Runtime.Extensions/tests/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/tests/System/Net/WebUtility.cs
@@ -56,6 +56,10 @@ namespace System.Net.Tests
             // Empty
             yield return new object[] { "", "" };
             yield return new object[] { null, null };
+
+            // Should decode the innermost entity
+            yield return new object[] { "& &amp;", "& &" };
+            yield return new object[] { "&quot; &lt &gt;", "\" &lt >" };
         }
 
         [Theory]


### PR DESCRIPTION
Fixes #42219

The .NET Core implementation of `System.Net.WebUtility.HtmlDecode()` diverges slightly from the behaviour in full framework. Based on [this comment](https://github.com/dotnet/corefx/blob/a66a2b40508dbf32fcd2247f012572b93f638dc5/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs#L263-L265) it is most likely an unintentional regression. Fix is a verbatim application of @VinceGitHub's proposal.