### PR TITLE
Add desktop build of System.Runtime.CompilerServices.Unsafe

### DIFF
--- a/src/System.Runtime.CompilerServices.Unsafe/src/Configurations.props
+++ b/src/System.Runtime.CompilerServices.Unsafe/src/Configurations.props
@@ -4,10 +4,12 @@
       netcoreapp2.0;
       netstandard1.0;
       netstandard2.0;
+      net45;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);
-      netcoreapp
+      netcoreapp;
+      netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.ilproj
+++ b/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.ilproj
@@ -8,9 +8,10 @@
     <DocumentationFile>$(MSBuildThisFileDirectory)System.Runtime.CompilerServices.Unsafe.xml</DocumentationFile>
     <ProjectGuid>{04BA3E3C-6979-4792-B19E-C797AD607F42}</ProjectGuid>
     <IncludePath>include\$(TargetGroup)</IncludePath>
-    <IncludePath Condition="'$(TargetFramework)' == 'netcoreapp2.0'">include\netcoreapp</IncludePath>
+    <IncludePath Condition="'$(TargetsNetCoreApp)' == 'true'">include\netcoreapp</IncludePath>
+    <IncludePath Condition="'$(TargetsNetFx)' == 'true'">include\netfx</IncludePath>
     <IlasmFlags>$(IlasmFlags) -INCLUDE=$(IncludePath) -DEBUG=$(DebugOptimization)</IlasmFlags>
-    <Configurations>netcoreapp-Debug;netcoreapp-Release;netcoreapp2.0-Debug;netcoreapp2.0-Release;netstandard2.0-Debug;netstandard2.0-Release;netstandard1.0-Debug;netstandard1.0-Release</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release;netcoreapp2.0-Debug;netcoreapp2.0-Release;netstandard2.0-Debug;netstandard2.0-Release;netstandard1.0-Debug;netstandard1.0-Release;net45-Debug;net45-Release;netfx-Debug;netfx-Release</Configurations>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Runtime.CompilerServices.Unsafe/src/include/netfx/coreassembly.h
+++ b/src/System.Runtime.CompilerServices.Unsafe/src/include/netfx/coreassembly.h
@@ -1,0 +1,9 @@
+#define CORE_ASSEMBLY "mscorlib"
+#define net45
+
+// Metadata version: v4.0.30319
+.assembly extern CORE_ASSEMBLY
+{
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
+  .ver 4:0:0:0
+}


### PR DESCRIPTION
Avoids netstandard contracts references when consuming System.Runtime.CompilerServices.Unsafe on desktop.