### PR TITLE
Prevent DivideByZeroException in EventCounter.ToString()

### DIFF
--- a/src/Common/src/CoreLib/System/Diagnostics/Tracing/EventCounter.cs
+++ b/src/Common/src/CoreLib/System/Diagnostics/Tracing/EventCounter.cs
@@ -56,7 +56,7 @@ namespace System.Diagnostics.Tracing
             Enqueue(value);
         }
 
-        public override string ToString() => $"EventCounter '{Name}' Count {_count} Mean {(_sum / _count).ToString("n3")}";
+        public override string ToString() => $"EventCounter '{Name}' Count {_count} Mean {(_count == 0 ? "" : (_sum / _count).ToString("n3"))}";
 
         #region Statistics Calculation
 


### PR DESCRIPTION
Maybe it should print something other than 0. Maybe "Mean" should be excluded. But at least with this it doesn't divide by zero.