### PR TITLE
Special case strings in System.Linq.Enumerable.OrderBy

### DIFF
--- a/src/System.Linq/src/System/Linq/OrderedEnumerable.cs
+++ b/src/System.Linq/src/System/Linq/OrderedEnumerable.cs
@@ -172,11 +172,11 @@ namespace System.Linq
             // Special case the common use of string with default comparer. Comparer<string>.Default checks the
             // thread's Culture on each call which is an overhead which is not required, because we are about to
             // do a sort which remains on the current thread (and EnumerableSorter is not used afterwards).
-            var comparer =
-                typeof(TKey) == typeof(string) // should always be true if => _comparer == Comparer<string>.Default...
-                && _comparer == Comparer<string>.Default
-                ? (IComparer<TKey>)StringComparer.CurrentCulture
-                : _comparer;
+            IComparer<TKey> comparer = _comparer;
+            if (typeof(TKey) == typeof(string) && comparer == Comparer<string>.Default)
+            {
+                comparer = (IComparer<TKey>)StringComparer.CurrentCulture;
+            }
 
             EnumerableSorter<TElement> sorter = new EnumerableSorter<TElement, TKey>(_keySelector, comparer, _descending, next);
             if (_parent != null)

--- a/src/System.Linq/src/System/Linq/OrderedEnumerable.cs
+++ b/src/System.Linq/src/System/Linq/OrderedEnumerable.cs
@@ -173,11 +173,12 @@ namespace System.Linq
             // thread's Culture on each call which is an overhead which is not required, because we are about to
             // do a sort which remains on the current thread (and EnumerableSorter is not used afterwards).
             IComparer<TKey> comparer = _comparer;
+#if BLOCKING_THIS_OUT_SO_TEST_SUITE_CAN_RUN_PRIOR_TO_CHANGE
             if (typeof(TKey) == typeof(string) && comparer == Comparer<string>.Default)
             {
                 comparer = (IComparer<TKey>)StringComparer.CurrentCulture;
             }
-
+#endif
             EnumerableSorter<TElement> sorter = new EnumerableSorter<TElement, TKey>(_keySelector, comparer, _descending, next);
             if (_parent != null)
             {

--- a/src/System.Linq/src/System/Linq/OrderedEnumerable.cs
+++ b/src/System.Linq/src/System/Linq/OrderedEnumerable.cs
@@ -173,12 +173,11 @@ namespace System.Linq
             // thread's Culture on each call which is an overhead which is not required, because we are about to
             // do a sort which remains on the current thread (and EnumerableSorter is not used afterwards).
             IComparer<TKey> comparer = _comparer;
-#if BLOCKING_THIS_OUT_SO_TEST_SUITE_CAN_RUN_PRIOR_TO_CHANGE
             if (typeof(TKey) == typeof(string) && comparer == Comparer<string>.Default)
             {
                 comparer = (IComparer<TKey>)StringComparer.CurrentCulture;
             }
-#endif
+
             EnumerableSorter<TElement> sorter = new EnumerableSorter<TElement, TKey>(_keySelector, comparer, _descending, next);
             if (_parent != null)
             {

--- a/src/System.Linq/tests/OrderByTests.cs
+++ b/src/System.Linq/tests/OrderByTests.cs
@@ -445,90 +445,106 @@ namespace System.Linq.Tests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)]
         public void CultureOrderBy()
         {
-            CultureInfo current = Thread.CurrentThread.CurrentCulture;
+            CultureInfo current = CultureInfo.CurrentCulture;
             try
             {
                 string[] source = new[] { "Apple0", "Æble0", "Apple1", "Æble1", "Apple2", "Æble2" };
 
-                string[] resultDK = new[] { "Apple0", "Apple1", "Apple2", "Æble0", "Æble1", "Æble2" };
-                string[] resultAU = new[] { "Æble0", "Æble1", "Æble2", "Apple0", "Apple1", "Apple2" };
-
-                string[] check;
-
                 CultureInfo dk = new CultureInfo("da-DK");
                 CultureInfo au = new CultureInfo("en-AU");
 
-                Thread.CurrentThread.CurrentCulture = dk;
+                StringComparer comparerDk = StringComparer.Create(dk, false);
+                StringComparer comparerAu = StringComparer.Create(au, false);
+
+                // we don't provide a defined sorted result set because the Windows culture sorting
+                // provides a different result set to the Linux culture sorting. But as we're really just
+                // concerned that OrderBy default string ordering matches current culture then this
+                // should be sufficient
+                string[] resultDK = source.ToArray();
+                Array.Sort(resultDK, comparerDk);
+                string[] resultAU = source.ToArray();
+                Array.Sort(resultAU, comparerAu);
+
+                string[] check;
+
+                CultureInfo.CurrentCulture = dk;
                 check = source.OrderBy(x => x).ToArray();
                 Assert.Equal(check, resultDK, StringComparer.Ordinal);
 
-                Thread.CurrentThread.CurrentCulture = au;
+                CultureInfo.CurrentCulture = au;
                 check = source.OrderBy(x => x).ToArray();
                 Assert.Equal(check, resultAU, StringComparer.Ordinal);
 
                 IEnumerator<string> s;
                 int idx;
 
-                Thread.CurrentThread.CurrentCulture = dk;
+                CultureInfo.CurrentCulture = dk;
                 s = source.OrderBy(x => x).GetEnumerator(); // "dk" whilst GetEnumerator
-                Thread.CurrentThread.CurrentCulture = au; // but "au" whilst accessing...
+                CultureInfo.CurrentCulture = au; // but "au" whilst accessing...
                 idx = 0;
                 while (s.MoveNext()) // sort is done on first MoveNext, so should have "au" sorting
                 {
                     Assert.Equal(s.Current, resultAU[idx++], StringComparer.Ordinal);
                 }
 
-                Thread.CurrentThread.CurrentCulture = au;
+                CultureInfo.CurrentCulture = au;
                 s = source.OrderBy(x => x).GetEnumerator(); // "au" whilst GetEnumerator
-                Thread.CurrentThread.CurrentCulture = dk; // but "dk" whilst accessing...
+                CultureInfo.CurrentCulture = dk; // but "dk" whilst accessing...
                 idx = 0;
                 while (s.MoveNext()) // sort is done on first MoveNext, so should have "dk" sorting
                 {
                     Assert.Equal(s.Current, resultDK[idx++], StringComparer.Ordinal);
 
                     // ensure changing culture whilst enumerating doesn't affect sort
-                    Thread.CurrentThread.CurrentCulture = au;
+                    CultureInfo.CurrentCulture = au;
                 }
             }
             finally
             {
                 // be polite and restore previous culture
-                Thread.CurrentThread.CurrentCulture = current;
+                CultureInfo.CurrentCulture = current;
             }
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)]
         public void CultureOrderByElementAt()
         {
-            CultureInfo current = Thread.CurrentThread.CurrentCulture;
+            CultureInfo current = CultureInfo.CurrentCulture;
             try
             {
                 string[] source = new[] { "Apple0", "Æble0", "Apple1", "Æble1", "Apple2", "Æble2" };
 
-                string[] resultDK = new[] { "Apple0", "Apple1", "Apple2", "Æble0", "Æble1", "Æble2" };
-                string[] resultAU = new[] { "Æble0", "Æble1", "Æble2", "Apple0", "Apple1", "Apple2" };
-
                 CultureInfo dk = new CultureInfo("da-DK");
                 CultureInfo au = new CultureInfo("en-AU");
 
+                StringComparer comparerDk = StringComparer.Create(dk, false);
+                StringComparer comparerAu = StringComparer.Create(au, false);
+
+                // we don't provide a defined sorted result set because the Windows culture sorting
+                // provides a different result set to the Linux culture sorting. But as we're really just
+                // concerned that OrderBy default string ordering matches current culture then this
+                // should be sufficient
+                string[] resultDK = source.ToArray();
+                Array.Sort(resultDK, comparerDk);
+                string[] resultAU = source.ToArray();
+                Array.Sort(resultAU, comparerAu);
+
                 IEnumerable<string> delaySortedSource = source.OrderBy(x => x);
-                for (var i = 0; i < source.Length; ++i)
+                for (int i = 0; i < source.Length; ++i)
                 {
-                    Thread.CurrentThread.CurrentCulture = dk;
+                    CultureInfo.CurrentCulture = dk;
                     Assert.Equal(delaySortedSource.ElementAt(i), resultDK[i], StringComparer.Ordinal);
 
-                    Thread.CurrentThread.CurrentCulture = au;
+                    CultureInfo.CurrentCulture = au;
                     Assert.Equal(delaySortedSource.ElementAt(i), resultAU[i], StringComparer.Ordinal);
                 }
             }
             finally
             {
                 // be polite and restore previous culture
-                Thread.CurrentThread.CurrentCulture = current;
+                CultureInfo.CurrentCulture = current;
             }
         }
     }

--- a/src/System.Linq/tests/OrderByTests.cs
+++ b/src/System.Linq/tests/OrderByTests.cs
@@ -453,8 +453,8 @@ namespace System.Linq.Tests
             CultureInfo dk = new CultureInfo("da-DK");
             CultureInfo au = new CultureInfo("en-AU");
 
-            StringComparer comparerDk = StringComparer.Create(dk, false);
-            StringComparer comparerAu = StringComparer.Create(au, false);
+            StringComparer comparerDk = StringComparer.Create(dk, ignoreCase: false);
+            StringComparer comparerAu = StringComparer.Create(au, ignoreCase: false);
 
             // we don't provide a defined sorted result set because the Windows culture sorting
             // provides a different result set to the Linux culture sorting. But as we're really just
@@ -500,7 +500,7 @@ namespace System.Linq.Tests
                 using (new ThreadCultureChange(dk)) 
                 {
                     // but "dk" on first MoveNext
-                    var moveNext = s.MoveNext(); 
+                    bool moveNext = s.MoveNext(); 
                     Assert.True(moveNext);
 
                     // ensure changing culture after MoveNext doesn't affect sort
@@ -525,8 +525,8 @@ namespace System.Linq.Tests
             CultureInfo dk = new CultureInfo("da-DK");
             CultureInfo au = new CultureInfo("en-AU");
 
-            StringComparer comparerDk = StringComparer.Create(dk, false);
-            StringComparer comparerAu = StringComparer.Create(au, false);
+            StringComparer comparerDk = StringComparer.Create(dk, ignoreCase: false);
+            StringComparer comparerAu = StringComparer.Create(au, ignoreCase: false);
 
             // we don't provide a defined sorted result set because the Windows culture sorting
             // provides a different result set to the Linux culture sorting. But as we're really just

--- a/src/System.Linq/tests/OrderByTests.cs
+++ b/src/System.Linq/tests/OrderByTests.cs
@@ -445,7 +445,7 @@ namespace System.Linq.Tests
         }
 
         [Fact]
-        public void CultureOrdering()
+        public void CultureOrderBy()
         {
             CultureInfo current = Thread.CurrentThread.CurrentCulture;
             try
@@ -462,11 +462,11 @@ namespace System.Linq.Tests
 
                 Thread.CurrentThread.CurrentCulture = dk;
                 check = source.OrderBy(x => x).ToArray();
-                Assert.Equal(check, resultDK, StringComparer.InvariantCultureIgnoreCase);
+                Assert.Equal(check, resultDK, StringComparer.Ordinal);
 
                 Thread.CurrentThread.CurrentCulture = au;
                 check = source.OrderBy(x => x).ToArray();
-                Assert.Equal(check, resultAU, StringComparer.InvariantCultureIgnoreCase);
+                Assert.Equal(check, resultAU, StringComparer.Ordinal);
 
                 IEnumerator<string> s;
                 int idx;
@@ -477,7 +477,7 @@ namespace System.Linq.Tests
                 idx = 0;
                 while (s.MoveNext()) // sort is done on first MoveNext, so should have "au" sorting
                 {
-                    Assert.Equal(s.Current, resultAU[idx++], StringComparer.InvariantCultureIgnoreCase);
+                    Assert.Equal(s.Current, resultAU[idx++], StringComparer.Ordinal);
                 }
 
                 Thread.CurrentThread.CurrentCulture = au;
@@ -486,10 +486,41 @@ namespace System.Linq.Tests
                 idx = 0;
                 while (s.MoveNext()) // sort is done on first MoveNext, so should have "dk" sorting
                 {
-                    Assert.Equal(s.Current, resultDK[idx++], StringComparer.InvariantCultureIgnoreCase);
+                    Assert.Equal(s.Current, resultDK[idx++], StringComparer.Ordinal);
 
                     // ensure changing culture whilst enumerating doesn't affect sort
                     Thread.CurrentThread.CurrentCulture = au;
+                }
+            }
+            finally
+            {
+                // be polite and restore previous culture
+                Thread.CurrentThread.CurrentCulture = current;
+            }
+        }
+
+        [Fact]
+        public void CultureOrderByElementAt()
+        {
+            CultureInfo current = Thread.CurrentThread.CurrentCulture;
+            try
+            {
+                string[] source = new[] { "Apple0", "Æble0", "Apple1", "Æble1", "Apple2", "Æble2" };
+
+                string[] resultDK = new[] { "Apple0", "Apple1", "Apple2", "Æble0", "Æble1", "Æble2" };
+                string[] resultAU = new[] { "Æble0", "Æble1", "Æble2", "Apple0", "Apple1", "Apple2" };
+
+                CultureInfo dk = new CultureInfo("da-DK");
+                CultureInfo au = new CultureInfo("en-AU");
+
+                IEnumerable<string> delaySortedSource = source.OrderBy(x => x);
+                for (var i = 0; i < source.Length; ++i)
+                {
+                    Thread.CurrentThread.CurrentCulture = dk;
+                    Assert.Equal(delaySortedSource.ElementAt(i), resultDK[i], StringComparer.Ordinal);
+
+                    Thread.CurrentThread.CurrentCulture = au;
+                    Assert.Equal(delaySortedSource.ElementAt(i), resultAU[i], StringComparer.Ordinal);
                 }
             }
             finally

--- a/src/System.Linq/tests/OrderByTests.cs
+++ b/src/System.Linq/tests/OrderByTests.cs
@@ -445,6 +445,7 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
         public void CultureOrderBy()
         {
             CultureInfo current = Thread.CurrentThread.CurrentCulture;
@@ -500,6 +501,7 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
         public void CultureOrderByElementAt()
         {
             CultureInfo current = Thread.CurrentThread.CurrentCulture;


### PR DESCRIPTION
First in possibly a series of performance related pull requests to enhance performance of System.Linq. (Depending on how this is received...)

There changed originated from [Cistern.Linq](https://github.com/manofstick/Cistern.Linq) which is a complete overhaul of System.Linq architecture, but is probably a [bit too much of a change](https://github.com/dotnet/corefx/pull/34208) for corefx to bear!

So anyway, this PR special cases string handling in OrderBy (when the default comparer is used - i.e. no extra parameter). I think this is a pretty common situation (although your telemetry might inform otherwise?). It increases performance because the comparer doesn't need to constantly get the current threads culture - which is consistent for the period of the sort, so an unnecessary overhead.

For strings like that of a person's name on a person object, this cuts about ~20% off the runtime, for a  slow-down when there is only a single item to be sorted - I assume due to my additional check and replacement of the comparer, but could of just been an artifact of the particular run? Would be good for some other verification of alternative machines... Anyone?

Following [benchmarking procedures](https://github.com/dotnet/performance/blob/master/docs/benchmarking-workflow-corefx.md), the following results were obtained:

(The additional performance test that is used here is [in a PR here](https://github.com/dotnet/performance/pull/992))

| Slower                                                             | diff/base | Base Median (ns) | Diff Median (ns) | Modality|
| ------------------------------------------------------------------ | ---------:| ----------------:| ----------------:| --------:|
| System.Linq.Tests.Perf_OrderBy.OrderByFirstName(NumberOfPeople: 1) |      1.40 |           187.96 |           263.96 |         |
| System.Linq.Tests.Perf_OrderBy.OrderByFullName(NumberOfPeople: 1)  |      1.22 |           352.27 |           430.88 |         |

| Faster                                                                | base/diff | Base Median (ns) | Diff Median (ns) | Modality|
| --------------------------------------------------------------------- | ---------:| ----------------:| ----------------:| --------:|
| System.Linq.Tests.Perf_OrderBy.OrderByFirstName(NumberOfPeople: 100)  |      1.26 |         52061.62 |         41456.28 |         |
| System.Linq.Tests.Perf_OrderBy.OrderByFirstName(NumberOfPeople: 1000) |      1.24 |        805309.06 |        647744.40 |         |
| System.Linq.Tests.Perf_OrderBy.OrderByFirstName(NumberOfPeople: 10)   |      1.23 |          2538.67 |          2060.65 |         |
| System.Linq.Tests.Perf_OrderBy.OrderByFullName(NumberOfPeople: 1000)  |      1.19 |       1020842.19 |        859375.00 |         |
| System.Linq.Tests.Perf_OrderBy.OrderByFullName(NumberOfPeople: 100)   |      1.18 |         65284.81 |         55141.30 |         |
| System.Linq.Tests.Perf_OrderBy.OrderByFullName(NumberOfPeople: 10)    |      1.07 |          3710.74 |          3481.37 |         |