### PR TITLE
[release/3.1] Fix deserialize issue with a large Stream containing a BOM (#42206)

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
@@ -183,7 +183,7 @@ namespace System.Text.Json
                     else if (bytesInBuffer != 0)
                     {
                         // Shift the processed bytes to the beginning of buffer to make more room.
-                        Buffer.BlockCopy(buffer, bytesConsumed, buffer, 0, bytesInBuffer);
+                        Buffer.BlockCopy(buffer, bytesConsumed + start, buffer, 0, bytesInBuffer);
                     }
                 }
             }


### PR DESCRIPTION
Fixes #42145
Original PR merged in 5.0: #42206

### Description
Under these conditions, deserializing either fails with a `JsonException` or will deserialize incorrectly:
- A `Stream`-based deserialize method is used.
- The stream starts with the 3-byte UTF8 BOM (byte order mark).
- The stream contents are larger than the configured buffer size (default is 16K; configured by setting `JsonSerializerOptions.DefaultBufferSize`).

The issue results in 3 extra bytes (the BOM bytes) being added and 3 missing bytes (the end of the first buffer) when the first buffer is exhausted. The end result is a either a silent failure (incorrect deserialization results that contain the wrong bytes) or a `JsonException` (due to those wrong bytes causing the JSON to become invalid).

### Customer impact
Before this change, when the conditions above occur, JSON is unable to be properly deserialized with no viable workarounds other than to remove the 3-byte UTF8 BOM from the Stream or increase the size of the default buffer.

This is a community-reported issue.

### Regression
No.

### Risk
Low. One line of code changed to add the 3-byte offset for when the BOM is first encountered.

### Testing
Test added which reproduces the community-report issue (before the fix).