### PR TITLE
Reduce intrinsic converters

### DIFF
--- a/src/System.ComponentModel.Primitives/ref/System.ComponentModel.Primitives.cs
+++ b/src/System.ComponentModel.Primitives/ref/System.ComponentModel.Primitives.cs
@@ -154,6 +154,7 @@ namespace System.ComponentModel
         public void Dispose() { }
         public void RemoveHandler(object key, System.Delegate? value) { }
     }
+    [System.ComponentModel.TypeConverterAttribute("System.ComponentModel.ComponentConverter, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public partial interface IComponent : System.IDisposable
     {
         System.ComponentModel.ISite? Site { get; set; }

--- a/src/System.ComponentModel.Primitives/ref/System.ComponentModel.Primitives.csproj
+++ b/src/System.ComponentModel.Primitives/ref/System.ComponentModel.Primitives.csproj
@@ -7,6 +7,7 @@
     <Compile Include="System.ComponentModel.Primitives.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\System.ObjectModel\ref\System.ObjectModel.csproj" />
     <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />
     <ProjectReference Include="..\..\System.Collections.NonGeneric\ref\System.Collections.NonGeneric.csproj" />
     <ProjectReference Include="..\..\System.ComponentModel\ref\System.ComponentModel.csproj" />

--- a/src/System.ComponentModel.Primitives/src/System.ComponentModel.Primitives.csproj
+++ b/src/System.ComponentModel.Primitives/src/System.ComponentModel.Primitives.csproj
@@ -41,6 +41,7 @@
     <Reference Include="System.Collections.NonGeneric" />
     <Reference Include="System.ComponentModel" />
     <Reference Include="System.Diagnostics.Tools" />
+    <Reference Include="System.ObjectModel" />
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />

--- a/src/System.ComponentModel.Primitives/src/System/ComponentModel/IComponent.cs
+++ b/src/System.ComponentModel.Primitives/src/System/ComponentModel/IComponent.cs
@@ -20,6 +20,7 @@ namespace System.ComponentModel
     /// provided "site".
     /// Provides functionality required by all components.
     /// </summary>
+    [TypeConverter("System.ComponentModel.ComponentConverter, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public interface IComponent : IDisposable
     {
         /// <summary>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
@@ -127,16 +127,10 @@ namespace System.ComponentModel
             [typeof(Guid)] = typeof(GuidConverter),
             [typeof(Uri)] = typeof(UriTypeConverter),
             [typeof(Version)] = typeof(VersionConverter),
-            [typeof(Color)] = typeof(ColorConverter),
-            [typeof(Point)] = typeof(PointConverter),
-            [typeof(Rectangle)] = typeof(RectangleConverter),
-            [typeof(Size)] = typeof(SizeConverter),
-            [typeof(SizeF)] = typeof(SizeFConverter),
             // Special cases for things that are not bound to a specific type
             //
             [typeof(Array)] = typeof(ArrayConverter),
             [typeof(ICollection)] = typeof(CollectionConverter),
-            [typeof(IComponent)] = typeof(ComponentConverter),
             [typeof(Enum)] = typeof(EnumConverter),
             [s_intrinsicNullableKey] = typeof(NullableConverter),
         });

--- a/src/System.ComponentModel.TypeConverter/tests/Drawing/ColorConverterTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/Drawing/ColorConverterTests.cs
@@ -14,6 +14,13 @@ namespace System.ComponentModel.TypeConverterTests
 {
     public class ColorConverterTests
     {
+        [Fact]
+        public void IsConverterForColor()
+        {
+            var conv = TypeDescriptor.GetConverter(typeof(Color));
+            Assert.IsType<ColorConverter>(conv);
+        }
+
         [Theory]
         [InlineData(typeof(string))]
         public void CanConvertFromTrue(Type type)

--- a/src/System.ComponentModel.TypeConverter/tests/Drawing/StringTypeConverterTestBase.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/Drawing/StringTypeConverterTestBase.cs
@@ -23,6 +23,13 @@ namespace System.ComponentModel.TypeConverterTests
         }
 
         [Fact]
+        public void IsConverterForT()
+        {
+            var conv = TypeDescriptor.GetConverter(typeof(T));
+            Assert.IsType(Converter.GetType(), conv);
+        }
+
+        [Fact]
         public void GetStandardValuesSupported()
         {
             Assert.Equal(StandardValuesSupported, Converter.GetStandardValuesSupported());

--- a/src/System.Drawing.Primitives/ref/System.Drawing.Primitives.cs
+++ b/src/System.Drawing.Primitives/ref/System.Drawing.Primitives.cs
@@ -7,6 +7,7 @@
 
 namespace System.Drawing
 {
+    [System.ComponentModel.TypeConverterAttribute("System.Drawing.ColorConverter, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
     public readonly partial struct Color : System.IEquatable<System.Drawing.Color>
     {
         private readonly object _dummy;
@@ -366,6 +367,7 @@ namespace System.Drawing
         MenuBar = 173,
         MenuHighlight = 174,
     }
+    [System.ComponentModel.TypeConverterAttribute("System.Drawing.PointConverter, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
     public partial struct Point : System.IEquatable<System.Drawing.Point>
     {
         private int _dummyPrimitive;
@@ -419,6 +421,7 @@ namespace System.Drawing
         public static System.Drawing.PointF Subtract(System.Drawing.PointF pt, System.Drawing.SizeF sz) { throw null; }
         public override readonly string ToString() { throw null; }
     }
+    [System.ComponentModel.TypeConverterAttribute("System.Drawing.RectangleConverter, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
     public partial struct Rectangle : System.IEquatable<System.Drawing.Rectangle>
     {
         private int _dummyPrimitive;
@@ -511,6 +514,7 @@ namespace System.Drawing
         public override readonly string ToString() { throw null; }
         public static System.Drawing.RectangleF Union(System.Drawing.RectangleF a, System.Drawing.RectangleF b) { throw null; }
     }
+    [System.ComponentModel.TypeConverterAttribute("System.Drawing.SizeConverter, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
     public partial struct Size : System.IEquatable<System.Drawing.Size>
     {
         private int _dummyPrimitive;
@@ -543,6 +547,7 @@ namespace System.Drawing
         public override readonly string ToString() { throw null; }
         public static System.Drawing.Size Truncate(System.Drawing.SizeF value) { throw null; }
     }
+    [System.ComponentModel.TypeConverterAttribute("System.Drawing.SizeFConverter, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
     public partial struct SizeF : System.IEquatable<System.Drawing.SizeF>
     {
         private int _dummyPrimitive;

--- a/src/System.Drawing.Primitives/ref/System.Drawing.Primitives.csproj
+++ b/src/System.Drawing.Primitives/ref/System.Drawing.Primitives.csproj
@@ -7,6 +7,7 @@
     <Compile Include="System.Drawing.Primitives.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\System.ObjectModel\ref\System.ObjectModel.csproj" />
     <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />
     <ProjectReference Include="..\..\System.ComponentModel.Primitives\ref\System.ComponentModel.Primitives.csproj" />
   </ItemGroup>

--- a/src/System.Drawing.Primitives/src/System.Drawing.Primitives.csproj
+++ b/src/System.Drawing.Primitives/src/System.Drawing.Primitives.csproj
@@ -11,6 +11,7 @@
     <Reference Include="System.Collections" />
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.Diagnostics.Tools" />
+    <Reference Include="System.ObjectModel" />
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />

--- a/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Color.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
@@ -9,6 +10,7 @@ namespace System.Drawing
 {
     [DebuggerDisplay("{NameAndARGBValue}")]
     [Serializable]
+    [TypeConverter("System.Drawing.ColorConverter, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
     [TypeForwardedFrom("System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
     public readonly struct Color : IEquatable<Color>
     {

--- a/src/System.Drawing.Primitives/src/System/Drawing/Point.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Point.cs
@@ -11,6 +11,7 @@ namespace System.Drawing
     /// </summary>
     [Serializable]
     [System.Runtime.CompilerServices.TypeForwardedFrom("System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+    [TypeConverter("System.Drawing.PointConverter, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
     public struct Point : IEquatable<Point>
     {
         /// <summary>

--- a/src/System.Drawing.Primitives/src/System/Drawing/Rectangle.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Rectangle.cs
@@ -11,6 +11,7 @@ namespace System.Drawing
     /// </summary>
     [Serializable]
     [System.Runtime.CompilerServices.TypeForwardedFrom("System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+    [TypeConverter("System.Drawing.RectangleConverter, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
     public struct Rectangle : IEquatable<Rectangle>
     {
         public static readonly Rectangle Empty = new Rectangle();

--- a/src/System.Drawing.Primitives/src/System/Drawing/Size.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Size.cs
@@ -11,6 +11,7 @@ namespace System.Drawing
     /// </summary>
     [Serializable]
     [System.Runtime.CompilerServices.TypeForwardedFrom("System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+    [TypeConverter("System.Drawing.SizeConverter, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
     public struct Size : IEquatable<Size>
     {
         /// <summary>

--- a/src/System.Drawing.Primitives/src/System/Drawing/SizeF.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/SizeF.cs
@@ -11,6 +11,7 @@ namespace System.Drawing
     /// </summary>
     [Serializable]
     [System.Runtime.CompilerServices.TypeForwardedFrom("System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+    [TypeConverter("System.Drawing.SizeFConverter, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
     public struct SizeF : IEquatable<SizeF>
     {
         /// <summary>


### PR DESCRIPTION
We're seeing various places where folks took dependencies on attributes
being present rather than calling GetConverter (WPF and Winforms design
time components).  Now we can add TypeConverterAttribute in more places
as we pushed the type down.  Do this rather than relying on the
intrinsic converter table.

This still has instrinsic mappings for Uri and Version, which desktop did not.  
If we wanted to fix those, we'd need to push TypeConverterAttribute down to System.Private.Corelib.

@jkotas @stephentoub will this hurt linker analysis?

/cc @rladuca @DustinCampbell 