### PR TITLE
Assert ValueTask completion in SslStream.Read/Write

### DIFF
--- a/src/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -754,7 +754,9 @@ namespace System.Net.Security
             ThrowIfExceptionalOrNotAuthenticated();
             ValidateParameters(buffer, offset, count);
             SslReadSync reader = new SslReadSync(this);
-            return ReadAsyncInternal(reader, new Memory<byte>(buffer, offset, count)).GetAwaiter().GetResult();
+            ValueTask<int> vt = ReadAsyncInternal(reader, new Memory<byte>(buffer, offset, count));
+            Debug.Assert(vt.IsCompleted, "Sync operation must have completed synchronously");
+            return vt.GetAwaiter().GetResult();
         }
 
         public void Write(byte[] buffer) => Write(buffer, 0, buffer.Length);
@@ -765,7 +767,9 @@ namespace System.Net.Security
             ValidateParameters(buffer, offset, count);
 
             SslWriteSync writeAdapter = new SslWriteSync(this);
-            WriteAsyncInternal(writeAdapter, new ReadOnlyMemory<byte>(buffer, offset, count)).AsTask().GetAwaiter().GetResult();
+            ValueTask vt = WriteAsyncInternal(writeAdapter, new ReadOnlyMemory<byte>(buffer, offset, count));
+            Debug.Assert(vt.IsCompleted, "Sync operation must have completed synchronously");
+            vt.GetAwaiter().GetResult();
         }
 
         public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback asyncCallback, object asyncState)


### PR DESCRIPTION
We're employing a pattern in SslStream to avoid redundant code: we reuse the same code paths for both sync and async operations, with different interface implementations for each.  The sync implementation has implementations that complete synchronously, and we then guarantee that the whole operation actually completes synchronously, even though it's implemented with async methods.  We then .GetAwaiter().GetResult() to extract the result.  Since by construction the task will have already completed, it's ok to do so, but it's difficult for a human to see this, and harder for an analyzer.  Add an assert to both convey to an analyzer that we know what we're doing, and add a message for a human to understand it better. We can also remove an unnecessary "AsTask()" operation from the synchronous Write path, which should also remove a tiny bit of overhead.