### PR TITLE
Disable some FileSystemWatcher tests on MacOS

### DIFF
--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.MultipleWatchers.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.MultipleWatchers.cs
@@ -319,6 +319,7 @@ namespace System.IO.Tests
             }
         }
 
+        [ActiveIssue(42344)]
         [OuterLoop]
         [Fact]
         [PlatformSpecific(TestPlatforms.OSX)]


### PR DESCRIPTION
Contributes to #42344