### PR TITLE
Fix EventWaitHandle/Mutex/Semaphore name max length unit tests failure

### DIFF
--- a/src/System.Threading.AccessControl/tests/EventWaitHandleAclTests.cs
+++ b/src/System.Threading.AccessControl/tests/EventWaitHandleAclTests.cs
@@ -92,7 +92,9 @@ namespace System.Threading.Tests
         [Fact]
         public void EventWaitHandle_Create_BeyondMaxPathLength()
         {
-            string name = new string('x', Interop.Kernel32.MAX_PATH + 100);
+            // GetRandomName prevents name collision when two tests run at the same time
+            string name = GetRandomName() + new string('x', Interop.Kernel32.MAX_PATH);
+
             EventWaitHandleSecurity security = GetBasicEventWaitHandleSecurity();
             EventResetMode mode = EventResetMode.AutoReset;
 

--- a/src/System.Threading.AccessControl/tests/MutexAclTests.cs
+++ b/src/System.Threading.AccessControl/tests/MutexAclTests.cs
@@ -42,7 +42,8 @@ namespace System.Threading.Tests
         [Fact]
         public void Mutex_Create_BeyondMaxPathLength()
         {
-            string name = new string('x', Interop.Kernel32.MAX_PATH + 100);
+            // GetRandomName prevents name collision when two tests run at the same time
+            string name = GetRandomName() + new string('x', Interop.Kernel32.MAX_PATH);
 
             if (PlatformDetection.IsFullFramework)
             {

--- a/src/System.Threading.AccessControl/tests/SemaphoreAclTests.cs
+++ b/src/System.Threading.AccessControl/tests/SemaphoreAclTests.cs
@@ -90,7 +90,8 @@ namespace System.Threading.Tests
         [Fact]
         public void Semaphore_Create_BeyondMaxPathLength()
         {
-            string name = new string('x', Interop.Kernel32.MAX_PATH + 100);
+            // GetRandomName prevents name collision when two tests run at the same time
+            string name = GetRandomName() + new string('x', Interop.Kernel32.MAX_PATH);
 
             if (PlatformDetection.IsFullFramework)
             {


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/42470

There can only be one EventWaitHandle/Mutex/Semaphore with a particular name. So if the unit tests testing the max length run at the same time in the same machine, they'll fail.

Unit tests with this problem:

- EventWaitHandle_Create_BeyondMaxPathLength
- Mutex_Create_BeyondMaxPathLength
- Semaphore_Create_BeyondMaxPathLength
