### PR TITLE
Remove hardcoded paths from native build scripts

### DIFF
--- a/src/Native/Unix/gen-buildsys-clang.sh
+++ b/src/Native/Unix/gen-buildsys-clang.sh
@@ -45,7 +45,7 @@ else
 fi
 
 cmake_cmd=cmake
-cmake_extra_defines="-DCMAKE_BUILD_TYPE=$buildtype -DCMAKE_REPO_ROOT=\"$repo_root\""
+cmake_extra_defines="-DCMAKE_BUILD_TYPE=$buildtype"
 if [[ -n "$CROSSCOMPILE" ]]; then
     if ! [[ -n "$ROOTFS_DIR" ]]; then
         echo "ROOTFS_DIR not set for crosscompile"

--- a/src/Native/Unix/gen-buildsys-clang.sh
+++ b/src/Native/Unix/gen-buildsys-clang.sh
@@ -15,7 +15,7 @@ then
   exit 1
 fi
 
-#Set the root directory of the project
+#root directory of the project
 repo_root="$1"
 
 # Set up the environment to be used for building with clang.

--- a/src/Native/Unix/gen-buildsys-clang.sh
+++ b/src/Native/Unix/gen-buildsys-clang.sh
@@ -52,11 +52,11 @@ if [[ -n "$CROSSCOMPILE" ]]; then
         exit 1
     fi
     if [[ -z "$CONFIG_DIR" ]]; then
-        CONFIG_DIR="$repo_root/cross"
+        CONFIG_DIR=$repo_root/cross
     fi
     export TARGET_BUILD_ARCH=$build_arch
-    cmake_extra_defines="$cmake_extra_defines -C $CONFIG_DIR/tryrun.cmake"
-    cmake_extra_defines="$cmake_extra_defines -DCMAKE_TOOLCHAIN_FILE=$CONFIG_DIR/toolchain.cmake"
+    cmake_extra_defines="$cmake_extra_defines -C \"$CONFIG_DIR/tryrun.cmake\""
+    cmake_extra_defines="$cmake_extra_defines -DCMAKE_TOOLCHAIN_FILE=\"$CONFIG_DIR/toolchain.cmake\""
 fi
 if [ "$build_arch" == "armel" ]; then
     cmake_extra_defines="$cmake_extra_defines -DARM_SOFTFP=1"

--- a/src/Native/Unix/gen-buildsys-clang.sh
+++ b/src/Native/Unix/gen-buildsys-clang.sh
@@ -16,7 +16,7 @@ then
 fi
 
 #root directory of the project
-repo_root="$1"
+repo_root=$1
 
 # Set up the environment to be used for building with clang.
 if which "clang-$3.$4" > /dev/null 2>&1

--- a/src/Native/Unix/gen-buildsys-clang.sh
+++ b/src/Native/Unix/gen-buildsys-clang.sh
@@ -56,7 +56,7 @@ if [[ -n "$CROSSCOMPILE" ]]; then
     fi
     export TARGET_BUILD_ARCH=$build_arch
     cmake_extra_defines="$cmake_extra_defines -C \"$CONFIG_DIR/tryrun.cmake\""
-    cmake_extra_defines="$cmake_extra_defines -DCMAKE_TOOLCHAIN_FILE=\"$CONFIG_DIR/toolchain.cmake\""
+    cmake_extra_defines="$cmake_extra_defines \"-DCMAKE_TOOLCHAIN_FILE=$CONFIG_DIR/toolchain.cmake\""
 fi
 if [ "$build_arch" == "armel" ]; then
     cmake_extra_defines="$cmake_extra_defines -DARM_SOFTFP=1"

--- a/src/Native/Unix/gen-buildsys-clang.sh
+++ b/src/Native/Unix/gen-buildsys-clang.sh
@@ -3,10 +3,10 @@
 # This file invokes cmake and generates the build system for Clang.
 #
 
-if [ $# -lt 4 -o $# -gt 6 ]
+if [ $# -lt 5 -o $# -gt 7 ]
 then
   echo "Usage..."
-  echo "gen-buildsys-clang.sh <path to top level CMakeLists.txt> <ClangMajorVersion> <ClangMinorVersion> <Architecture> [build flavor] [cmakeargs]"
+  echo "gen-buildsys-clang.sh <path to repo root> <path to top level CMakeLists.txt> <ClangMajorVersion> <ClangMinorVersion> <Architecture> [build flavor] [cmakeargs]"
   echo "Specify the path to the top level CMake file - <corefx>/src/Native/Unix"
   echo "Specify the clang version to use, split into major and minor version"
   echo "Specify the target architecture." 
@@ -16,15 +16,15 @@ then
 fi
 
 #Set the root directory of the project
-project_root="$1"/../../..
+repo_root="$1"
 
 # Set up the environment to be used for building with clang.
-if which "clang-$2.$3" > /dev/null 2>&1
+if which "clang-$3.$4" > /dev/null 2>&1
     then
-        export CC="$(which clang-$2.$3)"
-elif which "clang$2$3" > /dev/null 2>&1
+        export CC="$(which clang-$3.$4)"
+elif which "clang$3$4" > /dev/null 2>&1
     then
-        export CC="$(which clang$2$3)"
+        export CC="$(which clang$3$4)"
 elif which clang > /dev/null 2>&1
     then
         export CC="$(which clang)"
@@ -33,26 +33,26 @@ else
     exit 1
 fi
 
-build_arch="$4"
+build_arch="$5"
 # Possible build types are DEBUG, RELEASE, RELWITHDEBINFO, MINSIZEREL.
 # Default to DEBUG
-if [ -z "$5" ]
+if [ -z "$6" ]
 then
   echo "Defaulting to DEBUG build."
   buildtype="DEBUG"
 else
-  buildtype="$5"
+  buildtype="$6"
 fi
 
 cmake_cmd=cmake
-cmake_extra_defines="-DCMAKE_BUILD_TYPE=$buildtype"
+cmake_extra_defines="-DCMAKE_BUILD_TYPE=$buildtype -DCMAKE_REPO_ROOT=\"$repo_root\""
 if [[ -n "$CROSSCOMPILE" ]]; then
     if ! [[ -n "$ROOTFS_DIR" ]]; then
         echo "ROOTFS_DIR not set for crosscompile"
         exit 1
     fi
     if [[ -z "$CONFIG_DIR" ]]; then
-        CONFIG_DIR="$project_root/cross"
+        CONFIG_DIR="$repo_root/cross"
     fi
     export TARGET_BUILD_ARCH=$build_arch
     cmake_extra_defines="$cmake_extra_defines -C $CONFIG_DIR/tryrun.cmake"
@@ -70,13 +70,13 @@ if [ "$build_arch" == "wasm" ]; then
 fi
 
 __UnprocessedCMakeArgs=""
-if [ -z "$6" ]; then
+if [ -z "$7" ]; then
     echo "No CMake extra Args specified"
 else
-    __UnprocessedCMakeArgs="$6"
+    __UnprocessedCMakeArgs="$7"
 fi
 
-echo "Invoking \"$cmake_cmd $cmake_extra_defines $__UnprocessedCMakeArgs $1\""
+echo "Invoking \"$cmake_cmd $cmake_extra_defines $__UnprocessedCMakeArgs $2\""
 $cmake_cmd $cmake_extra_defines \
     $__UnprocessedCMakeArgs \
-    $1
+    $2

--- a/src/Native/Unix/gen-buildsys-clang.sh
+++ b/src/Native/Unix/gen-buildsys-clang.sh
@@ -55,8 +55,8 @@ if [[ -n "$CROSSCOMPILE" ]]; then
         CONFIG_DIR=$repo_root/cross
     fi
     export TARGET_BUILD_ARCH=$build_arch
-    cmake_extra_defines="$cmake_extra_defines -C \"$CONFIG_DIR/tryrun.cmake\""
-    cmake_extra_defines="$cmake_extra_defines \"-DCMAKE_TOOLCHAIN_FILE=$CONFIG_DIR/toolchain.cmake\""
+    cmake_extra_defines="$cmake_extra_defines -C $CONFIG_DIR/tryrun.cmake"
+    cmake_extra_defines="$cmake_extra_defines -DCMAKE_TOOLCHAIN_FILE=$CONFIG_DIR/toolchain.cmake"
 fi
 if [ "$build_arch" == "armel" ]; then
     cmake_extra_defines="$cmake_extra_defines -DARM_SOFTFP=1"

--- a/src/Native/Unix/gen-buildsys-gcc.sh
+++ b/src/Native/Unix/gen-buildsys-gcc.sh
@@ -3,10 +3,10 @@
 # This file invokes cmake and generates the build system for Gcc.
 #
 
-if [ $# -lt 4 ]
+if [ $# -lt 5 ]
 then
   echo "Usage..."
-  echo "gen-buildsys-gcc.sh <path to top level CMakeLists.txt> <GccMajorVersion> <GccMinorVersion> <Architecture> [build flavor] [cmakeargs]"
+  echo "gen-buildsys-gcc.sh <path to repo root> <path to top level CMakeLists.txt> <GccMajorVersion> <GccMinorVersion> <Architecture> [build flavor] [cmakeargs]"
   echo "Specify the path to the top level CMake file - <corefx>/src/Native/Unix"
   echo "Specify the gcc version to use, split into major and minor version"
   echo "Specify the target architecture."
@@ -14,6 +14,9 @@ then
   echo "Optionally pass additional arguments to CMake call."
   exit 1
 fi
+
+#root directory of the project
+repo_root="$1"
 
 # Locate gcc
 gcc_prefix=""
@@ -26,15 +29,15 @@ if [ "$CROSSCOMPILE" = "1" ]; then
 fi
 
 # Set up the environment to be used for building with gcc.
-if command -v "${gcc_prefix}gcc-$2.$3" > /dev/null
+if command -v "${gcc_prefix}gcc-$3.$4" > /dev/null
     then
-        desired_gcc_version="-$2.$3"
-elif command -v "${gcc_prefix}gcc$2$3" > /dev/null
+        desired_gcc_version="-$3.$4"
+elif command -v "${gcc_prefix}gcc$3$4" > /dev/null
     then
-        desired_gcc_version="$2$3"
-elif command -v "${gcc_prefix}gcc-$2$3" > /dev/null
+        desired_gcc_version="$3$4"
+elif command -v "${gcc_prefix}gcc-$3$4" > /dev/null
     then
-        desired_gcc_version="-$2$3"
+        desired_gcc_version="-$3$4"
 elif command -v "${gcc_prefix}gcc" > /dev/null
     then
         desired_gcc_version=
@@ -57,7 +60,7 @@ fi
 
 export CC CXX
 
-build_arch="$4"
+build_arch="$5"
 buildtype=DEBUG
 __UnprocessedCMakeArgs=""
 
@@ -79,18 +82,18 @@ done
 OS=$(uname)
 
 locate_gcc_exec() {
-  ENV_KNOB="CLR_$(echo "$1" | tr '[:lower:]' '[:upper:]')"
+  ENV_KNOB="CLR_$(echo "$2" | tr '[:lower:]' '[:upper:]')"
   if env | grep -q "^$ENV_KNOB="; then
     eval "echo \"\$$ENV_KNOB\""
     return
   fi
 
-  if command -v "$gcc_prefix$1$desired_gcc_version" > /dev/null 2>&1
+  if command -v "$gcc_prefix$2$desired_gcc_version" > /dev/null 2>&1
   then
-    command -v "$gcc_prefix$1$desired_gcc_version"
-  elif command -v "$gcc_prefix$1" > /dev/null 2>&1
+    command -v "$gcc_prefix$2$desired_gcc_version"
+  elif command -v "$gcc_prefix$2" > /dev/null 2>&1
   then
-    command -v "$gcc_prefix$1"
+    command -v "$gcc_prefix$2"
   else
     exit 1
   fi
@@ -110,7 +113,7 @@ if ! gcc_objcopy="$(locate_gcc_exec objcopy)"; then { echo "Unable to locate gcc
 
 if ! gcc_ranlib="$(locate_gcc_exec ranlib)"; then { echo "Unable to locate gcc-ranlib"; exit 1; } fi
 
-cmake_extra_defines=
+cmake_extra_defines="-DCMAKE_REPO_ROOT=\"$repo_root\""
 if [ -n "$LLDB_LIB_DIR" ]; then
     cmake_extra_defines="$cmake_extra_defines -DWITH_LLDB_LIBS=$LLDB_LIB_DIR"
 fi
@@ -123,7 +126,7 @@ if [ "$CROSSCOMPILE" = "1" ]; then
         exit 1
     fi
     if [ -z "$CONFIG_DIR" ]; then
-        CONFIG_DIR="$1/cross"
+        CONFIG_DIR="$2/cross"
     fi
     export TARGET_BUILD_ARCH=$build_arch
     cmake_extra_defines="$cmake_extra_defines -C $CONFIG_DIR/tryrun.cmake"
@@ -146,4 +149,4 @@ cmake \
   "-DCMAKE_EXPORT_COMPILE_COMMANDS=1 " \
   $cmake_extra_defines \
   "$__UnprocessedCMakeArgs" \
-  "$1"
+  "$2"

--- a/src/Native/Unix/gen-buildsys-gcc.sh
+++ b/src/Native/Unix/gen-buildsys-gcc.sh
@@ -16,7 +16,7 @@ then
 fi
 
 #root directory of the project
-repo_root="$1"
+repo_root=$1
 
 # Locate gcc
 gcc_prefix=""

--- a/src/Native/Unix/gen-buildsys-gcc.sh
+++ b/src/Native/Unix/gen-buildsys-gcc.sh
@@ -113,7 +113,7 @@ if ! gcc_objcopy="$(locate_gcc_exec objcopy)"; then { echo "Unable to locate gcc
 
 if ! gcc_ranlib="$(locate_gcc_exec ranlib)"; then { echo "Unable to locate gcc-ranlib"; exit 1; } fi
 
-cmake_extra_defines="-DCMAKE_REPO_ROOT=\"$repo_root\""
+cmake_extra_defines=
 if [ -n "$LLDB_LIB_DIR" ]; then
     cmake_extra_defines="$cmake_extra_defines -DWITH_LLDB_LIBS=$LLDB_LIB_DIR"
 fi

--- a/src/Native/Windows/clrcompression/CMakeLists.txt
+++ b/src/Native/Windows/clrcompression/CMakeLists.txt
@@ -84,7 +84,7 @@ add_library(clrcompression
     SHARED
     ${NATIVECOMPRESSION_SOURCES}
     # This will add versioning to the library
-    ${CMAKE_SOURCE_DIR}/../../../artifacts/obj/NativeVersion.rc
+    ${CMAKE_REPO_ROOT}/artifacts/obj/NativeVersion.rc
 )
 
 # Allow specification of arguments that should be passed to the linker

--- a/src/Native/Windows/gen-buildsys-win.bat
+++ b/src/Native/Windows/gen-buildsys-win.bat
@@ -26,6 +26,10 @@ if /i "%3" == "arm"     (set __ExtraCmakeParams=%__ExtraCmakeParams% -A ARM)
 if /i "%3" == "arm64"   (set __ExtraCmakeParams=%__ExtraCmakeParams% -A ARM64)
 if /i "%3" == "wasm"    (set __sourceDir=%~dp0..\Unix && goto DoGen)
 
+:: cmake requires forward slashes in paths
+set __cmakeRepoRoot=%__repoRoot:\=/%
+set __ExtraCmakeParams=%__ExtraCmakeParams% "-DCMAKE_REPO_ROOT=%__cmakeRepoRoot%"
+
 if defined CMakePath goto DoGen
 
 :: Eval the output from probe-win1.ps1
@@ -44,7 +48,7 @@ if "%3" == "wasm" (
     if "%EMSCRIPTEN_ROOT%" == "" (
       set EMSCRIPTEN_ROOT="%EMSDK_PATH/upstream/emscripten%"
     )
-    emcmake cmake "-DEMSCRIPTEN_GENERATE_BITCODE_STATIC_LIBRARIES=1" "-DCMAKE_TOOLCHAIN_FILE=%EMSCRIPTEN%/cmake/Modules/Platform/Emscripten.cmake" "-DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%" -G "NMake Makefiles" %__sourceDir%
+    emcmake cmake "-DEMSCRIPTEN_GENERATE_BITCODE_STATIC_LIBRARIES=1" "-DCMAKE_REPO_ROOT=%__cmakeRepoRoot%" "-DCMAKE_TOOLCHAIN_FILE=%EMSCRIPTEN%/cmake/Modules/Platform/Emscripten.cmake" "-DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%" -G "NMake Makefiles" %__sourceDir%
 ) else (
     "%CMakePath%" %__SDKVersion% "-DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%" "-DCMAKE_INSTALL_PREFIX=%__CMakeBinDir%" -G "Visual Studio %__VSString%" -B. -H%1 %__ExtraCmakeParams%
 )

--- a/src/Native/build-native.cmd
+++ b/src/Native/build-native.cmd
@@ -4,8 +4,8 @@ setlocal
 :SetupArgs
 :: Initialize the args that will be passed to cmake
 set __nativeWindowsDir=%~dp0\Windows
-set __artifactsDir=%~dp0..\..\artifacts
-set __rootDir=%~dp0..\..
+set __repoRoot=%~dp0..\..
+set __artifactsDir=%__repoRoot%\artifacts
 set __CMakeBinDir=""
 set __IntermediatesDir=""
 set __BuildArch=x64
@@ -105,6 +105,7 @@ if %__IntermediatesDir% == "" (
 )
 set "__CMakeBinDir=%__CMakeBinDir:\=/%"
 set "__IntermediatesDir=%__IntermediatesDir:\=/%"
+set "CMAKE_ROOT_REPO=%__repoRoot%
 
 :: Check that the intermediate directory exists so we can place our cmake build tree there
 if "%__BuildTarget%"=="rebuild" if exist "%__IntermediatesDir%" rd /s /q "%__IntermediatesDir%"

--- a/src/Native/build-native.cmd
+++ b/src/Native/build-native.cmd
@@ -105,7 +105,6 @@ if %__IntermediatesDir% == "" (
 )
 set "__CMakeBinDir=%__CMakeBinDir:\=/%"
 set "__IntermediatesDir=%__IntermediatesDir:\=/%"
-set "CMAKE_ROOT_REPO=%__repoRoot%
 
 :: Check that the intermediate directory exists so we can place our cmake build tree there
 if "%__BuildTarget%"=="rebuild" if exist "%__IntermediatesDir%" rd /s /q "%__IntermediatesDir%"

--- a/src/Native/build-native.cmd
+++ b/src/Native/build-native.cmd
@@ -4,7 +4,12 @@ setlocal
 :SetupArgs
 :: Initialize the args that will be passed to cmake
 set __nativeWindowsDir=%~dp0\Windows
-set __repoRoot=%~dp0..\..
+:: TODO: (Consolidation) Remove when consolidated
+if exist "%~dp0..\..\..\.dotnet-runtime-placeholder" (
+    set __repoRoot=%~dp0..\..\..
+) else (
+    set __repoRoot=%~dp0..\..
+)
 set __artifactsDir=%__repoRoot%\artifacts
 set __CMakeBinDir=""
 set __IntermediatesDir=""

--- a/src/Native/build-native.sh
+++ b/src/Native/build-native.sh
@@ -153,10 +153,10 @@ build_native()
     # Regenerate the CMake solution
     if [ "$__GccBuild" = 0 ]; then
         echo "Invoking \"$__nativeroot/gen-buildsys-clang.sh\" \"$__rootRepo\" \"$__nativeroot\" \"$__ClangMajorVersion\" \"$__ClangMinorVersion\" \"$__BuildArch\" \"$__CMakeArgs\" \"$__CMakeExtraArgs\""
-        "$__nativeroot/gen-buildsys-clang.sh" "$__nativeroot" "$__ClangMajorVersion" "$__ClangMinorVersion" "$__BuildArch" "$__CMakeArgs" "$__CMakeExtraArgs"
+        "$__nativeroot/gen-buildsys-clang.sh" \"$__rootRepo\" "$__nativeroot" "$__ClangMajorVersion" "$__ClangMinorVersion" "$__BuildArch" "$__CMakeArgs" "$__CMakeExtraArgs"
     else
         echo "Invoking \"$__nativeroot/gen-buildsys-gcc.sh\" \"$__rootRepo\" \"$__nativeroot\" \"$__GccMajorVersion\" \"$__GccMinorVersion\" \"$__BuildArch\" \"$__CMakeArgs\" \"$__CMakeExtraArgs\""
-        "$__nativeroot/gen-buildsys-gcc.sh" "$__nativeroot" "$__GccMajorVersion" "$__GccMinorVersion" "$__BuildArch" "$__CMakeArgs" "$__CMakeExtraArgs"
+        "$__nativeroot/gen-buildsys-gcc.sh" \"$__rootRepo\" "$__nativeroot" "$__GccMajorVersion" "$__GccMinorVersion" "$__BuildArch" "$__CMakeArgs" "$__CMakeExtraArgs"
     fi
 
     # Check that the makefiles were created.

--- a/src/Native/build-native.sh
+++ b/src/Native/build-native.sh
@@ -26,7 +26,7 @@ usage()
 
 __scriptpath=$(cd "$(dirname "$0")"; pwd -P)
 __nativeroot=$__scriptpath/Unix
-__rootRepo="$__scriptpath/../.."
+__rootRepo=$(cd "$__scriptpath/../.."; pwd -P)
 __artifactsDir="$__rootRepo/artifacts"
 
 initHostDistroRid()

--- a/src/Native/build-native.sh
+++ b/src/Native/build-native.sh
@@ -159,10 +159,10 @@ build_native()
     # Regenerate the CMake solution
     if [ "$__GccBuild" = 0 ]; then
         echo "Invoking \"$__nativeroot/gen-buildsys-clang.sh\" \"$__rootRepo\" \"$__nativeroot\" \"$__ClangMajorVersion\" \"$__ClangMinorVersion\" \"$__BuildArch\" \"$__CMakeArgs\" \"$__CMakeExtraArgs\""
-        "$__nativeroot/gen-buildsys-clang.sh" \"$__rootRepo\" "$__nativeroot" "$__ClangMajorVersion" "$__ClangMinorVersion" "$__BuildArch" "$__CMakeArgs" "$__CMakeExtraArgs"
+        "$__nativeroot/gen-buildsys-clang.sh" "$__rootRepo" "$__nativeroot" "$__ClangMajorVersion" "$__ClangMinorVersion" "$__BuildArch" "$__CMakeArgs" "$__CMakeExtraArgs"
     else
         echo "Invoking \"$__nativeroot/gen-buildsys-gcc.sh\" \"$__rootRepo\" \"$__nativeroot\" \"$__GccMajorVersion\" \"$__GccMinorVersion\" \"$__BuildArch\" \"$__CMakeArgs\" \"$__CMakeExtraArgs\""
-        "$__nativeroot/gen-buildsys-gcc.sh" \"$__rootRepo\" "$__nativeroot" "$__GccMajorVersion" "$__GccMinorVersion" "$__BuildArch" "$__CMakeArgs" "$__CMakeExtraArgs"
+        "$__nativeroot/gen-buildsys-gcc.sh" "$__rootRepo" "$__nativeroot" "$__GccMajorVersion" "$__GccMinorVersion" "$__BuildArch" "$__CMakeArgs" "$__CMakeExtraArgs"
     fi
 
     # Check that the makefiles were created.

--- a/src/Native/build-native.sh
+++ b/src/Native/build-native.sh
@@ -24,6 +24,11 @@ usage()
     exit 1
 }
 
+__scriptpath=$(cd "$(dirname "$0")"; pwd -P)
+__nativeroot=$__scriptpath/Unix
+__rootRepo="$__scriptpath/../.."
+__artifactsDir="$__rootRepo/artifacts"
+
 initHostDistroRid()
 {
     __HostDistroRid=""
@@ -147,10 +152,10 @@ build_native()
 
     # Regenerate the CMake solution
     if [ "$__GccBuild" = 0 ]; then
-        echo "Invoking \"$__nativeroot/gen-buildsys-clang.sh\" \"$__nativeroot\" \"$__ClangMajorVersion\" \"$__ClangMinorVersion\" \"$__BuildArch\" \"$__CMakeArgs\" \"$__CMakeExtraArgs\""
+        echo "Invoking \"$__nativeroot/gen-buildsys-clang.sh\" \"$__rootRepo\" \"$__nativeroot\" \"$__ClangMajorVersion\" \"$__ClangMinorVersion\" \"$__BuildArch\" \"$__CMakeArgs\" \"$__CMakeExtraArgs\""
         "$__nativeroot/gen-buildsys-clang.sh" "$__nativeroot" "$__ClangMajorVersion" "$__ClangMinorVersion" "$__BuildArch" "$__CMakeArgs" "$__CMakeExtraArgs"
     else
-        echo "Invoking \"$__nativeroot/gen-buildsys-gcc.sh\" \"$__nativeroot\" \"$__GccMajorVersion\" \"$__GccMinorVersion\" \"$__BuildArch\" \"$__CMakeArgs\" \"$__CMakeExtraArgs\""
+        echo "Invoking \"$__nativeroot/gen-buildsys-gcc.sh\" \"$__rootRepo\" \"$__nativeroot\" \"$__GccMajorVersion\" \"$__GccMinorVersion\" \"$__BuildArch\" \"$__CMakeArgs\" \"$__CMakeExtraArgs\""
         "$__nativeroot/gen-buildsys-gcc.sh" "$__nativeroot" "$__GccMajorVersion" "$__GccMinorVersion" "$__BuildArch" "$__CMakeArgs" "$__CMakeExtraArgs"
     fi
 
@@ -171,11 +176,6 @@ build_native()
         exit 1
     fi
 }
-
-__scriptpath=$(cd "$(dirname "$0")"; pwd -P)
-__nativeroot=$__scriptpath/Unix
-__rootRepo="$__scriptpath/../.."
-__artifactsDir="$__rootRepo/artifacts"
 
 # Set the various build properties here so that CMake and MSBuild can pick them up
 __CMakeExtraArgs=""

--- a/src/Native/build-native.sh
+++ b/src/Native/build-native.sh
@@ -26,7 +26,13 @@ usage()
 
 __scriptpath=$(cd "$(dirname "$0")"; pwd -P)
 __nativeroot=$__scriptpath/Unix
-__rootRepo=$(cd "$__scriptpath/../.."; pwd -P)
+# TODO: (Consolidation) Remove when consolidated
+if [ -f "$__scriptpath/../../../.dotnet-runtime-placeholder" ]; then
+    __rootRepo=$(cd "$__scriptpath/../../.."; pwd -P)
+else
+    # we're still in corefx
+    __rootRepo=$(cd "$__scriptpath/../.."; pwd -P)
+fi
 __artifactsDir="$__rootRepo/artifacts"
 
 initHostDistroRid()


### PR DESCRIPTION
In anticipation of the repo consolidation, removes a few hardcoded relative paths from the native build script. They are now calculated relative to the corefx/repo root path which is declared at the start of the build scripts.