### PR TITLE
[release/3.0] Remove throw in exception handling of dispose

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsHandle.cs
@@ -51,7 +51,6 @@ namespace System.Data.SqlClient.SNI
             catch (Exception e)
             {
                 SNICommon.ReportSNIError(SNIProviders.SMUX_PROV, SNICommon.InternalExceptionError, e);
-                throw;
             }
         }
 


### PR DESCRIPTION
Back port a fix from Microsoft.Data.Sqlclient issue [#20](https://github.com/dotnet/SqlClient/issues/20).

The same PR #42457 is already merged on master branch.

**3.0 Servicing:**

### Summary
User gets `System.IO.IOException: Unable to write data to the transport connection: Broken pipe.` 
with or without MARS enabled

### Customer Impact

Customer reported.

Users using older verions of EFCore (< 3.0) cannot use Microsoft.Data.SqlClient. They need this change in order to not get the `Unable to write data to the transport connection: Broken pipe` error intermittently.

### Regression?

No, this exist in 2.1 as well.

### Risk

Low: The code change is already in Microsoft.Data.SqlClient, and users have reported the fix works for them.