### PR TITLE
Add new method for parameterless Listen()

### DIFF
--- a/src/System.Net.Sockets/ref/System.Net.Sockets.cs
+++ b/src/System.Net.Sockets/ref/System.Net.Sockets.cs
@@ -312,6 +312,7 @@ namespace System.Net.Sockets
         public byte[] GetSocketOption(System.Net.Sockets.SocketOptionLevel optionLevel, System.Net.Sockets.SocketOptionName optionName, int optionLength) { throw null; }
         public int IOControl(int ioControlCode, byte[] optionInValue, byte[] optionOutValue) { throw null; }
         public int IOControl(System.Net.Sockets.IOControlCode ioControlCode, byte[] optionInValue, byte[] optionOutValue) { throw null; }
+        public void Listen() { }
         public void Listen(int backlog) { }
         public bool Poll(int microSeconds, System.Net.Sockets.SelectMode mode) { throw null; }
         public int Receive(byte[] buffer) { throw null; }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -945,7 +945,15 @@ namespace System.Net.Sockets
             if (NetEventSource.IsEnabled) NetEventSource.Exit(this, timeout);
         }
 
-        // Places a socket in a listening state.
+        /// <summary>
+        /// Places a <see cref="Socket"/> in a listening state.
+        /// </summary>
+        public void Listen() => Listen(int.MaxValue);
+
+        /// <summary>
+        /// Places a <see cref="Socket"/> in a listening state.
+        /// </summary>
+        /// <param name="backlog">The maximum length of the pending connections queue.</param>
         public void Listen(int backlog)
         {
             if (NetEventSource.IsEnabled) NetEventSource.Enter(this, backlog);

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -948,6 +948,9 @@ namespace System.Net.Sockets
         /// <summary>
         /// Places a <see cref="Socket"/> in a listening state.
         /// </summary>
+        /// <remarks>
+        /// The maximum length of the pending connections queue will be determined automatically.
+        /// </remarks>
         public void Listen() => Listen(int.MaxValue);
 
         /// <summary>

--- a/src/System.Net.Sockets/tests/FunctionalTests/CreateSocketTests.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/CreateSocketTests.cs
@@ -134,7 +134,7 @@ namespace System.Net.Sockets.Tests
                 using (var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
                 {
                     listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
-                    listener.Listen(int.MaxValue);
+                    listener.Listen();
                     EndPoint ep = listener.LocalEndPoint;
 
                     // Create a client and connect to that listener.

--- a/src/System.Net.Sockets/tests/FunctionalTests/DisposedSocketTests.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DisposedSocketTests.cs
@@ -303,6 +303,7 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void Listen_Throws_ObjectDisposed()
         {
+            Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().Listen());
             Assert.Throws<ObjectDisposedException>(() => GetDisposedSocket().Listen(1));
         }
 

--- a/src/System.Net.Sockets/tests/FunctionalTests/DisposedSocketTests.netcoreapp.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DisposedSocketTests.netcoreapp.cs
@@ -34,7 +34,7 @@ namespace System.Net.Sockets.Tests
             using (var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
             {
                 listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
-                listener.Listen(int.MaxValue);
+                listener.Listen();
 
                 for (int i = 0; i < 100; i++)
                 {

--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -425,7 +425,7 @@ namespace System.Net.Sockets.Tests
                 a.ExclusiveAddressUse = true;
 
                 a.Bind(new IPEndPoint(IPAddress.Loopback, 0));
-                a.Listen(10);
+                a.Listen();
                 int port = (a.LocalEndPoint as IPEndPoint).Port;
 
                 using (Socket b = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
@@ -531,7 +531,7 @@ namespace System.Net.Sockets.Tests
             {
                 a.Bind(new IPEndPoint(IPAddress.Loopback, 0));
                 port = (a.LocalEndPoint as IPEndPoint).Port;
-                a.Listen(10);
+                a.Listen();
 
                 // Connect a client
                 using (Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))


### PR DESCRIPTION
This adds a parameterless overload for Listen(int) which passes in int.MaxValue as the default value. I changed existing tests that were explicitly using int.MaxValue or a random value to use the new overload with no parameter.

Fixes https://github.com/dotnet/corefx/issues/9680