### PR TITLE
Use Package suffix instead of PackageId and Version suffix instead of PackageVersion

### DIFF
--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -10,12 +10,12 @@
   <!-- source-built packages -->
   <ItemGroup>
     <!-- arcade -->
-    <PackageReference Include="Microsoft.DotNet.GenFacades" Version="$(MicrosoftDotNetGenFacadesPackageVersion)" />
-    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Packaging" Version="$(MicrosoftDotNetBuildTasksPackagingPackageVersion)" />
+    <PackageReference Include="Microsoft.DotNet.GenFacades" Version="$(MicrosoftDotNetGenFacadesVersion)" />
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Packaging" Version="$(MicrosoftDotNetBuildTasksPackagingVersion)" />
     
     <!-- coreclr -->
     <!-- Download the package in the initial arcade restore step to work around race conditions when restoring an msbuild SDK. -->
-    <PackageDownload Include="Microsoft.NET.Sdk.IL" Version="[$(MicrosoftNETSdkILPackageVersion)]" />
+    <PackageDownload Include="Microsoft.NET.Sdk.IL" Version="[$(MicrosoftNETSdkILVersion)]" />
 
     <!-- roslyn -->
     <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="$(MicrosoftNetCompilersToolsetVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
@@ -24,14 +24,14 @@
   <!-- excluded from offline portion of source build -->
   <ItemGroup Condition="'$(DotNetBuildOffline)' != 'true'">
     <!-- arcade -->
-    <PackageReference Include="Microsoft.DotNet.GenAPI" Version="$(MicrosoftDotNetGenApiPackageVersion)" />
+    <PackageReference Include="Microsoft.DotNet.GenAPI" Version="$(MicrosoftDotNetGenAPIVersion)" />
   </ItemGroup>
 
   <!-- excluded from source build -->
   <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
-    <PackageReference Include="Microsoft.DotNet.ApiCompat" Version="$(MicrosoftDotNetApiCompatPackageVersion)" />
+    <PackageReference Include="Microsoft.DotNet.ApiCompat" Version="$(MicrosoftDotNetApiCompatVersion)" />
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Feed" Version="$(MicrosoftDotNetBuildTasksFeedVersion)" />
-    <PackageReference Include="Microsoft.DotNet.VersionTools.Tasks" Version="$(MicrosoftDotNetVersionToolsTasksPackageVersion)" />
+    <PackageReference Include="Microsoft.DotNet.VersionTools.Tasks" Version="$(MicrosoftDotNetVersionToolsTasksVersion)" />
 
     <!-- SourceLink -->
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -18,85 +18,85 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.NETCore.App" Version="5.0.0-alpha.1.19531.19">
+    <Dependency Name="Microsoft.NETCore.App" Version="5.0.0-alpha.1.19551.1">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>14e7a3b2fb40b377562d3d3e739d471841ae3316</Sha>
+      <Sha>e460275e7463fdc900bf5c9e0a574ec8946ac6c2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.DotNetHost" Version="5.0.0-alpha.1.19531.19">
+    <Dependency Name="Microsoft.NETCore.DotNetHost" Version="5.0.0-alpha.1.19551.1">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>14e7a3b2fb40b377562d3d3e739d471841ae3316</Sha>
+      <Sha>e460275e7463fdc900bf5c9e0a574ec8946ac6c2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.DotNetHostPolicy" Version="5.0.0-alpha.1.19531.19">
+    <Dependency Name="Microsoft.NETCore.DotNetHostPolicy" Version="5.0.0-alpha.1.19551.1">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>14e7a3b2fb40b377562d3d3e739d471841ae3316</Sha>
+      <Sha>e460275e7463fdc900bf5c9e0a574ec8946ac6c2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-alpha.1.19531.13">
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="5.0.0-alpha.1.19551.1">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>a24db0ba5666f46f50649810fe698ad267b60331</Sha>
+      <Sha>dd2ad4367bc4e070f3e8ca81ca6421db5733e731</Sha>
     </Dependency>
-    <Dependency Name="runtime.native.System.IO.Ports" Version="5.0.0-alpha.1.19531.13">
+    <Dependency Name="runtime.native.System.IO.Ports" Version="5.0.0-alpha.1.19551.1">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>a24db0ba5666f46f50649810fe698ad267b60331</Sha>
+      <Sha>dd2ad4367bc4e070f3e8ca81ca6421db5733e731</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.19531.14">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.19551.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>db50c8d7378a7a81033a1b8fcfa5461694a891c3</Sha>
+      <Sha>d2d8d9f5c14e353acc7dfcf69c5fa5a8c368af40</Sha>
     </Dependency>
-    <Dependency Name="NETStandard.Library" Version="2.2.0-prerelease.19531.1">
+    <Dependency Name="NETStandard.Library" Version="2.2.0-prerelease.19551.1">
       <Uri>https://github.com/dotnet/standard</Uri>
-      <Sha>a2bca7f4f89c899c2c0325c2790faf6f7d29870c</Sha>
+      <Sha>1063b6811691a2e009d7733cbf68f897511f00b2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="5.0.0-beta.19531.14">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="5.0.0-beta.19551.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>db50c8d7378a7a81033a1b8fcfa5461694a891c3</Sha>
+      <Sha>d2d8d9f5c14e353acc7dfcf69c5fa5a8c368af40</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.ApiCompat" Version="5.0.0-beta.19531.14">
+    <Dependency Name="Microsoft.DotNet.ApiCompat" Version="5.0.0-beta.19551.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>db50c8d7378a7a81033a1b8fcfa5461694a891c3</Sha>
+      <Sha>d2d8d9f5c14e353acc7dfcf69c5fa5a8c368af40</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenAPI" Version="5.0.0-beta.19531.14">
+    <Dependency Name="Microsoft.DotNet.GenAPI" Version="5.0.0-beta.19551.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>db50c8d7378a7a81033a1b8fcfa5461694a891c3</Sha>
+      <Sha>d2d8d9f5c14e353acc7dfcf69c5fa5a8c368af40</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenFacades" Version="5.0.0-beta.19531.14">
+    <Dependency Name="Microsoft.DotNet.GenFacades" Version="5.0.0-beta.19551.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>db50c8d7378a7a81033a1b8fcfa5461694a891c3</Sha>
+      <Sha>d2d8d9f5c14e353acc7dfcf69c5fa5a8c368af40</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="5.0.0-beta.19531.14">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="5.0.0-beta.19551.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>db50c8d7378a7a81033a1b8fcfa5461694a891c3</Sha>
+      <Sha>d2d8d9f5c14e353acc7dfcf69c5fa5a8c368af40</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitConsoleRunner" Version="2.5.1-beta.19531.14">
+    <Dependency Name="Microsoft.DotNet.XUnitConsoleRunner" Version="2.5.1-beta.19551.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>db50c8d7378a7a81033a1b8fcfa5461694a891c3</Sha>
+      <Sha>d2d8d9f5c14e353acc7dfcf69c5fa5a8c368af40</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Packaging" Version="5.0.0-beta.19531.14">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Packaging" Version="5.0.0-beta.19551.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>db50c8d7378a7a81033a1b8fcfa5461694a891c3</Sha>
+      <Sha>d2d8d9f5c14e353acc7dfcf69c5fa5a8c368af40</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="5.0.0-beta.19531.14">
+    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="5.0.0-beta.19551.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>db50c8d7378a7a81033a1b8fcfa5461694a891c3</Sha>
+      <Sha>d2d8d9f5c14e353acc7dfcf69c5fa5a8c368af40</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.CoreFxTesting" Version="5.0.0-beta.19531.14">
+    <Dependency Name="Microsoft.DotNet.CoreFxTesting" Version="5.0.0-beta.19551.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>db50c8d7378a7a81033a1b8fcfa5461694a891c3</Sha>
+      <Sha>d2d8d9f5c14e353acc7dfcf69c5fa5a8c368af40</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="5.0.0-beta.19531.14">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="5.0.0-beta.19551.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>db50c8d7378a7a81033a1b8fcfa5461694a891c3</Sha>
+      <Sha>d2d8d9f5c14e353acc7dfcf69c5fa5a8c368af40</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Configuration" Version="5.0.0-beta.19531.14">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Configuration" Version="5.0.0-beta.19551.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>db50c8d7378a7a81033a1b8fcfa5461694a891c3</Sha>
+      <Sha>d2d8d9f5c14e353acc7dfcf69c5fa5a8c368af40</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="5.0.0-beta.19531.14">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="5.0.0-beta.19551.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>db50c8d7378a7a81033a1b8fcfa5461694a891c3</Sha>
+      <Sha>d2d8d9f5c14e353acc7dfcf69c5fa5a8c368af40</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.VersionTools.Tasks" Version="5.0.0-beta.19531.14">
+    <Dependency Name="Microsoft.DotNet.VersionTools.Tasks" Version="5.0.0-beta.19551.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>db50c8d7378a7a81033a1b8fcfa5461694a891c3</Sha>
+      <Sha>d2d8d9f5c14e353acc7dfcf69c5fa5a8c368af40</Sha>
     </Dependency>
     <Dependency Name="optimization.windows_nt-x64.IBC.CoreFx" Version="99.99.99-master-20190716.1">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-optimization</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -22,63 +22,60 @@
   </PropertyGroup>
   <!-- Package names if they are used in more then one location in the repo -->
   <PropertyGroup>
-    <NETStandardLibraryPackageId>NETStandard.Library</NETStandardLibraryPackageId>
-    <WindowsCoreFxOptimizationDataPackageId>optimization.windows_nt-x64.ibc.corefx</WindowsCoreFxOptimizationDataPackageId>
-    <LinuxCoreFxOptimizationDataPackageId>optimization.linux-x64.ibc.corefx</LinuxCoreFxOptimizationDataPackageId>
-    <MicrosoftPrivateIntellisensePackageId>microsoft.private.intellisense</MicrosoftPrivateIntellisensePackageId>
+    <NETStandardLibraryPackage>netstandard.library</NETStandardLibraryPackage>
+    <WindowsCoreFxOptimizationDataPackage>optimization.windows_nt-x64.ibc.corefx</WindowsCoreFxOptimizationDataPackage>
+    <LinuxCoreFxOptimizationDataPackage>optimization.linux-x64.ibc.corefx</LinuxCoreFxOptimizationDataPackage>
+    <MicrosoftPrivateIntellisensePackage>microsoft.private.intellisense</MicrosoftPrivateIntellisensePackage>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Arcade dependencies -->
-    <MicrosoftDotNetApiCompatPackageVersion>5.0.0-beta.19531.14</MicrosoftDotNetApiCompatPackageVersion>
-    <MicrosoftDotNetCodeAnalysisPackageVersion>5.0.0-beta.19531.14</MicrosoftDotNetCodeAnalysisPackageVersion>
-    <MicrosoftDotNetGenAPIPackageVersion>5.0.0-beta.19531.14</MicrosoftDotNetGenAPIPackageVersion>
-    <MicrosoftDotNetGenFacadesPackageVersion>5.0.0-beta.19531.14</MicrosoftDotNetGenFacadesPackageVersion>
-    <MicrosoftDotNetXUnitExtensionsPackageVersion>5.0.0-beta.19531.14</MicrosoftDotNetXUnitExtensionsPackageVersion>
-    <MicrosoftDotNetXUnitConsoleRunnerPackageVersion>2.5.1-beta.19531.14</MicrosoftDotNetXUnitConsoleRunnerPackageVersion>
-    <MicrosoftDotNetBuildTasksPackagingPackageVersion>5.0.0-beta.19531.14</MicrosoftDotNetBuildTasksPackagingPackageVersion>
-    <MicrosoftDotNetRemoteExecutorPackageVersion>5.0.0-beta.19531.14</MicrosoftDotNetRemoteExecutorPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>5.0.0-beta.19531.14</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetVersionToolsTasksPackageVersion>5.0.0-beta.19531.14</MicrosoftDotNetVersionToolsTasksPackageVersion>
+    <MicrosoftDotNetApiCompatVersion>5.0.0-beta.19530.15</MicrosoftDotNetApiCompatVersion>
+    <MicrosoftDotNetCodeAnalysisVersion>5.0.0-beta.19530.15</MicrosoftDotNetCodeAnalysisVersion>
+    <MicrosoftDotNetGenAPIVersion>5.0.0-beta.19530.15</MicrosoftDotNetGenAPIVersion>
+    <MicrosoftDotNetGenFacadesVersion>5.0.0-beta.19530.15</MicrosoftDotNetGenFacadesVersion>
+    <MicrosoftDotNetXUnitExtensionsVersion>5.0.0-beta.19530.15</MicrosoftDotNetXUnitExtensionsVersion>
+    <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.19530.15</MicrosoftDotNetXUnitConsoleRunnerVersion>
+    <MicrosoftDotNetBuildTasksPackagingVersion>5.0.0-beta.19530.15</MicrosoftDotNetBuildTasksPackagingVersion>
+    <MicrosoftDotNetRemoteExecutorVersion>5.0.0-beta.19530.15</MicrosoftDotNetRemoteExecutorVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>5.0.0-beta.19530.15</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetVersionToolsTasksVersion>5.0.0-beta.19530.15</MicrosoftDotNetVersionToolsTasksVersion>
     <!-- Core-setup dependencies -->
-    <MicrosoftNETCoreAppPackageVersion>5.0.0-alpha.1.19531.19</MicrosoftNETCoreAppPackageVersion>
-    <MicrosoftNETCoreDotNetHostPackageVersion>5.0.0-alpha.1.19531.19</MicrosoftNETCoreDotNetHostPackageVersion>
-    <MicrosoftNETCoreDotNetHostPolicyPackageVersion>5.0.0-alpha.1.19531.19</MicrosoftNETCoreDotNetHostPolicyPackageVersion>
+    <MicrosoftNETCoreAppVersion>5.0.0-alpha.1.19530.10</MicrosoftNETCoreAppVersion>
+    <MicrosoftNETCoreDotNetHostVersion>5.0.0-alpha.1.19530.10</MicrosoftNETCoreDotNetHostVersion>
+    <MicrosoftNETCoreDotNetHostPolicyVersion>5.0.0-alpha.1.19530.10</MicrosoftNETCoreDotNetHostPolicyVersion>
     <!-- Coreclr dependencies -->
-    <MicrosoftNETCoreILAsmPackageVersion>5.0.0-alpha1.19525.1</MicrosoftNETCoreILAsmPackageVersion>
-    <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>5.0.0-alpha1.19525.1</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
-    <MicrosoftNETSdkILPackageVersion>5.0.0-alpha1.19525.1</MicrosoftNETSdkILPackageVersion>
+    <MicrosoftNETCoreILAsmVersion>5.0.0-alpha1.19525.1</MicrosoftNETCoreILAsmVersion>
+    <MicrosoftNETCoreRuntimeCoreCLRVersion>5.0.0-alpha1.19525.1</MicrosoftNETCoreRuntimeCoreCLRVersion>
+    <MicrosoftNETSdkILVersion>5.0.0-alpha1.19525.1</MicrosoftNETSdkILVersion>
     <!-- Corefx dependencies -->
-    <MicrosoftNETCorePlatformsPackageVersion>5.0.0-alpha.1.19531.13</MicrosoftNETCorePlatformsPackageVersion>
-    <runtimenativeSystemIOPortsPackageVersion>5.0.0-alpha.1.19531.13</runtimenativeSystemIOPortsPackageVersion>
+    <MicrosoftNETCorePlatformsVersion>5.0.0-alpha.1.19531.1</MicrosoftNETCorePlatformsVersion>
+    <runtimenativeSystemIOPortsVersion>5.0.0-alpha.1.19531.1</runtimenativeSystemIOPortsVersion>
     <!-- Standard dependencies -->
-    <NETStandardLibraryPackageVersion>2.2.0-prerelease.19531.1</NETStandardLibraryPackageVersion>
+    <NETStandardLibraryVersion>2.2.0-prerelease.19530.2</NETStandardLibraryVersion>
     <!-- dotnet-optimization dependencies -->
-    <optimizationwindows_ntx64IBCCoreFxPackageVersion>99.99.99-master-20190716.1</optimizationwindows_ntx64IBCCoreFxPackageVersion>
+    <optimizationwindows_ntx64IBCCoreFxVersion>99.99.99-master-20190716.1</optimizationwindows_ntx64IBCCoreFxVersion>
     <!-- sni -->
-    <RuntimeWinX64RuntimeNativeSystemDataSqlClientSniPackageVersion>4.4.0</RuntimeWinX64RuntimeNativeSystemDataSqlClientSniPackageVersion>
-    <RuntimeNativeSystemDataSqlClientSniPackageVersion>4.4.0</RuntimeNativeSystemDataSqlClientSniPackageVersion>
+    <RuntimeWinX64RuntimeNativeSystemDataSqlClientSniVersion>4.4.0</RuntimeWinX64RuntimeNativeSystemDataSqlClientSniVersion>
+    <RuntimeNativeSystemDataSqlClientSniVersion>4.4.0</RuntimeNativeSystemDataSqlClientSniVersion>
     <!-- Testing -->
-    <MicrosoftNETTestSdkPackageVersion>16.2.0</MicrosoftNETTestSdkPackageVersion>
-    <XUnitPackageVersion>2.4.1</XUnitPackageVersion>
-    <TraceEventPackageVersion>2.0.5</TraceEventPackageVersion>
-    <NewtonsoftJsonPackageVersion>12.0.1</NewtonsoftJsonPackageVersion>
-    <MicrosoftDotNetPlatformAbstractionsPackageVersion>3.0.0-preview6-27804-01</MicrosoftDotNetPlatformAbstractionsPackageVersion>
+    <MicrosoftNETTestSdkVersion>16.3.0</MicrosoftNETTestSdkVersion>
+    <XUnitVersion>2.4.1</XUnitVersion>
+    <TraceEventVersion>2.0.5</TraceEventVersion>
+    <NewtonsoftJsonVersion>12.0.1</NewtonsoftJsonVersion>
+    <MicrosoftDotNetPlatformAbstractionsVersion>3.0.0-preview6-27804-01</MicrosoftDotNetPlatformAbstractionsVersion>
     <!-- Test data -->
     <SystemIOCompressionTestDataPackageVersion>1.0.16</SystemIOCompressionTestDataPackageVersion>
-    <SystemIOPackagingTestDataPackageVersion>1.0.4</SystemIOPackagingTestDataPackageVersion>
-    <SystemSecurityCryptographyX509CertificatesTestDataPackageVersion>1.0.7</SystemSecurityCryptographyX509CertificatesTestDataPackageVersion>
-    <SystemNetTestDataPackageVersion>1.0.6</SystemNetTestDataPackageVersion>
-    <SystemComponentModelTypeConverterTestDataPackageVersion>1.0.4</SystemComponentModelTypeConverterTestDataPackageVersion>
-    <SystemDrawingCommonTestDataPackageVersion>1.0.12</SystemDrawingCommonTestDataPackageVersion>
-    <SystemWindowsExtensionsTestDataPackageVersion>1.0.5</SystemWindowsExtensionsTestDataPackageVersion>
-    <MoqPackageVersion>4.12.0</MoqPackageVersion>
-    <!-- Code coverage package version -->
-    <CoverletConsolePackageVersion>1.5.0</CoverletConsolePackageVersion>
-    <DotNetReportGeneratorGlobalToolPackageVersion>4.1.4</DotNetReportGeneratorGlobalToolPackageVersion>
+    <SystemIOPackagingTestDataVersion>1.0.4</SystemIOPackagingTestDataVersion>
+    <SystemSecurityCryptographyX509CertificatesTestDataVersion>1.0.7</SystemSecurityCryptographyX509CertificatesTestDataVersion>
+    <SystemNetTestDataVersion>1.0.6</SystemNetTestDataVersion>
+    <SystemComponentModelTypeConverterTestDataVersion>1.0.4</SystemComponentModelTypeConverterTestDataVersion>
+    <SystemDrawingCommonTestDataVersion>1.0.12</SystemDrawingCommonTestDataVersion>
+    <SystemWindowsExtensionsTestDataVersion>1.0.5</SystemWindowsExtensionsTestDataVersion>
+    <MoqVersion>4.12.0</MoqVersion>
     <!-- Docs -->
-    <MicrosoftPrivateIntellisensePackageVersion>3.0.0-preview9-190909-1</MicrosoftPrivateIntellisensePackageVersion>
+    <MicrosoftPrivateIntellisenseVersion>3.0.0-preview9-190909-1</MicrosoftPrivateIntellisenseVersion>
     <!-- ILLink -->
-    <ILLinkTasksPackageVersion>0.1.6-prerelease.19523.1</ILLinkTasksPackageVersion>
+    <ILLinkTasksVersion>0.1.6-prerelease.19523.1</ILLinkTasksVersion>
   </PropertyGroup>
   <!-- Override isolated build dependency versions with versions from Repo API. -->
   <Import Project="$(DotNetPackageVersionPropsPath)" Condition="'$(DotNetPackageVersionPropsPath)' != ''" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -64,7 +64,7 @@
     <NewtonsoftJsonVersion>12.0.1</NewtonsoftJsonVersion>
     <MicrosoftDotNetPlatformAbstractionsVersion>3.0.0-preview6-27804-01</MicrosoftDotNetPlatformAbstractionsVersion>
     <!-- Test data -->
-    <SystemIOCompressionTestDataPackageVersion>1.0.16</SystemIOCompressionTestDataPackageVersion>
+    <SystemIOCompressionTestDataVersion>1.0.16</SystemIOCompressionTestDataVersion>
     <SystemIOPackagingTestDataVersion>1.0.4</SystemIOPackagingTestDataVersion>
     <SystemSecurityCryptographyX509CertificatesTestDataVersion>1.0.7</SystemSecurityCryptographyX509CertificatesTestDataVersion>
     <SystemNetTestDataVersion>1.0.6</SystemNetTestDataVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -29,29 +29,29 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Arcade dependencies -->
-    <MicrosoftDotNetApiCompatVersion>5.0.0-beta.19530.15</MicrosoftDotNetApiCompatVersion>
-    <MicrosoftDotNetCodeAnalysisVersion>5.0.0-beta.19530.15</MicrosoftDotNetCodeAnalysisVersion>
-    <MicrosoftDotNetGenAPIVersion>5.0.0-beta.19530.15</MicrosoftDotNetGenAPIVersion>
-    <MicrosoftDotNetGenFacadesVersion>5.0.0-beta.19530.15</MicrosoftDotNetGenFacadesVersion>
-    <MicrosoftDotNetXUnitExtensionsVersion>5.0.0-beta.19530.15</MicrosoftDotNetXUnitExtensionsVersion>
-    <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.19530.15</MicrosoftDotNetXUnitConsoleRunnerVersion>
-    <MicrosoftDotNetBuildTasksPackagingVersion>5.0.0-beta.19530.15</MicrosoftDotNetBuildTasksPackagingVersion>
-    <MicrosoftDotNetRemoteExecutorVersion>5.0.0-beta.19530.15</MicrosoftDotNetRemoteExecutorVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>5.0.0-beta.19530.15</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetVersionToolsTasksVersion>5.0.0-beta.19530.15</MicrosoftDotNetVersionToolsTasksVersion>
+    <MicrosoftDotNetApiCompatVersion>5.0.0-beta.19551.2</MicrosoftDotNetApiCompatVersion>
+    <MicrosoftDotNetCodeAnalysisVersion>5.0.0-beta.19551.2</MicrosoftDotNetCodeAnalysisVersion>
+    <MicrosoftDotNetGenAPIVersion>5.0.0-beta.19551.2</MicrosoftDotNetGenAPIVersion>
+    <MicrosoftDotNetGenFacadesVersion>5.0.0-beta.19551.2</MicrosoftDotNetGenFacadesVersion>
+    <MicrosoftDotNetXUnitExtensionsVersion>5.0.0-beta.19551.2</MicrosoftDotNetXUnitExtensionsVersion>
+    <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.19551.2</MicrosoftDotNetXUnitConsoleRunnerVersion>
+    <MicrosoftDotNetBuildTasksPackagingVersion>5.0.0-beta.19551.2</MicrosoftDotNetBuildTasksPackagingVersion>
+    <MicrosoftDotNetRemoteExecutorVersion>5.0.0-beta.19551.2</MicrosoftDotNetRemoteExecutorVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>5.0.0-beta.19551.2</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetVersionToolsTasksVersion>5.0.0-beta.19551.2</MicrosoftDotNetVersionToolsTasksVersion>
     <!-- Core-setup dependencies -->
-    <MicrosoftNETCoreAppVersion>5.0.0-alpha.1.19530.10</MicrosoftNETCoreAppVersion>
-    <MicrosoftNETCoreDotNetHostVersion>5.0.0-alpha.1.19530.10</MicrosoftNETCoreDotNetHostVersion>
-    <MicrosoftNETCoreDotNetHostPolicyVersion>5.0.0-alpha.1.19530.10</MicrosoftNETCoreDotNetHostPolicyVersion>
+    <MicrosoftNETCoreAppVersion>5.0.0-alpha.1.19551.1</MicrosoftNETCoreAppVersion>
+    <MicrosoftNETCoreDotNetHostVersion>5.0.0-alpha.1.19551.1</MicrosoftNETCoreDotNetHostVersion>
+    <MicrosoftNETCoreDotNetHostPolicyVersion>5.0.0-alpha.1.19551.1</MicrosoftNETCoreDotNetHostPolicyVersion>
     <!-- Coreclr dependencies -->
     <MicrosoftNETCoreILAsmVersion>5.0.0-alpha1.19525.1</MicrosoftNETCoreILAsmVersion>
     <MicrosoftNETCoreRuntimeCoreCLRVersion>5.0.0-alpha1.19525.1</MicrosoftNETCoreRuntimeCoreCLRVersion>
     <MicrosoftNETSdkILVersion>5.0.0-alpha1.19525.1</MicrosoftNETSdkILVersion>
     <!-- Corefx dependencies -->
-    <MicrosoftNETCorePlatformsVersion>5.0.0-alpha.1.19531.1</MicrosoftNETCorePlatformsVersion>
-    <runtimenativeSystemIOPortsVersion>5.0.0-alpha.1.19531.1</runtimenativeSystemIOPortsVersion>
+    <MicrosoftNETCorePlatformsVersion>5.0.0-alpha.1.19551.1</MicrosoftNETCorePlatformsVersion>
+    <runtimenativeSystemIOPortsVersion>5.0.0-alpha.1.19551.1</runtimenativeSystemIOPortsVersion>
     <!-- Standard dependencies -->
-    <NETStandardLibraryVersion>2.2.0-prerelease.19530.2</NETStandardLibraryVersion>
+    <NETStandardLibraryVersion>2.2.0-prerelease.19551.1</NETStandardLibraryVersion>
     <!-- dotnet-optimization dependencies -->
     <optimizationwindows_ntx64IBCCoreFxVersion>99.99.99-master-20190716.1</optimizationwindows_ntx64IBCCoreFxVersion>
     <!-- sni -->

--- a/eng/analyzers.props
+++ b/eng/analyzers.props
@@ -1,6 +1,6 @@
 <Project>
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.CodeAnalysis" Version="$(MicrosoftDotNetCodeAnalysisPackageVersion)" />
+    <PackageReference Include="Microsoft.DotNet.CodeAnalysis" Version="$(MicrosoftDotNetCodeAnalysisVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.4.0-beta2-final" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.6" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.66" />

--- a/eng/codeOptimization.targets
+++ b/eng/codeOptimization.targets
@@ -10,8 +10,8 @@
           Condition="'$(IsEligibleForNgenOptimization)' == 'true'"
           BeforeTargets="CoreCompile">
     <PropertyGroup>
-      <IbcOptimizationDataDir Condition="'$(OSGroup)' == 'Unix' or '$(OSGroup)' == 'Linux'">$(IbcOptimizationDataDir)$(LinuxCoreFxOptimizationDataPackageId)\</IbcOptimizationDataDir>
-      <IbcOptimizationDataDir Condition="'$(OSGroup)' != 'Unix' and '$(OSGroup)' != 'Linux'">$(IbcOptimizationDataDir)$(WindowsCoreFxOptimizationDataPackageId)\</IbcOptimizationDataDir>
+      <IbcOptimizationDataDir Condition="'$(OSGroup)' == 'Unix' or '$(OSGroup)' == 'Linux'">$(IbcOptimizationDataDir)$(LinuxCoreFxOptimizationDataPackage)\</IbcOptimizationDataDir>
+      <IbcOptimizationDataDir Condition="'$(OSGroup)' != 'Unix' and '$(OSGroup)' != 'Linux'">$(IbcOptimizationDataDir)$(WindowsCoreFxOptimizationDataPackage)\</IbcOptimizationDataDir>
     </PropertyGroup>
     <ItemGroup>
       <_optimizationDataAssembly Include="$(IbcOptimizationDataDir)**\$(TargetFileName)" />

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -446,10 +446,7 @@ function GetSdkTaskProject([string]$taskName) {
 }
 
 function InitializeNativeTools() {
-  if ($null -eq $env:DisableNativeToolsetInstalls) {
-    return
-  }
-  if (Get-Member -InputObject $GlobalJson -Name "native-tools") {
+  if (-Not (Test-Path variable:DisableNativeToolsetInstalls) -And (Get-Member -InputObject $GlobalJson -Name "native-tools")) {
     $nativeArgs= @{}
     if ($ci) {
       $nativeArgs = @{

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -4,7 +4,7 @@
 
 # CI mode - set to true on CI server for PR validation build or official build.
 ci=${ci:-false}
-disable_configure_toolset_import=${disable_configure_toolset_import:-null}
+disable_configure_toolset_import=${disable_configure_toolset_import:-}
 
 # Set to true to use the pipelines logger which will enable Azure logging output.
 # https://github.com/Microsoft/azure-pipelines-tasks/blob/master/docs/authoring/commands.md
@@ -273,7 +273,7 @@ function GetNuGetPackageCachePath {
 }
 
 function InitializeNativeTools() {
-  if [[ -z "${DisableNativeToolsetInstalls:-}" ]]; then
+  if [[ -n "${DisableNativeToolsetInstalls:-}" ]]; then
     return
   fi
   if grep -Fq "native-tools" $global_json_file
@@ -437,7 +437,7 @@ Write-PipelineSetVariable -name "Temp" -value "$temp_dir"
 Write-PipelineSetVariable -name "TMP" -value "$temp_dir"
 
 # Import custom tools configuration, if present in the repo.
-if [[ "$disable_configure_toolset_import" != null ]]; then
+if [[ -z "$disable_configure_toolset_import" ]]; then
   configure_toolset_script="$eng_root/configure-toolset.sh"
   if [[ -a "$configure_toolset_script" ]]; then
     . "$configure_toolset_script"

--- a/eng/packaging.props
+++ b/eng/packaging.props
@@ -13,7 +13,7 @@
     <PackagePlatform Condition="'$(PackagePlatform)' == 'amd64'">x64</PackagePlatform>
 
     <!-- Used by PackageLibs.targets -->
-    <XmlDocFileRoot>$(NuGetPackageRoot)$(MicrosoftPrivateIntellisensePackageId)/$(MicrosoftPrivateIntellisensePackageVersion)/xmldocs/netcoreapp</XmlDocFileRoot>
+    <XmlDocFileRoot>$(NuGetPackageRoot)$(MicrosoftPrivateIntellisensePackage)/$(MicrosoftPrivateIntellisenseVersion)/xmldocs/netcoreapp</XmlDocFileRoot>
 
     <!-- By default the packaging targets will package desktop facades as ref,
          but we don't use this as we now build partial-reference-facades. -->

--- a/eng/restore/docs.targets
+++ b/eng/restore/docs.targets
@@ -1,7 +1,7 @@
 <Project>
 
   <ItemGroup>
-    <PackageReference Include="$(MicrosoftPrivateIntellisensePackageId)" Version="$(MicrosoftPrivateIntellisensePackageVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
+    <PackageReference Include="$(MicrosoftPrivateIntellisensePackage)" Version="$(MicrosoftPrivateIntellisenseVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
   </ItemGroup>
 
   <!-- the intellisense package doesn't use nuget conventions so we need to select manually -->
@@ -9,7 +9,7 @@
           AfterTargets="Restore">
 
     <ItemGroup>
-      <DocFile Include="$(NuGetPackageRoot)$(MicrosoftPrivateIntellisensePackageId)/$(MicrosoftPrivateIntellisensePackageVersion)/xmldocs/netcoreapp/**/*.xml"/>
+      <DocFile Include="$(NuGetPackageRoot)$(MicrosoftPrivateIntellisensePackage)/$(MicrosoftPrivateIntellisenseVersion)/xmldocs/netcoreapp/**/*.xml"/>
       <DocFile>
         <!-- trim off slash since it differs by platform and we need to do a string compare -->
         <LCID>$([System.String]::new('%(RecursiveDir)').TrimEnd('\/'))</LCID>

--- a/eng/restore/illink.targets
+++ b/eng/restore/illink.targets
@@ -1,14 +1,14 @@
 <Project>
 
   <ItemGroup>
-    <PackageReference Include="illink.tasks" Version="$(ILLinkTasksPackageVersion)" PrivateAssets="all" IsImplicitlyDefined="true" ExcludeAssets="build" />
+    <PackageReference Include="illink.tasks" Version="$(ILLinkTasksVersion)" PrivateAssets="all" IsImplicitlyDefined="true" ExcludeAssets="build" />
   </ItemGroup>
 
   <Target Name="IncludeToolsFiles"
           AfterTargets="Restore">
 
     <ItemGroup>
-      <_illinkSrcFiles Include="$(NuGetPackageRoot)illink.tasks\$(ILLinkTasksPackageVersion)\tools\**\*" />
+      <_illinkSrcFiles Include="$(NuGetPackageRoot)illink.tasks\$(ILLinkTasksVersion)\tools\**\*" />
     </ItemGroup>
 
     <Copy SourceFiles="@(_illinkSrcFiles)"

--- a/eng/restore/optimizationData.targets
+++ b/eng/restore/optimizationData.targets
@@ -1,8 +1,8 @@
 ﻿<Project>
 
   <ItemGroup>
-    <IBCPackage Include="$(WindowsCoreFxOptimizationDataPackageId)" Version="$(optimizationwindows_ntx64IBCCoreFxPackageVersion)" />
-    <IBCPackage Include="$(LinuxCoreFxOptimizationDataPackageId)" Version="$(optimizationwindows_ntx64IBCCoreFxPackageVersion)" />
+    <IBCPackage Include="$(WindowsCoreFxOptimizationDataPackage)" Version="$(optimizationwindows_ntx64IBCCoreFxVersion)" />
+    <IBCPackage Include="$(LinuxCoreFxOptimizationDataPackage)" Version="$(optimizationwindows_ntx64IBCCoreFxVersion)" />
     <PackageReference Include="@(IBCPackage)" PrivateAssets="all" IsImplicitlyDefined="true" />
   </ItemGroup>
   

--- a/global.json
+++ b/global.json
@@ -8,10 +8,10 @@
     "dotnet": "3.0.100"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.19531.14",
-    "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.19531.14",
-    "Microsoft.DotNet.Build.Tasks.Configuration": "5.0.0-beta.19531.14",
-    "Microsoft.DotNet.CoreFxTesting": "5.0.0-beta.19531.14",
+    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.19551.2",
+    "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.19551.2",
+    "Microsoft.DotNet.Build.Tasks.Configuration": "5.0.0-beta.19551.2",
+    "Microsoft.DotNet.CoreFxTesting": "5.0.0-beta.19551.2",
     "FIX-85B6-MERGE-9C38-CONFLICT": "1.0.0",
     "Microsoft.NET.Sdk.IL": "5.0.0-alpha1.19525.1"
   }

--- a/src/Common/tests/CoreFx.Private.TestUtilities/CoreFx.Private.TestUtilities.csproj
+++ b/src/Common/tests/CoreFx.Private.TestUtilities/CoreFx.Private.TestUtilities.csproj
@@ -73,9 +73,9 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.XUnitExtensions" Version="$(MicrosoftDotNetXUnitExtensionsPackageVersion)" />
-    <PackageReference Include="xunit.core" Version="$(XUnitPackageVersion)" ExcludeAssets="build" />
-    <PackageReference Include="xunit.assert" Version="$(XUnitPackageVersion)" />
-    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="$(MicrosoftDotNetPlatformAbstractionsPackageVersion)" />
+    <PackageReference Include="Microsoft.DotNet.XUnitExtensions" Version="$(MicrosoftDotNetXUnitExtensionsVersion)" />
+    <PackageReference Include="xunit.core" Version="$(XUnitVersion)" ExcludeAssets="build" />
+    <PackageReference Include="xunit.assert" Version="$(XUnitVersion)" />
+    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="$(MicrosoftDotNetPlatformAbstractionsVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Common/tests/System/Xml/ModuleCore/ModuleCore.csproj
+++ b/src/Common/tests/System/Xml/ModuleCore/ModuleCore.csproj
@@ -19,7 +19,7 @@
     <Compile Include="XunitTestCase.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="xunit.extensibility.execution" Version="$(XUnitPackageVersion)" />
-    <PackageReference Include="xunit.assert" Version="$(XUnitPackageVersion)" />
+    <PackageReference Include="xunit.extensibility.execution" Version="$(XUnitVersion)" />
+    <PackageReference Include="xunit.assert" Version="$(XUnitVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Diagnostics.Tracing.EventSource.Redist/tests/Microsoft.Diagnostics.Tracing.EventSource.Redist.Tests.csproj
+++ b/src/Microsoft.Diagnostics.Tracing.EventSource.Redist/tests/Microsoft.Diagnostics.Tracing.EventSource.Redist.Tests.csproj
@@ -36,6 +36,6 @@
     <Compile Include="$(SDTTestDir)\CustomEventSources\UseInterfaceEventSource.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="$(TraceEventPackageVersion)" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="$(TraceEventVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/runtime.native.System.Data.SqlClient.sni.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Data.SqlClient.sni/runtime.native.System.Data.SqlClient.sni.pkgproj
@@ -6,13 +6,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Dependency Include="runtime.win-x64.runtime.native.System.Data.SqlClient.sni">
-      <Version>$(RuntimeWinX64RuntimeNativeSystemDataSqlClientSniPackageVersion)</Version>
+      <Version>$(RuntimeWinX64RuntimeNativeSystemDataSqlClientSniVersion)</Version>
     </Dependency>
     <Dependency Include="runtime.win-x86.runtime.native.System.Data.SqlClient.sni">
-      <Version>$(RuntimeWinX64RuntimeNativeSystemDataSqlClientSniPackageVersion)</Version>
+      <Version>$(RuntimeWinX64RuntimeNativeSystemDataSqlClientSniVersion)</Version>
     </Dependency>
     <Dependency Include="runtime.win-arm64.runtime.native.System.Data.SqlClient.sni">
-      <Version>$(RuntimeWinX64RuntimeNativeSystemDataSqlClientSniPackageVersion)</Version>
+      <Version>$(RuntimeWinX64RuntimeNativeSystemDataSqlClientSniVersion)</Version>
     </Dependency>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />

--- a/src/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj
+++ b/src/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj
@@ -156,8 +156,8 @@
     <Compile Include="XTypeDescriptionProviderTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ComponentModel.TypeConverter.TestData" Version="$(SystemComponentModelTypeConverterTestDataPackageVersion)" />
-    <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
+    <PackageReference Include="System.ComponentModel.TypeConverter.TestData" Version="$(SystemComponentModelTypeConverterTestDataVersion)" />
+    <PackageReference Include="Moq" Version="$(MoqVersion)" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\TestResx.resx">

--- a/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
@@ -37,6 +37,6 @@
     <ProjectReference Include="..\Tools\TDS\TDS\TDS.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="runtime.native.System.Data.SqlClient.sni" Version="$(RuntimeWinX64RuntimeNativeSystemDataSqlClientSniPackageVersion)" />
+    <PackageReference Include="runtime.native.System.Data.SqlClient.sni" Version="$(RuntimeWinX64RuntimeNativeSystemDataSqlClientSniVersion)" />
   </ItemGroup>
 </Project>

--- a/src/System.Diagnostics.Tracing/tests/System.Diagnostics.Tracing.Tests.csproj
+++ b/src/System.Diagnostics.Tracing/tests/System.Diagnostics.Tracing.Tests.csproj
@@ -42,6 +42,6 @@
     <Compile Include="CustomEventSources\UseInterfaceEventSource.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="$(TraceEventPackageVersion)" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="$(TraceEventVersion)" />
   </ItemGroup>
 </Project>

--- a/src/System.Drawing.Common/tests/System.Drawing.Common.Tests.csproj
+++ b/src/System.Drawing.Common/tests/System.Drawing.Common.Tests.csproj
@@ -89,7 +89,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Drawing.Common.TestData" Version="$(SystemDrawingCommonTestDataPackageVersion)" GeneratePathProperty="true" />    
+    <PackageReference Include="System.Drawing.Common.TestData" Version="$(SystemDrawingCommonTestDataVersion)" GeneratePathProperty="true" />    
     <EmbeddedResource Include="$(PkgSystem_Drawing_Common_TestData)\contentFiles\any\any\bitmaps\48x48_multiple_entries_4bit.ico">
       <LogicalName>System.Drawing.Tests.48x48_multiple_entries_4bit.ico</LogicalName>
     </EmbeddedResource>

--- a/src/System.IO.Compression.Brotli/tests/System.IO.Compression.Brotli.Tests.csproj
+++ b/src/System.IO.Compression.Brotli/tests/System.IO.Compression.Brotli.Tests.csproj
@@ -31,7 +31,7 @@
     TODO: Remove when macOS 10.12 support ended.
   -->
   <ItemGroup>
-    <PackageReference Include="System.IO.Compression.TestData" Version="$(SystemIOCompressionTestDataPackageVersion)" ExcludeAssets="contentFiles" GeneratePathProperty="true" />
+    <PackageReference Include="System.IO.Compression.TestData" Version="$(SystemIOCompressionTestDataVersion)" ExcludeAssets="contentFiles" GeneratePathProperty="true" />
     <None Include="$(PkgSystem_IO_Compression_TestData)\contentFiles\any\any\**\*" CopyToOutputDirectory="PreserveNewest" Visible="false" />
   </ItemGroup>
 </Project>

--- a/src/System.IO.Compression.ZipFile/tests/System.IO.Compression.ZipFile.Tests.csproj
+++ b/src/System.IO.Compression.ZipFile/tests/System.IO.Compression.ZipFile.Tests.csproj
@@ -38,7 +38,7 @@
     TODO: Remove when macOS 10.12 support ended.
   -->
   <ItemGroup>
-    <PackageReference Include="System.IO.Compression.TestData" Version="$(SystemIOCompressionTestDataPackageVersion)" ExcludeAssets="contentFiles" GeneratePathProperty="true" />
+    <PackageReference Include="System.IO.Compression.TestData" Version="$(SystemIOCompressionTestDataVersion)" ExcludeAssets="contentFiles" GeneratePathProperty="true" />
     <None Include="$(PkgSystem_IO_Compression_TestData)\contentFiles\any\any\**\*" CopyToOutputDirectory="PreserveNewest" Visible="false" />
   </ItemGroup>
 </Project>

--- a/src/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
+++ b/src/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
@@ -52,7 +52,7 @@
     TODO: Remove when macOS 10.12 support ended.
   -->
   <ItemGroup>
-    <PackageReference Include="System.IO.Compression.TestData" Version="$(SystemIOCompressionTestDataPackageVersion)" ExcludeAssets="contentFiles" GeneratePathProperty="true" />
+    <PackageReference Include="System.IO.Compression.TestData" Version="$(SystemIOCompressionTestDataVersion)" ExcludeAssets="contentFiles" GeneratePathProperty="true" />
     <None Include="$(PkgSystem_IO_Compression_TestData)\contentFiles\any\any\**\*" CopyToOutputDirectory="PreserveNewest" Visible="false" />
   </ItemGroup>
 </Project>

--- a/src/System.IO.Packaging/tests/System.IO.Packaging.Tests.csproj
+++ b/src/System.IO.Packaging/tests/System.IO.Packaging.Tests.csproj
@@ -6,6 +6,6 @@
     <Compile Include="Tests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.IO.Packaging.TestData" Version="$(SystemIOPackagingTestDataPackageVersion)" />
+    <PackageReference Include="System.IO.Packaging.TestData" Version="$(SystemIOPackagingTestDataVersion)" />
   </ItemGroup>
 </Project>

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -246,6 +246,6 @@
     <Compile Include="Dynamic\ExpandoObjectProxyTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="xunit.extensibility.execution" Version="$(XUnitPackageVersion)" />
+    <PackageReference Include="xunit.extensibility.execution" Version="$(XUnitVersion)" />
   </ItemGroup>
 </Project>

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -178,7 +178,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Net.TestData" Version="$(SystemNetTestDataPackageVersion)" />
+    <PackageReference Include="System.Net.TestData" Version="$(SystemNetTestDataVersion)" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="SelectedSitesTest.txt">

--- a/src/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
+++ b/src/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
@@ -43,6 +43,6 @@
     <Compile Include="HttpWebResponseHeaderTest.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Net.TestData" Version="$(SystemNetTestDataPackageVersion)" />
+    <PackageReference Include="System.Net.TestData" Version="$(SystemNetTestDataVersion)" />
   </ItemGroup>
 </Project>

--- a/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -157,7 +157,7 @@
         </Compile>
       </ItemGroup>
       <ItemGroup>
-        <PackageReference Include="System.Net.TestData" Version="$(SystemNetTestDataPackageVersion)" />
+        <PackageReference Include="System.Net.TestData" Version="$(SystemNetTestDataVersion)" />
       </ItemGroup>
     </When>
   </Choose>

--- a/src/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
+++ b/src/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
@@ -60,6 +60,6 @@
     <Compile Include="WebSocketHelper.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Net.TestData" Version="$(SystemNetTestDataPackageVersion)" />
+    <PackageReference Include="System.Net.TestData" Version="$(SystemNetTestDataVersion)" />
   </ItemGroup>
 </Project>

--- a/src/System.Private.Xml/tests/Writers/XmlWriterApi/System.Xml.RW.XmlWriterApi.Tests.csproj
+++ b/src/System.Private.Xml/tests/Writers/XmlWriterApi/System.Xml.RW.XmlWriterApi.Tests.csproj
@@ -43,6 +43,6 @@
     <ProjectReference Include="$(CommonTestPath)\System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="xunit.extensibility.execution" Version="$(XUnitPackageVersion)" />
+    <PackageReference Include="xunit.extensibility.execution" Version="$(XUnitVersion)" />
   </ItemGroup>
 </Project>

--- a/src/System.Resources.Extensions/tests/System.Resources.Extensions.Tests.csproj
+++ b/src/System.Resources.Extensions/tests/System.Resources.Extensions.Tests.csproj
@@ -20,7 +20,7 @@
     <EmbeddedResource Include="TestData.resources" WithCulture="false" Type="Non-Resx" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Drawing.Common.TestData" Version="$(SystemDrawingCommonTestDataPackageVersion)" />    
+    <PackageReference Include="System.Drawing.Common.TestData" Version="$(SystemDrawingCommonTestDataVersion)" />    
   </ItemGroup>
   <!-- use the following target to regenerate the test resources file
        This is done from a test application and checked in so that we don't run

--- a/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
@@ -130,6 +130,6 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Security.Cryptography.X509Certificates.TestData" Version="$(SystemSecurityCryptographyX509CertificatesTestDataPackageVersion)" />
+    <PackageReference Include="System.Security.Cryptography.X509Certificates.TestData" Version="$(SystemSecurityCryptographyX509CertificatesTestDataVersion)" />
   </ItemGroup>
 </Project>

--- a/src/System.Text.Json/tests/System.Text.Json.Tests.csproj
+++ b/src/System.Text.Json/tests/System.Text.Json.Tests.csproj
@@ -119,7 +119,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="JsonArrayTests.cs" />

--- a/src/System.Windows.Extensions/tests/System.Windows.Extensions.Tests.csproj
+++ b/src/System.Windows.Extensions/tests/System.Windows.Extensions.Tests.csproj
@@ -23,8 +23,8 @@
     <Compile Include="System\Media\SystemSoundsTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.ComponentModel.TypeConverter.TestData" Version="$(SystemComponentModelTypeConverterTestDataPackageVersion)" />
-    <PackageReference Include="System.Drawing.Common.TestData" Version="$(SystemDrawingCommonTestDataPackageVersion)" />
-    <PackageReference Include="System.Windows.Extensions.TestData" Version="$(SystemWindowsExtensionsTestDataPackageVersion)" />
+    <PackageReference Include="System.ComponentModel.TypeConverter.TestData" Version="$(SystemComponentModelTypeConverterTestDataVersion)" />
+    <PackageReference Include="System.Drawing.Common.TestData" Version="$(SystemDrawingCommonTestDataVersion)" />
+    <PackageReference Include="System.Windows.Extensions.TestData" Version="$(SystemWindowsExtensionsTestDataVersion)" />
   </ItemGroup>
 </Project>

--- a/src/pkg/Microsoft.Private.PackageBaseline/Microsoft.Private.PackageBaseline.pkgproj
+++ b/src/pkg/Microsoft.Private.PackageBaseline/Microsoft.Private.PackageBaseline.pkgproj
@@ -27,10 +27,10 @@
       <FrameworkLayout Include="$(NETCoreAppPackageRefPath)">
         <TargetFramework>netcoreapp2.0</TargetFramework>
       </FrameworkLayout>
-      <FrameworkLayout Include="$(NuGetPackageRoot)$(NETStandardLibraryPackageId)\$(NETStandardLibraryPackageVersion)\build\netstandard2.0\ref">
+      <FrameworkLayout Include="$(NuGetPackageRoot)$(NETStandardLibraryPackage)\$(NETStandardLibraryVersion)\build\netstandard2.0\ref">
         <TargetFramework>netstandard2.0</TargetFramework>
       </FrameworkLayout>
-      <FrameworkLayout Include="$(NuGetPackageRoot)$(NETStandardLibraryPackageId)\$(NETStandardLibraryPackageVersion)\build\net461\ref">
+      <FrameworkLayout Include="$(NuGetPackageRoot)$(NETStandardLibraryPackage)\$(NETStandardLibraryVersion)\build\net461\ref">
         <TargetFramework>net461</TargetFramework>
       </FrameworkLayout>
     </ItemGroup>

--- a/src/pkg/frameworkPackage.targets
+++ b/src/pkg/frameworkPackage.targets
@@ -5,7 +5,7 @@
     <PreventImplementationReference Condition="'$(PackageTargetRuntime)' != ''">true</PreventImplementationReference>
 
     <NETStandardVersion Condition="'$(NETStandardVersion)' == ''">2.0</NETStandardVersion>
-    <NETStandardPackageRefPath Condition="'$(NETStandardPackageRefPath)' == ''">$(NuGetPackageRoot)$(NETStandardLibraryPackageId.ToLower())\$(NETStandardLibraryPackageVersion)\build\netstandard$(NETStandardVersion)\ref</NETStandardPackageRefPath>
+    <NETStandardPackageRefPath Condition="'$(NETStandardPackageRefPath)' == ''">$(NuGetPackageRoot)$(NETStandardLibraryPackage)\$(NETStandardLibraryVersion)\build\netstandard$(NETStandardVersion)\ref</NETStandardPackageRefPath>
 
     <IncludeReferenceFiles Condition="'$(IncludeReferenceFiles)' == '' AND '$(PackageTargetRuntime)' == ''">true</IncludeReferenceFiles>
     <IncludeLibFiles Condition="'$(IncludeLibFiles)' == '' AND '$(PackageTargetRuntime)' != ''">true</IncludeLibFiles>
@@ -162,8 +162,8 @@
     <Error Condition="'@(_NETStandardFile)' == ''"
            Text="Could not locate NETStandard package content at '$(NETStandardPackageRefPath)'" />
 
-    <Message Condition="'@(_NETStandardSuppressedMissingFile)' != ''" Text="Files'@(_NETStandardSuppressedMissingFile)' are part of '$(NETStandardLibraryPackageId)' but missing from this package's $(_fileSet) files.  This error has been suppressed." />
-    <Error Condition="'@(_NETStandardMissingFileError)' != ''" Text="Files '@(_NETStandardMissingFileError)' are part of '$(NETStandardLibraryPackageId)' but missing from this package's $(_fileSet) files." />
+    <Message Condition="'@(_NETStandardSuppressedMissingFile)' != ''" Text="Files'@(_NETStandardSuppressedMissingFile)' are part of '$(NETStandardLibraryPackage)' but missing from this package's $(_fileSet) files.  This error has been suppressed." />
+    <Error Condition="'@(_NETStandardMissingFileError)' != ''" Text="Files '@(_NETStandardMissingFileError)' are part of '$(NETStandardLibraryPackage)' but missing from this package's $(_fileSet) files." />
   </Target>
 
   <Target Name="GetSymbolPackageFiles" BeforeTargets="GetPackageFiles">

--- a/src/pkg/test/frameworkSettings/netcoreapp5.0/settings.targets
+++ b/src/pkg/test/frameworkSettings/netcoreapp5.0/settings.targets
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp5.0</TargetFramework>
     <NETCoreAppMaximumVersion>5.0</NETCoreAppMaximumVersion>
-    <RuntimeFrameworkVersion>$(MicrosoftNETCoreAppPackageVersion)</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>$(MicrosoftNETCoreAppVersion)</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/pkg/test/packageSettings/System.IO.Ports/workaroundDowngrade.targets
+++ b/src/pkg/test/packageSettings/System.IO.Ports/workaroundDowngrade.targets
@@ -1,6 +1,6 @@
 <Project>
   <ItemGroup>
     <!-- We cannot reference the current build of runtime.native.System.IO.Ports because its built across multiple machines -->
-    <PackageReference Include="runtime.native.System.IO.Ports" Version="$(runtimenativeSystemIOPortsPackageVersion)" NoWarn="NU1605" />
+    <PackageReference Include="runtime.native.System.IO.Ports" Version="$(runtimenativeSystemIOPortsVersion)" NoWarn="NU1605" />
   </ItemGroup>
 </Project>

--- a/src/restore/netstandard/netstandard.depproj
+++ b/src/restore/netstandard/netstandard.depproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="NETStandard.Library">
-      <Version>$(NETStandardLibraryPackageVersion)</Version>
+      <Version>$(NETStandardLibraryVersion)</Version>
     </PackageReference>
   </ItemGroup>
 
@@ -77,7 +77,7 @@
 
   <Target Name="AddNETStandard21Refs" AfterTargets="ResolveReferences">
     <PropertyGroup>
-      <_NETStandard21RefFolder>$(NuGetPackageRoot)$(NETStandardLibraryPackageId.ToLower())\$(NETStandardLibraryPackageVersion)\build\netstandard2.1\ref</_NETStandard21RefFolder>
+      <_NETStandard21RefFolder>$(NuGetPackageRoot)$(NETStandardLibraryPackage)\$(NETStandardLibraryVersion)\build\netstandard2.1\ref</_NETStandard21RefFolder>
     </PropertyGroup>
 
     <ItemGroup>
@@ -102,7 +102,7 @@
   <Target Name="AddNETStandard20Refs" AfterTargets="ResolveReferences"
           Condition="'$(_NETStandardTFMFolder)' != ''">
     <PropertyGroup>
-      <_NETStandardRefFolder>$(NuGetPackageRoot)$(NETStandardLibraryPackageId.ToLower())\$(NETStandardLibraryPackageVersion)\build\$(_NETStandardTFMFolder)\ref</_NETStandardRefFolder>
+      <_NETStandardRefFolder>$(NuGetPackageRoot)$(NETStandardLibraryPackage)\$(NETStandardLibraryVersion)\build\$(_NETStandardTFMFolder)\ref</_NETStandardRefFolder>
     </PropertyGroup>
 
     <ItemGroup>
@@ -117,8 +117,8 @@
     <ItemGroup>
       <Reference Include="@(NetStandardRefs)">
         <Private>False</Private>
-        <NuGetPackageId>$(NETStandardLibraryPackageId)</NuGetPackageId>
-        <NuGetPackageVersion>$(NETStandardLibraryPackageVersion)</NuGetPackageVersion>
+        <NuGetPackageId>$(NETStandardLibraryPackage)</NuGetPackageId>
+        <NuGetPackageVersion>$(NETStandardLibraryVersion)</NuGetPackageVersion>
       </Reference>
     </ItemGroup>
   </Target>

--- a/src/restore/runtime/runtime.depproj
+++ b/src/restore/runtime/runtime.depproj
@@ -13,17 +13,17 @@
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
     <!-- Non-shipping packages do not produce stable versions. -->
-    <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>3.0.0-rc2.19462.14</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
+    <MicrosoftNETCoreRuntimeCoreCLRVersion>3.0.0-rc2.19462.14</MicrosoftNETCoreRuntimeCoreCLRVersion>
     <MicrosoftPrivateCorefxNETCoreAppVersion>4.6.0-rc2.19462.14</MicrosoftPrivateCorefxNETCoreAppVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.Platforms" Version="$(MicrosoftNETCorePlatformsPackageVersion)" />
-    <PackageReference Include="transport.Microsoft.NETCore.Runtime.CoreCLR" Version="$(MicrosoftNETCoreRuntimeCoreCLRPackageVersion)" />
-    <PackageReference Include="Microsoft.NETCore.TestHost" Version="$(MicrosoftNETCoreRuntimeCoreCLRPackageVersion)" />
-    <PackageReference Include="runtime.native.System.Data.SqlClient.sni" Version="$(RuntimeNativeSystemDataSqlClientSniPackageVersion)" />
-    <PackageReference Include="Microsoft.NETCore.DotNetHost" Version="$(MicrosoftNETCoreDotNetHostPackageVersion)" />
-    <PackageReference Include="Microsoft.NETCore.DotNetHostPolicy" Version="$(MicrosoftNETCoreDotNetHostPolicyPackageVersion)" />
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="$(MicrosoftNETCorePlatformsVersion)" />
+    <PackageReference Include="transport.Microsoft.NETCore.Runtime.CoreCLR" Version="$(MicrosoftNETCoreRuntimeCoreCLRVersion)" />
+    <PackageReference Include="Microsoft.NETCore.TestHost" Version="$(MicrosoftNETCoreRuntimeCoreCLRVersion)" />
+    <PackageReference Include="runtime.native.System.Data.SqlClient.sni" Version="$(RuntimeNativeSystemDataSqlClientSniVersion)" />
+    <PackageReference Include="Microsoft.NETCore.DotNetHost" Version="$(MicrosoftNETCoreDotNetHostVersion)" />
+    <PackageReference Include="Microsoft.NETCore.DotNetHostPolicy" Version="$(MicrosoftNETCoreDotNetHostPolicyVersion)" />
     <!-- We do not need apphost.exe and the 3.0 SDK will actually remove it.
          Exclude here so that when building with the 2.x SDK we don't place it in the test shared framework.
          This can be removed once we have a new SDK -->

--- a/src/restore/tools/tools.depproj
+++ b/src/restore/tools/tools.depproj
@@ -8,10 +8,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.ILAsm">
-      <Version>$(MicrosoftNETCoreILAsmPackageVersion)</Version>
+      <Version>$(MicrosoftNETCoreILAsmVersion)</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.ILDAsm">
-      <Version>$(MicrosoftNETCoreILAsmPackageVersion)</Version>
+      <Version>$(MicrosoftNETCoreILAsmVersion)</Version>
     </PackageReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
I'm consolidating all the version properties to use the `Version` suffix instead of `PackageVersion`. This aligns to Arcade conventions and extension point which also use the `Version` suffix.

Requires https://github.com/dotnet/arcade/pull/4266