### PR TITLE
Remove throw in exception handling of dispose

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsHandle.cs
@@ -51,7 +51,6 @@ namespace System.Data.SqlClient.SNI
             catch (Exception e)
             {
                 SNICommon.ReportSNIError(SNIProviders.SMUX_PROV, SNICommon.InternalExceptionError, e);
-                throw;
             }
         }
 


### PR DESCRIPTION
Back port fix from Microsoft.Data.Sqlclient issue [#20](https://github.com/dotnet/SqlClient/issues/20).