### PR TITLE
Simplify Array.Copy(a, 0, b, 0, c) to Array.Copy(a, b, c)

### DIFF
--- a/src/Common/src/Interop/Windows/BCrypt/BCryptAlgorithmCache.cs
+++ b/src/Common/src/Interop/Windows/BCrypt/BCryptAlgorithmCache.cs
@@ -40,7 +40,7 @@ internal partial class Interop
 
                 Entry[] newCache = new Entry[cache.Length + 1];
                 Entry newEntry = new Entry(hashAlgorithmId, flags, safeBCryptAlgorithmHandle);
-                Array.Copy(cache, 0, newCache, 0, cache.Length);
+                Array.Copy(cache, newCache, cache.Length);
                 newCache[newCache.Length - 1] = newEntry;
 
                 // Atomically overwrite the cache with our new cache. It's possible some other thread raced to add a new entry with us - if so, one of the new entries

--- a/src/Common/src/System/Collections/Generic/ArrayBuilder.cs
+++ b/src/Common/src/System/Collections/Generic/ArrayBuilder.cs
@@ -112,7 +112,7 @@ namespace System.Collections.Generic
                 // Avoid a bit of overhead (method call, some branches, extra codegen)
                 // which would be incurred by using Array.Resize
                 result = new T[_count];
-                Array.Copy(_array, 0, result, 0, _count);
+                Array.Copy(_array, result, _count);
             }
 
 #if DEBUG
@@ -156,7 +156,7 @@ namespace System.Collections.Generic
             T[] next = new T[nextCapacity];
             if (_count > 0)
             {
-                Array.Copy(_array!, 0, next, 0, _count);
+                Array.Copy(_array!, next, _count);
             }
             _array = next;
         }

--- a/src/Common/src/System/Collections/Generic/LargeArrayBuilder.SpeedOpt.cs
+++ b/src/Common/src/System/Collections/Generic/LargeArrayBuilder.SpeedOpt.cs
@@ -308,7 +308,7 @@ namespace System.Collections.Generic
                 int nextCapacity = Math.Min(_count == 0 ? StartingCapacity : _count * 2, _maxCapacity);
 
                 _current = new T[nextCapacity];
-                Array.Copy(_first, 0, _current, 0, _count);
+                Array.Copy(_first, _current, _count);
                 _first = _current;
             }
             else

--- a/src/Common/tests/StaticTestGenerator/Program.cs
+++ b/src/Common/tests/StaticTestGenerator/Program.cs
@@ -497,7 +497,7 @@ namespace StaticTestGenerator
                 else if (arguments.Length < parameters.Length)
                 {
                     var newArguments = new object[parameters.Length];
-                    Array.Copy(arguments, 0, newArguments, 0, arguments.Length);
+                    Array.Copy(arguments, newArguments, arguments.Length);
                     for (int i = arguments.Length; i < parameters.Length; i++)
                     {
                         if (parameters[i].HasDefaultValue)

--- a/src/Common/tests/System/Collections/IListTest.cs
+++ b/src/Common/tests/System/Collections/IListTest.cs
@@ -477,7 +477,7 @@ namespace Tests.Collections
                     items = new object[sizeWithNull];
                     list.Add(null);
                     items[sizeWithNull/2] = null;
-                    Array.Copy(tempItems, 0, items, 0, sizeWithNull/2);
+                    Array.Copy(tempItems, items, sizeWithNull/2);
                     Array.Copy(
                         tempItems,
                         sizeWithNull/2,
@@ -567,7 +567,7 @@ namespace Tests.Collections
                     list.AddRange(tempItems);
                     list.AddRange(tempItems);
 
-                    Array.Copy(tempItems, 0, items, 0, 16);
+                    Array.Copy(tempItems, items, 16);
                     Array.Copy(tempItems, 0, items, 16, 16);
                 }
                 CollectionAssert.Equal(items, list);
@@ -1311,7 +1311,7 @@ namespace Tests.Collections
             {
                 object newObject = GenerateItem();
                 list.Insert(i, newObject);
-                Array.Copy(items, 0, tempItems, 0, i);
+                Array.Copy(items, tempItems, i);
                 tempItems[i] = newObject;
                 Array.Copy(items, i, tempItems, i + 1, items.Length - i);
                 CollectionAssert.Equal(tempItems, list);
@@ -1533,7 +1533,7 @@ namespace Tests.Collections
             IList list = GetList(null);
             object[] tempItems = GenerateItems(16);
             list.AddRange(tempItems);
-            Array.Copy(tempItems, 0, items, 0, 11);
+            Array.Copy(tempItems, items, 11);
             Array.Copy(tempItems, 12, items, 11, 4);
             list.Insert(8, null);
             list.Remove(tempItems[11]);

--- a/src/Common/tests/System/Collections/Utils.cs
+++ b/src/Common/tests/System/Collections/Utils.cs
@@ -40,7 +40,7 @@ namespace Tests.Collections
         public static T[] RemoveAt<T>(this T[] array, int removeIndex)
         {
             var ret = new T[array.Length - 1];
-            Array.Copy(array, 0, ret, 0, removeIndex);
+            Array.Copy(array, ret, removeIndex);
             Array.Copy(
                 array,
                 removeIndex + 1,

--- a/src/Common/tests/Tests/System/StringTests.cs
+++ b/src/Common/tests/Tests/System/StringTests.cs
@@ -7288,7 +7288,7 @@ namespace System.Tests
             for (int i = 0; i < input.Length; i++)
             {
                 var remainder = new T[input.Length - 1];
-                Array.Copy(input, 0, remainder, 0, i);
+                Array.Copy(input, remainder, i);
                 Array.Copy(input, i + 1, remainder, i, input.Length - i - 1);
                 foreach (T[] output in Permute(remainder))
                 {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorHandling.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Errors/ErrorHandling.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Errors
             {
                 // Copy the strings over to another buffer.
                 string[] prgpszNew = new string[cpsz];
-                Array.Copy(prgpsz, 0, prgpszNew, 0, cpsz);
+                Array.Copy(prgpsz, prgpszNew, cpsz);
 
                 for (int i = 0; i < cpsz; i++)
                 {

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeArray.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeArray.cs
@@ -156,7 +156,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
 
             CType[] combined = new CType[prgtype1.Length + prgtype2.Length];
-            Array.Copy(prgtype1, 0, combined, 0, prgtype1.Length);
+            Array.Copy(prgtype1, combined, prgtype1.Length);
             Array.Copy(prgtype2, 0, combined, prgtype1.Length, prgtype2.Length);
             return Allocate(combined);
         }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -211,7 +211,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     if (src != dst)
                     {
                         CType[] dsts = new CType[srcs.Length];
-                        Array.Copy(srcs, 0, dsts, 0, i);
+                        Array.Copy(srcs, dsts, i);
                         dsts[i] = dst;
                         while (++i < srcs.Length)
                         {

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentBag.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentBag.cs
@@ -796,7 +796,7 @@ namespace System.Collections.Concurrent
                             int headIdx = head & _mask;
                             if (headIdx == 0)
                             {
-                                Array.Copy(_array, 0, newArray, 0, _array.Length);
+                                Array.Copy(_array, newArray, _array.Length);
                             }
                             else
                             {

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -1837,7 +1837,7 @@ namespace System.Collections.Concurrent
                 if (_growLockArray && tables._locks.Length < MaxLockNumber)
                 {
                     newLocks = new object[tables._locks.Length * 2];
-                    Array.Copy(tables._locks, 0, newLocks, 0, tables._locks.Length);
+                    Array.Copy(tables._locks, newLocks, tables._locks.Length);
                     for (int i = tables._locks.Length; i < newLocks.Length; i++)
                     {
                         newLocks[i] = new object();

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray.cs
@@ -557,7 +557,7 @@ namespace System.Collections.Immutable
 
             // defensive copy
             var tmp = new T[items.Length];
-            Array.Copy(items, 0, tmp, 0, items.Length);
+            Array.Copy(items, tmp, items.Length);
             return new ImmutableArray<T>(tmp);
         }
     }

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
@@ -68,7 +68,7 @@ namespace System.Collections.Immutable
                             var temp = new T[value];
                             if (_count > 0)
                             {
-                                Array.Copy(_elements, 0, temp, 0, _count);
+                                Array.Copy(_elements, temp, _count);
                             }
 
                             _elements = temp;
@@ -437,7 +437,7 @@ namespace System.Collections.Immutable
                 }
 
                 T[] result = new T[this.Count];
-                Array.Copy(_elements, 0, result, 0, this.Count);
+                Array.Copy(_elements, result, this.Count);
                 return result;
             }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.cs
@@ -316,7 +316,7 @@ namespace System.Collections.Immutable
 
             if (index != 0)
             {
-                Array.Copy(self.array, 0, tmp, 0, index);
+                Array.Copy(self.array, tmp, index);
             }
             if (index != self.Length)
             {
@@ -355,7 +355,7 @@ namespace System.Collections.Immutable
 
             if (index != 0)
             {
-                Array.Copy(self.array, 0, tmp, 0, index);
+                Array.Copy(self.array, tmp, index);
             }
             if (index != self.Length)
             {
@@ -407,7 +407,7 @@ namespace System.Collections.Immutable
 
             if (index != 0)
             {
-                Array.Copy(self.array, 0, tmp, 0, index);
+                Array.Copy(self.array, tmp, index);
             }
             if (index != self.Length)
             {
@@ -474,7 +474,7 @@ namespace System.Collections.Immutable
             Requires.Range(index >= 0 && index < self.Length, nameof(index));
 
             T[] tmp = new T[self.Length];
-            Array.Copy(self.array, 0, tmp, 0, self.Length);
+            Array.Copy(self.array, tmp, self.Length);
             tmp[index] = item;
             return new ImmutableArray<T>(tmp);
         }
@@ -580,7 +580,7 @@ namespace System.Collections.Immutable
             }
 
             T[] tmp = new T[self.Length - length];
-            Array.Copy(self.array, 0, tmp, 0, index);
+            Array.Copy(self.array, tmp, index);
             Array.Copy(self.array, index + length, tmp, index, self.Length - index - length);
             return new ImmutableArray<T>(tmp);
         }
@@ -800,7 +800,7 @@ namespace System.Collections.Immutable
                 if (outOfOrder)
                 {
                     var tmp = new T[self.Length];
-                    Array.Copy(self.array, 0, tmp, 0, self.Length);
+                    Array.Copy(self.array, tmp, self.Length);
                     Array.Sort(tmp, index, count, comparer);
                     return new ImmutableArray<T>(tmp);
                 }

--- a/src/System.Collections.NonGeneric/src/System/Collections/SortedList.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/SortedList.cs
@@ -214,8 +214,8 @@ namespace System.Collections
                         object[] newValues = new object[value];
                         if (_size > 0)
                         {
-                            Array.Copy(keys, 0, newKeys, 0, _size);
-                            Array.Copy(values, 0, newValues, 0, _size);
+                            Array.Copy(keys, newKeys, _size);
+                            Array.Copy(values, newValues, _size);
                         }
                         keys = newKeys;
                         values = newValues;
@@ -301,8 +301,8 @@ namespace System.Collections
         public virtual object Clone()
         {
             SortedList sl = new SortedList(_size);
-            Array.Copy(keys, 0, sl.keys, 0, _size);
-            Array.Copy(values, 0, sl.values, 0, _size);
+            Array.Copy(keys, sl.keys, _size);
+            Array.Copy(values, sl.values, _size);
             sl._size = _size;
             sl.version = version;
             sl.comparer = comparer;

--- a/src/System.Collections.NonGeneric/src/System/Collections/Stack.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/Stack.cs
@@ -91,7 +91,7 @@ namespace System.Collections
         {
             Stack s = new Stack(_size);
             s._size = _size;
-            Array.Copy(_array, 0, s._array, 0, _size);
+            Array.Copy(_array, s._array, _size);
             s._version = _version;
             return s;
         }
@@ -183,7 +183,7 @@ namespace System.Collections
             if (_size == _array.Length)
             {
                 object[] newArray = new object[2 * _array.Length];
-                Array.Copy(_array, 0, newArray, 0, _size);
+                Array.Copy(_array, newArray, _size);
                 _array = newArray;
             }
             _array[_size++] = obj;

--- a/src/System.Collections/src/System/Collections/BitArray.cs
+++ b/src/System.Collections/src/System/Collections/BitArray.cs
@@ -157,7 +157,7 @@ namespace System.Collections
             }
 
             m_array = new int[values.Length];
-            Array.Copy(values, 0, m_array, 0, values.Length);
+            Array.Copy(values, m_array, values.Length);
             m_length = values.Length * BitsPerInt32;
 
             _version = 0;
@@ -181,7 +181,7 @@ namespace System.Collections
 
             Debug.Assert(bits.m_array.Length <= arrayLength);
 
-            Array.Copy(bits.m_array, 0, m_array, 0, arrayLength);
+            Array.Copy(bits.m_array, m_array, arrayLength);
             m_length = bits.m_length;
 
             _version = bits._version;

--- a/src/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -1185,7 +1185,7 @@ namespace System.Collections.Generic
             Slot[] newSlots = new Slot[newSize];
             if (_slots != null)
             {
-                Array.Copy(_slots, 0, newSlots, 0, _lastIndex);
+                Array.Copy(_slots, newSlots, _lastIndex);
             }
 
             int[] newBuckets = new int[newSize];

--- a/src/System.Collections/src/System/Collections/Generic/SortedList.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedList.cs
@@ -243,8 +243,8 @@ namespace System.Collections.Generic
                         TValue[] newValues = new TValue[value];
                         if (_size > 0)
                         {
-                            Array.Copy(keys, 0, newKeys, 0, _size);
-                            Array.Copy(values, 0, newValues, 0, _size);
+                            Array.Copy(keys, newKeys, _size);
+                            Array.Copy(values, newValues, _size);
                         }
                         keys = newKeys;
                         values = newValues;

--- a/src/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.AddAfter.cs
+++ b/src/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.AddAfter.cs
@@ -44,7 +44,7 @@ namespace System.Collections.Tests
             linkedList.AddFirst(headItems[0]);
 
             tempItems = new T[headItems.Length];
-            Array.Copy(headItems, 0, tempItems, 0, headItems.Length);
+            Array.Copy(headItems, tempItems, headItems.Length);
             Array.Reverse(tempItems, 1, headItems.Length - 1);
 
             for (int i = 1; i < arraySize; ++i)
@@ -66,7 +66,7 @@ namespace System.Collections.Tests
             linkedList.AddLast(headItems[1]);
 
             tempItems = new T[headItems.Length];
-            Array.Copy(headItems, 0, tempItems, 0, headItems.Length);
+            Array.Copy(headItems, tempItems, headItems.Length);
             Array.Reverse(tempItems, 2, headItems.Length - 2);
 
             for (int i = 2; i < arraySize; ++i)
@@ -128,7 +128,7 @@ namespace System.Collections.Tests
                 linkedList.AddAfter(linkedList.Last, tailItems[i]);
 
             T[] tempItems2 = new T[tempItems.Length + tailItems.Length];
-            Array.Copy(tempItems, 0, tempItems2, 0, tempItems.Length);
+            Array.Copy(tempItems, tempItems2, tempItems.Length);
             Array.Copy(tailItems, 0, tempItems2, tempItems.Length, tailItems.Length);
 
             InitialItems_Tests(linkedList, tempItems2);
@@ -173,7 +173,7 @@ namespace System.Collections.Tests
             }
 
             tempItems = new T[headItemsReverse.Length + tailItems.Length];
-            Array.Copy(headItemsReverse, 0, tempItems, 0, headItemsReverse.Length);
+            Array.Copy(headItemsReverse, tempItems, headItemsReverse.Length);
             Array.Copy(tailItems, 0, tempItems, headItemsReverse.Length, tailItems.Length);
             InitialItems_Tests(linkedList, tempItems);
         }
@@ -247,7 +247,7 @@ namespace System.Collections.Tests
             linkedList.AddFirst(headItems[0]);
 
             tempItems = new T[headItems.Length];
-            Array.Copy(headItems, 0, tempItems, 0, headItems.Length);
+            Array.Copy(headItems, tempItems, headItems.Length);
             Array.Reverse(tempItems, 1, headItems.Length - 1);
 
             for (int i = 1; i < arraySize; ++i)
@@ -268,7 +268,7 @@ namespace System.Collections.Tests
             linkedList.AddFirst(headItems[0]);
             linkedList.AddLast(headItems[1]);
             tempItems = new T[headItems.Length];
-            Array.Copy(headItems, 0, tempItems, 0, headItems.Length);
+            Array.Copy(headItems, tempItems, headItems.Length);
             Array.Reverse(tempItems, 2, headItems.Length - 2);
 
             for (int i = 2; i < arraySize; ++i)
@@ -331,7 +331,7 @@ namespace System.Collections.Tests
                 linkedList.AddAfter(linkedList.Last, new LinkedListNode<T>(tailItems[i]));
 
             T[] tempItems2 = new T[tempItems.Length + tailItems.Length];
-            Array.Copy(tempItems, 0, tempItems2, 0, tempItems.Length);
+            Array.Copy(tempItems, tempItems2, tempItems.Length);
             Array.Copy(tailItems, 0, tempItems2, tempItems.Length, tailItems.Length);
 
             InitialItems_Tests(linkedList, tempItems2);
@@ -384,7 +384,7 @@ namespace System.Collections.Tests
             }
 
             tempItems = new T[headItemsReverse.Length + tailItems.Length];
-            Array.Copy(headItemsReverse, 0, tempItems, 0, headItemsReverse.Length);
+            Array.Copy(headItemsReverse, tempItems, headItemsReverse.Length);
             Array.Copy(tailItems, 0, tempItems, headItemsReverse.Length, tailItems.Length);
             InitialItems_Tests(linkedList, tempItems);
         }

--- a/src/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.AddBefore.cs
+++ b/src/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.AddBefore.cs
@@ -66,7 +66,7 @@ namespace System.Collections.Tests
             linkedList.AddLast(headItems[1]);
 
             tempItems = new T[headItems.Length];
-            Array.Copy(headItems, 0, tempItems, 0, headItems.Length);
+            Array.Copy(headItems, tempItems, headItems.Length);
             Array.Reverse(tempItems, 1, headItems.Length - 1);
 
             for (int i = 2; i < arraySize; ++i)
@@ -129,7 +129,7 @@ namespace System.Collections.Tests
                 linkedList.AddBefore(linkedList.First, tailItems[i]);
 
             T[] tempItems2 = new T[tailItemsReverse.Length + tempItems.Length];
-            Array.Copy(tailItemsReverse, 0, tempItems2, 0, tailItemsReverse.Length);
+            Array.Copy(tailItemsReverse, tempItems2, tailItemsReverse.Length);
             Array.Copy(tempItems, 0, tempItems2, tailItemsReverse.Length, tempItems.Length);
 
             InitialItems_Tests(linkedList, tempItems2);
@@ -174,7 +174,7 @@ namespace System.Collections.Tests
             }
 
             tempItems = new T[headItemsReverse.Length + tailItems.Length];
-            Array.Copy(headItemsReverse, 0, tempItems, 0, headItemsReverse.Length);
+            Array.Copy(headItemsReverse, tempItems, headItemsReverse.Length);
             Array.Copy(tailItems, 0, tempItems, headItemsReverse.Length, tailItems.Length);
 
             InitialItems_Tests(linkedList, tempItems);
@@ -266,7 +266,7 @@ namespace System.Collections.Tests
             linkedList.AddFirst(headItems[0]);
             linkedList.AddLast(headItems[1]);
             tempItems = new T[headItems.Length];
-            Array.Copy(headItems, 0, tempItems, 0, headItems.Length);
+            Array.Copy(headItems, tempItems, headItems.Length);
             Array.Reverse(tempItems, 1, headItems.Length - 1);
 
             for (int i = 2; i < arraySize; ++i)
@@ -328,7 +328,7 @@ namespace System.Collections.Tests
                 linkedList.AddBefore(linkedList.First, new LinkedListNode<T>(tailItems[i]));
 
             T[] tempItems2 = new T[tailItemsReverse.Length + tempItems.Length];
-            Array.Copy(tailItemsReverse, 0, tempItems2, 0, tailItemsReverse.Length);
+            Array.Copy(tailItemsReverse, tempItems2, tailItemsReverse.Length);
             Array.Copy(tempItems, 0, tempItems2, tailItemsReverse.Length, tempItems.Length);
 
             InitialItems_Tests(linkedList, tempItems2);
@@ -373,7 +373,7 @@ namespace System.Collections.Tests
             }
 
             tempItems = new T[headItemsReverse.Length + tailItems.Length];
-            Array.Copy(headItemsReverse, 0, tempItems, 0, headItemsReverse.Length);
+            Array.Copy(headItemsReverse, tempItems, headItemsReverse.Length);
             Array.Copy(tailItems, 0, tempItems, headItemsReverse.Length, tailItems.Length);
 
             InitialItems_Tests(linkedList, tempItems);

--- a/src/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.AddFirst.cs
+++ b/src/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.AddFirst.cs
@@ -68,7 +68,7 @@ namespace System.Collections.Tests
                 linkedList.AddFirst(tailItems[i]);
 
             tempItems2 = new T[tempItems.Length + tailItemsReverse.Length];
-            Array.Copy(tailItemsReverse, 0, tempItems2, 0, tailItemsReverse.Length);
+            Array.Copy(tailItemsReverse, tempItems2, tailItemsReverse.Length);
             Array.Copy(tempItems, 0, tempItems2, tailItemsReverse.Length, tempItems.Length);
             InitialItems_Tests(linkedList, tempItems2);
 
@@ -106,7 +106,7 @@ namespace System.Collections.Tests
             }
 
             tempItems = new T[headItemsReverse.Length + tailItems.Length];
-            Array.Copy(headItemsReverse, 0, tempItems, 0, headItemsReverse.Length);
+            Array.Copy(headItemsReverse, tempItems, headItemsReverse.Length);
             Array.Copy(tailItems, 0, tempItems, headItemsReverse.Length, tailItems.Length);
 
             InitialItems_Tests(linkedList, tempItems);
@@ -167,7 +167,7 @@ namespace System.Collections.Tests
                 linkedList.AddFirst(new LinkedListNode<T>(tailItems[i]));
 
             tempItems2 = new T[tailItemsReverse.Length + tempItems.Length];
-            Array.Copy(tailItemsReverse, 0, tempItems2, 0, tailItemsReverse.Length);
+            Array.Copy(tailItemsReverse, tempItems2, tailItemsReverse.Length);
             Array.Copy(tempItems, 0, tempItems2, tailItemsReverse.Length, tempItems.Length);
             InitialItems_Tests(linkedList, tempItems2);
 
@@ -194,7 +194,7 @@ namespace System.Collections.Tests
             }
 
             tempItems = new T[headItemsReverse.Length + tailItems.Length];
-            Array.Copy(headItemsReverse, 0, tempItems, 0, headItemsReverse.Length);
+            Array.Copy(headItemsReverse, tempItems, headItemsReverse.Length);
             Array.Copy(tailItems, 0, tempItems, headItemsReverse.Length, tailItems.Length);
             InitialItems_Tests(linkedList, tempItems);
         }

--- a/src/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.AddLast.cs
+++ b/src/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.AddLast.cs
@@ -61,7 +61,7 @@ namespace System.Collections.Tests
                 linkedList.AddLast(headItems[i]);
 
             T[] tempItems2 = new T[tempItems.Length + headItems.Length];
-            Array.Copy(tempItems, 0, tempItems2, 0, tempItems.Length);
+            Array.Copy(tempItems, tempItems2, tempItems.Length);
             Array.Copy(headItems, 0, tempItems2, tempItems.Length, headItems.Length);
             InitialItems_Tests(linkedList, tempItems2);
 
@@ -94,7 +94,7 @@ namespace System.Collections.Tests
             }
 
             tempItems2 = new T[tempItems.Length + tailItems.Length];
-            Array.Copy(tempItems, 0, tempItems2, 0, tempItems.Length);
+            Array.Copy(tempItems, tempItems2, tempItems.Length);
             Array.Copy(tailItems, 0, tempItems2, tempItems.Length, tailItems.Length);
             InitialItems_Tests(linkedList, tempItems2);
         }
@@ -153,7 +153,7 @@ namespace System.Collections.Tests
                 linkedList.AddLast(new LinkedListNode<T>(headItems[i]));
 
             T[] tempItems2 = new T[tempItems.Length + headItems.Length];
-            Array.Copy(tempItems, 0, tempItems2, 0, tempItems.Length);
+            Array.Copy(tempItems, tempItems2, tempItems.Length);
             Array.Copy(headItems, 0, tempItems2, tempItems.Length, headItems.Length);
 
             InitialItems_Tests(linkedList, tempItems2);
@@ -179,7 +179,7 @@ namespace System.Collections.Tests
             }
 
             tempItems = new T[headItemsReverse.Length + tailItems.Length];
-            Array.Copy(headItemsReverse, 0, tempItems, 0, headItemsReverse.Length);
+            Array.Copy(headItemsReverse, tempItems, headItemsReverse.Length);
             Array.Copy(tailItems, 0, tempItems, headItemsReverse.Length, tailItems.Length);
             InitialItems_Tests(linkedList, tempItems);
         }

--- a/src/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.Find.cs
+++ b/src/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.Find.cs
@@ -76,7 +76,7 @@ namespace System.Collections.Tests
             Assert.Null(linkedList.Find(tailItems[0])); //"Err_8548ajia Expected Find to return false with an non null item not in the collection size=16"
             Assert.Null(linkedList.Find(default(T))); //"Err_3108qoa Expected Find to return false with an null item not in the collection size=16"
             T[] tempItems = new T[headItems.Length + headItems.Length];
-            Array.Copy(headItems, 0, tempItems, 0, headItems.Length);
+            Array.Copy(headItems, tempItems, headItems.Length);
             Array.Copy(headItems, 0, tempItems, headItems.Length, headItems.Length);
             VerifyFindDuplicates(linkedList, tempItems);
 
@@ -111,7 +111,7 @@ namespace System.Collections.Tests
             Array.Copy(tailItems, 0, tempItems, 1, tailItems.Length);
 
             T[] tempItems2 = new T[headItems.Length + tempItems.Length];
-            Array.Copy(headItems, 0, tempItems2, 0, headItems.Length);
+            Array.Copy(headItems, tempItems2, headItems.Length);
             Array.Copy(tempItems, 0, tempItems2, headItems.Length, tempItems.Length);
 
             VerifyFind(linkedList, tempItems2);
@@ -125,7 +125,7 @@ namespace System.Collections.Tests
             Assert.Null(linkedList.Find(tailItems[0])); //"Err_208089ajdi Expected Find to return false with an non null item not in the collection default(T) at the end"
             tempItems = new T[headItems.Length + 1];
             tempItems[headItems.Length] = default(T);
-            Array.Copy(headItems, 0, tempItems, 0, headItems.Length);
+            Array.Copy(headItems, tempItems, headItems.Length);
             VerifyFind(linkedList, tempItems);
         }
     }

--- a/src/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.FindLast.cs
+++ b/src/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.FindLast.cs
@@ -85,7 +85,7 @@ namespace System.Collections.Tests
             Assert.Null(linkedList.FindLast(tailItems[0])); //"Err_8548ajia Expected FindLast to return false with an non null item not in the collection size=16"
             Assert.Null(linkedList.FindLast(default(T))); //"Err_3108qoa Expected FindLast to return false with an null item not in the collection size=16"
             T[] tempItems = new T[headItems.Length + headItems.Length];
-            Array.Copy(headItems, 0, tempItems, 0, headItems.Length);
+            Array.Copy(headItems, tempItems, headItems.Length);
             Array.Copy(headItems, 0, tempItems, headItems.Length, headItems.Length);
             VerifyFindLastDuplicates(linkedList, tempItems);
 
@@ -109,7 +109,7 @@ namespace System.Collections.Tests
             Assert.Null(linkedList.FindLast(CreateT(seed++))); //"Err_78585ajhed Expected FindLast to return false with an non null item not in the collection default(T) in the middle"
 
             tempItems = new T[headItems.Length + prependDefaultTailItems.Length];
-            Array.Copy(headItems, 0, tempItems, 0, headItems.Length);
+            Array.Copy(headItems, tempItems, headItems.Length);
             Array.Copy(prependDefaultTailItems, 0, tempItems, headItems.Length, prependDefaultTailItems.Length);
 
             VerifyFindLast(linkedList, tempItems);

--- a/src/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.RemoveLast.cs
+++ b/src/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.RemoveLast.cs
@@ -85,7 +85,7 @@ namespace System.Collections.Tests
                 linkedList.RemoveLast();
                 int length = arraySize - i - 1;
                 T[] expectedItems = new T[length];
-                Array.Copy(headItems, 0, expectedItems, 0, length);
+                Array.Copy(headItems, expectedItems, length);
                 InitialItems_Tests(linkedList, expectedItems);
             }
 

--- a/src/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.RemoveNode.cs
+++ b/src/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.RemoveNode.cs
@@ -150,7 +150,7 @@ namespace System.Collections.Tests
             {
                 linkedList.Remove(linkedList.Last); //Remove when  VS Whidbey: 234648 is resolved
                 T[] expectedItems = new T[i];
-                Array.Copy(headItems, 0, expectedItems, 0, i);
+                Array.Copy(headItems, expectedItems, i);
                 InitialItems_Tests(linkedList, expectedItems);
             }
 

--- a/src/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.cs
+++ b/src/System.Collections/tests/Generic/LinkedList/LinkedList.Generic.Tests.cs
@@ -477,7 +477,7 @@ namespace System.Collections.Tests
             Assert.Equal(expectedValue, node.Value); //"Err_823902jaied Node.Value"
 
             T[] expected = new T[linkedListValues.Length + 1];
-            Array.Copy(linkedListValues, 0, expected, 0, linkedListValues.Length);
+            Array.Copy(linkedListValues, expected, linkedListValues.Length);
             expected[linkedListValues.Length] = expectedValue;
 
             InitialItems_Tests(linkedList, expected);

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/UIHintAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/UIHintAttribute.cs
@@ -81,7 +81,7 @@ namespace System.ComponentModel.DataAnnotations
                 if (controlParameters != null)
                 {
                     _inputControlParameters = new object[controlParameters.Length];
-                    Array.Copy(controlParameters, 0, _inputControlParameters, 0, controlParameters.Length);
+                    Array.Copy(controlParameters, _inputControlParameters, controlParameters.Length);
                 }
             }
 

--- a/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/AtomicComposition.cs
+++ b/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/AtomicComposition.cs
@@ -319,7 +319,7 @@ namespace System.ComponentModel.Composition.Hosting
                 var newQueries = new KeyValuePair<object, object>[_valueCount == 0 ? 5 : _valueCount * 2];
                 if (_values != null)
                 {
-                    Array.Copy(_values, 0, newQueries, 0, _valueCount);
+                    Array.Copy(_values, newQueries, _valueCount);
                 }
                 _values = newQueries;
             }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/AttributeCollection.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/AttributeCollection.cs
@@ -108,7 +108,7 @@ namespace System.ComponentModel
             if (actualCount < newArray.Length)
             {
                 attributes = new Attribute[actualCount];
-                Array.Copy(newArray, 0, attributes, 0, actualCount);
+                Array.Copy(newArray, attributes, actualCount);
             }
             else
             {

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Container.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Container.cs
@@ -57,7 +57,7 @@ namespace System.ComponentModel
                     if (_sites.Length == _siteCount)
                     {
                         ISite[] newSites = new ISite[_siteCount * 2];
-                        Array.Copy(_sites, 0, newSites, 0, _siteCount);
+                        Array.Copy(_sites, newSites, _siteCount);
                         _sites = newSites;
                     }
                 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/CultureInfoConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/CultureInfoConverter.cs
@@ -192,7 +192,7 @@ namespace System.ComponentModel
                     array = new CultureInfo[installedCultures.Length + 1];
                 }
 
-                Array.Copy(installedCultures, 0, array, 0, installedCultures.Length);
+                Array.Copy(installedCultures, array, installedCultures.Length);
                 Array.Sort(array, new CultureComparer(this));
                 Debug.Assert(array[0] == null);
                 if (array[0] == null)

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EventDescriptorCollection.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EventDescriptorCollection.cs
@@ -131,7 +131,7 @@ namespace System.ComponentModel
                 if (_events != null)
                 {
                     EventDescriptor[] newEvents = new EventDescriptor[Count];
-                    Array.Copy(_events, 0, newEvents, 0, Count);
+                    Array.Copy(_events, newEvents, Count);
                     _events = newEvents;
                 }
             }
@@ -161,7 +161,7 @@ namespace System.ComponentModel
 
             int newSize = Math.Max(sizeNeeded, _events.Length * 2);
             EventDescriptor[] newEvents = new EventDescriptor[newSize];
-            Array.Copy(_events, 0, newEvents, 0, Count);
+            Array.Copy(_events, newEvents, Count);
             _events = newEvents;
         }
 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/PropertyDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/PropertyDescriptor.cs
@@ -299,8 +299,8 @@ namespace System.ComponentModel
                 {
                     Type[] newTypes = new Type[_editorTypes.Length * 2];
                     object[] newEditors = new object[_editors.Length * 2];
-                    Array.Copy(_editorTypes, 0, newTypes, 0, _editorTypes.Length);
-                    Array.Copy(_editors, 0, newEditors, 0, _editors.Length);
+                    Array.Copy(_editorTypes, newTypes, _editorTypes.Length);
+                    Array.Copy(_editors, newEditors, _editors.Length);
                     _editorTypes = newTypes;
                     _editors = newEditors;
                 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/PropertyDescriptorCollection.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/PropertyDescriptorCollection.cs
@@ -142,7 +142,7 @@ namespace System.ComponentModel
                 if (_properties != null)
                 {
                     PropertyDescriptor[] newProps = new PropertyDescriptor[Count];
-                    Array.Copy(_properties, 0, newProps, 0, Count);
+                    Array.Copy(_properties, newProps, Count);
                     _properties = newProps;
                 }
             }
@@ -172,7 +172,7 @@ namespace System.ComponentModel
 
             int newSize = Math.Max(sizeNeeded, _properties.Length * 2);
             PropertyDescriptor[] newProps = new PropertyDescriptor[newSize];
-            Array.Copy(_properties, 0, newProps, 0, Count);
+            Array.Copy(_properties, newProps, Count);
             _properties = newProps;
         }
 
@@ -400,7 +400,7 @@ namespace System.ComponentModel
             if (_properties.Length != Count)
             {
                 PropertyDescriptor[] enumProps = new PropertyDescriptor[Count];
-                Array.Copy(_properties, 0, enumProps, 0, Count);
+                Array.Copy(_properties, enumProps, Count);
                 return enumProps.GetEnumerator();
             }
             return _properties.GetEnumerator();
@@ -531,7 +531,7 @@ namespace System.ComponentModel
                 if (_properties.Length != Count)
                 {
                     PropertyDescriptor[] newProps = new PropertyDescriptor[Count];
-                    Array.Copy(_properties, 0, newProps, 0, Count);
+                    Array.Copy(_properties, newProps, Count);
                     return newProps;
                 }
                 else

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.ReflectedTypeData.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.ReflectedTypeData.cs
@@ -87,7 +87,7 @@ namespace System.ComponentModel
                     {
                         Attribute[] baseArray = ReflectGetAttributes(baseType);
                         Attribute[] temp = new Attribute[attrArray.Length + baseArray.Length];
-                        Array.Copy(attrArray, 0, temp, 0, attrArray.Length);
+                        Array.Copy(attrArray, temp, attrArray.Length);
                         Array.Copy(baseArray, 0, temp, attrArray.Length, baseArray.Length);
                         attrArray = temp;
                         baseType = baseType.BaseType;
@@ -110,7 +110,7 @@ namespace System.ComponentModel
                             if (ifaceAttrs.Count > 0)
                             {
                                 Attribute[] temp = new Attribute[attrArray.Length + ifaceAttrs.Count];
-                                Array.Copy(attrArray, 0, temp, 0, attrArray.Length);
+                                Array.Copy(attrArray, temp, attrArray.Length);
                                 ifaceAttrs.CopyTo(temp, attrArray.Length);
                                 attrArray = temp;
                             }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
@@ -1007,7 +1007,7 @@ namespace System.ComponentModel
                     if (eventCount != events.Length)
                     {
                         EventDescriptor[] newEvents = new EventDescriptor[eventCount];
-                        Array.Copy(events, 0, newEvents, 0, eventCount);
+                        Array.Copy(events, newEvents, eventCount);
                         events = newEvents;
                     }
 
@@ -1196,7 +1196,7 @@ namespace System.ComponentModel
                     if (propertyCount != properties.Length)
                     {
                         PropertyDescriptor[] newProperties = new PropertyDescriptor[propertyCount];
-                        Array.Copy(properties, 0, newProperties, 0, propertyCount);
+                        Array.Copy(properties, newProperties, propertyCount);
                         properties = newProperties;
                     }
 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
@@ -2770,7 +2770,7 @@ namespace System.ComponentModel
                     if (actualCount < newArray.Length)
                     {
                         finalAttr = new Attribute[actualCount];
-                        Array.Copy(newArray, 0, finalAttr, 0, actualCount);
+                        Array.Copy(newArray, finalAttr, actualCount);
                     }
                     else
                     {

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeListConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeListConverter.cs
@@ -99,7 +99,7 @@ namespace System.ComponentModel
                 if (_types != null)
                 {
                     objTypes = new object[_types.Length];
-                    Array.Copy(_types, 0, objTypes, 0, _types.Length);
+                    Array.Copy(_types, objTypes, _types.Length);
                 }
                 else
                 {

--- a/src/System.Data.Common/src/System/Data/ColumnTypeConverter.cs
+++ b/src/System.Data.Common/src/System/Data/ColumnTypeConverter.cs
@@ -139,7 +139,7 @@ namespace System.Data
                 if (s_types != null)
                 {
                     objTypes = new object[s_types.Length];
-                    Array.Copy(s_types, 0, objTypes, 0, s_types.Length);
+                    Array.Copy(s_types, objTypes, s_types.Length);
                 }
                 else
                 {

--- a/src/System.Data.Common/src/System/Data/Common/BigIntegerStorage.cs
+++ b/src/System.Data.Common/src/System/Data/Common/BigIntegerStorage.cs
@@ -144,7 +144,7 @@ namespace System.Data.Common
             BigInteger[] newValues = new BigInteger[capacity];
             if (null != _values)
             {
-                Array.Copy(_values, 0, newValues, 0, Math.Min(capacity, _values.Length));
+                Array.Copy(_values, newValues, Math.Min(capacity, _values.Length));
             }
             _values = newValues;
             base.SetCapacity(capacity);

--- a/src/System.Data.Common/src/System/Data/Common/BooleanStorage.cs
+++ b/src/System.Data.Common/src/System/Data/Common/BooleanStorage.cs
@@ -164,7 +164,7 @@ namespace System.Data.Common
             bool[] newValues = new bool[capacity];
             if (null != _values)
             {
-                Array.Copy(_values, 0, newValues, 0, Math.Min(capacity, _values.Length));
+                Array.Copy(_values, newValues, Math.Min(capacity, _values.Length));
             }
             _values = newValues;
             base.SetCapacity(capacity);

--- a/src/System.Data.Common/src/System/Data/Common/ByteStorage.cs
+++ b/src/System.Data.Common/src/System/Data/Common/ByteStorage.cs
@@ -236,7 +236,7 @@ namespace System.Data.Common
             byte[] newValues = new byte[capacity];
             if (null != _values)
             {
-                Array.Copy(_values, 0, newValues, 0, Math.Min(capacity, _values.Length));
+                Array.Copy(_values, newValues, Math.Min(capacity, _values.Length));
             }
             _values = newValues;
             base.SetCapacity(capacity);

--- a/src/System.Data.Common/src/System/Data/Common/CharStorage.cs
+++ b/src/System.Data.Common/src/System/Data/Common/CharStorage.cs
@@ -168,7 +168,7 @@ namespace System.Data.Common
             char[] newValues = new char[capacity];
             if (null != _values)
             {
-                Array.Copy(_values, 0, newValues, 0, Math.Min(capacity, _values.Length));
+                Array.Copy(_values, newValues, Math.Min(capacity, _values.Length));
             }
             _values = newValues;
             base.SetCapacity(capacity);

--- a/src/System.Data.Common/src/System/Data/Common/DateTimeOffsetStorage.cs
+++ b/src/System.Data.Common/src/System/Data/Common/DateTimeOffsetStorage.cs
@@ -171,7 +171,7 @@ namespace System.Data.Common
             DateTimeOffset[] newValues = new DateTimeOffset[capacity];
             if (null != _values)
             {
-                Array.Copy(_values, 0, newValues, 0, Math.Min(capacity, _values.Length));
+                Array.Copy(_values, newValues, Math.Min(capacity, _values.Length));
             }
             _values = newValues;
             base.SetCapacity(capacity);

--- a/src/System.Data.Common/src/System/Data/Common/DateTimeStorage.cs
+++ b/src/System.Data.Common/src/System/Data/Common/DateTimeStorage.cs
@@ -210,7 +210,7 @@ namespace System.Data.Common
             DateTime[] newValues = new DateTime[capacity];
             if (null != _values)
             {
-                Array.Copy(_values, 0, newValues, 0, Math.Min(capacity, _values.Length));
+                Array.Copy(_values, newValues, Math.Min(capacity, _values.Length));
             }
             _values = newValues;
             base.SetCapacity(capacity);

--- a/src/System.Data.Common/src/System/Data/Common/DbConnectionStringBuilder.cs
+++ b/src/System.Data.Common/src/System/Data/Common/DbConnectionStringBuilder.cs
@@ -548,7 +548,7 @@ namespace System.Data.Common
 
             // Create a new array that only contains the filtered properties
             PropertyDescriptor[] filteredPropertiesArray = new PropertyDescriptor[index];
-            Array.Copy(propertiesArray, 0, filteredPropertiesArray, 0, index);
+            Array.Copy(propertiesArray, filteredPropertiesArray, index);
 
             return new PropertyDescriptorCollection(filteredPropertiesArray);
         }

--- a/src/System.Data.Common/src/System/Data/Common/DbDataAdapter.cs
+++ b/src/System.Data.Common/src/System/Data/Common/DbDataAdapter.cs
@@ -1286,7 +1286,7 @@ namespace System.Data.Common
                                 if (commandCount < rowBatch.Length)
                                 {
                                     finalRowBatch = new DataRow[commandCount];
-                                    Array.Copy(rowBatch, 0, finalRowBatch, 0, commandCount);
+                                    Array.Copy(rowBatch, finalRowBatch, commandCount);
                                 }
                                 rowUpdatedEvent.AdapterInit(finalRowBatch);
 

--- a/src/System.Data.Common/src/System/Data/Common/DecimalStorage.cs
+++ b/src/System.Data.Common/src/System/Data/Common/DecimalStorage.cs
@@ -232,7 +232,7 @@ namespace System.Data.Common
             decimal[] newValues = new decimal[capacity];
             if (null != _values)
             {
-                Array.Copy(_values, 0, newValues, 0, Math.Min(capacity, _values.Length));
+                Array.Copy(_values, newValues, Math.Min(capacity, _values.Length));
             }
             _values = newValues;
             base.SetCapacity(capacity);

--- a/src/System.Data.Common/src/System/Data/Common/DoubleStorage.cs
+++ b/src/System.Data.Common/src/System/Data/Common/DoubleStorage.cs
@@ -236,7 +236,7 @@ namespace System.Data.Common
             double[] newValues = new double[capacity];
             if (null != _values)
             {
-                Array.Copy(_values, 0, newValues, 0, Math.Min(capacity, _values.Length));
+                Array.Copy(_values, newValues, Math.Min(capacity, _values.Length));
             }
             _values = newValues;
             base.SetCapacity(capacity);

--- a/src/System.Data.Common/src/System/Data/Common/Int16Storage.cs
+++ b/src/System.Data.Common/src/System/Data/Common/Int16Storage.cs
@@ -250,7 +250,7 @@ namespace System.Data.Common
             short[] newValues = new short[capacity];
             if (null != _values)
             {
-                Array.Copy(_values, 0, newValues, 0, Math.Min(capacity, _values.Length));
+                Array.Copy(_values, newValues, Math.Min(capacity, _values.Length));
             }
             _values = newValues;
             base.SetCapacity(capacity);

--- a/src/System.Data.Common/src/System/Data/Common/Int32Storage.cs
+++ b/src/System.Data.Common/src/System/Data/Common/Int32Storage.cs
@@ -250,7 +250,7 @@ namespace System.Data.Common
             int[] newValues = new int[capacity];
             if (null != _values)
             {
-                Array.Copy(_values, 0, newValues, 0, Math.Min(capacity, _values.Length));
+                Array.Copy(_values, newValues, Math.Min(capacity, _values.Length));
             }
             _values = newValues;
             base.SetCapacity(capacity);

--- a/src/System.Data.Common/src/System/Data/Common/Int64Storage.cs
+++ b/src/System.Data.Common/src/System/Data/Common/Int64Storage.cs
@@ -242,7 +242,7 @@ namespace System.Data.Common
             long[] newValues = new long[capacity];
             if (null != _values)
             {
-                Array.Copy(_values, 0, newValues, 0, Math.Min(capacity, _values.Length));
+                Array.Copy(_values, newValues, Math.Min(capacity, _values.Length));
             }
             _values = newValues;
             base.SetCapacity(capacity);

--- a/src/System.Data.Common/src/System/Data/Common/ObjectStorage.cs
+++ b/src/System.Data.Common/src/System/Data/Common/ObjectStorage.cs
@@ -302,7 +302,7 @@ namespace System.Data.Common
             object[] newValues = new object[capacity];
             if (_values != null)
             {
-                Array.Copy(_values, 0, newValues, 0, Math.Min(capacity, _values.Length));
+                Array.Copy(_values, newValues, Math.Min(capacity, _values.Length));
             }
             _values = newValues;
         }

--- a/src/System.Data.Common/src/System/Data/Common/SByteStorage.cs
+++ b/src/System.Data.Common/src/System/Data/Common/SByteStorage.cs
@@ -238,7 +238,7 @@ namespace System.Data.Common
             sbyte[] newValues = new sbyte[capacity];
             if (null != _values)
             {
-                Array.Copy(_values, 0, newValues, 0, Math.Min(capacity, _values.Length));
+                Array.Copy(_values, newValues, Math.Min(capacity, _values.Length));
             }
             _values = newValues;
             base.SetCapacity(capacity);

--- a/src/System.Data.Common/src/System/Data/Common/SQLTypes/SQLBinaryStorage.cs
+++ b/src/System.Data.Common/src/System/Data/Common/SQLTypes/SQLBinaryStorage.cs
@@ -93,7 +93,7 @@ namespace System.Data.Common
             SqlBinary[] newValues = new SqlBinary[capacity];
             if (null != _values)
             {
-                Array.Copy(_values, 0, newValues, 0, Math.Min(capacity, _values.Length));
+                Array.Copy(_values, newValues, Math.Min(capacity, _values.Length));
             }
             _values = newValues;
         }

--- a/src/System.Data.Common/src/System/Data/Common/SQLTypes/SQLByteStorage.cs
+++ b/src/System.Data.Common/src/System/Data/Common/SQLTypes/SQLByteStorage.cs
@@ -203,7 +203,7 @@ namespace System.Data.Common
             SqlByte[] newValues = new SqlByte[capacity];
             if (null != _values)
             {
-                Array.Copy(_values, 0, newValues, 0, Math.Min(capacity, _values.Length));
+                Array.Copy(_values, newValues, Math.Min(capacity, _values.Length));
             }
             _values = newValues;
         }

--- a/src/System.Data.Common/src/System/Data/Common/SQLTypes/SQLBytesStorage.cs
+++ b/src/System.Data.Common/src/System/Data/Common/SQLTypes/SQLBytesStorage.cs
@@ -92,7 +92,7 @@ namespace System.Data.Common
             SqlBytes[] newValues = new SqlBytes[capacity];
             if (null != _values)
             {
-                Array.Copy(_values, 0, newValues, 0, Math.Min(capacity, _values.Length));
+                Array.Copy(_values, newValues, Math.Min(capacity, _values.Length));
             }
             _values = newValues;
         }

--- a/src/System.Data.Common/src/System/Data/Common/SQLTypes/SQLCharsStorage.cs
+++ b/src/System.Data.Common/src/System/Data/Common/SQLTypes/SQLCharsStorage.cs
@@ -94,7 +94,7 @@ namespace System.Data.Common
             SqlChars[] newValues = new SqlChars[capacity];
             if (null != _values)
             {
-                Array.Copy(_values, 0, newValues, 0, Math.Min(capacity, _values.Length));
+                Array.Copy(_values, newValues, Math.Min(capacity, _values.Length));
             }
             _values = newValues;
         }

--- a/src/System.Data.Common/src/System/Data/Common/SQLTypes/SQLDateTimeStorage.cs
+++ b/src/System.Data.Common/src/System/Data/Common/SQLTypes/SQLDateTimeStorage.cs
@@ -129,7 +129,7 @@ namespace System.Data.Common
             SqlDateTime[] newValues = new SqlDateTime[capacity];
             if (null != _values)
             {
-                Array.Copy(_values, 0, newValues, 0, Math.Min(capacity, _values.Length));
+                Array.Copy(_values, newValues, Math.Min(capacity, _values.Length));
             }
             _values = newValues;
         }

--- a/src/System.Data.Common/src/System/Data/Common/SQLTypes/SQLDecimalStorage.cs
+++ b/src/System.Data.Common/src/System/Data/Common/SQLTypes/SQLDecimalStorage.cs
@@ -201,7 +201,7 @@ namespace System.Data.Common
             SqlDecimal[] newValues = new SqlDecimal[capacity];
             if (null != _values)
             {
-                Array.Copy(_values, 0, newValues, 0, Math.Min(capacity, _values.Length));
+                Array.Copy(_values, newValues, Math.Min(capacity, _values.Length));
             }
             _values = newValues;
         }

--- a/src/System.Data.Common/src/System/Data/Common/SQLTypes/SQLDoubleStorage.cs
+++ b/src/System.Data.Common/src/System/Data/Common/SQLTypes/SQLDoubleStorage.cs
@@ -202,7 +202,7 @@ namespace System.Data.Common
             SqlDouble[] newValues = new SqlDouble[capacity];
             if (null != _values)
             {
-                Array.Copy(_values, 0, newValues, 0, Math.Min(capacity, _values.Length));
+                Array.Copy(_values, newValues, Math.Min(capacity, _values.Length));
             }
             _values = newValues;
         }

--- a/src/System.Data.Common/src/System/Data/Common/SQLTypes/SQLGuidStorage.cs
+++ b/src/System.Data.Common/src/System/Data/Common/SQLTypes/SQLGuidStorage.cs
@@ -94,7 +94,7 @@ namespace System.Data.Common
             SqlGuid[] newValues = new SqlGuid[capacity];
             if (null != _values)
             {
-                Array.Copy(_values, 0, newValues, 0, Math.Min(capacity, _values.Length));
+                Array.Copy(_values, newValues, Math.Min(capacity, _values.Length));
             }
             _values = newValues;
         }

--- a/src/System.Data.Common/src/System/Data/Common/SQLTypes/SQLInt16Storage.cs
+++ b/src/System.Data.Common/src/System/Data/Common/SQLTypes/SQLInt16Storage.cs
@@ -202,7 +202,7 @@ namespace System.Data.Common
             SqlInt16[] newValues = new SqlInt16[capacity];
             if (null != _values)
             {
-                Array.Copy(_values, 0, newValues, 0, Math.Min(capacity, _values.Length));
+                Array.Copy(_values, newValues, Math.Min(capacity, _values.Length));
             }
             _values = newValues;
         }

--- a/src/System.Data.Common/src/System/Data/Common/SQLTypes/SQLInt32Storage.cs
+++ b/src/System.Data.Common/src/System/Data/Common/SQLTypes/SQLInt32Storage.cs
@@ -202,7 +202,7 @@ namespace System.Data.Common
             SqlInt32[] newValues = new SqlInt32[capacity];
             if (null != _values)
             {
-                Array.Copy(_values, 0, newValues, 0, Math.Min(capacity, _values.Length));
+                Array.Copy(_values, newValues, Math.Min(capacity, _values.Length));
             }
             _values = newValues;
         }

--- a/src/System.Data.Common/src/System/Data/Common/SQLTypes/SQLInt64Storage.cs
+++ b/src/System.Data.Common/src/System/Data/Common/SQLTypes/SQLInt64Storage.cs
@@ -203,7 +203,7 @@ namespace System.Data.Common
             SqlInt64[] newValues = new SqlInt64[capacity];
             if (null != _values)
             {
-                Array.Copy(_values, 0, newValues, 0, Math.Min(capacity, _values.Length));
+                Array.Copy(_values, newValues, Math.Min(capacity, _values.Length));
             }
             _values = newValues;
         }

--- a/src/System.Data.Common/src/System/Data/Common/SQLTypes/SQLMoneyStorage.cs
+++ b/src/System.Data.Common/src/System/Data/Common/SQLTypes/SQLMoneyStorage.cs
@@ -202,7 +202,7 @@ namespace System.Data.Common
             SqlMoney[] newValues = new SqlMoney[capacity];
             if (null != _values)
             {
-                Array.Copy(_values, 0, newValues, 0, Math.Min(capacity, _values.Length));
+                Array.Copy(_values, newValues, Math.Min(capacity, _values.Length));
             }
             _values = newValues;
         }

--- a/src/System.Data.Common/src/System/Data/Common/SQLTypes/SQLSingleStorage.cs
+++ b/src/System.Data.Common/src/System/Data/Common/SQLTypes/SQLSingleStorage.cs
@@ -200,7 +200,7 @@ namespace System.Data.Common
             SqlSingle[] newValues = new SqlSingle[capacity];
             if (null != _values)
             {
-                Array.Copy(_values, 0, newValues, 0, Math.Min(capacity, _values.Length));
+                Array.Copy(_values, newValues, Math.Min(capacity, _values.Length));
             }
             _values = newValues;
         }

--- a/src/System.Data.Common/src/System/Data/Common/SQLTypes/SQLStringStorage.cs
+++ b/src/System.Data.Common/src/System/Data/Common/SQLTypes/SQLStringStorage.cs
@@ -155,7 +155,7 @@ namespace System.Data.Common
             SqlString[] newValues = new SqlString[capacity];
             if (null != _values)
             {
-                Array.Copy(_values, 0, newValues, 0, Math.Min(capacity, _values.Length));
+                Array.Copy(_values, newValues, Math.Min(capacity, _values.Length));
             }
             _values = newValues;
         }

--- a/src/System.Data.Common/src/System/Data/Common/SQLTypes/SQlBooleanStorage.cs
+++ b/src/System.Data.Common/src/System/Data/Common/SQLTypes/SQlBooleanStorage.cs
@@ -127,7 +127,7 @@ namespace System.Data.Common
             SqlBoolean[] newValues = new SqlBoolean[capacity];
             if (null != _values)
             {
-                Array.Copy(_values, 0, newValues, 0, Math.Min(capacity, _values.Length));
+                Array.Copy(_values, newValues, Math.Min(capacity, _values.Length));
             }
             _values = newValues;
         }

--- a/src/System.Data.Common/src/System/Data/Common/SingleStorage.cs
+++ b/src/System.Data.Common/src/System/Data/Common/SingleStorage.cs
@@ -237,7 +237,7 @@ namespace System.Data.Common
             float[] newValues = new float[capacity];
             if (null != _values)
             {
-                Array.Copy(_values, 0, newValues, 0, Math.Min(capacity, _values.Length));
+                Array.Copy(_values, newValues, Math.Min(capacity, _values.Length));
             }
             _values = newValues;
             base.SetCapacity(capacity);

--- a/src/System.Data.Common/src/System/Data/Common/SqlUDTStorage.cs
+++ b/src/System.Data.Common/src/System/Data/Common/SqlUDTStorage.cs
@@ -135,7 +135,7 @@ namespace System.Data.Common
             object[] newValues = new object[capacity];
             if (_values != null)
             {
-                Array.Copy(_values, 0, newValues, 0, Math.Min(capacity, _values.Length));
+                Array.Copy(_values, newValues, Math.Min(capacity, _values.Length));
             }
             _values = newValues;
             base.SetCapacity(capacity);

--- a/src/System.Data.Common/src/System/Data/Common/StringStorage.cs
+++ b/src/System.Data.Common/src/System/Data/Common/StringStorage.cs
@@ -182,7 +182,7 @@ namespace System.Data.Common
             string[] newValues = new string[capacity];
             if (_values != null)
             {
-                Array.Copy(_values, 0, newValues, 0, Math.Min(capacity, _values.Length));
+                Array.Copy(_values, newValues, Math.Min(capacity, _values.Length));
             }
             _values = newValues;
         }

--- a/src/System.Data.Common/src/System/Data/Common/TimeSpanStorage.cs
+++ b/src/System.Data.Common/src/System/Data/Common/TimeSpanStorage.cs
@@ -256,7 +256,7 @@ namespace System.Data.Common
             TimeSpan[] newValues = new TimeSpan[capacity];
             if (null != _values)
             {
-                Array.Copy(_values, 0, newValues, 0, Math.Min(capacity, _values.Length));
+                Array.Copy(_values, newValues, Math.Min(capacity, _values.Length));
             }
             _values = newValues;
             base.SetCapacity(capacity);

--- a/src/System.Data.Common/src/System/Data/Common/UInt16Storage.cs
+++ b/src/System.Data.Common/src/System/Data/Common/UInt16Storage.cs
@@ -249,7 +249,7 @@ namespace System.Data.Common
             ushort[] newValues = new ushort[capacity];
             if (null != _values)
             {
-                Array.Copy(_values, 0, newValues, 0, Math.Min(capacity, _values.Length));
+                Array.Copy(_values, newValues, Math.Min(capacity, _values.Length));
             }
             _values = newValues;
             base.SetCapacity(capacity);

--- a/src/System.Data.Common/src/System/Data/Common/UInt32Storage.cs
+++ b/src/System.Data.Common/src/System/Data/Common/UInt32Storage.cs
@@ -248,7 +248,7 @@ namespace System.Data.Common
             uint[] newValues = new uint[capacity];
             if (null != _values)
             {
-                Array.Copy(_values, 0, newValues, 0, Math.Min(capacity, _values.Length));
+                Array.Copy(_values, newValues, Math.Min(capacity, _values.Length));
             }
             _values = newValues;
             base.SetCapacity(capacity);

--- a/src/System.Data.Common/src/System/Data/Common/UInt64Storage.cs
+++ b/src/System.Data.Common/src/System/Data/Common/UInt64Storage.cs
@@ -239,7 +239,7 @@ namespace System.Data.Common
             ulong[] newValues = new ulong[capacity];
             if (null != _values)
             {
-                Array.Copy(_values, 0, newValues, 0, Math.Min(capacity, _values.Length));
+                Array.Copy(_values, newValues, Math.Min(capacity, _values.Length));
             }
             _values = newValues;
             base.SetCapacity(capacity);

--- a/src/System.Data.Common/src/System/Data/DataError.cs
+++ b/src/System.Data.Common/src/System/Data/DataError.cs
@@ -142,7 +142,7 @@ namespace System.Data
             {
                 int newCapacity = Math.Min(_count * 2, column.Table.Columns.Count);
                 var biggerList = new ColumnError[newCapacity];
-                Array.Copy(_errorList, 0, biggerList, 0, _count);
+                Array.Copy(_errorList, biggerList, _count);
                 _errorList = biggerList;
             }
             return _count;

--- a/src/System.Data.Common/src/System/Data/DataTable.cs
+++ b/src/System.Data.Common/src/System/Data/DataTable.cs
@@ -3352,7 +3352,7 @@ namespace System.Data
             Debug.Assert(key.HasValue);
             IndexField[] indexDesc = key.GetIndexDesc();
             IndexField[] newIndexDesc = new IndexField[indexDesc.Length];
-            Array.Copy(indexDesc, 0, newIndexDesc, 0, indexDesc.Length);
+            Array.Copy(indexDesc, newIndexDesc, indexDesc.Length);
             return newIndexDesc;
         }
 

--- a/src/System.Data.Common/src/System/Data/Filter/FunctionNode.cs
+++ b/src/System.Data.Common/src/System/Data/Filter/FunctionNode.cs
@@ -68,7 +68,7 @@ namespace System.Data
             else if (_argumentCount == _arguments.Length)
             {
                 ExpressionNode[] bigger = new ExpressionNode[_argumentCount * 2];
-                Array.Copy(_arguments, 0, bigger, 0, _argumentCount);
+                Array.Copy(_arguments, bigger, _argumentCount);
                 _arguments = bigger;
             }
             _arguments[_argumentCount++] = argument;

--- a/src/System.Data.Common/src/System/Data/ProviderBase/SchemaMapping.cs
+++ b/src/System.Data.Common/src/System/Data/ProviderBase/SchemaMapping.cs
@@ -518,7 +518,7 @@ namespace System.Data.ProviderBase
             Debug.Assert(rgcol != null, "invalid call to ResizeArray");
             Debug.Assert(len <= rgcol.Length, "invalid len passed to ResizeArray");
             var tmp = new DataColumn[len];
-            Array.Copy(rgcol, 0, tmp, 0, len);
+            Array.Copy(rgcol, tmp, len);
             return tmp;
         }
 

--- a/src/System.Data.Common/src/System/Data/RbTree.cs
+++ b/src/System.Data.Common/src/System/Data/RbTree.cs
@@ -161,9 +161,9 @@ namespace System.Data
             {
                 // no free position found, increase pageTable size
                 TreePage[] newPageTable = new TreePage[_pageTable.Length * 2];
-                Array.Copy(_pageTable, 0, newPageTable, 0, _pageTable.Length);
+                Array.Copy(_pageTable, newPageTable, _pageTable.Length);
                 int[] newPageTableMap = new int[(newPageTable.Length + TreePage.slotLineSize - 1) / TreePage.slotLineSize];
-                Array.Copy(_pageTableMap, 0, newPageTableMap, 0, _pageTableMap.Length);
+                Array.Copy(_pageTableMap, newPageTableMap, _pageTableMap.Length);
 
                 _nextFreePageLine = _pageTableMap.Length;
                 freePageIndex = _pageTable.Length;

--- a/src/System.Data.Common/src/System/Data/RecordManager.cs
+++ b/src/System.Data.Common/src/System/Data/RecordManager.cs
@@ -37,7 +37,7 @@ namespace System.Data
             DataRow[] newRows = _table.NewRowArray(_recordCapacity);
             if (_rows != null)
             {
-                Array.Copy(_rows, 0, newRows, 0, Math.Min(_lastFreeRecord, _rows.Length));
+                Array.Copy(_rows, newRows, Math.Min(_lastFreeRecord, _rows.Length));
             }
             _rows = newRows;
         }

--- a/src/System.Data.Common/src/System/Data/SQLTypes/SQLBytes.cs
+++ b/src/System.Data.Common/src/System/Data/SQLTypes/SQLBytes.cs
@@ -185,7 +185,7 @@ namespace System.Data.SqlTypes
 
                     default:
                         buffer = new byte[_lCurLen];
-                        Array.Copy(_rgbBuf, 0, buffer, 0, (int)_lCurLen);
+                        Array.Copy(_rgbBuf, buffer, (int)_lCurLen);
                         break;
                 }
 

--- a/src/System.Data.Common/src/System/Data/SQLTypes/SQLChars.cs
+++ b/src/System.Data.Common/src/System/Data/SQLTypes/SQLChars.cs
@@ -179,7 +179,7 @@ namespace System.Data.SqlTypes
 
                     default:
                         buffer = new char[_lCurLen];
-                        Array.Copy(_rgchBuf, 0, buffer, 0, (int)_lCurLen);
+                        Array.Copy(_rgchBuf, buffer, (int)_lCurLen);
                         break;
                 }
 

--- a/src/System.Data.SqlClient/src/Microsoft/SqlServer/Server/SqlRecordBuffer.cs
+++ b/src/System.Data.SqlClient/src/Microsoft/SqlServer/Server/SqlRecordBuffer.cs
@@ -578,7 +578,7 @@ namespace Microsoft.SqlServer.Server
                     {    // dynamic expansion
                         char[] data = new char[Math.Max(ndataIndex + length, 2 * cchars)];
                         Debug.Assert(CharsLength < int.MaxValue);
-                        Array.Copy((char[])_object, 0, data, 0, (int)CharsLength);
+                        Array.Copy((char[])_object, data, (int)CharsLength);
                         _object = data;
                     }
                     CharsLength = ndataIndex + length;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
@@ -3894,7 +3894,7 @@ namespace System.Data.SqlClient
                 else
                 {
                     MultiPartTableName[] newTables = new MultiPartTableName[tables.Length + 1];
-                    Array.Copy(tables, 0, newTables, 0, tables.Length);
+                    Array.Copy(tables, newTables, tables.Length);
                     newTables[tables.Length] = mpt;
                     tables = newTables;
                 }

--- a/src/System.Diagnostics.EventLog/src/System/Diagnostics/EventLog.cs
+++ b/src/System.Diagnostics.EventLog/src/System/Diagnostics/EventLog.cs
@@ -837,7 +837,7 @@ namespace System.Diagnostics
             if (largestNumber > insertionStrings.Length)
             {
                 string[] newStrings = new string[largestNumber];
-                Array.Copy(insertionStrings, 0, newStrings, 0, insertionStrings.Length);
+                Array.Copy(insertionStrings, newStrings, insertionStrings.Length);
                 for (int i = insertionStrings.Length; i < newStrings.Length; i++)
                 {
                     newStrings[i] = "%" + (i + 1);

--- a/src/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterLib.cs
+++ b/src/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterLib.cs
@@ -166,8 +166,8 @@ namespace System.Diagnostics
                                 {
                                     int[] adjustedCounterIndexes = new int[index3];
                                     int[] adjustedHelpIndexes = new int[index3];
-                                    Array.Copy(newCategoryEntry.CounterIndexes, 0, adjustedCounterIndexes, 0, index3);
-                                    Array.Copy(newCategoryEntry.HelpIndexes, 0, adjustedHelpIndexes, 0, index3);
+                                    Array.Copy(newCategoryEntry.CounterIndexes, adjustedCounterIndexes, index3);
+                                    Array.Copy(newCategoryEntry.HelpIndexes, adjustedHelpIndexes, index3);
                                     newCategoryEntry.CounterIndexes = adjustedCounterIndexes;
                                     newCategoryEntry.HelpIndexes = adjustedHelpIndexes;
                                 }
@@ -894,7 +894,7 @@ namespace System.Diagnostics
             if (index2 < counters.Length)
             {
                 string[] adjustedCounters = new string[index2];
-                Array.Copy(counters, 0, adjustedCounters, 0, index2);
+                Array.Copy(counters, adjustedCounters, index2);
                 counters = adjustedCounters;
             }
 

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
@@ -292,7 +292,7 @@ namespace System.Diagnostics
                 break;
             }
             int[] ids = new int[size / 4];
-            Array.Copy(processIds, 0, ids, 0, ids.Length);
+            Array.Copy(processIds, ids, ids.Length);
             return ids;
         }
 

--- a/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADStoreKey.cs
+++ b/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADStoreKey.cs
@@ -39,7 +39,7 @@ namespace System.DirectoryServices.AccountManagement
 
             // Make a copy of the SID, since a byte[] is mutable
             _sid = new byte[sid.Length];
-            Array.Copy(sid, 0, _sid, 0, sid.Length);
+            Array.Copy(sid, _sid, sid.Length);
 
             _domainName = domainName;
             _wellKnownSid = true;

--- a/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/SAM/SAMStoreKey.cs
+++ b/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/SAM/SAMStoreKey.cs
@@ -22,7 +22,7 @@ namespace System.DirectoryServices.AccountManagement
 
             // Make a copy of the SID, since a byte[] is mutable
             _sid = new byte[sid.Length];
-            Array.Copy(sid, 0, _sid, 0, sid.Length);
+            Array.Copy(sid, _sid, sid.Length);
 
             GlobalDebug.WriteLineIf(
                             GlobalDebug.Info,

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/InflaterManaged.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/InflaterManaged.cs
@@ -728,7 +728,7 @@ namespace System.IO.Compression
             byte[] distanceTreeCodeLength = new byte[HuffmanTree.MaxDistTreeElements];
 
             // Create literal and distance tables
-            Array.Copy(_codeList, 0, literalTreeCodeLength, 0, _literalLengthCodeCount);
+            Array.Copy(_codeList, literalTreeCodeLength, _literalLengthCodeCount);
             Array.Copy(_codeList, _literalLengthCodeCount, distanceTreeCodeLength, 0, _distanceCodeCount);
 
             // Make sure there is an end-of-block code, otherwise how could we ever end?

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeCompletion.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeCompletion.cs
@@ -78,7 +78,7 @@ namespace System.IO.Pipelines
             if (newLength == _callbacks.Length)
             {
                 PipeCompletionCallback[] newArray = s_completionCallbackPool.Rent(_callbacks.Length * 2);
-                Array.Copy(_callbacks, 0, newArray, 0, _callbacks.Length);
+                Array.Copy(_callbacks, newArray, _callbacks.Length);
                 s_completionCallbackPool.Return(_callbacks, clearArray: true);
                 _callbacks = newArray;
             }

--- a/src/System.IO.Ports/tests/SerialPort/DiscardNull.cs
+++ b/src/System.IO.Ports/tests/SerialPort/DiscardNull.cs
@@ -354,7 +354,7 @@ namespace System.IO.Ports.Tests
                 else
                 {
                     expectedChars = new char[xmitChars.Length];
-                    Array.Copy(xmitChars, 0, expectedChars, 0, expectedChars.Length);
+                    Array.Copy(xmitChars, expectedChars, expectedChars.Length);
                 }
 
                 expectedBytes = com1.Encoding.GetBytes(expectedChars);

--- a/src/System.IO.Ports/tests/SerialPort/ReadChar.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReadChar.cs
@@ -533,7 +533,7 @@ namespace System.IO.Ports.Tests
             char[] expectedChars = new char[com1.Encoding.GetCharCount(bytesToWrite, 0, bytesToWrite.Length) * 2];
             char[] encodedChars = com1.Encoding.GetChars(bytesToWrite, 0, bytesToWrite.Length);
 
-            Array.Copy(encodedChars, 0, expectedChars, 0, bytesToWrite.Length);
+            Array.Copy(encodedChars, expectedChars, bytesToWrite.Length);
             Array.Copy(encodedChars, 0, expectedChars, encodedChars.Length, encodedChars.Length);
 
             BufferData(com1, com2, bytesToWrite);

--- a/src/System.IO.Ports/tests/SerialPort/ReadExisting.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReadExisting.cs
@@ -234,7 +234,7 @@ namespace System.IO.Ports.Tests
             char[] expectedChars = new char[com1.Encoding.GetCharCount(bytesToWrite, 0, bytesToWrite.Length) * 2];
             char[] encodedChars = com1.Encoding.GetChars(bytesToWrite, 0, bytesToWrite.Length);
 
-            Array.Copy(encodedChars, 0, expectedChars, 0, bytesToWrite.Length);
+            Array.Copy(encodedChars, expectedChars, bytesToWrite.Length);
             Array.Copy(encodedChars, 0, expectedChars, encodedChars.Length, encodedChars.Length);
 
             BufferData(com1, com2, bytesToWrite);

--- a/src/System.IO.Ports/tests/SerialPort/Read_char_int_int.cs
+++ b/src/System.IO.Ports/tests/SerialPort/Read_char_int_int.cs
@@ -448,7 +448,7 @@ namespace System.IO.Ports.Tests
                 //[] Fill the buffer up then read in all but one of the chars
                 var expectedChars = new char[charXmitBuffer.Length - 1];
                 var charRcvBuffer = new char[charXmitBuffer.Length - 1];
-                Array.Copy(charXmitBuffer, 0, expectedChars, 0, charXmitBuffer.Length - 1);
+                Array.Copy(charXmitBuffer, expectedChars, charXmitBuffer.Length - 1);
 
                 com2.Write(charXmitBuffer, 0, charXmitBuffer.Length);
                 TCSupport.WaitForPredicate(() => com1.BytesToRead == charXmitBuffer.Length, 2000,
@@ -635,7 +635,7 @@ namespace System.IO.Ports.Tests
 
                 char[] actualChars = new char[charXmitBuffer.Length];
 
-                Array.Copy(charRcvBuffer, 0, actualChars, 0, result);
+                Array.Copy(charRcvBuffer, actualChars, result);
                 result = com1.Read(actualChars, actualChars.Length - 2, 2);
 
                 Assert.Equal(2, result);
@@ -654,7 +654,7 @@ namespace System.IO.Ports.Tests
 
                 actualChars = new char[charXmitBuffer.Length];
 
-                Array.Copy(charRcvBuffer, 0, actualChars, 0, result);
+                Array.Copy(charRcvBuffer, actualChars, result);
                 result = com1.Read(actualChars, actualChars.Length - 2, 2);
 
                 Assert.Equal(2, result);
@@ -783,7 +783,7 @@ namespace System.IO.Ports.Tests
             char[] expectedChars = new char[com1.Encoding.GetCharCount(bytesToWrite, 0, bytesToWrite.Length) * 2];
             char[] encodedChars = com1.Encoding.GetChars(bytesToWrite, 0, bytesToWrite.Length);
 
-            Array.Copy(encodedChars, 0, expectedChars, 0, bytesToWrite.Length);
+            Array.Copy(encodedChars, expectedChars, bytesToWrite.Length);
             Array.Copy(encodedChars, 0, expectedChars, encodedChars.Length, encodedChars.Length);
 
             BufferData(com1, com2, bytesToWrite);

--- a/src/System.IO.Ports/tests/SerialPort/ReceivedEvent.cs
+++ b/src/System.IO.Ports/tests/SerialPort/ReceivedEvent.cs
@@ -428,7 +428,7 @@ namespace System.IO.Ports.Tests
                     if ((_bytesRead.Length - _numBytesRead) < com.BytesToRead)
                     {
                         byte[] tempByteArray = new byte[Math.Max(_bytesRead.Length * 2, _bytesRead.Length + com.BytesToRead)];
-                        Array.Copy(_bytesRead, 0, tempByteArray, 0, _numBytesRead);
+                        Array.Copy(_bytesRead, tempByteArray, _numBytesRead);
                         _bytesRead = tempByteArray;
                     }
 

--- a/src/System.Linq.Expressions/src/System/Dynamic/ExpandoClass.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/ExpandoClass.cs
@@ -75,7 +75,7 @@ namespace System.Dynamic
 
                 // no applicable transition, create a new one
                 string[] keys = new string[_keys.Length + 1];
-                Array.Copy(_keys, 0, keys, 0, _keys.Length);
+                Array.Copy(_keys, keys, _keys.Length);
                 keys[_keys.Length] = newKey;
                 ExpandoClass ec = new ExpandoClass(keys, hashCode);
 

--- a/src/System.Linq.Expressions/src/System/Dynamic/ExpandoObject.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/ExpandoObject.cs
@@ -1106,7 +1106,7 @@ namespace System.Dynamic
                     // we've grown too much - we need a new object array
                     int oldLength = _dataArray.Length;
                     object[] arr = new object[GetAlignedSize(newClass.Keys.Length)];
-                    Array.Copy(_dataArray, 0, arr, 0, _dataArray.Length);
+                    Array.Copy(_dataArray, arr, _dataArray.Length);
                     ExpandoData newData = new ExpandoData(newClass, arr, _version);
                     newData[oldLength] = ExpandoObject.Uninitialized;
                     return newData;

--- a/src/System.Linq.Expressions/src/System/Dynamic/Utils/CollectionExtensions.cs
+++ b/src/System.Linq.Expressions/src/System/Dynamic/Utils/CollectionExtensions.cs
@@ -45,7 +45,7 @@ namespace System.Dynamic.Utils
         public static T[] RemoveLast<T>(this T[] array)
         {
             T[] result = new T[array.Length - 1];
-            Array.Copy(array, 0, result, 0, result.Length);
+            Array.Copy(array, result, result.Length);
             return result;
         }
 

--- a/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/ReadOnlyCollectionBuilder.cs
+++ b/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/ReadOnlyCollectionBuilder.cs
@@ -94,7 +94,7 @@ namespace System.Runtime.CompilerServices
                         T[] newItems = new T[value];
                         if (_size > 0)
                         {
-                            Array.Copy(_items, 0, newItems, 0, _size);
+                            Array.Copy(_items, newItems, _size);
                         }
                         _items = newItems;
                     }
@@ -432,7 +432,7 @@ namespace System.Runtime.CompilerServices
         public T[] ToArray()
         {
             T[] array = new T[_size];
-            Array.Copy(_items, 0, array, 0, _size);
+            Array.Copy(_items, array, _size);
             return array;
         }
 

--- a/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/RuleCache.cs
+++ b/src/System.Linq.Expressions/src/System/Runtime/CompilerServices/RuleCache.cs
@@ -95,7 +95,7 @@ namespace System.Runtime.CompilerServices
             else
             {
                 newRules = new T[newLength];
-                Array.Copy(rules, 0, newRules, 0, InsertPosition);
+                Array.Copy(rules, newRules, InsertPosition);
             }
 
             newRules[InsertPosition] = item;

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Channels/AsynchronousChannel.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Channels/AsynchronousChannel.cs
@@ -383,7 +383,7 @@ namespace System.Linq.Parallel
                 // Trim the partially-full chunk to an array just big enough to hold it.
                 Debug.Assert(1 <= _producerChunkIndex && _producerChunkIndex <= _chunkSize);
                 T[] leftOverChunk = new T[_producerChunkIndex];
-                Array.Copy(_producerChunk, 0, leftOverChunk, 0, _producerChunkIndex);
+                Array.Copy(_producerChunk, leftOverChunk, _producerChunkIndex);
 
                 // And enqueue the right-sized temporary chunk, possibly blocking if it's full.
                 EnqueueChunk(leftOverChunk);

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Helpers.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Helpers.cs
@@ -113,7 +113,7 @@ namespace System.Linq.Parallel
             int newSize = checked(_count * 2 + 1);
             int[] newBuckets = new int[newSize];
             Slot[] newSlots = new Slot[newSize];
-            Array.Copy(_slots, 0, newSlots, 0, _count);
+            Array.Copy(_slots, newSlots, _count);
             for (int i = 0; i < _count; i++)
             {
                 int bucket = newSlots[i].hashCode % newSize;

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Utils/HashLookup.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Utils/HashLookup.cs
@@ -129,7 +129,7 @@ namespace System.Linq.Parallel
             int newSize = checked(count * 2 + 1);
             int[] newBuckets = new int[newSize];
             Slot[] newSlots = new Slot[newSize];
-            Array.Copy(slots, 0, newSlots, 0, count);
+            Array.Copy(slots, newSlots, count);
             for (int i = 0; i < count; i++)
             {
                 int bucket = newSlots[i].hashCode % newSize;

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Utils/Sorting.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Utils/Sorting.cs
@@ -477,7 +477,7 @@ namespace System.Linq.Parallel
                         // If it's not the last phase, we just bulk propagate the keys and values.
                         if (!isLastPhase && leftCount > 0)
                         {
-                            Array.Copy(myValues, 0, mergedValues, 0, leftCount);
+                            Array.Copy(myValues, mergedValues, leftCount);
                         }
 
                         // And now just wait for the second half.  We never reuse the same barrier across multiple

--- a/src/System.Linq/src/System/Linq/Set.cs
+++ b/src/System.Linq/src/System/Linq/Set.cs
@@ -142,7 +142,7 @@ namespace System.Linq
             int newSize = checked((_count * 2) + 1);
             int[] newBuckets = new int[newSize];
             Slot[] newSlots = new Slot[newSize];
-            Array.Copy(_slots, 0, newSlots, 0, _count);
+            Array.Copy(_slots, newSlots, _count);
             for (int i = 0; i < _count; i++)
             {
                 int bucket = newSlots[i]._hashCode % newSize;

--- a/src/System.Net.Http/tests/FunctionalTests/HttpContentTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpContentTest.cs
@@ -507,7 +507,7 @@ namespace System.Net.Http.Functional.Tests
             byte[] rawBytes = encoding.GetBytes(str);
             byte[] preamble = encoding.GetPreamble(); // Get the correct BOM characters
             byte[] contentBytes = new byte[preamble.Length + rawBytes.Length];
-            Array.Copy(preamble, 0, contentBytes, 0, preamble.Length);
+            Array.Copy(preamble, contentBytes, preamble.Length);
             Array.Copy(rawBytes, 0, contentBytes, preamble.Length, rawBytes.Length);
             return contentBytes;
         }

--- a/src/System.Numerics.Vectors/tests/GenericVectorTests.cs
+++ b/src/System.Numerics.Vectors/tests/GenericVectorTests.cs
@@ -1602,7 +1602,7 @@ namespace System.Numerics.Tests
             }
             while (Util.AnyEqual(values1, values2));
 
-            Array.Copy(values1, 0, values2, 0, Vector<T>.Count / 2);
+            Array.Copy(values1, values2, Vector<T>.Count / 2);
             Vector<T> vec1 = new Vector<T>(values1);
             Vector<T> vec2 = new Vector<T>(values2);
 
@@ -1647,7 +1647,7 @@ namespace System.Numerics.Tests
             }
             while (Util.AnyEqual(values1, values2));
 
-            Array.Copy(values1, 0, values2, 0, Vector<T>.Count / 2);
+            Array.Copy(values1, values2, Vector<T>.Count / 2);
             Vector<T> vec1 = new Vector<T>(values1);
             Vector<T> vec2 = new Vector<T>(values2);
 
@@ -1695,7 +1695,7 @@ namespace System.Numerics.Tests
             }
             while (Util.AnyEqual(values1, values2));
 
-            Array.Copy(values1, 0, values2, 0, Vector<T>.Count / 2);
+            Array.Copy(values1, values2, Vector<T>.Count / 2);
             Vector<T> vec1 = new Vector<T>(values1);
             Vector<T> vec2 = new Vector<T>(values2);
 

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ClassDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ClassDataContract.cs
@@ -446,7 +446,7 @@ namespace System.Runtime.Serialization
             int baseChildElementNamespaceCount = (baseChildElementNamespaces != null) ? baseChildElementNamespaces.Length : 0;
             XmlDictionaryString[] childElementNamespaces = new XmlDictionaryString[Members.Count + baseChildElementNamespaceCount];
             if (baseChildElementNamespaceCount > 0)
-                Array.Copy(baseChildElementNamespaces, 0, childElementNamespaces, 0, baseChildElementNamespaces.Length);
+                Array.Copy(baseChildElementNamespaces, childElementNamespaces, baseChildElementNamespaces.Length);
 
             XmlDictionary dictionary = new XmlDictionary();
             for (int i = 0; i < this.Members.Count; i++)
@@ -802,12 +802,12 @@ namespace System.Runtime.Serialization
                     {
                         baseMemberCount = BaseContract.MemberNames.Length;
                         MemberNames = new XmlDictionaryString[Members.Count + baseMemberCount];
-                        Array.Copy(BaseContract.MemberNames, 0, MemberNames, 0, baseMemberCount);
+                        Array.Copy(BaseContract.MemberNames, MemberNames, baseMemberCount);
                         MemberNamespaces = new XmlDictionaryString[Members.Count + baseMemberCount];
-                        Array.Copy(BaseContract.MemberNamespaces, 0, MemberNamespaces, 0, baseMemberCount);
+                        Array.Copy(BaseContract.MemberNamespaces, MemberNamespaces, baseMemberCount);
                         baseContractCount = BaseContract.ContractNamespaces.Length;
                         ContractNamespaces = new XmlDictionaryString[1 + baseContractCount];
-                        Array.Copy(BaseContract.ContractNamespaces, 0, ContractNamespaces, 0, baseContractCount);
+                        Array.Copy(BaseContract.ContractNamespaces, ContractNamespaces, baseContractCount);
                     }
                     ContractNamespaces[baseContractCount] = Namespace;
                     for (int i = 0; i < Members.Count; i++)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ExtensionDataReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ExtensionDataReader.cs
@@ -465,7 +465,7 @@ namespace System.Runtime.Serialization
             else if (_elements.Length == _depth)
             {
                 ElementData[] newElements = new ElementData[_elements.Length * 2];
-                Array.Copy(_elements, 0, newElements, 0, _elements.Length);
+                Array.Copy(_elements, newElements, _elements.Length);
                 _elements = newElements;
             }
         }
@@ -549,7 +549,7 @@ namespace System.Runtime.Serialization
             else if (attributes.Length == attributeCount)
             {
                 AttributeData[] newAttributes = new AttributeData[attributes.Length * 2];
-                Array.Copy(attributes, 0, newAttributes, 0, attributes.Length);
+                Array.Copy(attributes, newAttributes, attributes.Length);
                 attributes = newAttributes;
             }
         }

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlJsonReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlJsonReader.cs
@@ -1073,7 +1073,7 @@ namespace System.Runtime.Serialization.Json
             else if (_scopes.Length == _scopeDepth)
             {
                 JsonNodeType[] newScopes = new JsonNodeType[_scopeDepth * 2];
-                Array.Copy(_scopes, 0, newScopes, 0, _scopeDepth);
+                Array.Copy(_scopes, newScopes, _scopeDepth);
                 _scopes = newScopes;
             }
             _scopes[_scopeDepth] = currentNodeType;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlJsonWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlJsonWriter.cs
@@ -1229,7 +1229,7 @@ namespace System.Runtime.Serialization.Json
             else if (_scopes.Length == _depth)
             {
                 JsonNodeType[] newScopes = new JsonNodeType[_depth * 2];
-                Array.Copy(_scopes, 0, newScopes, 0, _depth);
+                Array.Copy(_scopes, newScopes, _depth);
                 _scopes = newScopes;
             }
             _scopes[_depth] = currentNodeType;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerReadContext.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerReadContext.cs
@@ -494,7 +494,7 @@ namespace System.Runtime.Serialization
                 }
                 int newSize = (index < int.MaxValue / 2) ? index * 2 : int.MaxValue;
                 T[] newArray = new T[newSize];
-                Array.Copy(array, 0, newArray, 0, array.Length);
+                Array.Copy(array, newArray, array.Length);
                 array = newArray;
             }
             return array;
@@ -509,7 +509,7 @@ namespace System.Runtime.Serialization
             if (size != array.Length)
             {
                 T[] newArray = new T[size];
-                Array.Copy(array, 0, newArray, 0, size);
+                Array.Copy(array, newArray, size);
                 array = newArray;
             }
             return array;

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlBaseReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlBaseReader.cs
@@ -309,7 +309,7 @@ namespace System.Xml
             else if (_elementNodes.Length == _depth)
             {
                 XmlElementNode[] newElementNodes = new XmlElementNode[_depth * 2];
-                Array.Copy(_elementNodes, 0, newElementNodes, 0, _depth);
+                Array.Copy(_elementNodes, newElementNodes, _depth);
                 _elementNodes = newElementNodes;
             }
             XmlElementNode elementNode = _elementNodes[_depth];
@@ -343,7 +343,7 @@ namespace System.Xml
             else if (_attributeNodes.Length == attributeIndex)
             {
                 XmlAttributeNode[] newAttributeNodes = new XmlAttributeNode[attributeIndex * 2];
-                Array.Copy(_attributeNodes, 0, newAttributeNodes, 0, attributeIndex);
+                Array.Copy(_attributeNodes, newAttributeNodes, attributeIndex);
                 _attributeNodes = newAttributeNodes;
             }
             XmlAttributeNode attributeNode = _attributeNodes[attributeIndex];
@@ -2900,7 +2900,7 @@ namespace System.Xml
                 else if (_attributes.Length == _attributeCount)
                 {
                     XmlAttribute[] newAttributes = new XmlAttribute[_attributeCount * 2];
-                    Array.Copy(_attributes, 0, newAttributes, 0, _attributeCount);
+                    Array.Copy(_attributes, newAttributes, _attributeCount);
                     _attributes = newAttributes;
                 }
                 XmlAttribute attribute = _attributes[_attributeCount];
@@ -2938,7 +2938,7 @@ namespace System.Xml
                 else if (_namespaces.Length == _nsCount)
                 {
                     Namespace[] newNamespaces = new Namespace[_nsCount * 2];
-                    Array.Copy(_namespaces, 0, newNamespaces, 0, _nsCount);
+                    Array.Copy(_namespaces, newNamespaces, _nsCount);
                     _namespaces = newNamespaces;
                 }
                 Namespace nameSpace = _namespaces[_nsCount];

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlBaseWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlBaseWriter.cs
@@ -686,7 +686,7 @@ namespace System.Xml
             else if (_elements.Length == _depth)
             {
                 Element[] newElementNodes = new Element[_depth * 2];
-                Array.Copy(_elements, 0, newElementNodes, 0, _depth);
+                Array.Copy(_elements, newElementNodes, _depth);
                 _elements = newElementNodes;
             }
             Element element = _elements[_depth];
@@ -1987,7 +1987,7 @@ namespace System.Xml
                 else if (_attributes.Length == _attributeCount)
                 {
                     XmlAttribute[] newAttributes = new XmlAttribute[_attributeCount * 2];
-                    Array.Copy(_attributes, 0, newAttributes, 0, _attributeCount);
+                    Array.Copy(_attributes, newAttributes, _attributeCount);
                     _attributes = newAttributes;
                 }
                 XmlAttribute attribute = _attributes[_attributeCount];
@@ -2081,7 +2081,7 @@ namespace System.Xml
                 if (_namespaces.Length == _nsCount)
                 {
                     Namespace[] newNamespaces = new Namespace[_nsCount * 2];
-                    Array.Copy(_namespaces, 0, newNamespaces, 0, _nsCount);
+                    Array.Copy(_namespaces, newNamespaces, _nsCount);
                     _namespaces = newNamespaces;
                 }
                 nameSpace = _namespaces[_nsCount];

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryReaderSession.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryReaderSession.cs
@@ -47,7 +47,7 @@ namespace System.Xml
                 else if (id >= _strings.Length)
                 {
                     XmlDictionaryString[] newStrings = new XmlDictionaryString[Math.Min(Math.Max(id + 1, _strings.Length * 2), MaxArrayEntries)];
-                    Array.Copy(_strings, 0, newStrings, 0, _strings.Length);
+                    Array.Copy(_strings, newStrings, _strings.Length);
                     _strings = newStrings;
                 }
                 _strings[id] = xmlString;

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryWriterSession.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryWriterSession.cs
@@ -250,7 +250,7 @@ namespace System.Xml
                     if (index >= _array.Length)
                     {
                         int[] newArray = new int[Math.Max(index + 1, _array.Length * 2)];
-                        Array.Copy(_array, 0, newArray, 0, _array.Length);
+                        Array.Copy(_array, newArray, _array.Length);
                         _array = newArray;
                     }
 

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlCanonicalWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlCanonicalWriter.cs
@@ -164,7 +164,7 @@ namespace System.Xml
             else if (_depth == _scopes.Length)
             {
                 Scope[] newScopes = new Scope[_depth * 2];
-                Array.Copy(_scopes, 0, newScopes, 0, _depth);
+                Array.Copy(_scopes, newScopes, _depth);
                 _scopes = newScopes;
             }
             _scopes[_depth].xmlnsAttributeCount = _xmlnsAttributeCount;
@@ -736,7 +736,7 @@ namespace System.Xml
             else if (_attributeCount == _attributes.Length)
             {
                 Attribute[] newAttributes = new Attribute[_attributeCount * 2];
-                Array.Copy(_attributes, 0, newAttributes, 0, _attributeCount);
+                Array.Copy(_attributes, newAttributes, _attributeCount);
                 _attributes = newAttributes;
             }
 
@@ -756,7 +756,7 @@ namespace System.Xml
             else if (_xmlnsAttributes.Length == _xmlnsAttributeCount)
             {
                 XmlnsAttribute[] newXmlnsAttributes = new XmlnsAttribute[_xmlnsAttributeCount * 2];
-                Array.Copy(_xmlnsAttributes, 0, newXmlnsAttributes, 0, _xmlnsAttributeCount);
+                Array.Copy(_xmlnsAttributes, newXmlnsAttributes, _xmlnsAttributeCount);
                 _xmlnsAttributes = newXmlnsAttributes;
             }
 

--- a/src/System.Private.Xml/src/System/Xml/BinaryXml/XmlBinaryReader.cs
+++ b/src/System.Private.Xml/src/System/Xml/BinaryXml/XmlBinaryReader.cs
@@ -1899,7 +1899,7 @@ namespace System.Xml
             if (symNum == symtable.Length)
             {
                 string[] n = new string[checked(symNum * 2)];
-                System.Array.Copy(symtable, 0, n, 0, symNum);
+                System.Array.Copy(symtable, n, symNum);
                 _symbolTables.symtable = symtable = n;
             }
             symtable[symNum] = _xnt.Add(txt);
@@ -1915,7 +1915,7 @@ namespace System.Xml
             if (qnameNum == qnametable.Length)
             {
                 QName[] n = new QName[checked(qnameNum * 2)];
-                System.Array.Copy(qnametable, 0, n, 0, qnameNum);
+                System.Array.Copy(qnametable, n, qnameNum);
                 _symbolTables.qnametable = qnametable = n;
             }
             string[] symtable = _symbolTables.symtable;
@@ -2418,7 +2418,7 @@ namespace System.Xml
             int newcount = _elementStack.Length * 2;
             ElemInfo[] n = new ElemInfo[newcount];
 
-            System.Array.Copy(_elementStack, 0, n, 0, _elementStack.Length);
+            System.Array.Copy(_elementStack, n, _elementStack.Length);
             _elementStack = n;
         }
 
@@ -2427,7 +2427,7 @@ namespace System.Xml
             int newcount = _attributes.Length * 2;
             AttrInfo[] n = new AttrInfo[newcount];
 
-            System.Array.Copy(_attributes, 0, n, 0, _attrCount);
+            System.Array.Copy(_attributes, n, _attrCount);
             _attributes = n;
         }
 

--- a/src/System.Private.Xml/src/System/Xml/BitStack.cs
+++ b/src/System.Private.Xml/src/System/Xml/BitStack.cs
@@ -96,7 +96,7 @@ namespace System.Xml
             if (_stackPos >= len)
             {
                 uint[] bitStackNew = new uint[2 * len];
-                Array.Copy(_bitStack, 0, bitStackNew, 0, len);
+                Array.Copy(_bitStack, bitStackNew, len);
                 _bitStack = bitStackNew;
             }
         }

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriter.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriter.cs
@@ -1706,7 +1706,7 @@ namespace System.Xml
         {
             Debug.Assert(_lastMarkPos + 1 == _textContentMarks.Length);
             int[] newTextContentMarks = new int[_textContentMarks.Length * 2];
-            Array.Copy(_textContentMarks, 0, newTextContentMarks, 0, _textContentMarks.Length);
+            Array.Copy(_textContentMarks, newTextContentMarks, _textContentMarks.Length);
             _textContentMarks = newTextContentMarks;
         }
         // Write NewLineChars to the specified buffer position and return an updated position.

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlSubtreeReader.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlSubtreeReader.cs
@@ -1295,7 +1295,7 @@ namespace System.Xml
             if (index == _nsAttributes.Length)
             {
                 NodeData[] newNsAttrs = new NodeData[_nsAttributes.Length * 2];
-                Array.Copy(_nsAttributes, 0, newNsAttrs, 0, index);
+                Array.Copy(_nsAttributes, newNsAttrs, index);
                 _nsAttributes = newNsAttrs;
             }
 

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImpl.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImpl.cs
@@ -7736,7 +7736,7 @@ namespace System.Xml
             if (nodeIndex >= _nodes.Length - 1)
             {
                 NodeData[] newNodes = new NodeData[_nodes.Length * 2];
-                Array.Copy(_nodes, 0, newNodes, 0, _nodes.Length);
+                Array.Copy(_nodes, newNodes, _nodes.Length);
                 _nodes = newNodes;
             }
             Debug.Assert(nodeIndex < _nodes.Length);
@@ -8190,7 +8190,7 @@ namespace System.Xml
             else if (_parsingStatesStackTop + 1 == _parsingStatesStack.Length)
             {
                 ParsingState[] newParsingStateStack = new ParsingState[_parsingStatesStack.Length * 2];
-                Array.Copy(_parsingStatesStack, 0, newParsingStateStack, 0, _parsingStatesStack.Length);
+                Array.Copy(_parsingStatesStack, newParsingStateStack, _parsingStatesStack.Length);
                 _parsingStatesStack = newParsingStateStack;
             }
             _parsingStatesStackTop++;

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlTextWriter.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlTextWriter.cs
@@ -1507,7 +1507,7 @@ namespace System.Xml
             if (nsIndex == _nsStack.Length)
             {
                 Namespace[] newStack = new Namespace[nsIndex * 2];
-                Array.Copy(_nsStack, 0, newStack, 0, nsIndex);
+                Array.Copy(_nsStack, newStack, nsIndex);
                 _nsStack = newStack;
             }
             _nsStack[nsIndex].Set(prefix, ns, declared);
@@ -1767,7 +1767,7 @@ namespace System.Xml
             if (_top == _stack.Length - 1)
             {
                 TagInfo[] na = new TagInfo[_stack.Length + 10];
-                if (_top > 0) Array.Copy(_stack, 0, na, 0, _top + 1);
+                if (_top > 0) Array.Copy(_stack, na, _top + 1);
                 _stack = na;
             }
 

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlWellFormedWriter.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlWellFormedWriter.cs
@@ -494,7 +494,7 @@ namespace System.Xml
                 if (top == _elemScopeStack.Length)
                 {
                     ElementScope[] newStack = new ElementScope[top * 2];
-                    Array.Copy(_elemScopeStack, 0, newStack, 0, top);
+                    Array.Copy(_elemScopeStack, newStack, top);
                     _elemScopeStack = newStack;
                 }
                 _elemScopeStack[top].Set(prefix, localName, ns, _nsTop);
@@ -1835,7 +1835,7 @@ namespace System.Xml
             if (top == _nsStack.Length)
             {
                 Namespace[] newStack = new Namespace[top * 2];
-                Array.Copy(_nsStack, 0, newStack, 0, top);
+                Array.Copy(_nsStack, newStack, top);
                 _nsStack = newStack;
             }
             _nsStack[top].Set(prefix, ns, kind);
@@ -2206,7 +2206,7 @@ namespace System.Xml
             if (top == _attrStack.Length)
             {
                 AttrName[] newStack = new AttrName[top * 2];
-                Array.Copy(_attrStack, 0, newStack, 0, top);
+                Array.Copy(_attrStack, newStack, top);
                 _attrStack = newStack;
             }
             _attrStack[top].Set(prefix, localName, namespaceName);

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlWellFormedWriterAsync.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlWellFormedWriterAsync.cs
@@ -292,7 +292,7 @@ namespace System.Xml
                 if (top == _elemScopeStack.Length)
                 {
                     ElementScope[] newStack = new ElementScope[top * 2];
-                    Array.Copy(_elemScopeStack, 0, newStack, 0, top);
+                    Array.Copy(_elemScopeStack, newStack, top);
                     _elemScopeStack = newStack;
                 }
                 _elemScopeStack[top].Set(prefix, localName, ns, _nsTop);

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlWellFormedWriterHelpers.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlWellFormedWriterHelpers.cs
@@ -511,7 +511,7 @@ namespace System.Xml
                 else if (_items.Length == newItemIndex)
                 {
                     Item[] newItems = new Item[newItemIndex * 2];
-                    Array.Copy(_items, 0, newItems, 0, newItemIndex);
+                    Array.Copy(_items, newItems, newItemIndex);
                     _items = newItems;
                 }
                 if (_items[newItemIndex] == null)

--- a/src/System.Private.Xml/src/System/Xml/Core/XsdCachingReader.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XsdCachingReader.cs
@@ -657,7 +657,7 @@ namespace System.Xml
             if (attIndex >= _attributeEvents.Length - 1)
             { //reached capacity of array, Need to increase capacity to twice the initial
                 ValidatingReaderNodeData[] newAttributeEvents = new ValidatingReaderNodeData[_attributeEvents.Length * 2];
-                Array.Copy(_attributeEvents, 0, newAttributeEvents, 0, _attributeEvents.Length);
+                Array.Copy(_attributeEvents, newAttributeEvents, _attributeEvents.Length);
                 _attributeEvents = newAttributeEvents;
             }
             attInfo = _attributeEvents[attIndex];
@@ -682,7 +682,7 @@ namespace System.Xml
             if (_contentIndex >= _contentEvents.Length - 1)
             { //reached capacity of array, Need to increase capacity to twice the initial
                 ValidatingReaderNodeData[] newContentEvents = new ValidatingReaderNodeData[_contentEvents.Length * 2];
-                Array.Copy(_contentEvents, 0, newContentEvents, 0, _contentEvents.Length);
+                Array.Copy(_contentEvents, newContentEvents, _contentEvents.Length);
                 _contentEvents = newContentEvents;
             }
             contentInfo = _contentEvents[_contentIndex];

--- a/src/System.Private.Xml/src/System/Xml/Core/XsdValidatingReader.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XsdValidatingReader.cs
@@ -2180,7 +2180,7 @@ namespace System.Xml
             if (attIndex >= _attributePSVINodes.Length - 1)
             { //reached capacity of PSVIInfo array, Need to increase capacity to twice the initial
                 AttributePSVIInfo[] newPSVINodes = new AttributePSVIInfo[_attributePSVINodes.Length * 2];
-                Array.Copy(_attributePSVINodes, 0, newPSVINodes, 0, _attributePSVINodes.Length);
+                Array.Copy(_attributePSVINodes, newPSVINodes, _attributePSVINodes.Length);
                 _attributePSVINodes = newPSVINodes;
             }
             attInfo = _attributePSVINodes[attIndex];

--- a/src/System.Private.Xml/src/System/Xml/Dom/DocumentSchemaValidator.cs
+++ b/src/System.Private.Xml/src/System/Xml/Dom/DocumentSchemaValidator.cs
@@ -559,7 +559,7 @@ namespace System.Xml
             else if (currentIndex >= _nodeSequenceToValidate.Length - 1)
             { //reached capacity of array, Need to increase capacity to twice the initial
                 XmlNode[] newNodeSequence = new XmlNode[_nodeSequenceToValidate.Length * 2];
-                Array.Copy(_nodeSequenceToValidate, 0, newNodeSequence, 0, _nodeSequenceToValidate.Length);
+                Array.Copy(_nodeSequenceToValidate, newNodeSequence, _nodeSequenceToValidate.Length);
                 _nodeSequenceToValidate = newNodeSequence;
             }
         }

--- a/src/System.Private.Xml/src/System/Xml/HWStack.cs
+++ b/src/System.Private.Xml/src/System/Xml/HWStack.cs
@@ -38,7 +38,7 @@ namespace System.Xml
                 object[] newstack = new object[_size + _growthRate];
                 if (_used > 0)
                 {
-                    System.Array.Copy(_stack, 0, newstack, 0, _used);
+                    System.Array.Copy(_stack, newstack, _used);
                 }
                 _stack = newstack;
                 _size += _growthRate;

--- a/src/System.Private.Xml/src/System/Xml/Resolvers/XmlPreloadedResolver.cs
+++ b/src/System.Private.Xml/src/System/Xml/Resolvers/XmlPreloadedResolver.cs
@@ -351,7 +351,7 @@ namespace System.Xml.Resolvers
                 }
                 int size = checked((int)ms.Position);
                 byte[] bytes = new byte[size];
-                Array.Copy(ms.ToArray(), 0, bytes, 0, size);
+                Array.Copy(ms.ToArray(), bytes, size);
                 Add(uri, new ByteArrayChunk(bytes));
             }
         }

--- a/src/System.Private.Xml/src/System/Xml/Schema/BitSet.cs
+++ b/src/System.Private.Xml/src/System/Xml/Schema/BitSet.cs
@@ -243,7 +243,7 @@ namespace System.Xml.Schema
                 if (request < nRequiredLength)
                     request = nRequiredLength;
                 uint[] newBits = new uint[request];
-                Array.Copy(_bits, 0, newBits, 0, _bits.Length);
+                Array.Copy(_bits, newBits, _bits.Length);
                 _bits = newBits;
             }
         }

--- a/src/System.Private.Xml/src/System/Xml/Schema/ContentValidator.cs
+++ b/src/System.Private.Xml/src/System/Xml/Schema/ContentValidator.cs
@@ -1995,7 +1995,7 @@ namespace System.Xml.Schema
                         {
                             newRPosInfo.rangeCounters = new decimal[_minMaxNodesCount];
                         }
-                        Array.Copy(rposInfo.rangeCounters, 0, newRPosInfo.rangeCounters, 0, rposInfo.rangeCounters.Length);
+                        Array.Copy(rposInfo.rangeCounters, newRPosInfo.rangeCounters, rposInfo.rangeCounters.Length);
                         decimal count = ++newRPosInfo.rangeCounters[lrNode.Pos];
 
                         if (count == lrNode.Max)
@@ -2022,7 +2022,7 @@ namespace System.Xml.Schema
                             {
                                 newRPosInfo.rangeCounters = new decimal[_minMaxNodesCount];
                             }
-                            Array.Copy(rposInfo.rangeCounters, 0, newRPosInfo.rangeCounters, 0, rposInfo.rangeCounters.Length);
+                            Array.Copy(rposInfo.rangeCounters, newRPosInfo.rangeCounters, rposInfo.rangeCounters.Length);
                             newRPosInfo.curpos = _followpos[cPos];
                             newRPosInfo.rangeCounters[lrNode.Pos] = 0;
                             runningPositions[j] = newRPosInfo;

--- a/src/System.Private.Xml/src/System/Xml/Schema/DtdParser.cs
+++ b/src/System.Private.Xml/src/System/Xml/Schema/DtdParser.cs
@@ -1449,7 +1449,7 @@ namespace System.Xml
                         else if (_condSectionEntityIds.Length == _condSectionDepth)
                         {
                             int[] tmp = new int[_condSectionEntityIds.Length * 2];
-                            Array.Copy(_condSectionEntityIds, 0, tmp, 0, _condSectionEntityIds.Length);
+                            Array.Copy(_condSectionEntityIds, tmp, _condSectionEntityIds.Length);
                             _condSectionEntityIds = tmp;
                         }
                         _condSectionEntityIds[_condSectionDepth] = csEntityId;

--- a/src/System.Private.Xml/src/System/Xml/Schema/DtdParserAsync.cs
+++ b/src/System.Private.Xml/src/System/Xml/Schema/DtdParserAsync.cs
@@ -1061,7 +1061,7 @@ namespace System.Xml
                         else if (_condSectionEntityIds.Length == _condSectionDepth)
                         {
                             int[] tmp = new int[_condSectionEntityIds.Length * 2];
-                            Array.Copy(_condSectionEntityIds, 0, tmp, 0, _condSectionEntityIds.Length);
+                            Array.Copy(_condSectionEntityIds, tmp, _condSectionEntityIds.Length);
                             _condSectionEntityIds = tmp;
                         }
                         _condSectionEntityIds[_condSectionDepth] = csEntityId;

--- a/src/System.Private.Xml/src/System/Xml/Serialization/Mappings.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/Mappings.cs
@@ -392,7 +392,7 @@ namespace System.Xml.Serialization
                 if (_elements == null)
                     return null;
                 _sortedElements = new ElementAccessor[_elements.Length];
-                Array.Copy(_elements, 0, _sortedElements, 0, _elements.Length);
+                Array.Copy(_elements, _sortedElements, _elements.Length);
                 AccessorMapping.SortMostToLeastDerived(_sortedElements);
                 return _sortedElements;
             }
@@ -784,7 +784,7 @@ namespace System.Xml.Serialization
                 if (_elements == null)
                     return null;
                 _sortedElements = new ElementAccessor[_elements.Length];
-                Array.Copy(_elements, 0, _sortedElements, 0, _elements.Length);
+                Array.Copy(_elements, _sortedElements, _elements.Length);
                 SortMostToLeastDerived(_sortedElements);
                 return _sortedElements;
             }

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationGeneratedCode.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationGeneratedCode.cs
@@ -94,7 +94,7 @@ namespace System.Xml.Serialization
             if (a == null) return new TypeMapping[32];
             if (index < a.Length) return a;
             TypeMapping[] b = new TypeMapping[a.Length + 32];
-            Array.Copy(a, 0, b, 0, index);
+            Array.Copy(a, b, index);
             return b;
         }
 

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationILGen.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationILGen.cs
@@ -136,7 +136,7 @@ namespace System.Xml.Serialization
             if (a == null) return new TypeMapping[32];
             if (index < a.Length) return a;
             TypeMapping[] b = new TypeMapping[a.Length + 32];
-            Array.Copy(a, 0, b, 0, index);
+            Array.Copy(a, b, index);
             return b;
         }
 

--- a/src/System.Private.Xml/src/System/Xml/XmlNamespacemanager.cs
+++ b/src/System.Private.Xml/src/System/Xml/XmlNamespacemanager.cs
@@ -153,7 +153,7 @@ namespace System.Xml
             if (_lastDecl == _nsdecls.Length - 1)
             {
                 NamespaceDeclaration[] newNsdecls = new NamespaceDeclaration[_nsdecls.Length * 2];
-                Array.Copy(_nsdecls, 0, newNsdecls, 0, _nsdecls.Length);
+                Array.Copy(_nsdecls, newNsdecls, _nsdecls.Length);
                 _nsdecls = newNsdecls;
             }
 

--- a/src/System.Private.Xml/src/System/Xml/Xsl/QIL/QilList.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/QIL/QilList.cs
@@ -123,7 +123,7 @@ namespace System.Xml.Xsl.Qil
             if (_count == _members.Length)
             {
                 QilNode[] membersNew = new QilNode[_count * 2];
-                Array.Copy(_members, 0, membersNew, 0, _count);
+                Array.Copy(_members, membersNew, _count);
                 _members = membersNew;
             }
 

--- a/src/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlAttributeCache.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlAttributeCache.cs
@@ -363,7 +363,7 @@ namespace System.Xml.Xsl.Runtime
                 // Resize caching array
                 Debug.Assert(_numEntries == _arrAttrs.Length);
                 AttrNameVal[] arrNew = new AttrNameVal[_numEntries * 2];
-                Array.Copy(_arrAttrs, 0, arrNew, 0, _numEntries);
+                Array.Copy(_arrAttrs, arrNew, _numEntries);
                 _arrAttrs = arrNew;
             }
         }

--- a/src/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlNavigatorStack.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlNavigatorStack.cs
@@ -39,7 +39,7 @@ namespace System.Xml.Xsl.Runtime
                     // Resize the stack
                     XPathNavigator[] stkOld = _stkNav;
                     _stkNav = new XPathNavigator[2 * _sp];
-                    Array.Copy(stkOld, 0, _stkNav, 0, _sp);
+                    Array.Copy(stkOld, _stkNav, _sp);
                 }
             }
 

--- a/src/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlQueryRuntime.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlQueryRuntime.cs
@@ -960,7 +960,7 @@ namespace System.Xml.Xsl.Runtime
             {
                 // Resize array
                 ArrayList[] indexesNew = new ArrayList[indexId + 4];
-                Array.Copy(_indexes, 0, indexesNew, 0, _indexes.Length);
+                Array.Copy(_indexes, indexesNew, _indexes.Length);
                 _indexes = indexesNew;
             }
 

--- a/src/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlSortKeyAccumulator.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlSortKeyAccumulator.cs
@@ -83,7 +83,7 @@ namespace System.Xml.Xsl.Runtime
             if (_pos >= _keys.Length)
             {
                 XmlSortKey[] keysNew = new XmlSortKey[_pos * 2];
-                Array.Copy(_keys, 0, keysNew, 0, _keys.Length);
+                Array.Copy(_keys, keysNew, _keys.Length);
                 _keys = keysNew;
             }
             _keys[_pos] = null;

--- a/src/System.Private.Xml/src/System/Xml/Xsl/Xslt/CompilerScopeManager.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/Xslt/CompilerScopeManager.cs
@@ -136,7 +136,7 @@ namespace System.Xml.Xsl.Xslt
             if (++_lastRecord == _records.Length)
             {
                 ScopeRecord[] newRecords = new ScopeRecord[_lastRecord * 2];
-                Array.Copy(_records, 0, newRecords, 0, _lastRecord);
+                Array.Copy(_records, newRecords, _lastRecord);
                 _records = newRecords;
             }
             // reset scope count:

--- a/src/System.Private.Xml/src/System/Xml/Xsl/Xslt/OutputScopeManager.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/Xslt/OutputScopeManager.cs
@@ -71,7 +71,7 @@ namespace System.Xml.Xsl.Xslt
             if (_lastRecord == _records.Length)
             {
                 ScopeReord[] newRecords = new ScopeReord[_lastRecord * 2];
-                Array.Copy(_records, 0, newRecords, 0, _lastRecord);
+                Array.Copy(_records, newRecords, _lastRecord);
                 _records = newRecords;
             }
             _lastScopes = 0;

--- a/src/System.Private.Xml/src/System/Xml/Xsl/Xslt/XsltInput.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/Xslt/XsltInput.cs
@@ -90,7 +90,7 @@ namespace System.Xml.Xsl.Xslt
                     newSize = position + 1;
                 }
                 Record[] tmp = new Record[newSize];
-                Array.Copy(_records, 0, tmp, 0, _records.Length);
+                Array.Copy(_records, tmp, _records.Length);
                 _records = tmp;
             }
         }

--- a/src/System.Private.Xml/src/System/Xml/Xsl/XsltOld/BuilderInfo.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/XsltOld/BuilderInfo.cs
@@ -67,7 +67,7 @@ namespace System.Xml.Xsl.XsltOld
             if (this.TextInfo.Length < newSize)
             {
                 string[] newArr = new string[newSize * 2];
-                Array.Copy(this.TextInfo, 0, newArr, 0, this.TextInfoCount);
+                Array.Copy(this.TextInfo, newArr, this.TextInfoCount);
                 this.TextInfo = newArr;
             }
         }

--- a/src/System.Reflection.Context/src/System/Reflection/Context/Virtual/VirtualPropertyBase.cs
+++ b/src/System.Reflection.Context/src/System/Reflection/Context/Virtual/VirtualPropertyBase.cs
@@ -122,7 +122,7 @@ namespace System.Reflection.Context.Virtual
             {
                 args = new object[index.Length + 1];
 
-                Array.Copy(index, 0, args, 0, index.Length);
+                Array.Copy(index, args, index.Length);
 
                 args[index.Length] = value;
             }

--- a/src/System.Reflection.Metadata/tests/Metadata/MetadataReaderTests.cs
+++ b/src/System.Reflection.Metadata/tests/Metadata/MetadataReaderTests.cs
@@ -3016,7 +3016,7 @@ namespace System.Reflection.Metadata.Tests
 
             // copy unobfuscated to obfuscated, leaving room for 4 bytes of data right before the module table.
             byte[] obfuscated = new byte[unobfuscated.Length + sizeOfExtraData];
-            Array.Copy(unobfuscated, 0, obfuscated, 0, offsetToModuleTable);
+            Array.Copy(unobfuscated, obfuscated, offsetToModuleTable);
             Array.Copy(unobfuscated, offsetToModuleTable, obfuscated, offsetToModuleTable + sizeOfExtraData, unobfuscated.Length - offsetToModuleTable);
 
             fixed (byte* ptr = obfuscated)

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -444,7 +444,7 @@ namespace System.Numerics
                     {
                         _sign = -1;
                         _bits = new uint[len];
-                        Array.Copy(val, 0, _bits, 0, len);
+                        Array.Copy(val, _bits, len);
                     }
                     else
                     {
@@ -500,7 +500,7 @@ namespace System.Numerics
             {
                 _sign = negative ? -1 : +1;
                 _bits = new uint[len];
-                Array.Copy(value, 0, _bits, 0, len);
+                Array.Copy(value, _bits, len);
             }
             AssertValid();
         }
@@ -558,7 +558,7 @@ namespace System.Numerics
                 {
                     _sign = +1;
                     _bits = new uint[dwordCount];
-                    Array.Copy(value, 0, _bits, 0, dwordCount);
+                    Array.Copy(value, _bits, dwordCount);
                 }
                 // No trimming is possible.  Assign value directly to _bits.
                 else
@@ -600,7 +600,7 @@ namespace System.Numerics
             {
                 _sign = -1;
                 _bits = new uint[len];
-                Array.Copy(value, 0, _bits, 0, len);
+                Array.Copy(value, _bits, len);
             }
             // No trimming is possible.  Assign value directly to _bits.
             else
@@ -1449,7 +1449,7 @@ namespace System.Numerics
             bool needExtraByte = (dwords[msb] & 0x80000000) != (highDWord & 0x80000000);
 
             uint[] trimmed = new uint[msb + 1 + (needExtraByte ? 1 : 0)];
-            Array.Copy(dwords, 0, trimmed, 0, msb + 1);
+            Array.Copy(dwords, trimmed, msb + 1);
 
             if (needExtraByte) trimmed[trimmed.Length - 1] = highDWord;
             return trimmed;

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.BitsBuffer.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.BitsBuffer.cs
@@ -41,7 +41,7 @@ namespace System.Numerics
                 _bits = new uint[size];
                 _length = ActualLength(value);
 
-                Array.Copy(value, 0, _bits, 0, _length);
+                Array.Copy(value, _bits, _length);
             }
 
             public unsafe void MultiplySelf(ref BitsBuffer value,

--- a/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.DivRem.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.DivRem.cs
@@ -319,7 +319,7 @@ namespace System.Numerics
             Debug.Assert(value.Length != 0);
 
             uint[] bits = new uint[value.Length];
-            Array.Copy(value, 0, bits, 0, bits.Length);
+            Array.Copy(value, bits, bits.Length);
             return bits;
         }
 

--- a/src/System.Runtime.Numerics/tests/BigInteger/ctor.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/ctor.cs
@@ -1060,7 +1060,7 @@ namespace System.Numerics.Tests
                 tempBigInteger = bigInteger - (new BigInteger(tempByteArray));
 
                 tempByteArray = new byte[8];
-                Array.Copy(value, 0, tempByteArray, 0, 8);
+                Array.Copy(value, tempByteArray, 8);
 
                 if (!(((tempByteArray[7] & 0x80) == 0) ^ isNeg))
                 {
@@ -1092,7 +1092,7 @@ namespace System.Numerics.Tests
                 tempBigInteger = bigInteger - (new BigInteger(tempByteArray));
 
                 tempByteArray = new byte[8];
-                Array.Copy(value, 0, tempByteArray, 0, 8);
+                Array.Copy(value, tempByteArray, 8);
 
                 if ((tempByteArray[7] & 0x80) != 0)
                 {

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/FormatterServices.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/FormatterServices.cs
@@ -71,7 +71,7 @@ namespace System.Runtime.Serialization
                     if (allMembers != null && allMembers.Count > 0)
                     {
                         var membersTemp = new FieldInfo[allMembers.Count + typeMembers.Length];
-                        Array.Copy(typeMembers, 0, membersTemp, 0, typeMembers.Length);
+                        Array.Copy(typeMembers, membersTemp, typeMembers.Length);
                         allMembers.CopyTo(membersTemp, typeMembers.Length);
                         typeMembers = membersTemp;
                     }

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryObjectReader.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryObjectReader.cs
@@ -505,7 +505,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
                             pr._rectangularMap[i] = 0;
                         }
                     }
-                    Array.Copy(pr._rectangularMap, 0, pr._indexMap, 0, pr._rank);
+                    Array.Copy(pr._rectangularMap, pr._indexMap, pr._rank);
                     break;
                 }
             }
@@ -552,7 +552,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
                     // Object not instantiated
                     // Array fixup manager
                     int[] fixupIndex = new int[objectPr._rank];
-                    Array.Copy(objectPr._indexMap, 0, fixupIndex, 0, objectPr._rank);
+                    Array.Copy(objectPr._indexMap, fixupIndex, objectPr._rank);
 
                     _objectManager.RecordArrayElementFixup(objectPr._objectId, fixupIndex, pr._idRef);
                 }

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryUtilClasses.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryUtilClasses.cs
@@ -177,7 +177,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
         {
             int size = _objects.Length * 2;
             object[] newItems = new object[size];
-            Array.Copy(_objects, 0, newItems, 0, _objects.Length);
+            Array.Copy(_objects, newItems, _objects.Length);
             _objects = newItems;
         }
 
@@ -261,14 +261,14 @@ namespace System.Runtime.Serialization.Formatters.Binary
                 {
                     int size = Math.Max(_negObjects.Length * 2, (-index) + 1);
                     object[] newItems = new object[size];
-                    Array.Copy(_negObjects, 0, newItems, 0, _negObjects.Length);
+                    Array.Copy(_negObjects, newItems, _negObjects.Length);
                     _negObjects = newItems;
                 }
                 else
                 {
                     int size = Math.Max(_objects.Length * 2, index + 1);
                     object[] newItems = new object[size];
-                    Array.Copy(_objects, 0, newItems, 0, _objects.Length);
+                    Array.Copy(_objects, newItems, _objects.Length);
                     _objects = newItems;
                 }
             }
@@ -338,14 +338,14 @@ namespace System.Runtime.Serialization.Formatters.Binary
                 {
                     int size = Math.Max(_negObjects.Length * 2, (-index) + 1);
                     int[] newItems = new int[size];
-                    Array.Copy(_negObjects, 0, newItems, 0, _negObjects.Length);
+                    Array.Copy(_negObjects, newItems, _negObjects.Length);
                     _negObjects = newItems;
                 }
                 else
                 {
                     int size = Math.Max(_objects.Length * 2, index + 1);
                     int[] newItems = new int[size];
-                    Array.Copy(_objects, 0, newItems, 0, _objects.Length);
+                    Array.Copy(_objects, newItems, _objects.Length);
                     _objects = newItems;
                 }
             }

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/ObjectManager.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/ObjectManager.cs
@@ -113,7 +113,7 @@ namespace System.Runtime.Serialization
                 }
 
                 ObjectHolder[] temp = new ObjectHolder[newSize];
-                Array.Copy(_objects, 0, temp, 0, _objects.Length);
+                Array.Copy(_objects, temp, _objects.Length);
                 _objects = temp;
             }
 
@@ -288,7 +288,7 @@ namespace System.Runtime.Serialization
                 if ((currentFieldIndex + 1) >= fieldsTemp.Length)
                 {
                     var temp = new FieldInfo[fieldsTemp.Length * 2];
-                    Array.Copy(fieldsTemp, 0, temp, 0, fieldsTemp.Length);
+                    Array.Copy(fieldsTemp, temp, fieldsTemp.Length);
                     fieldsTemp = temp;
                 }
 
@@ -1418,7 +1418,7 @@ namespace System.Runtime.Serialization
             }
 
             FixupHolder[] temp = new FixupHolder[newLength];
-            Array.Copy(_values, 0, temp, 0, _count);
+            Array.Copy(_values, temp, _count);
             _values = temp;
         }
     }
@@ -1502,7 +1502,7 @@ namespace System.Runtime.Serialization
             }
 
             long[] temp = new long[newLength];
-            Array.Copy(_values, 0, temp, 0, _count);
+            Array.Copy(_values, temp, _count);
             _values = temp;
         }
     }
@@ -1545,7 +1545,7 @@ namespace System.Runtime.Serialization
             }
 
             ObjectHolder[] temp = new ObjectHolder[newLength];
-            Array.Copy(_values, 0, temp, 0, _count);
+            Array.Copy(_values, temp, _count);
             _values = temp;
         }
 

--- a/src/System.Runtime.Serialization.Xml/tests/Canonicalization/CryptoCanonicalization/CanonicalWriter.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/Canonicalization/CryptoCanonicalization/CanonicalWriter.cs
@@ -334,7 +334,7 @@ namespace System.Runtime.Serialization.Xml.Canonicalization.Tests
             if (_elementCount == _elements.Length)
             {
                 ElementEntry[] newElements = new ElementEntry[_elements.Length * 2];
-                Array.Copy(_elements, 0, newElements, 0, _elementCount);
+                Array.Copy(_elements, newElements, _elementCount);
                 _elements = newElements;
             }
             _elements[_elementCount++].Set(prefix, localName);
@@ -1110,7 +1110,7 @@ namespace System.Runtime.Serialization.Xml.Canonicalization.Tests
             if (_count == _list.Length)
             {
                 AttributeEntry[] newList = new AttributeEntry[_list.Length * 2];
-                Array.Copy(_list, 0, newList, 0, _count);
+                Array.Copy(_list, newList, _count);
                 _list = newList;
             }
 

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTestTypes/DataContract.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTestTypes/DataContract.cs
@@ -874,7 +874,7 @@ namespace SerializationTestTypes
                             {
                                 int baseTypesCount = baseContract.MemberNames.Length;
                                 memberNames = new string[baseTypesCount + 1][];
-                                Array.Copy(baseContract.MemberNames, 0, memberNames, 0, baseTypesCount);
+                                Array.Copy(baseContract.MemberNames, memberNames, baseTypesCount);
                             }
                             string[] declaredMemberNames = new string[Members.Count];
                             for (int i = 0; i < Members.Count; i++)

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.RuntimeOnly.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.RuntimeOnly.cs
@@ -3917,7 +3917,7 @@ public class ImplementDictionary : IDictionary
         public ImplementDictionaryEnumerator(ImplementDictionary sd)
         {
             _items = new DictionaryEntry[sd.Count];
-            Array.Copy(sd._items, 0, _items, 0, sd.Count);
+            Array.Copy(sd._items, _items, sd.Count);
         }
 
         public object Current { get { ValidateIndex(); return _items[_index]; } }

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/TripleDesImplementation.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/TripleDesImplementation.cs
@@ -69,7 +69,7 @@ namespace Internal.Cryptography
                 // Some platforms do not support Two-Key Triple DES, so manually support it here.
                 // Two-Key Triple DES contains two 8-byte keys {K1}{K2} with {K1} appended to make {K1}{K2}{K1}.
                 byte[] newkey = new byte[24];
-                Array.Copy(rgbKey, 0, newkey, 0, 16);
+                Array.Copy(rgbKey, newkey, 16);
                 Array.Copy(rgbKey, 0, newkey, 16, 8);
                 rgbKey = newkey;
             }

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/CryptoConfig.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/CryptoConfig.cs
@@ -307,7 +307,7 @@ namespace System.Security.Cryptography
                 throw new ArgumentNullException(nameof(names));
 
             string[] algorithmNames = new string[names.Length];
-            Array.Copy(names, 0, algorithmNames, 0, algorithmNames.Length);
+            Array.Copy(names, algorithmNames, algorithmNames.Length);
 
             // Pre-check the algorithm names for validity so that we don't add a few of the names and then
             // throw an exception if we find an invalid name partway through the list.
@@ -459,7 +459,7 @@ namespace System.Security.Cryptography
                 throw new ArgumentNullException(nameof(names));
 
             string[] oidNames = new string[names.Length];
-            Array.Copy(names, 0, oidNames, 0, oidNames.Length);
+            Array.Copy(names, oidNames, oidNames.Length);
 
             // Pre-check the input names for validity, so that we don't add a few of the names and throw an
             // exception if an invalid name is found further down the array.

--- a/src/System.Security.Cryptography.Algorithms/tests/HmacTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/HmacTests.cs
@@ -57,7 +57,7 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
             if (truncateSize != -1)
             {
                 byte[] tmp = new byte[truncateSize];
-                Array.Copy(computedDigest, 0, tmp, 0, truncateSize);
+                Array.Copy(computedDigest, tmp, truncateSize);
                 computedDigest = tmp;
             }
 

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/TripleDESCng.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/TripleDESCng.cs
@@ -124,7 +124,7 @@ namespace System.Security.Cryptography
                 // Cng does not support Two-Key Triple DES, so manually support it here for consistency with System.Security.Cryptography.Algorithms.
                 // Two-Key Triple DES contains two 8-byte keys {K1}{K2} with {K1} appended to make {K1}{K2}{K1}.
                 byte[] newkey = new byte[24];
-                Array.Copy(key, 0, newkey, 0, 16);
+                Array.Copy(key, newkey, 16);
                 Array.Copy(key, 0, newkey, 16, 8);
                 return newkey;
             }

--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/PkcsHelpers.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/PkcsHelpers.cs
@@ -107,7 +107,7 @@ namespace Internal.Cryptography
 
             if (idx != 0)
             {
-                Array.Copy(arr, 0, tmp, 0, idx);
+                Array.Copy(arr, tmp, idx);
             }
 
             if (idx < tmp.Length)

--- a/src/System.Security.Permissions/src/System/Security/Permissions/PrincipalPermission.cs
+++ b/src/System.Security.Permissions/src/System/Security/Permissions/PrincipalPermission.cs
@@ -189,7 +189,7 @@ namespace System.Security.Permissions
             }
 
             IDRole[] idrolesArray = new IDRole[_idArray.Length + operand._idArray.Length];
-            Array.Copy(_idArray, 0, idrolesArray, 0, _idArray.Length);
+            Array.Copy(_idArray, idrolesArray, _idArray.Length);
             Array.Copy(operand._idArray, 0, idrolesArray, _idArray.Length, operand._idArray.Length);
 
             return new PrincipalPermission(idrolesArray);

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -315,7 +315,7 @@ namespace System.Text.RegularExpressions
             else
             {
                 result = new string[capslist.Length];
-                Array.Copy(capslist, 0, result, 0, capslist.Length);
+                Array.Copy(capslist, result, capslist.Length);
             }
 
             return result;

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
@@ -192,7 +192,7 @@ namespace System.Text.RegularExpressions
 
                         if (i == 0)
                         {
-                            Array.Copy(NegativeASCII, 0, newarray, 0, 128);
+                            Array.Copy(NegativeASCII, newarray, 128);
                             NegativeASCII = newarray;
                         }
 

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -160,7 +160,7 @@ namespace System.Text.RegularExpressions
             {
                 BacktrackNote[] newnotes = new BacktrackNote[_notes == null ? 16 : _notes.Length * 2];
                 if (_notes != null)
-                    System.Array.Copy(_notes, 0, newnotes, 0, _notecount);
+                    System.Array.Copy(_notes, newnotes, _notecount);
                 _notes = newnotes;
             }
 

--- a/src/System.Threading.Channels/src/System/Collections/Generic/Deque.cs
+++ b/src/System.Threading.Channels/src/System/Collections/Generic/Deque.cs
@@ -108,7 +108,7 @@ namespace System.Collections.Generic
 
             if (_head == 0)
             {
-                Array.Copy(_array, 0, newArray, 0, _size);
+                Array.Copy(_array, newArray, _size);
             }
             else
             {

--- a/src/System.Threading.Tasks.Dataflow/src/Internal/ImmutableArray.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Internal/ImmutableArray.cs
@@ -51,7 +51,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
             // Copy the elements from this array and the item
             // to a new array that's returned.
             var newArray = new T[_array.Length + 1];
-            Array.Copy(_array, 0, newArray, 0, _array.Length);
+            Array.Copy(_array, newArray, _array.Length);
             newArray[newArray.Length - 1] = item;
             return new ImmutableArray<T>(newArray);
         }
@@ -70,7 +70,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
 
             // Otherwise, copy the other elements to a new array that's returned.
             var newArray = new T[_array.Length - 1];
-            Array.Copy(_array, 0, newArray, 0, index);
+            Array.Copy(_array, newArray, index);
             Array.Copy(_array, index + 1, newArray, index, _array.Length - index - 1);
             return new ImmutableArray<T>(newArray);
         }

--- a/src/System.Threading.Tasks/tests/Task/TaskCancelWaitTest.cs
+++ b/src/System.Threading.Tasks/tests/Task/TaskCancelWaitTest.cs
@@ -480,7 +480,7 @@ namespace System.Threading.Tasks.Tests.CancelWait
             {
                 string[] temp = new string[options.Length - 1];
                 int excludeIndex = index + 1;
-                Array.Copy(options, 0, temp, 0, index);
+                Array.Copy(options, temp, index);
                 int leftToCopy = options.Length - excludeIndex;
                 Array.Copy(options, excludeIndex, temp, index, leftToCopy);
 

--- a/src/System.Transactions.Local/src/System/Transactions/Transaction.cs
+++ b/src/System.Transactions.Local/src/System/Transactions/Transaction.cs
@@ -487,7 +487,7 @@ namespace System.Transactions
             }
 
             byte[] toReturn = new byte[internalPromotedToken.Length];
-            Array.Copy(internalPromotedToken, 0, toReturn, 0, toReturn.Length);
+            Array.Copy(internalPromotedToken, toReturn, toReturn.Length);
             return toReturn;
         }
 

--- a/src/System.Transactions.Local/src/System/Transactions/TransactionInterop.cs
+++ b/src/System.Transactions.Local/src/System/Transactions/TransactionInterop.cs
@@ -294,7 +294,7 @@ namespace System.Transactions
             }
 
             byte[] propagationTokenCopy = new byte[propagationToken.Length];
-            Array.Copy(propagationToken, 0, propagationTokenCopy, 0, propagationToken.Length);
+            Array.Copy(propagationToken, propagationTokenCopy, propagationToken.Length);
 
             return DistributedTransactionManager.GetDistributedTransactionFromTransmitterPropagationToken(propagationTokenCopy);
         }

--- a/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
@@ -287,7 +287,7 @@ namespace System.Web.Util
             if (decodedBytesCount < decodedBytes.Length)
             {
                 byte[] newDecodedBytes = new byte[decodedBytesCount];
-                Array.Copy(decodedBytes, 0, newDecodedBytes, 0, decodedBytesCount);
+                Array.Copy(decodedBytes, newDecodedBytes, decodedBytesCount);
                 decodedBytes = newDecodedBytes;
             }
 

--- a/src/System.Windows.Extensions/src/System/Media/SoundPlayer.cs
+++ b/src/System.Windows.Extensions/src/System/Media/SoundPlayer.cs
@@ -498,7 +498,7 @@ namespace System.Media
                     if (_streamData.Length < _currentPos + BlockSize)
                     {
                         byte[] newData = new byte[_streamData.Length * 2];
-                        Array.Copy(_streamData, 0, newData, 0, _streamData.Length);
+                        Array.Copy(_streamData, newData, _streamData.Length);
                         _streamData = newData;
                     }
                     readBytes = await _stream.ReadAsync(_streamData, _currentPos, BlockSize, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
corefx side of https://github.com/dotnet/coreclr/pull/27641.
cc: @jkotas 

VS regex search and replace from `Array.Copy\((.+), 0, (.+), 0` to `Array.Copy($1, $2`.  The only changes I reverted were those to the tests for Array itself.