### PR TITLE
Make ServiceBase.Dispose safer by avoiding double free

### DIFF
--- a/src/Common/src/Interop/Windows/Advapi32/Interop.SERVICE_TABLE_ENTRY.cs
+++ b/src/Common/src/Interop/Windows/Advapi32/Interop.SERVICE_TABLE_ENTRY.cs
@@ -15,7 +15,7 @@ internal partial class Interop
         public struct SERVICE_TABLE_ENTRY
         {
             public IntPtr name;
-            public ServiceMainCallback callback;
+            public IntPtr callback;
         }
     }
 }

--- a/src/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceBase.cs
+++ b/src/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceBase.cs
@@ -648,9 +648,7 @@ namespace System.ServiceProcess
             {
                 // Free the pointer to the name of the service on the unmanaged heap.
                 // We don't need to free the last element in the unmanaged array since the last element have null values (denotes the end of the table).
-                // Entries other than the last entry having a null pointer means that we failed while processing the entries for some reason
-                // and only elements up to this point has been successfully allocated so far (thus have to be deallocated)
-                for (int i = 0; i < services.Length && entries[i].name != IntPtr.Zero; i++)
+                for (int i = 0; i < services.Length; i++)
                 {
                     Marshal.FreeHGlobal(entries[i].name);
                 }

--- a/src/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceBase.cs
+++ b/src/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceBase.cs
@@ -308,10 +308,10 @@ namespace System.ServiceProcess
         /// </devdoc>
         protected override void Dispose(bool disposing)
         {
-            if (_handleName != (IntPtr)0)
+            IntPtr handleName = Interlocked.Exchange(ref _handleName, IntPtr.Zero);
+            if (handleName != IntPtr.Zero)
             {
-                Marshal.FreeHGlobal(_handleName);
-                _handleName = (IntPtr)0;
+                Marshal.FreeHGlobal(handleName);
             }
 
             _nameFrozen = false;

--- a/src/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceBase.cs
+++ b/src/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceBase.cs
@@ -599,6 +599,8 @@ namespace System.ServiceProcess
             {
                 bool multipleServices = services.Length > 1;
 
+                // The members of the last entry in the table must have NULL values to designate the end of the table.
+                // Leave the last element in the entries span to be zeroed out.
                 for (int index = 0; index < services.Length; ++index)
                 {
                     ServiceBase service = services[index];
@@ -606,9 +608,6 @@ namespace System.ServiceProcess
                     // This method allocates on unmanaged heap; Make sure that the contents are freed after use.
                     entries[index] = service.GetEntry();
                 }
-
-                // The members of the last entry in the table must have NULL values to designate the end of the table.
-                entries[entries.Length - 1] = default;
 
                 // While the service is running, this function will never return. It will return when the service
                 // is stopped.
@@ -647,8 +646,7 @@ namespace System.ServiceProcess
             finally
             {
                 // Free the pointer to the name of the service on the unmanaged heap.
-                // We don't need to free the last element in the unmanaged array since the last element have null values (denotes the end of the table).
-                for (int i = 0; i < services.Length; i++)
+                for (int i = 0; i < entries.Length; i++)
                 {
                     Marshal.FreeHGlobal(entries[i].name);
                 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/42469

* Use Interlocked.Exchange to avoid double freeing in multi-threading situations

I don't think the method should necessarily be thread safe, but at least it shouldn't cause heap corruptions by double-freeing something.