### PR TITLE
Improve diag tracing for NameResolution

### DIFF
--- a/src/Common/src/System/Net/Logging/NetEventSource.Common.cs
+++ b/src/Common/src/System/Net/Logging/NetEventSource.Common.cs
@@ -253,7 +253,7 @@ namespace System.Net
             if (IsEnabled) Log.ErrorMessage(IdOf(thisOrContextObject), memberName, Format(message).ToString());
         }
 
-        [Event(ErrorEventId, Level = EventLevel.Warning, Keywords = Keywords.Default)]
+        [Event(ErrorEventId, Level = EventLevel.Error, Keywords = Keywords.Default)]
         private void ErrorMessage(string thisOrContextObject, string? memberName, string? message) =>
             WriteEvent(ErrorEventId, thisOrContextObject, memberName ?? MissingMember, message);
         #endregion

--- a/src/System.Net.NameResolution/src/System.Net.NameResolution.csproj
+++ b/src/System.Net.NameResolution/src/System.Net.NameResolution.csproj
@@ -175,5 +175,6 @@
     <Reference Include="System.Threading.Overlapped" />
     <Reference Include="System.Threading.Tasks" />
     <Reference Include="System.Threading.ThreadPool" />
+    <Reference Include="System.Console" />
   </ItemGroup>
 </Project>

--- a/src/System.Net.NameResolution/src/System.Net.NameResolution.csproj
+++ b/src/System.Net.NameResolution/src/System.Net.NameResolution.csproj
@@ -175,6 +175,5 @@
     <Reference Include="System.Threading.Overlapped" />
     <Reference Include="System.Threading.Tasks" />
     <Reference Include="System.Threading.ThreadPool" />
-    <Reference Include="System.Console" />
   </ItemGroup>
 </Project>

--- a/src/System.Net.NameResolution/src/System/Net/Dns.cs
+++ b/src/System.Net.NameResolution/src/System/Net/Dns.cs
@@ -35,7 +35,7 @@ namespace System.Net
 
             if (address.Equals(IPAddress.Any) || address.Equals(IPAddress.IPv6Any))
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(address, $"Invalid address {address}");
+                if (NetEventSource.IsEnabled) NetEventSource.Error(address, $"Invalid address '{address}'");
                 throw new ArgumentException(SR.Format(SR.net_invalid_ip_addr, nameof(address)));
             }
 
@@ -61,7 +61,7 @@ namespace System.Net
             {
                 if (address.Equals(IPAddress.Any) || address.Equals(IPAddress.IPv6Any))
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Error(hostNameOrAddress, $"Invalid address {address}");
+                    if (NetEventSource.IsEnabled) NetEventSource.Error(address, $"Invalid address '{address}'");
                     throw new ArgumentException(SR.Format(SR.net_invalid_ip_addr, nameof(hostNameOrAddress)));
                 }
 
@@ -82,8 +82,8 @@ namespace System.Net
             {
                 NetEventSource.Enter(hostNameOrAddress, hostNameOrAddress);
                 Task<IPHostEntry> t = GetHostEntryCoreAsync(hostNameOrAddress, justReturnParsedIp: false, throwOnIIPAny: true);
-                t.ContinueWith((t, o) => NetEventSource.Exit(hostNameOrAddress, $"{t.Result} with {((IPHostEntry)t.Result).AddressList.Length} entries"),
-                    null, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+                t.ContinueWith((t, s) => NetEventSource.Exit((string)s, $"{t.Result} with {((IPHostEntry)t.Result).AddressList.Length} entries"),
+                    hostNameOrAddress, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnRanToCompletion, TaskScheduler.Default);
                 return t;
             }
             else
@@ -105,13 +105,13 @@ namespace System.Net
 
             if (address.Equals(IPAddress.Any) || address.Equals(IPAddress.IPv6Any))
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(address, $"Invalid address {address}");
+                if (NetEventSource.IsEnabled) NetEventSource.Error(address, $"Invalid address '{address}'");
                 throw new ArgumentException(SR.net_invalid_ip_addr, nameof(address));
             }
 
             return RunAsync(s => {
                     IPHostEntry ipHostEntry = GetHostEntryCore((IPAddress)s);
-                    if (NetEventSource.IsEnabled) NetEventSource.Exit(address, $"{ipHostEntry} with {ipHostEntry.AddressList.Length} entries");
+                    if (NetEventSource.IsEnabled) NetEventSource.Exit((IPAddress)s, $"{ipHostEntry} with {ipHostEntry.AddressList.Length} entries");
                     return ipHostEntry;
                 }, address);
         }
@@ -162,7 +162,7 @@ namespace System.Net
             {
                 if (address.Equals(IPAddress.Any) || address.Equals(IPAddress.IPv6Any))
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Error(address, $"Invalid address {address}");
+                    if (NetEventSource.IsEnabled) NetEventSource.Error(address, $"Invalid address '{address}'");
                     throw new ArgumentException(SR.Format(SR.net_invalid_ip_addr, nameof(hostNameOrAddress)));
                 }
 
@@ -406,7 +406,7 @@ namespace System.Net
 
             if (errorCode != SocketError.Success)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(address, $"forward lookup for {name} failed with {errorCode}");
+                if (NetEventSource.IsEnabled) NetEventSource.Error(address, $"forward lookup for '{name}' failed with {errorCode}");
             }
 
             // One of three things happened:
@@ -445,7 +445,7 @@ namespace System.Net
             {
                 if (throwOnIIPAny && (ipAddress.Equals(IPAddress.Any) || ipAddress.Equals(IPAddress.IPv6Any)))
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Error(hostName, $"Invalid address {ipAddress}");
+                    if (NetEventSource.IsEnabled) NetEventSource.Error(hostName, $"Invalid address '{ipAddress}'");
                     throw new ArgumentException(SR.net_invalid_ip_addr, nameof(hostName));
                 }
 

--- a/src/System.Net.NameResolution/src/System/Net/Dns.cs
+++ b/src/System.Net.NameResolution/src/System/Net/Dns.cs
@@ -350,7 +350,7 @@ namespace System.Net
             Console.WriteLine("GetHostEntryOrAddressesCore finished with {0} enabled {1}", errorCode, NetEventSource.IsEnabled);
 
             NetEventSource.Info(hostName, $"{hostName} DNS lookup failed with {errorCode}");
-            NetEventSource.Error(hostName, formattableString: $"{hostName} DNS lookup failed with {errorCode}");
+            NetEventSource.Error(hostName, memberName: "GetHostEntryOrAddressesCore", message: $"{hostName} DNS lookup failed with {errorCode}");
             NetEventSource.Error(hostName, $"{hostName} DNS lookup failed with {errorCode}");
 
             if (errorCode != SocketError.Success)

--- a/src/System.Net.NameResolution/src/System/Net/Dns.cs
+++ b/src/System.Net.NameResolution/src/System/Net/Dns.cs
@@ -16,10 +16,11 @@ namespace System.Net
         /// <summary>Gets the host name of the local machine.</summary>
         public static string GetHostName()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(null, null);
             NameResolutionPal.EnsureSocketsAreInitialized();
 
-            return NameResolutionPal.GetHostName();
+            string name = NameResolutionPal.GetHostName();
+            if (NetEventSource.IsEnabled) NetEventSource.Info(null, name);
+            return name;
         }
 
         public static IPHostEntry GetHostEntry(IPAddress address)
@@ -45,7 +46,7 @@ namespace System.Net
 
         public static IPHostEntry GetHostEntry(string hostNameOrAddress)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(null, hostNameOrAddress);
+            if (NetEventSource.IsEnabled) NetEventSource.Enter(hostNameOrAddress, hostNameOrAddress);
             NameResolutionPal.EnsureSocketsAreInitialized();
 
             if (hostNameOrAddress is null)
@@ -69,12 +70,16 @@ namespace System.Net
                 ipHostEntry = GetHostEntryCore(hostNameOrAddress);
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(null, ipHostEntry);
+            if (NetEventSource.IsEnabled) NetEventSource.Exit(hostNameOrAddress, ipHostEntry);
             return ipHostEntry;
         }
 
-        public static Task<IPHostEntry> GetHostEntryAsync(string hostNameOrAddress) =>
-            GetHostEntryCoreAsync(hostNameOrAddress, justReturnParsedIp: false, throwOnIIPAny: true);
+        public static Task<IPHostEntry> GetHostEntryAsync(string hostNameOrAddress)
+        {
+            if (NetEventSource.IsEnabled) NetEventSource.Info(hostNameOrAddress, hostNameOrAddress);
+
+            return GetHostEntryCoreAsync(hostNameOrAddress, justReturnParsedIp: false, throwOnIIPAny: true);
+        }
 
         public static Task<IPHostEntry> GetHostEntryAsync(IPAddress address)
         {
@@ -110,7 +115,7 @@ namespace System.Net
 
             IAsyncResult asyncResult = TaskToApm.Begin(GetHostEntryAsync(hostNameOrAddress), requestCallback, stateObject);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(null, asyncResult);
+            if (NetEventSource.IsEnabled) NetEventSource.Exit(asyncResult, asyncResult);
             return asyncResult;
         }
 
@@ -120,7 +125,8 @@ namespace System.Net
 
             IPHostEntry ipHostEntry = TaskToApm.End<IPHostEntry>(asyncResult ?? throw new ArgumentNullException(nameof(asyncResult)));
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(null, ipHostEntry);
+            //if (NetEventSource.IsEnabled) NetEventSource.Exit(null, ipHostEntry);
+            if (NetEventSource.IsEnabled) NetEventSource.Exit(asyncResult, ipHostEntry, $"got number of {ipHostEntry.AddressList.Length} entries" );
             return ipHostEntry;
         }
 
@@ -198,29 +204,29 @@ namespace System.Net
         [Obsolete("BeginGetHostByName is obsoleted for this type, please use BeginGetHostEntry instead. https://go.microsoft.com/fwlink/?linkid=14202")]
         public static IAsyncResult BeginGetHostByName(string hostName, AsyncCallback requestCallback, object stateObject)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(null, hostName);
+            if (NetEventSource.IsEnabled) NetEventSource.Enter(hostName, hostName);
 
             IAsyncResult asyncResult = TaskToApm.Begin(GetHostEntryCoreAsync(hostName, justReturnParsedIp: true, throwOnIIPAny: true), requestCallback, stateObject);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(null, asyncResult);
+            if (NetEventSource.IsEnabled) NetEventSource.Exit(hostName, asyncResult);
             return asyncResult;
         }
 
         [Obsolete("EndGetHostByName is obsoleted for this type, please use EndGetHostEntry instead. https://go.microsoft.com/fwlink/?linkid=14202")]
         public static IPHostEntry EndGetHostByName(IAsyncResult asyncResult)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(null, asyncResult);
+            if (NetEventSource.IsEnabled) NetEventSource.Enter(asyncResult, asyncResult);
 
             IPHostEntry ipHostEntry = TaskToApm.End<IPHostEntry>(asyncResult ?? throw new ArgumentNullException(nameof(asyncResult)));
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(null, ipHostEntry);
+            if (NetEventSource.IsEnabled) NetEventSource.Exit(asyncResult, ipHostEntry);
             return ipHostEntry;
         }
 
         [Obsolete("GetHostByAddress is obsoleted for this type, please use GetHostEntry instead. https://go.microsoft.com/fwlink/?linkid=14202")]
         public static IPHostEntry GetHostByAddress(string address)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(null, address);
+            if (NetEventSource.IsEnabled) NetEventSource.Enter(address, address);
             NameResolutionPal.EnsureSocketsAreInitialized();
 
             if (address is null)
@@ -230,14 +236,14 @@ namespace System.Net
 
             IPHostEntry ipHostEntry = GetHostEntryCore(IPAddress.Parse(address));
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(null, ipHostEntry);
+            if (NetEventSource.IsEnabled) NetEventSource.Exit(address, ipHostEntry);
             return ipHostEntry;
         }
 
         [Obsolete("GetHostByAddress is obsoleted for this type, please use GetHostEntry instead. https://go.microsoft.com/fwlink/?linkid=14202")]
         public static IPHostEntry GetHostByAddress(IPAddress address)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(null, address);
+            if (NetEventSource.IsEnabled) NetEventSource.Enter(address, address);
             NameResolutionPal.EnsureSocketsAreInitialized();
 
             if (address is null)
@@ -247,14 +253,14 @@ namespace System.Net
 
             IPHostEntry ipHostEntry = GetHostEntryCore(address);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(null, ipHostEntry);
+            if (NetEventSource.IsEnabled) NetEventSource.Exit(address, ipHostEntry);
             return ipHostEntry;
         }
 
         [Obsolete("Resolve is obsoleted for this type, please use GetHostEntry instead. https://go.microsoft.com/fwlink/?linkid=14202")]
         public static IPHostEntry Resolve(string hostName)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(null, hostName);
+            if (NetEventSource.IsEnabled) NetEventSource.Enter(hostName, hostName);
             NameResolutionPal.EnsureSocketsAreInitialized();
 
             if (hostName is null)
@@ -273,7 +279,7 @@ namespace System.Net
                 }
                 catch (SocketException ex)
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Error(null, ex);
+                    if (NetEventSource.IsEnabled) NetEventSource.Error(hostName, ex);
                     ipHostEntry = CreateHostEntryForAddress(address);
                 }
             }
@@ -282,7 +288,7 @@ namespace System.Net
                 ipHostEntry = GetHostEntryCore(hostName);
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(null, ipHostEntry);
+            if (NetEventSource.IsEnabled) NetEventSource.Exit(hostName, ipHostEntry);
             return ipHostEntry;
         }
 
@@ -335,12 +341,21 @@ namespace System.Net
 
         private static object GetHostEntryOrAddressesCore(string hostName, bool justAddresses)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(null, hostName);
+            int hash = hostName.GetHashCode();
+            if (NetEventSource.IsEnabled) NetEventSource.Enter(hostName, hostName);
+
             ValidateHostName(hostName);
 
-            SocketError errorCode = NameResolutionPal.TryGetAddrInfo(hostName, justAddresses, out hostName, out string[] aliases, out IPAddress[] addresses, out int nativeErrorCode);
+            SocketError errorCode = NameResolutionPal.TryGetAddrInfo(hostName, justAddresses, out string newHostName, out string[] aliases, out IPAddress[] addresses, out int nativeErrorCode);
+            Console.WriteLine("GetHostEntryOrAddressesCore finished with {0} enabled {1}", errorCode, NetEventSource.IsEnabled);
+
+            NetEventSource.Info(hostName, $"{hostName} DNS lookup failed with {errorCode}");
+            NetEventSource.Error(hostName, formattableString: $"{hostName} DNS lookup failed with {errorCode}");
+            NetEventSource.Error(hostName, $"{hostName} DNS lookup failed with {errorCode}");
+
             if (errorCode != SocketError.Success)
             {
+                if (NetEventSource.IsEnabled) NetEventSource.Error(hostName, $"{hostName} DNS lookup failed with {errorCode}");
                 throw SocketExceptionFactory.CreateSocketException(errorCode, nativeErrorCode);
             }
 
@@ -349,11 +364,12 @@ namespace System.Net
                 new IPHostEntry
                 {
                     AddressList = addresses,
-                    HostName = hostName,
+                    HostName = newHostName,
                     Aliases = aliases
                 };
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(null, result);
+            Console.WriteLine("GetHostEntryOrAddressesCore start: {0} {1}",  hostName, hostName.GetHashCode());
+            if (NetEventSource.IsEnabled) NetEventSource.Exit(hostName, result, addresses.Length);
             return result;
         }
 
@@ -411,7 +427,7 @@ namespace System.Net
         // If hostName is an IPString and justReturnParsedIP==true then no reverse lookup will be attempted, but the original address is returned.
         private static Task GetHostEntryOrAddressesCoreAsync(string hostName, bool justReturnParsedIp, bool throwOnIIPAny, bool justAddresses)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(null, hostName);
+            if (NetEventSource.IsEnabled) NetEventSource.Info(hostName, hostName);
             NameResolutionPal.EnsureSocketsAreInitialized();
 
             if (hostName is null)

--- a/src/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
+++ b/src/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
@@ -131,8 +131,11 @@ namespace System.Net
 
             const int HostNameBufferLength = 256;
             byte* buffer = stackalloc byte[HostNameBufferLength];
-            if (Interop.Winsock.gethostname(buffer, HostNameBufferLength) != SocketError.Success)
+            SocketError result = Interop.Winsock.gethostname(buffer, HostNameBufferLength);
+
+            if (result != SocketError.Success)
             {
+                if (NetEventSource.IsEnabled) NetEventSource.Error(hostName, $"GetHostName failed with {result}");
                 throw new SocketException();
             }
 

--- a/src/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
+++ b/src/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
@@ -135,7 +135,7 @@ namespace System.Net
 
             if (result != SocketError.Success)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(hostName, $"GetHostName failed with {result}");
+                if (NetEventSource.IsEnabled) NetEventSource.Error(null, $"GetHostName failed with {result}");
                 throw new SocketException();
             }
 

--- a/src/System.Net.NameResolution/tests/FunctionalTests/LoggingTest.cs
+++ b/src/System.Net.NameResolution/tests/FunctionalTests/LoggingTest.cs
@@ -5,8 +5,9 @@
 using System.Collections.Concurrent;
 using System.Diagnostics.Tracing;
 using System.Linq;
+using System.Net.Sockets;
 using System.Reflection;
-using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 using Xunit.Abstractions;
@@ -16,7 +17,7 @@ namespace System.Net.NameResolution.Tests
     using Configuration = System.Net.Test.Common.Configuration;
 
     [Collection("NoParallelTests")]
-    public static class LoggingTest
+    public class LoggingTest
     {
         [Fact]
         public static void EventSource_ExistsWithCorrectId()
@@ -31,14 +32,12 @@ namespace System.Net.NameResolution.Tests
         }
 
         [Fact]
-        public static void EventSource_LookupErrro_Success()
+        public void GetHostEntry_InvalidHost_LogsError()
         {
-            using (var listener = new TestEventListener("Microsoft-System-Net-NameResolution", EventLevel.Verbose))
+            using (var listener = new TestEventListener("Microsoft-System-Net-NameResolution", EventLevel.Error))
             {
                 var events = new ConcurrentQueue<EventWrittenEventArgs>();
 
-                //const int AcquiringAllLocksEventId = 3;
-                Clear(events);
                 listener.RunWithCallback(ev => events.Enqueue(ev), () =>
                 {
                     try
@@ -46,28 +45,86 @@ namespace System.Net.NameResolution.Tests
                         Dns.GetHostEntry(Configuration.Sockets.InvalidHost);
                         throw new SkipTestException("GetHostEntry() should fail but it did not.");
                     }
+                    catch (SocketException e) when (e.SocketErrorCode == SocketError.HostNotFound)
+                    {
+                    }
                     catch (Exception e)
-                    { Console.WriteLine(e); };
-                    Console.WriteLine("ALl DONE");
-                    Thread.Sleep(100);
+                    {
+                        throw new SkipTestException($"GetHostEntry failed unexpectedly: {e.Message}");
+                    }
                 });
 
                 Assert.True(events.Count() > 0);
-                Console.WriteLine($"Count = {events.Count()}");
-
                 foreach (EventWrittenEventArgs ev in events)
                 {
-                    Console.WriteLine(ev.ToString());
-                    Console.WriteLine($"git {ev.EventId},  m='{ev.Message}' , p='{ev.Payload}' {ev.Level} anbd {ev.EventSource.ToString()}");
+                    Assert.True(ev.Payload.Count >= 3);
+                    Assert.NotNull(ev.Payload[0]);
+                    Assert.NotNull(ev.Payload[1]);
+                    Assert.NotNull(ev.Payload[2]);
+                }
+            }
+        }
+        [Fact]
+        public void GetHostEntryAsync_InvalidHost_LogsError()
+        {
+            using (var listener = new TestEventListener("Microsoft-System-Net-NameResolution", EventLevel.Error))
+            {
+                var events = new ConcurrentQueue<EventWrittenEventArgs>();
 
+                listener.RunWithCallback(ev => events.Enqueue(ev), () =>
+                {
+                    try
+                    {
+                        Dns.GetHostEntryAsync(Configuration.Sockets.InvalidHost).GetAwaiter().GetResult();
+                        throw new SkipTestException("GetHostEntry() should fail but it did not.");
+                    }
+                    catch (SocketException e) when (e.SocketErrorCode == SocketError.HostNotFound)
+                    {
+                    }
+                    catch (Exception e)
+                    {
+                        throw new SkipTestException($"GetHostEntry failed unexpectedly: {e.Message}");
+                    }
+                });
+
+                Assert.True(events.Count() > 0);
+                foreach (EventWrittenEventArgs ev in events)
+                {
+                    Assert.True(ev.Payload.Count >= 3);
+                    Assert.NotNull(ev.Payload[0]);
+                    Assert.NotNull(ev.Payload[1]);
+                    Assert.NotNull(ev.Payload[2]);
                 }
             }
         }
 
-        private static void Clear<T>(ConcurrentQueue<T> queue)
+        [Fact]
+        public void GetHostEntry_ValidName_NoErrors()
         {
-            T item;
-            while (queue.TryDequeue(out item)) ;
+            using (var listener = new TestEventListener("Microsoft-System-Net-NameResolution", EventLevel.Verbose))
+            {
+                var events = new ConcurrentQueue<EventWrittenEventArgs>();
+
+                listener.RunWithCallback(ev => events.Enqueue(ev), () =>
+                {
+                    try
+                    {
+                        Dns.GetHostEntryAsync("localhost").GetAwaiter().GetResult();
+                        Dns.GetHostEntryAsync(IPAddress.Loopback).GetAwaiter().GetResult();
+                        Dns.GetHostEntry("localhost");
+                        Dns.GetHostEntry(IPAddress.Loopback);
+                    }
+                    catch (Exception e)
+                    {
+                        throw new SkipTestException($"Localhost lookup failed unexpectedly: {e.Message}");
+                    }
+                });
+
+                // We get some traces.
+                Assert.True(events.Count() > 0);
+                // No errors or warning for successful query.
+                Assert.True(events.Count(ev => (int)ev.Level > (int)EventLevel.Informational) == 0);
+            }
         }
     }
 }

--- a/src/System.Net.NameResolution/tests/FunctionalTests/LoggingTest.cs
+++ b/src/System.Net.NameResolution/tests/FunctionalTests/LoggingTest.cs
@@ -66,6 +66,7 @@ namespace System.Net.NameResolution.Tests
         }
 
         [ConditionalFact]
+        [PlatformSpecific(~TestPlatforms.Windows)]  // Unreliable on Windows.
         public void GetHostEntryAsync_InvalidHost_LogsError()
         {
             using (var listener = new TestEventListener("Microsoft-System-Net-NameResolution", EventLevel.Error))

--- a/src/System.Net.NameResolution/tests/FunctionalTests/LoggingTest.cs
+++ b/src/System.Net.NameResolution/tests/FunctionalTests/LoggingTest.cs
@@ -31,7 +31,7 @@ namespace System.Net.NameResolution.Tests
             Assert.NotEmpty(EventSource.GenerateManifest(esType, "assemblyPathToIncludeInManifest"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public void GetHostEntry_InvalidHost_LogsError()
         {
             using (var listener = new TestEventListener("Microsoft-System-Net-NameResolution", EventLevel.Error))
@@ -64,7 +64,8 @@ namespace System.Net.NameResolution.Tests
                 }
             }
         }
-        [Fact]
+
+        [ConditionalFact]
         public void GetHostEntryAsync_InvalidHost_LogsError()
         {
             using (var listener = new TestEventListener("Microsoft-System-Net-NameResolution", EventLevel.Error))
@@ -98,7 +99,7 @@ namespace System.Net.NameResolution.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public void GetHostEntry_ValidName_NoErrors()
         {
             using (var listener = new TestEventListener("Microsoft-System-Net-NameResolution", EventLevel.Verbose))

--- a/src/System.Net.NameResolution/tests/FunctionalTests/LoggingTest.cs
+++ b/src/System.Net.NameResolution/tests/FunctionalTests/LoggingTest.cs
@@ -2,12 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Concurrent;
 using System.Diagnostics.Tracing;
+using System.Linq;
 using System.Reflection;
+using System.Threading;
+using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace System.Net.NameResolution.Tests
 {
+    using Configuration = System.Net.Test.Common.Configuration;
+
+    [Collection("NoParallelTests")]
     public static class LoggingTest
     {
         [Fact]
@@ -20,6 +28,46 @@ namespace System.Net.NameResolution.Tests
             Assert.Equal(Guid.Parse("5f302add-3825-520e-8fa0-627b206e2e7e"), EventSource.GetGuid(esType));
 
             Assert.NotEmpty(EventSource.GenerateManifest(esType, "assemblyPathToIncludeInManifest"));
+        }
+
+        [Fact]
+        public static void EventSource_LookupErrro_Success()
+        {
+            using (var listener = new TestEventListener("Microsoft-System-Net-NameResolution", EventLevel.Verbose))
+            {
+                var events = new ConcurrentQueue<EventWrittenEventArgs>();
+
+                //const int AcquiringAllLocksEventId = 3;
+                Clear(events);
+                listener.RunWithCallback(ev => events.Enqueue(ev), () =>
+                {
+                    try
+                    {
+                        Dns.GetHostEntry(Configuration.Sockets.InvalidHost);
+                        throw new SkipTestException("GetHostEntry() should fail but it did not.");
+                    }
+                    catch (Exception e)
+                    { Console.WriteLine(e); };
+                    Console.WriteLine("ALl DONE");
+                    Thread.Sleep(100);
+                });
+
+                Assert.True(events.Count() > 0);
+                Console.WriteLine($"Count = {events.Count()}");
+
+                foreach (EventWrittenEventArgs ev in events)
+                {
+                    Console.WriteLine(ev.ToString());
+                    Console.WriteLine($"git {ev.EventId},  m='{ev.Message}' , p='{ev.Payload}' {ev.Level} anbd {ev.EventSource.ToString()}");
+
+                }
+            }
+        }
+
+        private static void Clear<T>(ConcurrentQueue<T> queue)
+        {
+            T item;
+            while (queue.TryDequeue(out item)) ;
         }
     }
 }

--- a/src/System.Net.NameResolution/tests/FunctionalTests/System.Net.NameResolution.Functional.Tests.csproj
+++ b/src/System.Net.NameResolution/tests/FunctionalTests/System.Net.NameResolution.Functional.Tests.csproj
@@ -15,5 +15,14 @@
     <Compile Include="$(CommonTestPath)\System\Threading\Tasks\TaskTimeoutExtensions.cs">
       <Link>Common\System\Threading\Tasks\TaskTimeoutExtensions.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Net\Configuration.cs">
+      <Link>Common\System\Net\Configuration.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Net\Configuration.Sockets.cs">
+      <Link>Common\System\Net\Configuration.Sockets.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs">
+      <Link>Common\System\Diagnostics\Tracing\TestEventListener.cs</Link>
+    </Compile>
   </ItemGroup>
 </Project>

--- a/src/System.Net.NameResolution/tests/FunctionalTests/TestSettings.cs
+++ b/src/System.Net.NameResolution/tests/FunctionalTests/TestSettings.cs
@@ -4,9 +4,14 @@
 
 using System.Net.Sockets;
 using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
 
 namespace System.Net.NameResolution.Tests
 {
+    [CollectionDefinition("NoParallelTests", DisableParallelization = true)]
+    public partial class NoParallelTests { }
+
     internal static class TestSettings
     {
         public const string LocalHost = "localhost";


### PR DESCRIPTION
This is attempt to improve diagnostic for DNS functions. 
As described in #41884, I added missing Error entries for failures and I removed Enter/Exit from inner function. I also use passed argument as context so it is possible to link Enter, Exit and Error entries.  To avoid try/catch/throw, I log errors in places where exception is generated. With that, EventSource would come from different function that Enter but we should be able to link them together. 

Now we will generate following traces: (original outcome in linked issue)
```
<Event MSec=    "39.1543" PID="12703" PName="Process(12703)" TID="12703" EventName="Info" ProviderName="Microsoft-System-Net-NameResolution" thisOrContextObject="(null)" memberName="GetHostName" message="Ubuntu16"/>
<Event MSec=    "51.7923" PID="12703" PName="Process(12703)" TID="12703" EventName="Enter" ProviderName="Microsoft-System-Net-NameResolution" thisOrContextObject="IPAddress#-1202420682" memberName="GetHostEntry" parameters="(127.0.0.1)"/>
<Event MSec=    "55.5470" PID="12703" PName="Process(12703)" TID="12703" EventName="Exit" ProviderName="Microsoft-System-Net-NameResolution" thisOrContextObject="IPAddress#-1202420682" memberName="GetHostEntry" result="IPHostEntry#33476626 with 3 entries"/>
<Event MSec=    "55.8455" PID="12703" PName="Process(12703)" TID="12703" EventName="Enter" ProviderName="Microsoft-System-Net-NameResolution" thisOrContextObject="String#827044211" memberName="GetHostEntry" parameters="(www.foo.com)"/>
<Event MSec=   "122.1286" PID="12703" PName="Process(12703)" TID="12703" EventName="Exit" ProviderName="Microsoft-System-Net-NameResolution" thisOrContextObject="String#827044211" memberName="GetHostEntry" result="IPHostEntry#32854180 with 6 entries"/>
<Event MSec=   "122.1435" PID="12703" PName="Process(12703)" TID="12703" EventName="Enter" ProviderName="Microsoft-System-Net-NameResolution" thisOrContextObject="String#870578365" memberName="GetHostEntry" parameters="(www.foo22.com)"/>
<Event MSec=   "194.1178" PID="12703" PName="Process(12703)" TID="12703" EventName="ErrorMessage" ProviderName="Microsoft-System-Net-NameResolution" thisOrContextObject="String#870578365" memberName="GetHostEntryOrAddressesCore" message="www.foo22.com DNS lookup failed with HostNotFound"/>
```
and ...Async

```
<Event MSec=    "51.9606" PID="16644" PName="Process(16644)" TID="16644" EventName="Enter" ProviderName="Microsoft-System-Net-NameResolution" thisOrContextObject="ReadOnlyIPAddress#-1361333976" memberName="GetHostEntryAsync" parameters="(127.0.0.1)"/>
<Event MSec=    "58.0448" PID="16644" PName="Process(16644)" TID="16651" EventName="Exit" ProviderName="Microsoft-System-Net-NameResolution" thisOrContextObject="ReadOnlyIPAddress#-1361333976" memberName="GetHostEntryAsync" result="IPHostEntry#6044116 with 3 entries"/>
<Event MSec=    "58.6924" PID="16644" PName="Process(16644)" TID="16644" EventName="Enter" ProviderName="Microsoft-System-Net-NameResolution" thisOrContextObject="String#1587549607" memberName="GetHostEntryAsync" parameters="(www.foo.com)"/>
<Event MSec=   "238.2328" PID="16644" PName="Process(16644)" TID="16644" EventName="Enter" ProviderName="Microsoft-System-Net-NameResolution" thisOrContextObject="String#-573734129" memberName="GetHostEntryAsync" parameters="(www.foo22.com)"/>
<Event MSec=   "238.3077" PID="16644" PName="Process(16644)" TID="16651" EventName="Exit" ProviderName="Microsoft-System-Net-NameResolution" thisOrContextObject="String#1587549607" memberName="GetHostEntryAsync" result="IPHostEntry#59817589 with 6 entries"/>
<Event MSec=   "370.5123" PID="16644" PName="Process(16644)" TID="16653" EventName="ErrorMessage" ProviderName="Microsoft-System-Net-NameResolution" thisOrContextObject="String#-573734129" memberName="GetHostEntryOrAddressesCore" message="www.foo22.com DNS lookup failed with HostNotFound"/>

```

So there will be Enter entry (if verbosity is high enough) and than either Exit or Error.

The change in NetEventSource.Common.cs looks like old oversight where we log Errors as Warnings. (found by writing test)
Adding @stephentoub as he touch surrounding areas last (3y ago)
It would be also great if @stephentoub can take look at the async ContinueWith().

For tests, I force serialization to avoid need to run this using RemoteExec in order to avoid isolation. Since the tests do not test lookup functionality, we will skip test if the lookup function does not return expected result to minimize noise with flaky DNS. 

fixes #41884

(and for ease copy of old trace entries)
```
<Event MSec=  "6067.9290" PID="10091" PName="Process(10091)" TID="10091" EventName="Enter" ProviderName="Microsoft-System-Net-NameResolution" thisOrContextObject="(null)" memberName="GetHostEntry" parameters="(www.foo.com)"/>
<Event MSec=  "6068.6685" PID="10091" PName="Process(10091)" TID="10091" EventName="Enter" ProviderName="Microsoft-System-Net-NameResolution" thisOrContextObject="(null)" memberName="InternalGetHostByName" parameters="(www.foo.com)"/>
<Event MSec= "11089.9084" PID="10091" PName="Process(10091)" TID="10091" EventName="Exit" ProviderName="Microsoft-System-Net-NameResolution" thisOrContextObject="(null)" memberName="InternalGetHostByName" result="IPHostEntry#33476626"/>
<Event MSec= "11089.9167" PID="10091" PName="Process(10091)" TID="10091" EventName="Exit" ProviderName="Microsoft-System-Net-NameResolution" thisOrContextObject="(null)" memberName="GetHostEntry" result="IPHostEntry#33476626"/>

<Event MSec=  "4770.0633" PID="10308" PName="Process(10308)" TID="10308" EventName="Enter" ProviderName="Microsoft-System-Net-NameResolution" thisOrContextObject="(null)" memberName="GetHostEntry" parameters="(www.foo2.com)"/>
<Event MSec=  "4771.6036" PID="10308" PName="Process(10308)" TID="10308" EventName="Enter" ProviderName="Microsoft-System-Net-NameResolution" thisOrContextObject="(null)" memberName="InternalGetHostByName" parameters="(www.foo22.com)"/>
```
