### PR TITLE
[release/3.1] Add file creation method that takes an ACL

### DIFF
--- a/src/Common/src/CoreLib/System/IO/Win32Marshal.cs
+++ b/src/Common/src/CoreLib/System/IO/Win32Marshal.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #nullable enable
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 namespace System.IO
@@ -25,6 +26,10 @@ namespace System.IO
         /// </summary>
         internal static Exception GetExceptionForWin32Error(int errorCode, string? path = "")
         {
+            // ERROR_SUCCESS gets thrown when another unexpected interop call was made before checking GetLastWin32Error().
+            // Errors have to get retrieved as soon as possible after P/Invoking to avoid this.
+            Debug.Assert(errorCode != Interop.Errors.ERROR_SUCCESS);
+
             switch (errorCode)
             {
                 case Interop.Errors.ERROR_FILE_NOT_FOUND:

--- a/src/System.IO.FileSystem.AccessControl/System.IO.FileSystem.AccessControl.sln
+++ b/src/System.IO.FileSystem.AccessControl/System.IO.FileSystem.AccessControl.sln
@@ -30,8 +30,8 @@ Global
 		{5915DD11-5D57-45A9-BFB0-56FEB7741E1F}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
 		{5915DD11-5D57-45A9-BFB0-56FEB7741E1F}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
 		{5915DD11-5D57-45A9-BFB0-56FEB7741E1F}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
-		{D77FBA6C-1AA6-45A4-93E2-97A370672C53}.Debug|Any CPU.ActiveCfg = netstandard-Windows_NT-Debug|Any CPU
-		{D77FBA6C-1AA6-45A4-93E2-97A370672C53}.Debug|Any CPU.Build.0 = netstandard-Windows_NT-Debug|Any CPU
+		{D77FBA6C-1AA6-45A4-93E2-97A370672C53}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
+		{D77FBA6C-1AA6-45A4-93E2-97A370672C53}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
 		{D77FBA6C-1AA6-45A4-93E2-97A370672C53}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
 		{D77FBA6C-1AA6-45A4-93E2-97A370672C53}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
 		{88A04AB0-F61E-4DD2-9E12-928DCA261263}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU

--- a/src/System.IO.FileSystem.AccessControl/ref/System.IO.FileSystem.AccessControl.cs
+++ b/src/System.IO.FileSystem.AccessControl/ref/System.IO.FileSystem.AccessControl.cs
@@ -10,6 +10,7 @@ namespace System.IO
     public static partial class FileSystemAclExtensions
     {
         public static void Create(this System.IO.DirectoryInfo directoryInfo, System.Security.AccessControl.DirectorySecurity directorySecurity) { }
+        public static System.IO.FileStream Create(this System.IO.FileInfo fileInfo, System.IO.FileMode mode, System.Security.AccessControl.FileSystemRights rights, System.IO.FileShare share, int bufferSize, System.IO.FileOptions options, System.Security.AccessControl.FileSecurity fileSecurity) { throw null; }
         public static System.Security.AccessControl.DirectorySecurity GetAccessControl(this System.IO.DirectoryInfo directoryInfo) { throw null; }
         public static System.Security.AccessControl.DirectorySecurity GetAccessControl(this System.IO.DirectoryInfo directoryInfo, System.Security.AccessControl.AccessControlSections includeSections) { throw null; }
         public static System.Security.AccessControl.FileSecurity GetAccessControl(this System.IO.FileInfo fileInfo) { throw null; }

--- a/src/System.IO.FileSystem.AccessControl/src/Resources/Strings.resx
+++ b/src/System.IO.FileSystem.AccessControl/src/Resources/Strings.resx
@@ -188,4 +188,10 @@
   <data name="Arg_PathEmpty" xml:space="preserve">
     <value>The path is empty.</value>
   </data>
+  <data name="ArgumentOutOfRange_NeedPosNum" xml:space="preserve">
+    <value>Positive number required.</value>
+  </data>
+  <data name="Argument_InvalidFileModeAndFileSystemRightsCombo" xml:space="preserve">
+    <value>Combining FileMode.{0} with FileSystemRights.{1} is invalid.</value>
+  </data>
 </root>

--- a/src/System.IO.FileSystem.AccessControl/src/System.IO.FileSystem.AccessControl.csproj
+++ b/src/System.IO.FileSystem.AccessControl/src/System.IO.FileSystem.AccessControl.csproj
@@ -26,17 +26,21 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
     <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\Interop.BOOL.cs" Link="Common\CoreLib\Interop\Windows\Interop.BOOL.cs" />
+    <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\Kernel32\Interop.CreateFile.cs" Link="Common\CoreLib\Interop\Windows\Interop.CreateFile.cs" />
     <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\Kernel32\Interop.FILE_TIME.cs" Link="Common\CoreLib\Interop\Windows\Interop.FILE_TIME.cs" />
     <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\Kernel32\Interop.FileAttributes.cs" Link="Common\Interop\Windows\Interop.FileAttributes.cs" />
+    <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\Kernel32\Interop.FileTypes.cs" Link="Common\Interop\Windows\Interop.FileTypes.cs" />
     <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\Kernel32\Interop.FindClose.cs" Link="Common\CoreLib\Interop\Windows\Interop.FindClose.cs" />
     <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\Kernel32\Interop.FindFirstFileEx.cs" Link="Common\CoreLib\Interop\Windows\Interop.FindFirstFileEx.cs" />
     <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\Kernel32\Interop.FormatMessage.cs" Link="Common\Interop\Windows\Interop.FormatMessage.cs" />
     <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\Kernel32\Interop.GET_FILEEX_INFO_LEVELS.cs" Link="Common\CoreLib\Interop\Windows\Interop.GET_FILEEX_INFO_LEVELS.cs" />
     <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\Kernel32\Interop.GetFileAttributesEx.cs" Link="Common\Interop\Windows\Interop.GetFileAttributesEx.cs" />
+    <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\Kernel32\Interop.GetFileType_SafeHandle.cs" Link="Common\Interop\Windows\Interop.GetFileType_SafeHandle.cs" />
     <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\Kernel32\Interop.GetFullPathNameW.cs" Link="Common\Interop\Windows\Interop.GetFullPathNameW.cs" />
     <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\Kernel32\Interop.GetLongPathNameW.cs" Link="Common\Interop\Windows\Interop.GetLongPathNameW.cs" />
     <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\Kernel32\Interop.GetLogicalDrives.cs" Link="Common\Interop\Windows\Interop.GetLogicalDrives.cs" />
     <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\Kernel32\Interop.MAX_PATH.cs" Link="Common\CoreLib\Interop\Windows\Interop.MAX_PATH.cs" />
+    <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\Kernel32\Interop.SecurityOptions.cs" Link="Common\CoreLib\Interop\Windows\Interop.SecurityOptions.cs" />
     <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\Kernel32\Interop.SECURITY_ATTRIBUTES.cs" Link="Common\CoreLib\Interop\Windows\Interop.SECURITY_ATTRIBUTES.cs" />
     <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\Kernel32\Interop.SetThreadErrorMode.cs" Link="Common\CoreLib\Interop\Windows\Interop.SetThreadErrorMode.cs" />
     <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\Kernel32\Interop.WIN32_FILE_ATTRIBUTE_DATA.cs" Link="Common\CoreLib\Interop\Windows\Interop.WIN32_FILE_ATTRIBUTE_DATA.cs" />
@@ -46,6 +50,7 @@
     <Compile Include="$(CommonPath)\CoreLib\System\IO\PathInternal.Windows.cs" Link="Common\CoreLib\System\IO\PathInternal.Windows.cs" />
     <Compile Include="$(CommonPath)\CoreLib\System\IO\Win32Marshal.cs" Link="Common\CoreLib\System\IO\Win32Marshal.cs" />
     <Compile Include="$(CommonPath)\CoreLib\System\Text\ValueStringBuilder.cs" Link="Common\CoreLib\System\Text\ValueStringBuilder.cs" />
+    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GenericOperations.cs" Link="Common\Interop\Windows\Interop.GenericOperations.cs" />
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs" Link="Common\Interop\Windows\Interop.Libraries.cs" />
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.LongFileTime.cs" Link="Common\Interop\Windows\Interop.LongFileTime.cs" />
     <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.CreateDirectory.cs" Link="Common\Interop\Windows\Interop.CreateDirectory.cs" />

--- a/src/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.net46.cs
+++ b/src/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.net46.cs
@@ -8,6 +8,17 @@ namespace System.IO
 {
     public static class FileSystemAclExtensions
     {
+        public static FileStream Create(this FileInfo fileInfo, FileMode mode, FileSystemRights rights, FileShare share, int bufferSize, FileOptions options, FileSecurity fileSecurity)
+        {
+            if (fileInfo == null)
+                throw new ArgumentNullException(nameof(fileInfo));
+
+            if (fileSecurity == null)
+                throw new ArgumentNullException(nameof(fileSecurity));
+
+            return new FileStream(fileInfo.FullName, mode, rights, share, bufferSize, options, fileSecurity);
+        }
+
         public static void Create(this DirectoryInfo directoryInfo, DirectorySecurity directorySecurity)
         {
             if (directoryInfo == null)

--- a/src/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.netcoreapp.cs
+++ b/src/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.netcoreapp.cs
@@ -2,7 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Security.AccessControl;
+using Microsoft.Win32.SafeHandles;
 
 namespace System.IO
 {
@@ -14,6 +17,7 @@ namespace System.IO
         /// <exception cref="ArgumentNullException"><paramref name="directoryInfo" /> or <paramref name="directorySecurity" /> is <see langword="null" />.</exception>
         /// <exception cref="DirectoryNotFoundException">Could not find a part of the path.</exception>
         /// <exception cref="UnauthorizedAccessException">Access to the path is denied.</exception>
+        /// <remarks>This extension method was added to .NET Core to bring the functionality that was provided by the `System.IO.DirectoryInfo.Create(System.Security.AccessControl.DirectorySecurity)` .NET Framework method.</remarks>
         public static void Create(this DirectoryInfo directoryInfo, DirectorySecurity directorySecurity)
         {
             if (directoryInfo == null)
@@ -23,6 +27,149 @@ namespace System.IO
                 throw new ArgumentNullException(nameof(directorySecurity));
 
             FileSystem.CreateDirectory(directoryInfo.FullName, directorySecurity.GetSecurityDescriptorBinaryForm());
+        }
+
+        /// <summary>
+        /// Creates a new file stream, ensuring it is created with the specified properties and security settings.
+        /// </summary>
+        /// <param name="fileInfo">The current instance describing a file that does not exist in disk yet.</param>
+        /// <param name="mode">One of the enumeration values that specifies how the operating system should open a file.</param>
+        /// <param name="rights">One of the enumeration values that defines the access rights to use when creating access and audit rules.</param>
+        /// <param name="share">One of the enumeration values for controlling the kind of access other FileStream objects can have to the same file.</param>
+        /// <param name="bufferSize">The number of bytes buffered for reads and writes to the file.</param>
+        /// <param name="options">One of the enumeration values that describes how to create or overwrite the file.</param>
+        /// <param name="fileSecurity">An object that determines the access control and audit security for the file.</param>
+        /// <returns>A file stream for the newly created file.</returns>
+        /// <exception cref="ArgumentException">The <paramref name="rights" /> and <paramref name="mode" /> combination is invalid.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="fileInfo" /> or <paramref name="fileSecurity" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="mode" /> or <paramref name="share" /> are out of their legal enum range.
+        ///-or-
+        /// <paramref name="bufferSize" /> is not a positive number.</exception>
+        /// <exception cref="DirectoryNotFoundException">Could not find a part of the path.</exception>
+        /// <exception cref="IOException">An I/O error occurs.</exception>
+        /// <exception cref="UnauthorizedAccessException">Access to the path is denied.</exception>
+        /// <remarks>This extension method was added to .NET Core to bring the functionality that was provided by the `System.IO.FileStream.#ctor(System.String,System.IO.FileMode,System.Security.AccessControl.FileSystemRights,System.IO.FileShare,System.Int32,System.IO.FileOptions,System.Security.AccessControl.FileSecurity)` .NET Framework constructor.</remarks>
+        public static FileStream Create(this FileInfo fileInfo, FileMode mode, FileSystemRights rights, FileShare share, int bufferSize, FileOptions options, FileSecurity fileSecurity)
+        {
+            if (fileInfo == null)
+            {
+                throw new ArgumentNullException(nameof(fileInfo));
+            }
+
+            if (fileSecurity == null)
+            {
+                throw new ArgumentNullException(nameof(fileSecurity));
+            }
+
+            // don't include inheritable in our bounds check for share
+            FileShare tempshare = share & ~FileShare.Inheritable;
+
+            if (mode < FileMode.CreateNew || mode > FileMode.Append)
+            {
+                throw new ArgumentOutOfRangeException(nameof(mode), SR.ArgumentOutOfRange_Enum);
+            }
+
+            if (tempshare < FileShare.None || tempshare > (FileShare.ReadWrite | FileShare.Delete))
+            {
+                throw new ArgumentOutOfRangeException(nameof(share), SR.ArgumentOutOfRange_Enum);
+            }
+
+            if (bufferSize <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(bufferSize), SR.ArgumentOutOfRange_NeedPosNum);
+            }
+
+            // Do not allow using combinations of non-writing file system rights with writing file modes
+            if ((rights & FileSystemRights.Write) == 0 &&
+                (mode == FileMode.Truncate || mode == FileMode.CreateNew || mode == FileMode.Create || mode == FileMode.Append))
+            {
+                throw new ArgumentException(SR.Format(SR.Argument_InvalidFileModeAndFileSystemRightsCombo, mode, rights));
+            }
+
+            SafeFileHandle handle = CreateFileHandle(fileInfo.FullName, mode, rights, share, options, fileSecurity);
+
+            try
+            {
+                return new FileStream(handle, GetFileStreamFileAccess(rights), bufferSize, (options & FileOptions.Asynchronous) != 0);
+            }
+            catch
+            {
+                // If anything goes wrong while setting up the stream, make sure we deterministically dispose of the opened handle.
+                handle.Dispose();
+                throw;
+            }
+        }
+
+        // In the context of a FileStream, the only ACCESS_MASK ACE rights we care about are reading/writing data and the generic read/write rights.
+        // See: https://docs.microsoft.com/en-us/windows/win32/secauthz/access-mask
+        private static FileAccess GetFileStreamFileAccess(FileSystemRights rights)
+        {
+            FileAccess access = 0;
+            if ((rights & FileSystemRights.ReadData) != 0 || ((int)rights & Interop.Kernel32.GenericOperations.GENERIC_READ) != 0)
+            {
+                access = FileAccess.Read;
+            }
+            if ((rights & FileSystemRights.WriteData) != 0 || ((int)rights & Interop.Kernel32.GenericOperations.GENERIC_WRITE) != 0)
+            {
+                access = access == FileAccess.Read ? FileAccess.ReadWrite : FileAccess.Write;
+            }
+            return access;
+        }
+
+        private static unsafe SafeFileHandle CreateFileHandle(string fullPath, FileMode mode, FileSystemRights rights, FileShare share, FileOptions options, FileSecurity security)
+        {
+            Debug.Assert(fullPath != null);
+
+            // Must use a valid Win32 constant
+            if (mode == FileMode.Append)
+            {
+                mode = FileMode.OpenOrCreate;
+            }
+
+            // For mitigating local elevation of privilege attack through named pipes make sure we always call CreateFile with SECURITY_ANONYMOUS so that the
+            // named pipe server can't impersonate a high privileged client security context (note that this is the effective default on CreateFile2)
+            // SECURITY_SQOS_PRESENT flags that a SECURITY_ flag is present.
+            int flagsAndAttributes = (int)options | Interop.Kernel32.SecurityOptions.SECURITY_SQOS_PRESENT | Interop.Kernel32.SecurityOptions.SECURITY_ANONYMOUS;
+
+            SafeFileHandle handle;
+
+            fixed (byte* pSecurityDescriptor = security.GetSecurityDescriptorBinaryForm())
+            {
+                var secAttrs = new Interop.Kernel32.SECURITY_ATTRIBUTES
+                {
+                    nLength = (uint)sizeof(Interop.Kernel32.SECURITY_ATTRIBUTES),
+                    bInheritHandle = ((share & FileShare.Inheritable) != 0) ? Interop.BOOL.TRUE : Interop.BOOL.FALSE,
+                    lpSecurityDescriptor = (IntPtr)pSecurityDescriptor
+                };
+
+                using (DisableMediaInsertionPrompt.Create())
+                {
+                    handle = Interop.Kernel32.CreateFile(fullPath, (int)rights, share, ref secAttrs, mode, flagsAndAttributes, IntPtr.Zero);
+                    ValidateFileHandle(handle, fullPath);
+                }
+            }
+
+            return handle;
+        }
+
+        private static void ValidateFileHandle(SafeFileHandle handle, string fullPath)
+        {
+            if (handle.IsInvalid)
+            {
+                // Return a meaningful exception with the full path.
+
+                // NT5 oddity - when trying to open "C:\" as a FileStream,
+                // we usually get ERROR_PATH_NOT_FOUND from the OS.  We should
+                // probably be consistent w/ every other directory.
+                int errorCode = Marshal.GetLastWin32Error();
+
+                if (errorCode == Interop.Errors.ERROR_PATH_NOT_FOUND && fullPath.Length == Path.GetPathRoot(fullPath).Length)
+                {
+                    errorCode = Interop.Errors.ERROR_ACCESS_DENIED;
+                }
+
+                throw Win32Marshal.GetExceptionForWin32Error(errorCode, fullPath);
+            }
         }
     }
 }

--- a/src/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.netstandard.cs
+++ b/src/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.netstandard.cs
@@ -8,6 +8,11 @@ namespace System.IO
 {
     public static partial class FileSystemAclExtensions
     {
+        public static FileStream Create(this FileInfo fileInfo, FileMode mode, FileSystemRights rights, FileShare share, int bufferSize, FileOptions options, FileSecurity fileSecurity)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
         public static void Create(this DirectoryInfo directoryInfo, DirectorySecurity directorySecurity)
         {
             throw new PlatformNotSupportedException();

--- a/src/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
+++ b/src/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
@@ -4,18 +4,20 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Security.AccessControl;
 using System.Security.Principal;
-using Microsoft.DotNet.PlatformAbstractions;
-using Microsoft.VisualBasic;
 using Xunit;
 
 namespace System.IO
 {
     public class FileSystemAclExtensionsTests
     {
+        private const int DefaultBufferSize = 4096;
+
+
         #region Test methods
+
+        #region GetAccessControl
 
         [Fact]
         public void GetAccessControl_DirectoryInfo_InvalidArguments()
@@ -120,6 +122,10 @@ namespace System.IO
             }
         }
 
+        #endregion
+
+        #region SetAccessControl
+
         [Fact]
         public void SetAccessControl_DirectoryInfo_DirectorySecurity_InvalidArguments()
         {
@@ -195,6 +201,10 @@ namespace System.IO
             }
         }
 
+        #endregion
+
+        #region DirectoryInfo Create
+
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)]
         public void DirectoryInfo_Create_NullDirectoryInfo()
@@ -202,14 +212,58 @@ namespace System.IO
             DirectoryInfo info = null;
             DirectorySecurity security = new DirectorySecurity();
 
-            if (PlatformDetection.IsFullFramework)
+            Assert.Throws<ArgumentNullException>("directoryInfo", () =>
             {
-                Assert.Throws<ArgumentNullException>(() => FileSystemAclExtensions.Create(info, security));
-            }
-            else
+                if (PlatformDetection.IsFullFramework)
+                {
+                    FileSystemAclExtensions.Create(info, security);
+                }
+                else
+                {
+                    info.Create(security);
+                }
+            });
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)]
+        public void DirectoryInfo_Create_NullDirectorySecurity()
+        {
+            DirectoryInfo info = new DirectoryInfo("path");
+
+            Assert.Throws<ArgumentNullException>("directorySecurity", () =>
             {
-                Assert.Throws<ArgumentNullException>(() => info.Create(security));
-            }
+                if (PlatformDetection.IsFullFramework)
+                {
+                    FileSystemAclExtensions.Create(info, null);
+                }
+                else
+                {
+                    info.Create(null);
+                }
+            });
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)]
+        public void DirectoryInfo_Create_NotFound()
+        {
+            using var directory = new TempDirectory();
+            string path = Path.Combine(directory.Path, Guid.NewGuid().ToString(), "ParentDoesNotExist");
+            DirectoryInfo info = new DirectoryInfo(path);
+            DirectorySecurity security = new DirectorySecurity();
+
+            Assert.Throws<UnauthorizedAccessException>(() =>
+            {
+                if (PlatformDetection.IsFullFramework)
+                {
+                    FileSystemAclExtensions.Create(info, security);
+                }
+                else
+                {
+                    info.Create(security);
+                }
+            });
         }
 
         [Fact]
@@ -220,48 +274,209 @@ namespace System.IO
             VerifyDirectorySecurity(security);
         }
 
-        [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)]
-        public void DirectoryInfo_Create_NullDirectorySecurity()
-        {
-            DirectoryInfo info = new DirectoryInfo("path");
-            if (PlatformDetection.IsFullFramework)
-            {
-                Assert.Throws<ArgumentNullException>(() => FileSystemAclExtensions.Create(info, null));
-            }
-            else
-            {
-                Assert.Throws<ArgumentNullException>(() => info.Create(null));
-            }
-        }
-
-        [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)]
-        public void DirectoryInfo_Create_NotFound()
-        {
-            DirectoryInfo info = new DirectoryInfo(@"W:\\I\\Do\\Not\\Exist");
-            DirectorySecurity security = new DirectorySecurity();
-            Assert.Throws<DirectoryNotFoundException>(() => info.Create(security));
-        }
-
         [Theory]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)]
+        [InlineData(WellKnownSidType.BuiltinUsersSid, FileSystemRights.ReadAndExecute, AccessControlType.Allow)]
+        [InlineData(WellKnownSidType.BuiltinUsersSid, FileSystemRights.ReadAndExecute, AccessControlType.Deny)]
+        [InlineData(WellKnownSidType.BuiltinUsersSid, FileSystemRights.WriteData, AccessControlType.Allow)]
+        [InlineData(WellKnownSidType.BuiltinUsersSid, FileSystemRights.WriteData, AccessControlType.Deny)]
         [InlineData(WellKnownSidType.BuiltinUsersSid, FileSystemRights.FullControl, AccessControlType.Allow)]
-        [InlineData(WellKnownSidType.BuiltinUsersSid, FileSystemRights.ReadData, AccessControlType.Allow)]
-        [InlineData(WellKnownSidType.BuiltinUsersSid, FileSystemRights.Write, AccessControlType.Allow)]
-        [InlineData(WellKnownSidType.BuiltinUsersSid, FileSystemRights.Write, AccessControlType.Deny)]
         [InlineData(WellKnownSidType.BuiltinUsersSid, FileSystemRights.FullControl, AccessControlType.Deny)]
         public void DirectoryInfo_Create_DirectorySecurityWithSpecificAccessRule(
             WellKnownSidType sid,
             FileSystemRights rights,
             AccessControlType controlType)
         {
-
             DirectorySecurity security = GetDirectorySecurity(sid, rights, controlType);
             VerifyDirectorySecurity(security);
         }
 
         #endregion
+
+        #region FileInfo Create
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)]
+        public void FileInfo_Create_NullFileInfo()
+        {
+            FileInfo info = null;
+            FileSecurity security = new FileSecurity();
+
+            Assert.Throws<ArgumentNullException>("fileInfo", () =>
+            {
+                if (PlatformDetection.IsFullFramework)
+                {
+                    FileSystemAclExtensions.Create(info, FileMode.Create, FileSystemRights.WriteData, FileShare.Read, DefaultBufferSize, FileOptions.None, security);
+                }
+                else
+                {
+                    info.Create(FileMode.Create, FileSystemRights.WriteData, FileShare.Read, DefaultBufferSize, FileOptions.None, security);
+                }
+            });
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)]
+        public void FileInfo_Create_NullFileSecurity()
+        {
+            FileInfo info = new FileInfo("path");
+
+            Assert.Throws<ArgumentNullException>("fileSecurity", () =>
+            {
+                if (PlatformDetection.IsFullFramework)
+                {
+                    FileSystemAclExtensions.Create(info, FileMode.Create, FileSystemRights.WriteData, FileShare.Read, DefaultBufferSize, FileOptions.None, null);
+                }
+                else
+                {
+                    info.Create(FileMode.Create, FileSystemRights.WriteData, FileShare.Read, DefaultBufferSize, FileOptions.None, null);
+                }
+            });
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)]
+        public void FileInfo_Create_NotFound()
+        {
+            using var directory = new TempDirectory();
+            string path = Path.Combine(directory.Path, Guid.NewGuid().ToString(), "file.txt");
+            FileInfo info = new FileInfo(path);
+            FileSecurity security = new FileSecurity();
+
+            Assert.Throws<DirectoryNotFoundException>(() =>
+            {
+                if (PlatformDetection.IsFullFramework)
+                {
+                    FileSystemAclExtensions.Create(info, FileMode.Create, FileSystemRights.WriteData, FileShare.Read, DefaultBufferSize, FileOptions.None, security);
+                }
+                else
+                {
+                    info.Create(FileMode.Create, FileSystemRights.WriteData, FileShare.Read, DefaultBufferSize, FileOptions.None, security);
+                }
+            });
+        }
+
+        [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)]
+        [InlineData((FileMode)int.MinValue)]
+        [InlineData((FileMode)0)]
+        [InlineData((FileMode)int.MaxValue)]
+        public void FileInfo_Create_FileSecurity_InvalidFileMode(FileMode invalidMode)
+        {
+            FileSecurity security = new FileSecurity();
+            FileInfo info = new FileInfo("path");
+
+            Assert.Throws<ArgumentOutOfRangeException>("mode", () =>
+            {
+                if (PlatformDetection.IsFullFramework)
+                {
+                    FileSystemAclExtensions.Create(info, invalidMode, FileSystemRights.WriteData, FileShare.Read, DefaultBufferSize, FileOptions.None, security); ;
+                }
+                else
+                {
+                    info.Create(invalidMode, FileSystemRights.WriteData, FileShare.Read, DefaultBufferSize, FileOptions.None, security);
+                }
+            });
+        }
+
+        [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)]
+        [InlineData((FileShare)(-1))]
+        [InlineData((FileShare)int.MaxValue)]
+        public void FileInfo_Create_FileSecurity_InvalidFileShare(FileShare invalidFileShare)
+        {
+            FileSecurity security = new FileSecurity();
+            FileInfo info = new FileInfo("path");
+
+            Assert.Throws<ArgumentOutOfRangeException>("share", () =>
+            {
+                if (PlatformDetection.IsFullFramework)
+                {
+                    FileSystemAclExtensions.Create(info, FileMode.Create, FileSystemRights.WriteData, invalidFileShare, DefaultBufferSize, FileOptions.None, security);
+                }
+                else
+                {
+                    info.Create(FileMode.Create, FileSystemRights.WriteData, invalidFileShare, DefaultBufferSize, FileOptions.None, security);
+                }
+            });
+        }
+
+        [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)]
+        [InlineData(int.MinValue)]
+        [InlineData(0)]
+        public void FileInfo_Create_FileSecurity_InvalidBufferSize(int invalidBufferSize)
+        {
+            FileSecurity security = new FileSecurity();
+            FileInfo info = new FileInfo("path");
+
+            Assert.Throws<ArgumentOutOfRangeException>("bufferSize", () =>
+            {
+                if (PlatformDetection.IsFullFramework)
+                {
+                    FileSystemAclExtensions.Create(info, FileMode.Create, FileSystemRights.WriteData, FileShare.Read, invalidBufferSize, FileOptions.None, security);
+                }
+                else
+                {
+                    info.Create(FileMode.Create, FileSystemRights.WriteData, FileShare.Read, invalidBufferSize, FileOptions.None, security);
+                }
+            });
+        }
+
+        [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)]
+        [InlineData(FileMode.Truncate, FileSystemRights.Read)]
+        [InlineData(FileMode.Truncate, FileSystemRights.ReadData)]
+        [InlineData(FileMode.CreateNew, FileSystemRights.Read)]
+        [InlineData(FileMode.CreateNew, FileSystemRights.ReadData)]
+        [InlineData(FileMode.Create, FileSystemRights.Read)]
+        [InlineData(FileMode.Create, FileSystemRights.ReadData)]
+        [InlineData(FileMode.Append, FileSystemRights.Read)]
+        [InlineData(FileMode.Append, FileSystemRights.ReadData)]
+        public void FileInfo_Create_FileSecurity_ForbiddenCombo_FileModeFileSystemSecurity(FileMode mode, FileSystemRights rights)
+        {
+            FileSecurity security = new FileSecurity();
+            FileInfo info = new FileInfo("path");
+
+            Assert.Throws<ArgumentException>(() =>
+            {
+                if (PlatformDetection.IsFullFramework)
+                {
+                    FileSystemAclExtensions.Create(info, mode, rights, FileShare.Read, DefaultBufferSize, FileOptions.None, security);
+                }
+                else
+                {
+                    info.Create(mode, rights, FileShare.Read, DefaultBufferSize, FileOptions.None, security);
+                }
+            });
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)]
+        public void FileInfo_Create_DefaultFileSecurity()
+        {
+            FileSecurity security = new FileSecurity();
+            VerifyFileSecurity(security);
+        }
+
+        [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)]
+        [InlineData(WellKnownSidType.BuiltinUsersSid, FileSystemRights.ReadAndExecute, AccessControlType.Allow)]
+        [InlineData(WellKnownSidType.BuiltinUsersSid, FileSystemRights.ReadAndExecute, AccessControlType.Deny)]
+        [InlineData(WellKnownSidType.BuiltinUsersSid, FileSystemRights.WriteData, AccessControlType.Allow)]
+        [InlineData(WellKnownSidType.BuiltinUsersSid, FileSystemRights.WriteData, AccessControlType.Deny)]
+        [InlineData(WellKnownSidType.BuiltinUsersSid, FileSystemRights.FullControl, AccessControlType.Allow)]
+        [InlineData(WellKnownSidType.BuiltinUsersSid, FileSystemRights.FullControl, AccessControlType.Deny)]
+        public void FileInfo_Create_FileSecurity_SpecificAccessRule(WellKnownSidType sid, FileSystemRights rights, AccessControlType controlType)
+        {
+            FileSecurity security = GetFileSecurity(sid, rights, controlType);
+            VerifyFileSecurity(security);
+        }
+
+        #endregion
+
+        #endregion
+
 
         #region Helper methods
 
@@ -279,24 +494,58 @@ namespace System.IO
         private void VerifyDirectorySecurity(DirectorySecurity expectedSecurity)
         {
             using var directory = new TempDirectory();
-
             string path = Path.Combine(directory.Path, "directory");
             DirectoryInfo info = new DirectoryInfo(path);
 
             info.Create(expectedSecurity);
 
             Assert.True(Directory.Exists(path));
-            Assert.Equal(typeof(FileSystemRights), expectedSecurity.AccessRightType);
 
             DirectoryInfo actualInfo = new DirectoryInfo(info.FullName);
 
             DirectorySecurity actualSecurity = actualInfo.GetAccessControl();
 
-            VerifyDirectoryAccessSecurity(expectedSecurity, actualSecurity);
+            VerifyAccessSecurity(expectedSecurity, actualSecurity);
         }
 
-        private void VerifyDirectoryAccessSecurity(DirectorySecurity expectedSecurity, DirectorySecurity actualSecurity)
+        private FileSecurity GetFileSecurity(WellKnownSidType sid, FileSystemRights rights, AccessControlType controlType)
         {
+            FileSecurity security = new FileSecurity();
+
+            SecurityIdentifier identity = new SecurityIdentifier(sid, null);
+            FileSystemAccessRule accessRule = new FileSystemAccessRule(identity, rights, controlType);
+            security.AddAccessRule(accessRule);
+
+            return security;
+        }
+
+        private void VerifyFileSecurity(FileSecurity expectedSecurity)
+        {
+            VerifyFileSecurity(FileMode.Create, FileSystemRights.WriteData, FileShare.Read, DefaultBufferSize, FileOptions.None, expectedSecurity);
+        }
+
+        private void VerifyFileSecurity(FileMode mode, FileSystemRights rights, FileShare share, int bufferSize, FileOptions options, FileSecurity expectedSecurity)
+        {
+            using var directory = new TempDirectory();
+
+            string path = Path.Combine(directory.Path, "file.txt");
+            FileInfo info = new FileInfo(path);
+
+            info.Create(mode, rights, share, bufferSize, options, expectedSecurity);
+
+            Assert.True(File.Exists(path));
+
+            FileInfo actualInfo = new FileInfo(info.FullName);
+
+            FileSecurity actualSecurity = actualInfo.GetAccessControl();
+
+            VerifyAccessSecurity(expectedSecurity, actualSecurity);
+        }
+
+        private void VerifyAccessSecurity(CommonObjectSecurity expectedSecurity, CommonObjectSecurity actualSecurity)
+        {
+            Assert.Equal(typeof(FileSystemRights), expectedSecurity.AccessRightType);
+
             Assert.Equal(typeof(FileSystemRights), actualSecurity.AccessRightType);
 
             List<FileSystemAccessRule> expectedAccessRules = expectedSecurity.GetAccessRules(includeExplicit: true, includeInherited: false, typeof(SecurityIdentifier))
@@ -305,7 +554,6 @@ namespace System.IO
             List<FileSystemAccessRule> actualAccessRules = actualSecurity.GetAccessRules(includeExplicit: true, includeInherited: false, typeof(SecurityIdentifier))
                 .Cast<FileSystemAccessRule>().ToList();
 
-            // If DirectorySecurity is created without arguments, GetAccessRules will return zero rules
             Assert.Equal(expectedAccessRules.Count, actualAccessRules.Count);
             if (expectedAccessRules.Count > 0)
             {

--- a/src/System.IO.FileSystem/src/System/IO/FileSystem.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileSystem.Windows.cs
@@ -18,8 +18,6 @@ namespace System.IO
 {
     internal static partial class FileSystem
     {
-        internal const int GENERIC_READ = unchecked((int)0x80000000);
-
         public static void CopyFile(string sourceFullPath, string destFullPath, bool overwrite)
         {
             int errorCode = Interop.Kernel32.CopyFile(sourceFullPath, destFullPath, !overwrite);
@@ -32,7 +30,7 @@ namespace System.IO
                 {
                     // For a number of error codes (sharing violation, path not found, etc) we don't know if the problem was with
                     // the source or dest file.  Try reading the source file.
-                    using (SafeFileHandle handle = Interop.Kernel32.CreateFile(sourceFullPath, GENERIC_READ, FileShare.Read, FileMode.Open, 0))
+                    using (SafeFileHandle handle = Interop.Kernel32.CreateFile(sourceFullPath, Interop.Kernel32.GenericOperations.GENERIC_READ, FileShare.Read, FileMode.Open, 0))
                     {
                         if (handle.IsInvalid)
                             fileName = sourceFullPath;

--- a/src/System.IO.FileSystem/tests/FileStream/CopyToAsync.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/CopyToAsync.cs
@@ -238,7 +238,7 @@ namespace System.IO.Tests
                 });
 
                 Assert.True(WaitNamedPipeW(@"\\.\pipe\" + name, -1));
-                using (SafeFileHandle clientHandle = CreateFileW(@"\\.\pipe\" + name, GENERIC_READ, FileShare.None, IntPtr.Zero, FileMode.Open, (int)pipeOptions, IntPtr.Zero))
+                using (SafeFileHandle clientHandle = CreateFileW(@"\\.\pipe\" + name, Interop.Kernel32.GenericOperations.GENERIC_READ, FileShare.None, IntPtr.Zero, FileMode.Open, (int)pipeOptions, IntPtr.Zero))
                 using (var client = new FileStream(clientHandle, FileAccess.Read, bufferSize: 3, isAsync: useAsync))
                 {
                     Task copyTask = client.CopyToAsync(results, (int)totalLength);
@@ -263,7 +263,7 @@ namespace System.IO.Tests
                 Task serverTask = server.WaitForConnectionAsync();
 
                 Assert.True(WaitNamedPipeW(@"\\.\pipe\" + name, -1));
-                using (SafeFileHandle clientHandle = CreateFileW(@"\\.\pipe\" + name, GENERIC_READ, FileShare.None, IntPtr.Zero, FileMode.Open, (int)PipeOptions.Asynchronous, IntPtr.Zero))
+                using (SafeFileHandle clientHandle = CreateFileW(@"\\.\pipe\" + name, Interop.Kernel32.GenericOperations.GENERIC_READ, FileShare.None, IntPtr.Zero, FileMode.Open, (int)PipeOptions.Asynchronous, IntPtr.Zero))
                 using (var client = new FileStream(clientHandle, FileAccess.Read, bufferSize: 3, isAsync: true))
                 {
                     await serverTask;
@@ -329,7 +329,6 @@ namespace System.IO.Tests
             string lpFileName, int dwDesiredAccess, FileShare dwShareMode,
             IntPtr securityAttrs, FileMode dwCreationDisposition, int dwFlagsAndAttributes, IntPtr hTemplateFile);
 
-        internal const int GENERIC_READ = unchecked((int)0x80000000);
         #endregion
     }
 }

--- a/src/System.IO.FileSystem/tests/FileStream/Pipes.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/Pipes.cs
@@ -109,7 +109,7 @@ namespace System.IO.Tests
                 });
 
                 WaitNamedPipeW(@"\\.\pipe\" + name, -1);
-                using (SafeFileHandle clientHandle = CreateFileW(@"\\.\pipe\" + name, GENERIC_WRITE, FileShare.None, IntPtr.Zero, FileMode.Open, (int)PipeOptions.Asynchronous, IntPtr.Zero))
+                using (SafeFileHandle clientHandle = CreateFileW(@"\\.\pipe\" + name, Interop.Kernel32.GenericOperations.GENERIC_WRITE, FileShare.None, IntPtr.Zero, FileMode.Open, (int)PipeOptions.Asynchronous, IntPtr.Zero))
                 using (var client = new FileStream(clientHandle, FileAccess.Write, bufferSize: 3, isAsync: true))
                 {
                     var data = new[] { new byte[] { 0, 1 }, new byte[] { 2, 3 }, new byte[] { 4, 5 } };
@@ -142,7 +142,7 @@ namespace System.IO.Tests
                 });
 
                 WaitNamedPipeW(@"\\.\pipe\" + name, -1);
-                using (SafeFileHandle clientHandle = CreateFileW(@"\\.\pipe\" + name, GENERIC_READ, FileShare.None, IntPtr.Zero, FileMode.Open, (int)PipeOptions.Asynchronous, IntPtr.Zero))
+                using (SafeFileHandle clientHandle = CreateFileW(@"\\.\pipe\" + name, Interop.Kernel32.GenericOperations.GENERIC_READ, FileShare.None, IntPtr.Zero, FileMode.Open, (int)PipeOptions.Asynchronous, IntPtr.Zero))
                 using (var client = new FileStream(clientHandle, FileAccess.Read, bufferSize: 3, isAsync: true))
                 {
                     var arr = new byte[1];
@@ -174,8 +174,6 @@ namespace System.IO.Tests
             string lpFileName, int dwDesiredAccess, FileShare dwShareMode, 
             IntPtr securityAttrs, FileMode dwCreationDisposition, int dwFlagsAndAttributes, IntPtr hTemplateFile);
 
-        internal const int GENERIC_READ = unchecked((int)0x80000000);
-        internal const int GENERIC_WRITE = 0x40000000;
         #endregion
     }
 }

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -166,6 +166,7 @@
     <Compile Include="FileInfo\AppendText.cs" />
     <Compile Include="FileInfo\CopyTo.cs" />
     <!-- Helpers -->
+    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GenericOperations.cs" Link="Common\Interop\Windows\Interop.GenericOperations.cs" />
     <Compile Include="$(CommonTestPath)\System\Buffers\NativeMemoryManager.cs">
       <Link>Common\System\Buffers\NativeMemoryManager.cs</Link>
     </Compile>


### PR DESCRIPTION
Approved API Proposal: #41614
Original PR merged in 5.0: #42099
Related change for directory creation method that takes an ACL: #41834 [merged and ported to 3.1 Prev2]

### Description
We have extension methods in `System.IO.FileSystem.AclExtensions` that let the user get and set ACLs for existing files, but we do not have methods that create files with predefined ACLs.
.NET ACL (Access Control List) support is Windows specific. This change will reside inside the `System.IO.FileSystem.AccessControl` assembly.

### Customer impact
Before this change, customers had to create a file or filestream, then set its ACLs. This presents a few problems:

- Potential security hole as files can be accessed between creation and modification.
- Porting difficulties as there isn't a 1-1 API replacement
- Stability issues with background processes (file filters) can prevent modifying ACLs right after creation (typically surfaces as a security exception).

This change addresses those problems by adding a new extension method that allows creating a file and ensuring the provided ACLs are set during creation.

### Regression
This change will not cause a regression.

### Risk

Medium-Low:
- Customers will only be able to test this change directly in 3.1 GA.
- ACL changes are risky because if they are set incorrectly by our APIs, we cannot fix them via servicing, since the ACLs will already have been written to filesystems everywhere.
- This change did almost no changes to existing codepaths, so the risk is contained inside the new code only.

### Testing
Added unit tests that verify the ACLs were correctly set and the expected exceptions are thrown.
