### PR TITLE
[release/2.1] Remove throw in exception handling of dispose

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsHandle.cs
@@ -67,7 +67,6 @@ namespace System.Data.SqlClient.SNI
             catch (Exception e)
             {
                 SNICommon.ReportSNIError(SNIProviders.SMUX_PROV, SNICommon.InternalExceptionError, e);
-                throw;
             }
         }
 


### PR DESCRIPTION
Back port a fix from Microsoft.Data.Sqlclient issue [#20](https://github.com/dotnet/SqlClient/issues/20). Recent issues: https://github.com/dotnet/corefx/issues/42586

The same PR #42457 is already merged on master branch.

**2.1 Servicing:**

### Summary
User gets `System.IO.IOException: Unable to write data to the transport connection: Broken pipe.` 
with or without MARS enabled

### Customer Impact

Users using older verions of EFCore (< 3.0) cannot use Microsoft.Data.SqlClient. They need this change in order to not get the `Unable to write data to the transport connection: Broken pipe` error intermittently.

This has recently been escalated by the field, working with  an ISV customer. Have not yet verified the version they are deployed on.

Also there's several recent customer reports - about 8 distinct reports in the linked issue eg
https://github.com/dotnet/SqlClient/issues/20#issuecomment-547892706
https://github.com/dotnet/SqlClient/issues/20#issuecomment-512055330
Most of these customers seem to be on 2.2, not 2.1.

### Regression?

No, this exist in 2.0 as well.

### Risk

Low: The code change is already in Microsoft.Data.SqlClient, and users have reported the fix works for them.