### PR TITLE
Guard against null refs when attempting to deserialize mismatched JSON into collections

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
@@ -10,7 +10,6 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text.Json.Serialization;
-using System.Text.Json.Serialization.Converters;
 
 namespace System.Text.Json
 {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
@@ -27,23 +27,16 @@ namespace System.Text.Json
             {
                 jsonPropertyInfo = state.Current.JsonClassInfo.CreateRootProperty(options);
             }
-            else if (state.Current.JsonClassInfo.ClassType == ClassType.Unknown)
-            {
-                jsonPropertyInfo = state.Current.JsonClassInfo.GetOrAddPolymorphicProperty(jsonPropertyInfo, typeof(object), options);
-            }
 
-            // Verify that we have a valid enumerable.
-            Type arrayType = jsonPropertyInfo.RuntimePropertyType;
-            if (!typeof(IEnumerable).IsAssignableFrom(arrayType))
+            // Verify that we are processing a valid enumerable or dictionary.
+            if (((ClassType.Enumerable | ClassType.Dictionary) & jsonPropertyInfo.ClassType) == 0)
             {
-                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(arrayType);
+                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(jsonPropertyInfo.RuntimePropertyType);
             }
-
-            Debug.Assert(state.Current.IsProcessingCollection());
 
             if (state.Current.CollectionPropertyInitialized)
             {
-                // A nested json array so push a new stack frame.
+                // An array nested in a dictionary or array, so push a new stack frame.
                 Type elementType = jsonPropertyInfo.ElementClassInfo.Type;
 
                 state.Push();
@@ -52,8 +45,16 @@ namespace System.Text.Json
 
             state.Current.CollectionPropertyInitialized = true;
 
-            // We should not be processing custom converters here (converters are of ClassType.Value).
-            Debug.Assert(state.Current.JsonClassInfo.ClassType != ClassType.Value);
+            // The current JsonPropertyInfo will be null if the current type is not one of
+            // ClassType.Value | ClassType.Enumerable | ClassType.Dictionary.
+            // We should not see ClassType.Value here because we handle it on a different code
+            // path invoked in the main read loop.
+            // Only ClassType.Enumerable is valid here since we just saw a StartArray token.
+            if (state.Current.JsonPropertyInfo == null ||
+                (ClassType.Enumerable & state.Current.JsonPropertyInfo.ClassType) == 0)
+            {
+                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(state.Current.JsonClassInfo.Type);
+            }
 
             // Set or replace the existing enumerable value.
             object value = ReadStackFrame.CreateEnumerableValue(ref state);

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
@@ -51,7 +51,7 @@ namespace System.Text.Json
             // path invoked in the main read loop.
             // Only ClassType.Enumerable is valid here since we just saw a StartArray token.
             if (state.Current.JsonPropertyInfo == null ||
-                (ClassType.Enumerable & state.Current.JsonPropertyInfo.ClassType) == 0)
+                state.Current.JsonPropertyInfo.ClassType != ClassType.Enumerable)
             {
                 ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(state.Current.JsonClassInfo.Type);
             }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleDictionary.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleDictionary.cs
@@ -45,16 +45,9 @@ namespace System.Text.Json
                 }
                 else if (state.Current.IsProcessingObject(ClassType.Object))
                 {
-                    if (classInfo.CreateObject is null)
+                    if (classInfo.CreateObject == null)
                     {
-                        if (classInfo.Type.IsInterface)
-                        {
-                            ThrowHelper.ThrowNotSupportedException_DeserializePolymorphicInterface(classInfo.Type);
-                        }
-                        else
-                        {
-                            ThrowHelper.ThrowNotSupportedException_DeserializeMissingParameterlessConstructor(classInfo.Type);
-                        }
+                        ThrowHelper.ThrowNotSupportedException_DeserializCreateObjectDelegateIsNull(classInfo.Type);
                     }
 
                     state.Current.ReturnValue = classInfo.CreateObject();

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleDictionary.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleDictionary.cs
@@ -22,13 +22,12 @@ namespace System.Text.Json
 
             Debug.Assert(jsonPropertyInfo != null);
 
-            // A nested object or dictionary so push new frame.
+            // A nested object or dictionary, so push new frame.
             if (state.Current.CollectionPropertyInitialized)
             {
                 state.Push();
                 state.Current.JsonClassInfo = jsonPropertyInfo.ElementClassInfo;
                 state.Current.InitializeJsonPropertyInfo();
-                state.Current.CollectionPropertyInitialized = true;
 
                 JsonClassInfo classInfo = state.Current.JsonClassInfo;
 
@@ -42,12 +41,14 @@ namespace System.Text.Json
                         state.Current.ReturnValue = dictValue;
                         state.Current.DetermineIfDictionaryCanBePopulated(state.Current.ReturnValue);
                     }
+
+                    state.Current.CollectionPropertyInitialized = true;
                 }
                 else if (state.Current.IsProcessingObject(ClassType.Object))
                 {
                     if (classInfo.CreateObject == null)
                     {
-                        ThrowHelper.ThrowNotSupportedException_DeserializCreateObjectDelegateIsNull(classInfo.Type);
+                        ThrowHelper.ThrowNotSupportedException_DeserializeCreateObjectDelegateIsNull(classInfo.Type);
                     }
 
                     state.Current.ReturnValue = classInfo.CreateObject();

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleObject.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleObject.cs
@@ -56,9 +56,9 @@ namespace System.Text.Json
             }
             else if (state.Current.IsProcessingObject(ClassType.Object))
             {
-                if (classInfo.CreateObject is null)
+                if (classInfo.CreateObject == null)
                 {
-                    ThrowHelper.ThrowNotSupportedException_DeserializCreateObjectDelegateIsNull(classInfo.Type);
+                    ThrowHelper.ThrowNotSupportedException_DeserializeCreateObjectDelegateIsNull(classInfo.Type);
                 }
 
                 state.Current.ReturnValue = classInfo.CreateObject();

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -37,13 +37,10 @@ namespace System.Text.Json
 
                 state.Current.KeyName = reader.GetString();
             }
-            else if (state.Current.JsonClassInfo.ClassType == ClassType.Value)
-            {
-                // We should be in a converter, thus we must have bad JSON.
-                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(state.Current.JsonPropertyInfo.RuntimePropertyType);
-            }
             else
             {
+                Debug.Assert(state.Current.JsonClassInfo.ClassType == ClassType.Object);
+
                 state.Current.EndProperty();
 
                 ReadOnlySpan<byte> propertyName = reader.HasValueSequence ? reader.ValueSequence.ToArray() : reader.ValueSpan;

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
@@ -186,16 +186,6 @@ namespace System.Text.Json
         {
             JsonPropertyInfo jsonPropertyInfo = state.Current.JsonPropertyInfo;
 
-            if (jsonPropertyInfo == null)
-            {
-                Debug.Assert(state.Current.JsonClassInfo != null);
-                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(state.Current.JsonClassInfo.Type);
-            }
-            else if (jsonPropertyInfo.ClassType != ClassType.Enumerable)
-            {
-                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(jsonPropertyInfo.RuntimePropertyType);
-            }
-
             // If the property has an EnumerableConverter, then we use tempEnumerableValues.
             if (jsonPropertyInfo.EnumerableConverter != null)
             {
@@ -240,16 +230,6 @@ namespace System.Text.Json
         public static object CreateDictionaryValue(ref ReadStack state)
         {
             JsonPropertyInfo jsonPropertyInfo = state.Current.JsonPropertyInfo;
-
-            if (jsonPropertyInfo == null)
-            {
-                Debug.Assert(state.Current.JsonClassInfo != null);
-                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(state.Current.JsonClassInfo.Type);
-            }
-            else if (jsonPropertyInfo.ClassType != ClassType.Dictionary)
-            {
-                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(jsonPropertyInfo.RuntimePropertyType);
-            }
 
             // If the property has a DictionaryConverter, then we use tempDictionaryValues.
             if (jsonPropertyInfo.DictionaryConverter != null)

--- a/src/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -247,7 +247,7 @@ namespace System.Text.Json
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static void ThrowNotSupportedException_DeserializCreateObjectDelegateIsNull(Type invalidType)
+        public static void ThrowNotSupportedException_DeserializeCreateObjectDelegateIsNull(Type invalidType)
         {
             if (invalidType.IsInterface)
             {

--- a/src/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -247,15 +247,16 @@ namespace System.Text.Json
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static void ThrowNotSupportedException_DeserializeMissingParameterlessConstructor(Type invalidType)
+        public static void ThrowNotSupportedException_DeserializCreateObjectDelegateIsNull(Type invalidType)
         {
-            throw new NotSupportedException(SR.Format(SR.DeserializeMissingParameterlessConstructor, invalidType));
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        public static void ThrowNotSupportedException_DeserializePolymorphicInterface(Type invalidType)
-        {
-            throw new NotSupportedException(SR.Format(SR.DeserializePolymorphicInterface, invalidType));
+            if (invalidType.IsInterface)
+            {
+                throw new NotSupportedException(SR.Format(SR.DeserializePolymorphicInterface, invalidType));
+            }
+            else
+            {
+                throw new NotSupportedException(SR.Format(SR.DeserializeMissingParameterlessConstructor, invalidType));
+            }
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -247,13 +247,13 @@ namespace System.Text.Json
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static void ThrowInvalidOperationException_DeserializeMissingParameterlessConstructor(Type invalidType)
+        public static void ThrowNotSupportedException_DeserializeMissingParameterlessConstructor(Type invalidType)
         {
             throw new NotSupportedException(SR.Format(SR.DeserializeMissingParameterlessConstructor, invalidType));
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static void ThrowInvalidOperationException_DeserializePolymorphicInterface(Type invalidType)
+        public static void ThrowNotSupportedException_DeserializePolymorphicInterface(Type invalidType)
         {
             throw new NotSupportedException(SR.Format(SR.DeserializePolymorphicInterface, invalidType));
         }

--- a/src/System.Text.Json/tests/NewtonsoftTests/CustomObjectConverterTests.cs
+++ b/src/System.Text.Json/tests/NewtonsoftTests/CustomObjectConverterTests.cs
@@ -158,17 +158,32 @@ namespace System.Text.Json.Tests
         [Fact]
         public void AssertDoesNotDeserializeInterface()
         {
-            const string json = @"[{
+            const string validJson = @"[{
 ""Value"": ""A value"",
 ""Thing"": {
 ""Number"": 123
 }
 ]";
-            NotSupportedException e = Assert.Throws<NotSupportedException>(() =>
+            NotSupportedException nse = Assert.Throws<NotSupportedException>(() =>
             {
-                JsonSerializer.Deserialize<List<MyClass>>(json);
+                JsonSerializer.Deserialize<List<MyClass>>(validJson);
             });
-            Assert.Equal("Deserialization of interface types is not supported. Type 'System.Text.Json.Tests.IThing'", e.Message);
+            Assert.Equal("Deserialization of interface types is not supported. Type 'System.Text.Json.Tests.IThing'", nse.Message);
+
+            const string invalidJson = @"{
+""Value"": ""A value"",
+""Thing"": {
+""Number"": 123
+}
+";
+            JsonException je = Assert.Throws<JsonException>(() =>
+            {
+                JsonSerializer.Deserialize<List<MyClass>>(invalidJson);
+            });
+
+            Assert.Equal(
+                "The JSON value could not be converted to System.Collections.Generic.List`1[System.Text.Json.Tests.MyClass]. Path: $ | LineNumber: 0 | BytePositionInLine: 1.",
+                je.Message);
         }
     }
 

--- a/src/System.Text.Json/tests/NewtonsoftTests/CustomObjectConverterTests.cs
+++ b/src/System.Text.Json/tests/NewtonsoftTests/CustomObjectConverterTests.cs
@@ -158,12 +158,12 @@ namespace System.Text.Json.Tests
         [Fact]
         public void AssertDoesNotDeserializeInterface()
         {
-            const string json = @"{
+            const string json = @"[{
 ""Value"": ""A value"",
 ""Thing"": {
 ""Number"": 123
 }
-}";
+]";
             NotSupportedException e = Assert.Throws<NotSupportedException>(() =>
             {
                 JsonSerializer.Deserialize<List<MyClass>>(json);

--- a/src/System.Text.Json/tests/NewtonsoftTests/CustomObjectConverterTests.cs
+++ b/src/System.Text.Json/tests/NewtonsoftTests/CustomObjectConverterTests.cs
@@ -158,32 +158,28 @@ namespace System.Text.Json.Tests
         [Fact]
         public void AssertDoesNotDeserializeInterface()
         {
-            const string validJson = @"[{
-""Value"": ""A value"",
-""Thing"": {
-""Number"": 123
-}
-]";
+            const string validJson =
+                @"[{
+                    ""Value"": ""A value"",
+                    ""Thing"": {
+                        ""Number"": 123
+                    }
+                }]";
             NotSupportedException nse = Assert.Throws<NotSupportedException>(() =>
             {
                 JsonSerializer.Deserialize<List<MyClass>>(validJson);
             });
             Assert.Equal("Deserialization of interface types is not supported. Type 'System.Text.Json.Tests.IThing'", nse.Message);
 
-            const string invalidJson = @"{
-""Value"": ""A value"",
-""Thing"": {
-""Number"": 123
-}
-";
-            JsonException je = Assert.Throws<JsonException>(() =>
-            {
-                JsonSerializer.Deserialize<List<MyClass>>(invalidJson);
-            });
+            const string invalidJson =
+                @"{
+                    ""Value"": ""A value"",
+                    ""Thing"": {
+                        ""Number"": 123
+                    }
+                }";
 
-            Assert.Equal(
-                "The JSON value could not be converted to System.Collections.Generic.List`1[System.Text.Json.Tests.MyClass]. Path: $ | LineNumber: 0 | BytePositionInLine: 1.",
-                je.Message);
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<List<MyClass>>(invalidJson));
         }
     }
 

--- a/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
+++ b/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
@@ -5,6 +5,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Reflection;
 using System.Text.Encodings.Web;
 using Xunit;
 
@@ -320,17 +321,201 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize(json, type));
         }
 
-        public class ClassWithArray
+        public static IEnumerable<string> InvalidJsonForIntValue()
         {
-            public int[] MyArray { get; set; }
+            yield return @"""1""" ;
+            yield return "[";
+            yield return "}";
+            yield return @"[""1""]";
+            yield return "[true]";
         }
 
-        public class ClassWithDictionary
+        public static IEnumerable<string> InvalidJsonForPoco()
         {
-            public Dictionary<string, int[]> MyDictionary { get; set; }
+            foreach (string value in InvalidJsonForIntValue())
+            {
+                yield return value;
+                yield return "[" + value + "]";
+                yield return "{" + value + "}";
+                yield return @"{""Id"":" + value + "}";
+            }
+        }
+
+        public class ClassWithInt
+        {
+            public int Obj { get; set; }
+        }
+
+        public class ClassWithIntList
+        {
+            public List<int> Obj { get; set; }
+        }
+
+        public class ClassWithIntArray
+        {
+            public int[] Obj { get; set; }
+        }
+
+        public class ClassWithPoco
+        {
+            public Poco Obj { get; set; }
+        }
+
+        public class ClassWithPocoArray
+        {
+            public Poco[] Obj { get; set; }
+        }
+
+        public class ClassWithDictionaryOfIntArray
+        {
+            public Dictionary<string, int[]> Obj { get; set; }
+        }
+
+        public class ClassWithDictionaryOfPoco
+        {
+            public Dictionary<string, Poco> Obj { get; set; }
+        }
+
+        public class ClassWithDictionaryOfPocoList
+        {
+            public Dictionary<string, List<Poco>> Obj { get; set; }
+        }
+
+        public static IEnumerable<Type> TypesForInvalidJsonForCollectionTests()
+        {
+            static Type MakeClosedCollectionType(Type openCollectionType, Type elementType)
+            {
+                if (openCollectionType == typeof(Dictionary<,>))
+                {
+                    return typeof(Dictionary<,>).MakeGenericType(typeof(string), elementType);
+                }
+                else
+                {
+                    return openCollectionType.MakeGenericType(elementType);
+                }
+            }
+
+            Type[] elementTypes = new Type[]
+            {
+                typeof(int),
+                typeof(Poco),
+                typeof(ClassWithInt),
+                typeof(ClassWithIntList),
+                typeof(ClassWithPoco),
+                typeof(ClassWithPocoArray),
+                typeof(ClassWithDictionaryOfIntArray),
+                typeof(ClassWithDictionaryOfPoco),
+                typeof(ClassWithDictionaryOfPocoList),
+            };
+
+            Type[] collectionTypes = new Type[]
+            {
+                typeof(List<>),
+                typeof(Dictionary<,>),
+            };
+
+            foreach (Type type in elementTypes)
+            {
+                yield return type;
+            }
+
+            List<Type> innerTypes = new List<Type>(elementTypes);
+
+            // Create permutations of collections with 1 and 2 levels of nesting.
+            for (int i = 0; i < 2; i++)
+            {
+                foreach (Type collectionType in collectionTypes)
+                {
+                    List<Type> newInnerTypes = new List<Type>();
+
+                    foreach (Type elementType in innerTypes)
+                    {
+                        Type newCollectionType = MakeClosedCollectionType(collectionType, elementType);
+                        newInnerTypes.Add(newCollectionType);
+                        yield return newCollectionType;
+                    }
+
+                    innerTypes = newInnerTypes;
+                }
+            }
+        }
+
+        static IEnumerable<string> GetInvalidJsonStringsForType(Type type)
+        {
+            if (type == typeof(int))
+            {
+                foreach (string json in InvalidJsonForIntValue())
+                {
+                    yield return json;
+                }
+                yield break;
+            }
+
+            if (type == typeof(Poco))
+            {
+                foreach (string json in InvalidJsonForPoco())
+                {
+                    yield return json;
+                }
+                yield break;
+            }
+
+            Type elementType;
+
+            if (!typeof(IEnumerable).IsAssignableFrom(type))
+            {
+                // Get type of "Obj" property.
+                elementType = type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)[0].PropertyType;
+            }
+            else if (type.IsArray)
+            {
+                elementType = type.GetElementType();
+            }
+            else if (!type.IsGenericType)
+            {
+                Assert.True(false, "Expected generic type");
+                yield break;
+            }
+            else
+            {
+                Type genericTypeDef = type.GetGenericTypeDefinition();
+
+                if (genericTypeDef == typeof(List<>))
+                {
+                    elementType = type.GetGenericArguments()[0];
+                }
+                else if (genericTypeDef == typeof(Dictionary<,>))
+                {
+                    elementType = type.GetGenericArguments()[1];
+                }
+                else
+                {
+                    Assert.True(false, "Expected List or Dictionary type");
+                    yield break;
+                }
+            }
+
+            foreach (string invalidJson in GetInvalidJsonStringsForType(elementType))
+            {
+                yield return "[" + invalidJson + "]";
+                yield return "{" + invalidJson + "}";
+                yield return @"{""Obj"":" + invalidJson + "}";
+            }
+        }
+
+        public static IEnumerable<object[]> DataForInvalidJsonForTypeTests()
+        {
+            foreach (Type type in TypesForInvalidJsonForCollectionTests())
+            {
+                foreach (string invalidJson in GetInvalidJsonStringsForType(type))
+                {
+                    yield return new object[] { type, invalidJson };
+                }
+            }
         }
 
         [Theory]
+        [MemberData(nameof(DataForInvalidJsonForTypeTests))]
         [InlineData(typeof(int[]), @"""test""")]
         [InlineData(typeof(int[]), @"1")]
         [InlineData(typeof(int[]), @"false")]
@@ -353,18 +538,18 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": [[]]}")]
         [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": [true]}")]
         [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": [{}]}")]
-        [InlineData(typeof(ClassWithArray), @"{""MyArray"": ""test""}")]
-        [InlineData(typeof(ClassWithArray), @"{""MyArray"": 1}")]
-        [InlineData(typeof(ClassWithArray), @"{""MyArray"": false}")]
-        [InlineData(typeof(ClassWithArray), @"{""MyArray"": {}}")]
-        [InlineData(typeof(ClassWithArray), @"{""MyArray"": {""test"": 1}}")]
-        [InlineData(typeof(ClassWithArray), @"{""MyArray"": [""test""}")]
-        [InlineData(typeof(ClassWithArray), @"{""MyArray"": [""test""]}")]
-        [InlineData(typeof(ClassWithArray), @"{""MyArray"": [true]}")]
-        [InlineData(typeof(ClassWithArray), @"{""MyArray"": [{}]}")]
-        [InlineData(typeof(ClassWithArray), @"{""MyArray"": [[]]}")]
-        [InlineData(typeof(ClassWithArray), @"{""MyArray"": [{""test"": 1}]}")]
-        [InlineData(typeof(ClassWithArray), @"{""MyArray"": [[true]]}")]
+        [InlineData(typeof(ClassWithIntArray), @"{""Obj"": ""test""}")]
+        [InlineData(typeof(ClassWithIntArray), @"{""Obj"": 1}")]
+        [InlineData(typeof(ClassWithIntArray), @"{""Obj"": false}")]
+        [InlineData(typeof(ClassWithIntArray), @"{""Obj"": {}}")]
+        [InlineData(typeof(ClassWithIntArray), @"{""Obj"": {""test"": 1}}")]
+        [InlineData(typeof(ClassWithIntArray), @"{""Obj"": [""test""}")]
+        [InlineData(typeof(ClassWithIntArray), @"{""Obj"": [""test""]}")]
+        [InlineData(typeof(ClassWithIntArray), @"{""Obj"": [true]}")]
+        [InlineData(typeof(ClassWithIntArray), @"{""Obj"": [{}]}")]
+        [InlineData(typeof(ClassWithIntArray), @"{""Obj"": [[]]}")]
+        [InlineData(typeof(ClassWithIntArray), @"{""Obj"": [{""test"": 1}]}")]
+        [InlineData(typeof(ClassWithIntArray), @"{""Obj"": [[true]]}")]
         [InlineData(typeof(Dictionary<string, string>), @"""test""")]
         [InlineData(typeof(Dictionary<string, string>), @"1")]
         [InlineData(typeof(Dictionary<string, string>), @"false")]
@@ -378,22 +563,33 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData(typeof(Dictionary<string, string>), @"[[]]")]
         [InlineData(typeof(Dictionary<string, string>), @"[{""test"": 1}]")]
         [InlineData(typeof(Dictionary<string, string>), @"[[true]]")]
-        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":""test""}")]
-        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":1}")]
-        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":false}")]
-        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":{"""": 1}}")]
-        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":{"""": {}}}")]
-        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":{"""": {"""":""""}}}")]
-        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":[""test""}")]
-        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":[""test""]}")]
-        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":[true]}")]
-        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":[{}]}")]
-        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":[[]]}")]
-        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":[{""test"": 1}]}")]
-        [InlineData(typeof(ClassWithDictionary), @"{""MyDictionary"":[[true]]}")]
-        public static void InvalidJsonForTypeShouldFail(Type type, string json)
+        [InlineData(typeof(ClassWithDictionaryOfIntArray), @"{""Obj"":""test""}")]
+        [InlineData(typeof(ClassWithDictionaryOfIntArray), @"{""Obj"":1}")]
+        [InlineData(typeof(ClassWithDictionaryOfIntArray), @"{""Obj"":false}")]
+        [InlineData(typeof(ClassWithDictionaryOfIntArray), @"{""Obj"":{"""": 1}}")]
+        [InlineData(typeof(ClassWithDictionaryOfIntArray), @"{""Obj"":{"""": {}}}")]
+        [InlineData(typeof(ClassWithDictionaryOfIntArray), @"{""Obj"":{"""": {"""":""""}}}")]
+        [InlineData(typeof(ClassWithDictionaryOfIntArray), @"{""Obj"":[""test""}")]
+        [InlineData(typeof(ClassWithDictionaryOfIntArray), @"{""Obj"":[""test""]}")]
+        [InlineData(typeof(ClassWithDictionaryOfIntArray), @"{""Obj"":[true]}")]
+        [InlineData(typeof(ClassWithDictionaryOfIntArray), @"{""Obj"":[{}]}")]
+        [InlineData(typeof(ClassWithDictionaryOfIntArray), @"{""Obj"":[[]]}")]
+        [InlineData(typeof(ClassWithDictionaryOfIntArray), @"{""Obj"":[{""test"": 1}]}")]
+        [InlineData(typeof(ClassWithDictionaryOfIntArray), @"{""Obj"":[[true]]}")]
+        [InlineData(typeof(Dictionary<string, Poco>), @"{""key"":[{""Id"":3}]}")]
+        [InlineData(typeof(Dictionary<string, Poco>), @"{""key"":[""test""]}")]
+        [InlineData(typeof(Dictionary<string, Poco>), @"{""key"":[1]}")]
+        [InlineData(typeof(Dictionary<string, Poco>), @"{""key"":[false]}")]
+        [InlineData(typeof(Dictionary<string, Poco>), @"{""key"":[]}")]
+        [InlineData(typeof(Dictionary<string, Poco>), @"{""key"":1}")]
+        [InlineData(typeof(Dictionary<string, List<Poco>>), @"{""key"":{""Id"":3}}")]
+        [InlineData(typeof(Dictionary<string, List<Poco>>), @"{""key"":{}}")]
+        [InlineData(typeof(Dictionary<string, List<Poco>>), @"{""key"":[[]]}")]
+        [InlineData(typeof(Dictionary<string, Dictionary<string, Poco>>), @"{""key"":[]}")]
+        [InlineData(typeof(Dictionary<string, Dictionary<string, Poco>>), @"{""key"":1}")]
+        public static void InvalidJsonForTypeShouldFail(Type type, string invalidJson)
         {
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize(json, type));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize(invalidJson, type));
         }
 
         [Fact]
@@ -1807,6 +2003,17 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(1, dictionary["One"].Id);
             Assert.Equal(2, dictionary["Two"].Id);
             Assert.Throws<NotSupportedException>(() => JsonSerializer.Serialize(dictionary));
+        }
+
+        public class ClassWithoutParameterlessCtor
+        {
+            public ClassWithoutParameterlessCtor(int num) { }
+        }
+
+        [Fact]
+        public static void DictionaryWith_ObjectWithNoParameterlessCtor_AsValue_Throws()
+        {
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<Dictionary<string, ClassWithoutParameterlessCtor>>(@"{""key"":{}}"));
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/PolymorphicTests.cs
+++ b/src/System.Text.Json/tests/Serialization/PolymorphicTests.cs
@@ -448,7 +448,19 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void GenericListOfInterface_WithValidJson_ThrowsNotSupportedException()
         {
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<MyThingCollection>("{}"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<MyThingCollection>("[{}]"));
+        }
+
+        [Fact]
+        public static void GenericDictionaryOfInterface_WithInvalidJson_ThrowsJsonException()
+        {
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<MyThingDictionary>(@"{"""":1}"));
+        }
+
+        [Fact]
+        public static void GenericDictionaryOfInterface_WithValidJson_ThrowsNotSupportedException()
+        {
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<MyThingDictionary>(@"{"""":{}}"));
         }
 
         class MyClass
@@ -468,5 +480,7 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         class MyThingCollection : List<IThing> { }
+
+        class MyThingDictionary : Dictionary<string, IThing> { }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/PolymorphicTests.cs
+++ b/src/System.Text.Json/tests/Serialization/PolymorphicTests.cs
@@ -443,6 +443,7 @@ namespace System.Text.Json.Serialization.Tests
         public static void GenericListOfInterface_WithInvalidJson_ThrowsJsonException()
         {
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<MyThingCollection>("false"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<MyThingCollection>("{}"));
         }
 
         [Fact]

--- a/src/System.Text.Json/tests/Serialization/TestClasses.NonGenericCollections.cs
+++ b/src/System.Text.Json/tests/Serialization/TestClasses.NonGenericCollections.cs
@@ -180,7 +180,7 @@ namespace System.Text.Json.Serialization.Tests
         }
     }
 
-    public class ReadOnlyWrapperForIlist : WrapperForIList
+    public class ReadOnlyWrapperForIList : WrapperForIList
     {
         public override bool IsReadOnly => true;
     }

--- a/src/System.Text.Json/tests/Serialization/TestClasses.NonGenericCollections.cs
+++ b/src/System.Text.Json/tests/Serialization/TestClasses.NonGenericCollections.cs
@@ -180,6 +180,11 @@ namespace System.Text.Json.Serialization.Tests
         }
     }
 
+    public class ReadOnlyWrapperForIlist : WrapperForIList
+    {
+        public override bool IsReadOnly => true;
+    }
+
     public class WrapperForIList : IList
     {
         private readonly List<object> _list = new List<object>();
@@ -188,7 +193,7 @@ namespace System.Text.Json.Serialization.Tests
 
         public bool IsFixedSize => ((IList)_list).IsFixedSize;
 
-        public bool IsReadOnly => ((IList)_list).IsReadOnly;
+        public virtual bool IsReadOnly => ((IList)_list).IsReadOnly;
 
         public int Count => _list.Count;
 

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
@@ -1150,6 +1150,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadReadOnlyCollections_Throws()
         {
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ReadOnlyWrapperForIlist>(@"[""1"", ""2""]"));
             Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ReadOnlyStringIListWrapper>(@"[""1"", ""2""]"));
             Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ReadOnlyStringICollectionWrapper>(@"[""1"", ""2""]"));
             Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ReadOnlyStringToStringIDictionaryWrapper>(@"{""Key"":""key"",""Value"":""value""}"));

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
@@ -1150,7 +1150,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadReadOnlyCollections_Throws()
         {
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ReadOnlyWrapperForIlist>(@"[""1"", ""2""]"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ReadOnlyWrapperForIList>(@"[""1"", ""2""]"));
             Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ReadOnlyStringIListWrapper>(@"[""1"", ""2""]"));
             Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ReadOnlyStringICollectionWrapper>(@"[""1"", ""2""]"));
             Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ReadOnlyStringToStringIDictionaryWrapper>(@"{""Key"":""key"",""Value"":""value""}"));


### PR DESCRIPTION
Addresses https://github.com/dotnet/corefx/issues/42143 for 5.0, and introduces further guards for null refs thrown when parsing mismatched Json into various combinations and nesting levels of collections and objects.

Also guards against null refs when trying to deserialize dictionaries with custom (not supported) interfaces and objects without parameterless ctors. We now throw `NotSupportedException`.

Some dead code is removed. The reasoning/validation is provided in the review comments.