### PR TITLE
[release/3.1] Read values from /proc/[pid]/status (#41122)

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Linux.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Linux.cs
@@ -30,11 +30,11 @@ namespace System.Diagnostics
             var processes = new List<Process>();
             foreach (int pid in ProcessManager.EnumerateProcessIds())
             {
-                Interop.procfs.ParsedStat parsedStat;
-                if (Interop.procfs.TryReadStatFile(pid, out parsedStat, reusableReader) &&
-                    string.Equals(processName, Process.GetUntruncatedProcessName(ref parsedStat), StringComparison.OrdinalIgnoreCase))
+                if (Interop.procfs.TryReadStatFile(pid, out Interop.procfs.ParsedStat parsedStat, reusableReader) &&
+                    string.Equals(processName, Process.GetUntruncatedProcessName(ref parsedStat), StringComparison.OrdinalIgnoreCase) &&
+                    Interop.procfs.TryReadStatusFile(pid, out Interop.procfs.ParsedStatus parsedStatus, reusableReader))
                 {
-                    ProcessInfo processInfo = ProcessManager.CreateProcessInfo(ref parsedStat, reusableReader, processName);
+                    ProcessInfo processInfo = ProcessManager.CreateProcessInfo(ref parsedStat, ref parsedStatus, reusableReader, processName);
                     processes.Add(new Process(machineName, false, processInfo.ProcessId, processInfo));
                 }
             }

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -60,6 +60,18 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        private void AssertNonZeroAllZeroDarwin(long value)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                Assert.Equal(0, value);
+            }
+            else
+            {
+                Assert.NotEqual(0, value);
+            }
+        }
+
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Retrieving information about local processes is not supported on uap")]
         [PlatformSpecific(TestPlatforms.Windows)]  // Expected behavior varies on Windows and Unix
@@ -650,7 +662,7 @@ namespace System.Diagnostics.Tests
         {
             CreateDefaultProcess();
 
-            AssertNonZeroWindowsZeroUnix(_process.PeakVirtualMemorySize64);
+            AssertNonZeroAllZeroDarwin(_process.PeakVirtualMemorySize64);
         }
 
         [Fact]
@@ -666,7 +678,7 @@ namespace System.Diagnostics.Tests
         {
             CreateDefaultProcess();
 
-            AssertNonZeroWindowsZeroUnix(_process.PeakWorkingSet64);
+            AssertNonZeroAllZeroDarwin(_process.PeakWorkingSet64);
         }
 
         [Fact]
@@ -682,7 +694,7 @@ namespace System.Diagnostics.Tests
         {
             CreateDefaultProcess();
 
-            AssertNonZeroWindowsZeroUnix(_process.PrivateMemorySize64);
+            AssertNonZeroAllZeroDarwin(_process.PrivateMemorySize64);
         }
 
         [Fact]
@@ -1700,7 +1712,7 @@ namespace System.Diagnostics.Tests
             CreateDefaultProcess();
 
 #pragma warning disable 0618
-            AssertNonZeroWindowsZeroUnix(_process.PeakVirtualMemorySize);
+            AssertNonZeroAllZeroDarwin(_process.PeakVirtualMemorySize);
 #pragma warning restore 0618
         }
 
@@ -1720,7 +1732,7 @@ namespace System.Diagnostics.Tests
             CreateDefaultProcess();
 
 #pragma warning disable 0618
-            AssertNonZeroWindowsZeroUnix(_process.PeakWorkingSet);
+            AssertNonZeroAllZeroDarwin(_process.PeakWorkingSet);
 #pragma warning restore 0618
         }
 
@@ -1740,7 +1752,7 @@ namespace System.Diagnostics.Tests
             CreateDefaultProcess();
 
 #pragma warning disable 0618
-            AssertNonZeroWindowsZeroUnix(_process.PrivateMemorySize);
+            AssertNonZeroAllZeroDarwin(_process.PrivateMemorySize);
 #pragma warning restore 0618
         }
 


### PR DESCRIPTION
Port of https://github.com/dotnet/corefx/pull/41122
Fixed #23449
Fixed #36086

### Summary
Adds or improves results for several memory stats on Linux.

#### Add support for:
Process.PeakWorkingSet64
Process.PrivateMemorySize64
Process.PagedMemorySize64
Process.PagedSystemMemorySize64
Process.PeakVirtualMemorySize64
#### Improves:
Process.VirtualMemorySize64
Process.WorkingSet64

### Customer Impact

This prevents some profilers from providing full memory information for services running on Linux, eg.,
* NewRelic ([per their documentation](https://docs.newrelic.com/docs/agents/net-agent/installation/compatibility-requirements-net-core-agent#unavailable-features))
* Microsoft Application Insights (issue in [their repo here](https://github.com/microsoft/ApplicationInsights-dotnet-server/issues/1299))

Fixing this makes it easier for customers to monitor and diagnose issues on their services through telemetry. There is a desire to get this into an LTS release for this purpose.

### Regression?

No, these have never worked on Linux.

### Testing

Unit tests have been modified to require non zero values on Linux. This change does not fix OSX.

### Risk

Affects reading of any process information on Linux (eg., GetProcessesByName). Previously it would read `/proc/<pid>/stat` and now it also reads `/proc/<pid>/status` to gather the other information. The risks include, slower performance from reading two files (although, Linux is already slower than Windows); bugs in reading the file could throw - although we catch IOException; bugs parsing the file could throw or produce garbage.

cc @stephentoub does the text above seem reasonable? Could you please sign off on the port? I just did cherry pick.