### PR TITLE
improve network stats on FreeBSD

### DIFF
--- a/src/Native/Unix/System.Native/pal_networkstatistics.c
+++ b/src/Native/Unix/System.Native/pal_networkstatistics.c
@@ -257,6 +257,13 @@ int32_t SystemNative_GetEstimatedTcpConnectionCount()
     return count;
 }
 
+#ifdef __FreeBSD__
+int32_t SystemNative_GetActiveTcpConnectionInfos(__attribute__((unused)) NativeTcpConnectionInformation* infos, int32_t* infoCount)
+{
+    *infoCount = 0;
+    return 0;
+}
+#else
 static size_t GetEstimatedTcpPcbSize()
 {
     void* oldp = NULL;
@@ -348,6 +355,7 @@ int32_t SystemNative_GetActiveTcpConnectionInfos(NativeTcpConnectionInformation*
     free(buffer);
     return 0;
 }
+#endif
 
 int32_t SystemNative_GetEstimatedUdpListenerCount()
 {
@@ -357,6 +365,13 @@ int32_t SystemNative_GetEstimatedUdpListenerCount()
     return count;
 }
 
+#ifdef __FreeBSD__
+int32_t SystemNative_GetActiveUdpListeners(__attribute__((unused)) IPEndPointInfo* infos, int32_t* infoCount)
+{
+    *infoCount = 0;
+    return 0;
+}
+#else
 static size_t GetEstimatedUdpPcbSize()
 {
     void* oldp = NULL;
@@ -436,6 +451,7 @@ int32_t SystemNative_GetActiveUdpListeners(IPEndPointInfo* infos, int32_t* infoC
     free(buffer);
     return 0;
 }
+#endif
 
 int32_t SystemNative_GetNativeIPInterfaceStatistics(char* interfaceName, NativeIPInterfaceStatistics* retStats)
 {

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -610,6 +610,7 @@ check_c_source_compiles(
     "
     #include <sys/types.h>
     #include <sys/socketvar.h>
+    #include <sys/queue.h>
     #include <netinet/in.h>
     #include <netinet/ip.h>
     #include <netinet/tcp.h>


### PR DESCRIPTION
I bump to this in attempt to run HTTP tests. Right now anything using NetworkInformation will blow up - event simple interface list - because that will try to create stats and it will fail.  

This is because we will fail to detect HAVE_TCP_VAR_H properly because of missing dependency header and with that whole body of pal_networkstatistics.c  will be missing.
I check and on OSX sys/queue.h also exist so improved detection should work. 
Currently two functions to get TCP connection details are stubbed out. The ioctl()calls  exist but current code to parse output does not compile. With this most of NetworkInfo should be functional and I can pass all HTTP tests now. 

cc:  @jasonpugsley @joperator