### PR TITLE
Set values of array and immutable collection properties directly

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/DefaultImmutableEnumerableConverter.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/DefaultImmutableEnumerableConverter.cs
@@ -102,19 +102,16 @@ namespace System.Text.Json.Serialization.Converters
             options.TryAddCreateRangeDelegate(delegateKey, createRangeDelegate);
         }
 
-        public static bool IsImmutableEnumerable(Type type, out bool IsImmutableArray)
+        public static bool IsImmutableEnumerable(Type type)
         {
             if (!type.IsGenericType)
             {
-                IsImmutableArray = false;
                 return false;
             }
 
             switch (type.GetGenericTypeDefinition().FullName)
             {
                 case ImmutableArrayGenericTypeName:
-                    IsImmutableArray = true;
-                    return true;
                 case ImmutableListGenericTypeName:
                 case ImmutableListGenericInterfaceTypeName:
                 case ImmutableStackGenericTypeName:
@@ -124,10 +121,8 @@ namespace System.Text.Json.Serialization.Converters
                 case ImmutableSortedSetGenericTypeName:
                 case ImmutableHashSetGenericTypeName:
                 case ImmutableSetGenericInterfaceTypeName:
-                    IsImmutableArray = false;
                     return true;
                 default:
-                    IsImmutableArray = false;
                     return false;
             }
         }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
@@ -27,7 +27,6 @@ namespace System.Text.Json
         private JsonPropertyInfo _dictionaryValuePropertyPolicy;
 
         public bool CanBeNull { get; private set; }
-        public bool IsImmutableArray { get; private set; }
 
         public ClassType ClassType;
 
@@ -156,12 +155,10 @@ namespace System.Text.Json
                             DefaultImmutableDictionaryConverter.RegisterImmutableDictionary(RuntimePropertyType, ElementType, Options);
                             DictionaryConverter = s_jsonImmutableDictionaryConverter;
                         }
-                        else if (ClassType == ClassType.Enumerable && DefaultImmutableEnumerableConverter.IsImmutableEnumerable(RuntimePropertyType, out bool isImmutableArray))
+                        else if (ClassType == ClassType.Enumerable && DefaultImmutableEnumerableConverter.IsImmutableEnumerable(RuntimePropertyType))
                         {
                             DefaultImmutableEnumerableConverter.RegisterImmutableCollection(RuntimePropertyType, ElementType, Options);
                             EnumerableConverter = s_jsonImmutableEnumerableConverter;
-
-                            IsImmutableArray = isImmutableArray;
                         }
                     }
                 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
@@ -202,9 +202,8 @@ namespace System.Text.Json
 
                 state.Current.TempEnumerableValues = converterList;
 
-                // Clear the value if present to ensure we don't confuse tempEnumerableValues with the collection.
-                if (!jsonPropertyInfo.IsPropertyPolicy &&
-                    !state.Current.JsonPropertyInfo.IsImmutableArray)
+                // Clear the value if present to ensure we don't confuse TempEnumerableValues with the collection.
+                if (!jsonPropertyInfo.IsPropertyPolicy && jsonPropertyInfo.CanBeNull)
                 {
                     jsonPropertyInfo.SetValueAsObject(state.Current.ReturnValue, null);
                 }
@@ -247,8 +246,8 @@ namespace System.Text.Json
 
                 state.Current.TempDictionaryValues = converterDictionary;
 
-                // Clear the value if present to ensure we don't confuse tempEnumerableValues with the collection.
-                if (!jsonPropertyInfo.IsPropertyPolicy)
+                // Clear the value if present to ensure we don't confuse TempDictionaryValues with the collection.
+                if (!jsonPropertyInfo.IsPropertyPolicy && jsonPropertyInfo.CanBeNull)
                 {
                     jsonPropertyInfo.SetValueAsObject(state.Current.ReturnValue, null);
                 }


### PR DESCRIPTION
When deserializing, the serializer is throwing a `NotSupportedException` whenever we see an array or immutable collection (non-dictionary) property which isn't initally null. See https://dotnetfiddle.net/hdhEDG.

Arrays and immutable collections are deserialized using internal converters that create new instances populated the JSON array.
This issue doesn't apply to dictionaries, or `ClassType.Enumerable` types where we don't use converters: https://github.com/dotnet/corefx/blob/f9564cdbfa6590aa14b1be5fe1f6b20f51e94fcc/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs#L107-L112.