### PR TITLE
System.Native: Add deployment target version for OSX

### DIFF
--- a/src/Native/build-native.sh
+++ b/src/Native/build-native.sh
@@ -426,6 +426,11 @@ if [ $__BuildArch != wasm ]; then
     esac
 fi
 
+# set default OSX deployment target
+if [[ $__BuildOS == OSX ]]; then
+    __CMakeExtraArgs="$__CMakeExtraArgs -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13"
+fi
+
 # Set the default clang version if not already set
 if [[ $__ClangMajorVersion == 0 && $__ClangMinorVersion == 0 ]]; then
     __ClangMajorVersion=9


### PR DESCRIPTION
As noticed in https://github.com/dotnet/corefx/pull/42408 we don't pass any minimum OSX target version to CMake.
This means it falls back to the host version, e.g. if you build on Mojave it would pass `-mmacosx-version-min=10.14` to the compiler.

.NET Core's minimum supported OSX version is 10.13 so pass that to CMake.