### PR TITLE
Use PackageLicenseExpression instead of URL

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -197,13 +197,6 @@
 
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
-  <PropertyGroup Condition="'$(CopyrightNetFoundation)' != ''">
-    <Copyright>$(CopyrightNetFoundation)</Copyright>
-    <!-- Temporarily disable PackageLicenseExpression until we can workaround 
-         https://github.com/NuGet/Home/issues/7894 -->
-    <!-- PackageLicenseExpression>MIT</PackageLicenseExpression -->
-  </PropertyGroup>
-
   <!-- Import packaging props -->
   <Import Project="$(RepositoryEngineeringDir)Packaging.props" />
 

--- a/eng/Packaging.props
+++ b/eng/Packaging.props
@@ -6,7 +6,8 @@
     <RuntimeIdGraphDefinitionFile>$(RepoRoot)pkg/Microsoft.NETCore.Platforms/runtime.json</RuntimeIdGraphDefinitionFile>
     <ReleaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</ReleaseNotes>
     <ProjectUrl>https://github.com/dotnet/corefx</ProjectUrl>
-    <LicenseUrl>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</LicenseUrl>
+    <Copyright>$(CopyrightNetFoundation)</Copyright>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <!-- defined in buildtools packaging.targets, but we need this before targets are imported -->
     <PackagePlatform Condition="'$(PackagePlatform)' == ''">$(Platform)</PackagePlatform>
     <PackagePlatform Condition="'$(PackagePlatform)' == 'amd64'">x64</PackagePlatform>


### PR DESCRIPTION
Fixes #42264

## Description
Package licenses refer to the corefx repository URL.  We intended to adopt the new feature earlier this release but had to roll it back due to a bug in NuGet.  We never undid the rollback after introducing a workaround.

## Customer Impact
NuGet doesn't classify our license as MIT, URL may be disrupted by repo-consolidation resulting in broken links resulting in 404's in the future.

## Regression?
No

## Risk
Low.  This is a build/package-metadata-only change.  If it builds it should be good, other parts of the stack have been using this feature without issue.