### PR TITLE
Fix ILLink when run from VS/desktop/direct

### DIFF
--- a/eng/illink.targets
+++ b/eng/illink.targets
@@ -120,12 +120,22 @@
       <ILLinkArgs Condition="@(_DependencyDirectories->Count()) > 0">$(ILLinkArgs) -d @(_DependencyDirectories->'"%(Identity)"', ' -d ')</ILLinkArgs>
     </PropertyGroup>
 
+    <!-- When running from Desktop MSBuild, DOTNET_HOST_PATH is not set.
+         In this case, explicitly specify the path to the dotnet host. -->
+    <PropertyGroup Condition=" '$(DOTNET_HOST_PATH)' == '' ">
+      <_DotNetHostDirectory>$(NetCoreRoot)</_DotNetHostDirectory>
+      <_DotNetHostFileName>dotnet</_DotNetHostFileName>
+      <_DotNetHostFileName Condition=" '$(OS)' == 'Windows_NT' ">dotnet.exe</_DotNetHostFileName>
+    </PropertyGroup>
+    
     <ILLink AssemblyPaths="$(ILLinkTrimInputAssembly)"
             RootAssemblyNames=""
             OutputDirectory="$(ILLinkTrimOutputPath)"
             ClearInitLocals="$(ILLinkClearInitLocals)"
             ClearInitLocalsAssemblies="$(TargetName)"
-            ExtraArgs="$(ILLinkArgs)" />
+            ExtraArgs="$(ILLinkArgs)"
+            ToolExe="$(_DotNetHostFileName)"
+            ToolPath="$(_DotNetHostDirectory)" />
 
   </Target>
 


### PR DESCRIPTION
ILLink needs the path to dotnet.exe and was relying on an optional
environment variable to find it.

Instead use the NetCoreRoot property set by the SDK.

This is a direct copy of
https://github.com/dotnet/sdk/blob/b28a8efbfb30d84019351abb3aa9a2b15e008662/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets#L74-L80

We should try to eliminate our custom illink.targets and just configure
the built in ones if we can.