### PR TITLE
Change Platform -> ArchGroup for timeout increase

### DIFF
--- a/src/sendtohelix.proj
+++ b/src/sendtohelix.proj
@@ -11,8 +11,8 @@
     <HelixBuild Condition="'$(HelixBuild)' == ''">$(BUILD_BUILDNUMBER)</HelixBuild>
     <HelixBuild Condition="'$(HelixBuild)' == ''">default</HelixBuild>
 
-    <!-- For arm64 we set a 30min timeout temporarily until we split up slow test assemblies. -->
-    <TimeoutInSeconds Condition="'$(Platform)' == 'arm64' or '$(Platform)' == 'arm'">1800</TimeoutInSeconds>
+    <!-- For arm64 we set a 30 min timeout temporarily until we split up slow test assemblies. -->
+    <TimeoutInSeconds Condition="'$(ArchGroup)' == 'arm64' or '$(ArchGroup)' == 'arm'">1800</TimeoutInSeconds>
     <TimeoutInSeconds Condition="'$(TimeoutInSeconds)' == ''">900</TimeoutInSeconds>
     <_timeoutSpan>$([System.TimeSpan]::FromSeconds($(TimeoutInSeconds)))</_timeoutSpan>
     

--- a/src/sendtohelix.proj
+++ b/src/sendtohelix.proj
@@ -11,7 +11,7 @@
     <HelixBuild Condition="'$(HelixBuild)' == ''">$(BUILD_BUILDNUMBER)</HelixBuild>
     <HelixBuild Condition="'$(HelixBuild)' == ''">default</HelixBuild>
 
-    <!-- For arm64 we set a 30 min timeout temporarily until we split up slow test assemblies. -->
+    <!-- For arm/arm64 we set a 30 min timeout temporarily until we split up slow test assemblies. -->
     <TimeoutInSeconds Condition="'$(ArchGroup)' == 'arm64' or '$(ArchGroup)' == 'arm'">1800</TimeoutInSeconds>
     <TimeoutInSeconds Condition="'$(TimeoutInSeconds)' == ''">900</TimeoutInSeconds>
     <_timeoutSpan>$([System.TimeSpan]::FromSeconds($(TimeoutInSeconds)))</_timeoutSpan>


### PR DESCRIPTION
From reviewing the binlogs of arm and arm64 builds, this property check should definitely be ArchGroup not Platform (which ends up being AnyCPU here)