### PR TITLE
initial support for serial port on FreeBSD

### DIFF
--- a/src/System.IO.Ports/src/Configurations.props
+++ b/src/System.IO.Ports/src/Configurations.props
@@ -4,6 +4,7 @@
       netstandard2.0-Windows_NT;
       netstandard2.0-Linux;
       netstandard2.0-OSX;
+      netstandard2.0-FreeBSD;
       netstandard2.0;
       net461-Windows_NT;
     </PackageConfigurations>

--- a/src/System.IO.Ports/src/System.IO.Ports.csproj
+++ b/src/System.IO.Ports/src/System.IO.Ports.csproj
@@ -7,7 +7,7 @@
     <IncludeDllSafeSearchPathAttribute>true</IncludeDllSafeSearchPathAttribute>
     <Configurations>net461-Windows_NT-Debug;net461-Windows_NT-Release;netfx-Windows_NT-Debug;netfx-Windows_NT-Release;netstandard2.0-Debug;netstandard2.0-Linux-Debug;netstandard2.0-Linux-Release;netstandard2.0-OSX-Debug;netstandard2.0-OSX-Release;netstandard2.0-Release;netstandard2.0-Windows_NT-Debug;netstandard2.0-Windows_NT-Release</Configurations>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetsNetStandard)' == 'true'">
+  <ItemGroup Condition="'$(TargetsNetStandard)' == 'true' and '$(OSGroup)' != 'AnyOS'">
     <Compile Include="System\IO\Ports\Handshake.cs" />
     <Compile Include="System\IO\Ports\InternalResources.cs" />
     <Compile Include="System\IO\Ports\Parity.cs" />

--- a/src/System.IO.Ports/src/System.IO.Ports.csproj
+++ b/src/System.IO.Ports/src/System.IO.Ports.csproj
@@ -2,12 +2,12 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly Condition="'$(TargetsNetFx)' == 'true'">true</IsPartialFacadeAssembly>
-    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsNetStandard)' == 'true' and '$(TargetsWindows)' != 'true' and '$(TargetsLinux)' != 'true' and '$(TargetsOSX)' != 'true' and '$(TargetsFreeBSD)' != 'true'">SR.PlatformNotSupported_IOPorts</GeneratePlatformNotSupportedAssemblyMessage>
+    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsNetStandard)' == 'true' and '$(OSGroup)' == 'AnyOS'">SR.PlatformNotSupported_IOPorts</GeneratePlatformNotSupportedAssemblyMessage>
     <DefineConstants>$(DefineConstants);NOSPAN</DefineConstants>
     <IncludeDllSafeSearchPathAttribute>true</IncludeDllSafeSearchPathAttribute>
     <Configurations>net461-Windows_NT-Debug;net461-Windows_NT-Release;netfx-Windows_NT-Debug;netfx-Windows_NT-Release;netstandard2.0-Debug;netstandard2.0-Linux-Debug;netstandard2.0-Linux-Release;netstandard2.0-OSX-Debug;netstandard2.0-OSX-Release;netstandard2.0-Release;netstandard2.0-Windows_NT-Debug;netstandard2.0-Windows_NT-Release</Configurations>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetsNetFx)' != 'true' and ('$(TargetsWindows)' == 'true' or '$(TargetsLinux)' == 'true' or '$(TargetsOSX)' == 'true' or '$(TargetsFreeBSD)' == 'true')">
+  <ItemGroup Condition="'$(TargetsNetStandard)' == 'true'">
     <Compile Include="System\IO\Ports\Handshake.cs" />
     <Compile Include="System\IO\Ports\InternalResources.cs" />
     <Compile Include="System\IO\Ports\Parity.cs" />

--- a/src/System.IO.Ports/src/System.IO.Ports.csproj
+++ b/src/System.IO.Ports/src/System.IO.Ports.csproj
@@ -2,12 +2,12 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly Condition="'$(TargetsNetFx)' == 'true'">true</IsPartialFacadeAssembly>
-    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsNetStandard)' == 'true' and '$(TargetsWindows)' != 'true' and '$(TargetsLinux)' != 'true' and '$(TargetsOSX)' != 'true'">SR.PlatformNotSupported_IOPorts</GeneratePlatformNotSupportedAssemblyMessage>
+    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsNetStandard)' == 'true' and '$(TargetsWindows)' != 'true' and '$(TargetsLinux)' != 'true' and '$(TargetsOSX)' != 'true' and '$(TargetsFreeBSD)' != 'true'">SR.PlatformNotSupported_IOPorts</GeneratePlatformNotSupportedAssemblyMessage>
     <DefineConstants>$(DefineConstants);NOSPAN</DefineConstants>
     <IncludeDllSafeSearchPathAttribute>true</IncludeDllSafeSearchPathAttribute>
     <Configurations>net461-Windows_NT-Debug;net461-Windows_NT-Release;netfx-Windows_NT-Debug;netfx-Windows_NT-Release;netstandard2.0-Debug;netstandard2.0-Linux-Debug;netstandard2.0-Linux-Release;netstandard2.0-OSX-Debug;netstandard2.0-OSX-Release;netstandard2.0-Release;netstandard2.0-Windows_NT-Debug;netstandard2.0-Windows_NT-Release</Configurations>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetsNetFx)' != 'true' and ('$(TargetsWindows)' == 'true' or '$(TargetsLinux)' == 'true' or '$(TargetsOSX)' == 'true')">
+  <ItemGroup Condition="'$(TargetsNetFx)' != 'true' and ('$(TargetsWindows)' == 'true' or '$(TargetsLinux)' == 'true' or '$(TargetsOSX)' == 'true' or '$(TargetsFreeBSD)' == 'true')">
     <Compile Include="System\IO\Ports\Handshake.cs" />
     <Compile Include="System\IO\Ports\InternalResources.cs" />
     <Compile Include="System\IO\Ports\Parity.cs" />
@@ -145,7 +145,10 @@
   <ItemGroup Condition=" '$(TargetsOSX)' == 'true' ">
     <Compile Include="System\IO\Ports\SerialPort.OSX.cs" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetsLinux)' == 'true'  or '$(TargetsOSX)' == 'true'">
+  <ItemGroup Condition=" '$(TargetsFreeBSD)' == 'true' ">
+    <Compile Include="System\IO\Ports\SerialPort.FreeBSD.cs" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetsLinux)' == 'true' or '$(TargetsOSX)' == 'true' or '$(TargetsFreeBSD)' == 'true'">
     <Compile Include="System\IO\Ports\SafeSerialDeviceHandle.Unix.cs" />
     <Compile Include="System\IO\Ports\SerialStream.Unix.cs" />
     <Compile Include="Interop\Unix\Interop.Termios.cs" />

--- a/src/System.IO.Ports/src/System/IO/Ports/SerialPort.FreeBSD.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/SerialPort.FreeBSD.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel;
+using System.Collections.Generic;
+using System.IO;
+
+namespace System.IO.Ports
+{
+    public partial class SerialPort : Component
+    {
+        public static string[] GetPortNames()
+        {
+            List<string> ports = new List<string>();
+
+            foreach (string name in Directory.GetFiles("/dev", "ttyd*"))
+            {
+                ports.Add(name);
+            }
+
+            foreach (string name in Directory.GetFiles("/dev", "cuad*"))
+            {
+                ports.Add(name);
+            }
+
+            return ports.ToArray();
+        }
+    }
+}

--- a/src/System.IO.Ports/src/System/IO/Ports/SerialPort.FreeBSD.cs
+++ b/src/System.IO.Ports/src/System/IO/Ports/SerialPort.FreeBSD.cs
@@ -17,12 +17,18 @@ namespace System.IO.Ports
 
             foreach (string name in Directory.GetFiles("/dev", "ttyd*"))
             {
-                ports.Add(name);
+                if (!name.EndsWith(".init") && !name.EndsWith(".lock"))
+                {
+                    ports.Add(name);
+                }
             }
 
-            foreach (string name in Directory.GetFiles("/dev", "cuad*"))
+            foreach (string name in Directory.GetFiles("/dev", "cuau*"))
             {
-                ports.Add(name);
+                if (!name.EndsWith(".init") && !name.EndsWith(".lock"))
+                {
+                    ports.Add(name);
+                }
             }
 
             return ports.ToArray();

--- a/src/System.IO.Ports/tests/Configurations.props
+++ b/src/System.IO.Ports/tests/Configurations.props
@@ -4,6 +4,7 @@
       netcoreapp-Windows_NT;
       netcoreapp-Linux;
       netcoreapp-OSX;
+      netcoreapp-FreeBSD;
       netfx;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.IO.Ports/tests/Support/PortHelper.cs
+++ b/src/System.IO.Ports/tests/Support/PortHelper.cs
@@ -22,7 +22,7 @@ namespace Legacy.Support
 
         public static string[] GetPorts()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD))
+            if (!PlatformDetection.IsWindows())
             {
                 return SerialPort.GetPortNames();
             }

--- a/src/System.IO.Ports/tests/Support/PortHelper.cs
+++ b/src/System.IO.Ports/tests/Support/PortHelper.cs
@@ -22,7 +22,7 @@ namespace Legacy.Support
 
         public static string[] GetPorts()
         {
-            if (!PlatformDetection.IsWindows())
+            if (!PlatformDetection.IsWindows)
             {
                 return SerialPort.GetPortNames();
             }

--- a/src/System.IO.Ports/tests/Support/PortHelper.cs
+++ b/src/System.IO.Ports/tests/Support/PortHelper.cs
@@ -22,7 +22,7 @@ namespace Legacy.Support
 
         public static string[] GetPorts()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD))
             {
                 return SerialPort.GetPortNames();
             }

--- a/src/pkg/runtime.native.System.IO.Ports/netcoreapp.rids.props
+++ b/src/pkg/runtime.native.System.IO.Ports/netcoreapp.rids.props
@@ -8,5 +8,6 @@
     </BuildRID>
     <BuildRID Include="linux-x64" />
     <BuildRID Include="osx-x64" />
+    <BuildRID Include="freebsd-x64" />
   </ItemGroup>
 </Project>

--- a/src/pkg/runtime.native.System.IO.Ports/runtime.native.System.IO.Ports.pkgproj
+++ b/src/pkg/runtime.native.System.IO.Ports/runtime.native.System.IO.Ports.pkgproj
@@ -4,7 +4,7 @@
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <SkipValidatePackage>true</SkipValidatePackage>
   </PropertyGroup>
-  <ItemGroup Condition="'$(PackageTargetRuntime)' == 'linux-arm' or '$(PackageTargetRuntime)' == 'linux-arm64' or '$(PackageTargetRuntime)' == 'linux-x64' or '$(PackageTargetRuntime)' == 'osx-x64'">
+  <ItemGroup Condition="'$(PackageTargetRuntime)' == 'linux-arm' or '$(PackageTargetRuntime)' == 'linux-arm64' or '$(PackageTargetRuntime)' == 'linux-x64' or '$(PackageTargetRuntime)' == 'osx-x64' or '$(PackageTargetRuntime)' == 'freebsd-x64'">
     <File Include="$(NativeBinDir)\System.IO.Ports.Native$(LibraryFileExtension)" >
       <TargetPath>runtimes/$(PackageRID)/native</TargetPath>
     </File>


### PR DESCRIPTION
I did some testing while back when I was working on Serial port but that never made it to product. FreeBSD has standard Unix termios and everything should just work. 
For port names, I used guidance from https://www.freebsd.org/doc/en_US.ISO8859-1/books/faq/serial.html

minimal set of tests will pass
```
  /usr/home/furt/git/wfurt-corefx/artifacts/bin/testhost/netcoreapp-FreeBSD-Debug-x64/dotnet exec --runtimeconfig System.IO.Ports.Tests.runtimeconfig.json xunit.console.dll System.IO.Ports.Tests.dll -xml testResults.xml -nologo -notrait category=nonnetcoreapptests -notrait category=nonfreebsdtests -notrait category=OuterLoop -notrait category=failing
  popd
  ===========================================================================================================
  /usr/home/furt/git/wfurt-corefx/artifacts/bin/System.IO.Ports.Tests/netcoreapp-FreeBSD-Debug ~/git/wfurt-corefx/src/System.IO.Ports/tests
    Discovering: System.IO.Ports.Tests (method display = ClassAndMethod, method display options = None)
  Installed ports : /dev/cuau0
  Openable ports  : /dev/cuau0
  No support hardware - not using serial ports
  First available port name  :
  Second available port name :
  Loopback port name         :
  NullModem present          : False
    Discovered:  System.IO.Ports.Tests (found 954 of 978 test cases)
    Starting:    System.IO.Ports.Tests (parallel test collections = on, max threads = 2)
...
...
    Finished:    System.IO.Ports.Tests
  === TEST EXECUTION SUMMARY ===
     System.IO.Ports.Tests  Total: 954, Errors: 0, Failed: 0, Skipped: 832, Time: 0.444s
  ~/git/wfurt-corefx/src/System.IO.Ports/tests
  ----- end Sat Nov 9 20:35:33 PST 2019 ----- exit code 0 ----------------------------------------------------------
  exit code 0 means Exited Successfully
```
