### PR TITLE
fix sockets tests on FreeBSD

### DIFF
--- a/src/Native/Unix/Common/pal_config.h.in
+++ b/src/Native/Unix/Common/pal_config.h.in
@@ -49,6 +49,7 @@
 #cmakedefine01 HAVE_KQUEUE
 #cmakedefine01 HAVE_SENDFILE_4
 #cmakedefine01 HAVE_SENDFILE_6
+#cmakedefine01 HAVE_SENDFILE_7
 #cmakedefine01 HAVE_CLONEFILE
 #cmakedefine01 HAVE_GETNAMEINFO_SIGNED_FLAGS
 #cmakedefine01 HAVE_GETPEEREID

--- a/src/Native/Unix/System.Native/pal_networking.c
+++ b/src/Native/Unix/System.Native/pal_networking.c
@@ -2821,12 +2821,16 @@ int32_t SystemNative_SendFile(intptr_t out_fd, intptr_t in_fd, int64_t offset, i
     *sent = 0;
     return SystemNative_ConvertErrorPlatformToPal(errno);
 
-#elif HAVE_SENDFILE_6
+#elif HAVE_SENDFILE_6 || HAVE_SENDFILE_7
     *sent = 0;
     while (1) // in case we need to retry for an EINTR
     {
         off_t len = count;
+#if HAVE_SENDFILE_7
+        ssize_t res = sendfile(infd, outfd, (off_t)offset, (size_t)count, NULL, &len, 0);
+#else
         ssize_t res = sendfile(infd, outfd, (off_t)offset, &len, NULL, 0);
+#endif
         assert(len >= 0);
 
         // If the call succeeded, store the number of bytes sent, and return.  We add

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -359,6 +359,16 @@ check_c_source_compiles(
     "
     HAVE_SENDFILE_6)
 
+check_c_source_compiles(
+    "
+    #include <stdlib.h>
+    #include <sys/types.h>
+    #include <sys/socket.h>
+    #include <sys/uio.h>
+    int main(void) { int i = sendfile(0, 0, 0, 0, NULL, NULL, 0); return 0; }
+    "
+    HAVE_SENDFILE_7)
+
 check_symbol_exists(
     clonefile
     "sys/clonefile.h"

--- a/src/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -88,7 +88,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(~TestPlatforms.OSX)] // Not supported on OSX.
+        [PlatformSpecific(~(TestPlatforms.OSX | TestPlatforms.FreeBSD))] // Not supported on BSD like OSes.
         public async Task ConnectGetsCanceledByDispose()
         {
             bool usesApm = UsesApm ||

--- a/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
@@ -2419,6 +2419,11 @@ namespace System.Net.Sockets.Tests
             {
                 Assert.True(socket.DualMode);
             }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD))
+            {
+                // This is not valid check on FreeBSD.
+                // Accepted socket is never DualMode and cannot be changed.
+            }
             else
             {
                 Assert.True((listenOn != IPAddress.IPv6Any && !listenOn.IsIPv4MappedToIPv6) || socket.DualMode);

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -766,7 +766,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [PlatformSpecific(~TestPlatforms.OSX)] // SendBufferSize, ReceiveBufferSize = 0 not supported on OSX.
+        [PlatformSpecific(~(TestPlatforms.OSX | TestPlatforms.FreeBSD))] // SendBufferSize, ReceiveBufferSize = 0 not supported on BSD like stacks.
         public async Task SendRecv_NoBuffering_Success()
         {
             if (UsesSync) return;

--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -129,7 +129,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // Skip on Nano: dotnet/corefx #29929
-        [PlatformSpecific(~TestPlatforms.OSX)]
+        [PlatformSpecific(~(TestPlatforms.OSX | TestPlatforms.FreeBSD))]
         public async Task MulticastInterface_Set_IPv6_AnyInterface_Succeeds()
         {
             if (PlatformDetection.IsRedHatFamily7)
@@ -244,6 +244,7 @@ namespace System.Net.Sockets.Tests
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // In WSL, the connect() call fails immediately.
         [InlineData(false)]
         [InlineData(true)]
+        [PlatformSpecific(~TestPlatforms.FreeBSD)] // on FreeBSD Connect may or may not fail immediately based on timing.
         public void FailedConnect_GetSocketOption_SocketOptionNameError(bool simpleGet)
         {
             using (var client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp) { Blocking = false })

--- a/src/System.Net.Sockets/tests/FunctionalTests/UdpClientTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/UdpClientTest.cs
@@ -256,7 +256,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [PlatformSpecific(~TestPlatforms.OSX)] // macOS doesn't have an equivalent of DontFragment
+        [PlatformSpecific(~(TestPlatforms.OSX | TestPlatforms.FreeBSD))] // BSD like doesn't have an equivalent of DontFragment
         [Fact]
         public void DontFragment_Roundtrips()
         {


### PR DESCRIPTION
We had ~50 failing tests on FreeBSD. There were 3 major groups:
- We did not detect properly sendfile() as it is different than OSX. With that, all file stream tests were failing. FreeBSD have extra parameter to pass in length instead of using one for both in and out size like OSX.
- DualMode sockets assume that accepted socket will also be DualMode for some reason. 
That does not work on FreeBSD. The accepting or connecting socket can be DualMode but when new connection is accepted new socket is not marked as DualMode. Since the connect and accept work with various address combination I assume that is OK.
- FreeBSD network stack behaves similar to OSX. Some tests were excluded or not applicable on OSX and some of them behave same on FreeBSD.  

```
 /usr/home/furt/git/wfurt-corefx/artifacts/bin/testhost/netcoreapp-FreeBSD-Debug-x64/dotnet exec --runtimeconfig System.Net.Sockets.Tests.runtimeconfig.json xunit.console.dll System.Net.Sockets.Tests.dll -xml testResults.xml -nologo -notrait category=nonnetcoreapptests -notrait category=nonfreebsdtests -notrait category=OuterLoop -notrait category=failing -nocolor
  popd
  ===========================================================================================================
  /usr/home/furt/git/wfurt-corefx/artifacts/bin/System.Net.Sockets.Tests/netcoreapp-Unix-Debug ~/git/wfurt-corefx/src/System.Net.Sockets/tests/FunctionalTests
    Discovering: System.Net.Sockets.Tests (method display = ClassAndMethod, method display options = None)
    Discovered:  System.Net.Sockets.Tests (found 734 of 1110 test cases)
    Starting:    System.Net.Sockets.Tests (parallel test collections = on, max threads = 2)
      System.Net.Sockets.Tests.KeepAliveTest.Socket_KeepAlive_RetryCount_Failure [SKIP]
        Condition(s) not met: "IsWindowsBelow1703"
      System.Net.Sockets.Tests.CreateSocket.Ctor_Raw_Supported_Success [SKIP]
        Condition(s) not met: "SupportsRawSockets"
      System.Net.Sockets.Tests.UnixDomainSocketTest.Socket_CreateUnixDomainSocket_Throws_OnWindows [SKIP]
        Condition(s) not met: "IsSubWindows10"
    Finished:    System.Net.Sockets.Tests
  === TEST EXECUTION SUMMARY ===
     System.Net.Sockets.Tests  Total: 954, Errors: 0, Failed: 0, Skipped: 3, Time: 12.177s
  ~/git/wfurt-corefx/src/System.Net.Sockets/tests/FunctionalTests
  ----- end Sat Nov 9 12:52:17 PST 2019 ----- exit code 0 ----------------------------------------------------------
  exit code 0 means Exited Successfully

```