### PR TITLE
Fix SNIPacket.ReadFromStreamAsync to not consume same ValueTask twice

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIPacket.NetCoreApp.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIPacket.NetCoreApp.cs
@@ -58,6 +58,11 @@ namespace System.Data.SqlClient.SNI
                     // Completed
                     return;
                 }
+                else
+                {
+                    // Avoid consuming the same instance twice.
+                    vt = new ValueTask<int>(_dataLength);
+                }
             }
 
             // Not complete or error call the async local function to complete


### PR DESCRIPTION
Found via an analyzer I'm working on for ValueTasks.

This calls stream.ReadAsync, and in the case where the ValueTask completes successfully by the time the code checks and where the returned Result <= 0, it then awaits the ValueTask again, representing a second consumption when only one is considered legal.

Fix it by replacing the original ValueTask with a new one containing the same result.