### PR TITLE
Fix System.Composition.* public key

### DIFF
--- a/src/System.Composition/Directory.Build.props
+++ b/src/System.Composition/Directory.Build.props
@@ -1,6 +1,7 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
+    <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <PackageVersion>1.4.0</PackageVersion>
     <AssemblyVersion>1.0.35.0</AssemblyVersion>
   </PropertyGroup>


### PR DESCRIPTION
Release port of https://github.com/dotnet/corefx/pull/42232.

Fixes #41913

## Description
System.Composition.* shipped in 3.0 with the wrong public key for live built assemblies.  Redistributed assemblies still had correct key.

## Customer Impact
When upgrading the package from 1.2.0 to 1.3.0 customer sees FileLoadException on desktop, or compile error if types are exposed in public surface.  Same issue occurs using only latest when a netstandard1.1 project is consumed by netstandard2.0 compatible project.

## Regression?
Yes, previous release.

## Risk
Low risk to build.  Fix will cause same symptom as original bug, but is necessary for consistency and compatibility with past releases.
