### PR TITLE
Fix CodeOwners syntax

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Users referenced in this file will automatically be requested as reviewers for PRs that modify the given paths.
 # See https://help.github.com/articles/about-code-owners/
 
-/src/Common/src/System/Net/Http/Http2                    @dotnet/http2
-/src/Common/tests/Tests/System/Net/Http2                 @dotnet/http2
+/src/Common/src/System/Net/Http/Http2/                    @dotnet/http2
+/src/Common/tests/Tests/System/Net/Http2/                 @dotnet/http2


### PR DESCRIPTION
I noticed in https://github.com/dotnet/corefx/pull/42425 that the codeowners didn't work as expected, likely due to a syntax error.