### PR TITLE
Add dotnet-eng feed

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -8,6 +8,7 @@
     <clear />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="dotnet-coreclr" value="https://dotnetfeed.blob.core.windows.net/dotnet-coreclr/index.json" />
+    <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <disabledPackageSources>


### PR DESCRIPTION
The dotnet-tools feed is being moved to dotnet-eng so that dotnet-tools can be used for actual tools.

https://github.com/dotnet/arcade/issues/4197