### PR TITLE
Fix for Base64 EncodeToUtf8 / DecodeFromUtf8 with empty input and isFinalBlock: false

### DIFF
--- a/src/System.Memory/src/System/Buffers/Text/Base64Decoder.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Base64Decoder.cs
@@ -39,7 +39,7 @@ namespace System.Buffers.Text
             {
                 bytesConsumed = 0;
                 bytesWritten = 0;
-                return OperationStatus.Done;
+                return isFinalBlock ? OperationStatus.Done : OperationStatus.NeedMoreData;
             }
 
             fixed (byte* srcBytes = &MemoryMarshal.GetReference(utf8))

--- a/src/System.Memory/src/System/Buffers/Text/Base64Encoder.cs
+++ b/src/System.Memory/src/System/Buffers/Text/Base64Encoder.cs
@@ -39,7 +39,7 @@ namespace System.Buffers.Text
             {
                 bytesConsumed = 0;
                 bytesWritten = 0;
-                return OperationStatus.Done;
+                return isFinalBlock ? OperationStatus.Done : OperationStatus.NeedMoreData;
             }
 
             fixed (byte* srcBytes = &MemoryMarshal.GetReference(bytes))

--- a/src/System.Memory/tests/Base64/Base64DecoderUnitTests.cs
+++ b/src/System.Memory/tests/Base64/Base64DecoderUnitTests.cs
@@ -32,14 +32,16 @@ namespace System.Buffers.Text.Tests
             }
         }
 
-        [Fact]
-        public void DecodeEmptySpan()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DecodeEmptySpan(bool isFinalBlock)
         {
             Span<byte> source = Span<byte>.Empty;
             Span<byte> decodedBytes = new byte[Base64.GetMaxDecodedFromUtf8Length(source.Length)];
 
-            Assert.Equal(OperationStatus.Done,
-                Base64.DecodeFromUtf8(source, decodedBytes, out int consumed, out int decodedByteCount));
+            OperationStatus expectedStatus = isFinalBlock ? OperationStatus.Done : OperationStatus.NeedMoreData;
+            Assert.Equal(expectedStatus, Base64.DecodeFromUtf8(source, decodedBytes, out int consumed, out int decodedByteCount, isFinalBlock));
             Assert.Equal(source.Length, consumed);
             Assert.Equal(decodedBytes.Length, decodedByteCount);
             Assert.True(Base64TestHelper.VerifyDecodingCorrectness(source.Length, decodedBytes.Length, source, decodedBytes));

--- a/src/System.Memory/tests/Base64/Base64EncoderUnitTests.cs
+++ b/src/System.Memory/tests/Base64/Base64EncoderUnitTests.cs
@@ -60,13 +60,16 @@ namespace System.Buffers.Text.Tests
             }
         }
 
-        [Fact]
-        public void EncodeEmptySpan()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void EncodeEmptySpan(bool isFinalBlock)
         {
             Span<byte> source = Span<byte>.Empty;
             Span<byte> encodedBytes = new byte[Base64.GetMaxEncodedToUtf8Length(source.Length)];
 
-            Assert.Equal(OperationStatus.Done, Base64.EncodeToUtf8(source, encodedBytes, out int consumed, out int encodedBytesCount));
+            OperationStatus expectedStatus = isFinalBlock ? OperationStatus.Done : OperationStatus.NeedMoreData;
+            Assert.Equal(expectedStatus, Base64.EncodeToUtf8(source, encodedBytes, out int consumed, out int encodedBytesCount, isFinalBlock));
             Assert.Equal(source.Length, consumed);
             Assert.Equal(encodedBytes.Length, encodedBytesCount);
             Assert.True(Base64TestHelper.VerifyEncodingCorrectness(source.Length, encodedBytes.Length, source, encodedBytes));


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/42236

Added test for this case, as there wasn't one + fixed it.