### PR TITLE
Fix ValueTask usage in XmlTextReaderImpl.ParseTextAsync

### DIFF
--- a/src/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImplAsync.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImplAsync.cs
@@ -3037,7 +3037,7 @@ namespace System.Xml
 
             // the whole value is in buffer
 
-            ValueTask<(int, int, int, bool)> parseTextTask = ParseTextAsync(orChars);
+            ValueTask<(int, int, int, bool)> parseTextTask = ParseTextAsync(orChars).Preserve();
             bool fullValue = false;
             if (!parseTextTask.IsCompletedSuccessfully)
             {


### PR DESCRIPTION
Found by an analyzer for ValueTasks I'm writing (and using corefx to test).

The ParseTextAsync(int) method returns a ValueTask, which then potentially has both .Result called on it and .AsTask (if fullValue is false), and such double-consumption of a ValueTask is not allowed.  It hasn't caused any problems because `async ValueTask` methods would always be backed by either a result or a Task, and as an implementation detail double-consumption of such instances doesn't cause a problem.  But for .NET 5 we've added the ability for `async ValueTask` methods to use pooled instances, in which case such double-consumption would cause problems (e.g. exceptions about the double use).  A fix here is to use Preserve.