### PR TITLE
Fix path in detection logic to be absolute

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,7 +10,7 @@
 
   <!-- TODO: Consolidate when moved to runtime repository: dotnet/corefx#42170 -->
   <PropertyGroup>
-    <IsRuntimeRepository Condition="Exists('..\..\.dotnet-runtime-placeholder')">true</IsRuntimeRepository>
+    <IsRuntimeRepository Condition="Exists('$(MSBuildThisFileDirectory)..\..\.dotnet-runtime-placeholder')">true</IsRuntimeRepository>
     <SkipImportArcadeSdkFromRoot>true</SkipImportArcadeSdkFromRoot>
   </PropertyGroup>
   <Import Project="..\..\Directory.Build.props" Condition="'$(IsRuntimeRepository)' == 'true'" />


### PR DESCRIPTION
Per https://github.com/MicrosoftDocs/visualstudio-docs/issues/4287, properties and items are project realtive. Therefore adding the scripts directory to fix the path resolution.