### PR TITLE
Fix NegotitateStream (server) on Linux for NTLM

### DIFF
--- a/src/Common/src/Interop/Unix/System.Net.Security.Native/Interop.GssBuffer.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Security.Native/Interop.GssBuffer.cs
@@ -12,7 +12,7 @@ internal static partial class Interop
     internal static partial class NetSecurityNative
     {
         [StructLayout(LayoutKind.Sequential)]
-        internal unsafe struct GssBuffer : IDisposable
+        internal struct GssBuffer : IDisposable
         {
             internal ulong _length;
             internal IntPtr _data;
@@ -51,6 +51,10 @@ internal static partial class Interop
                 Marshal.Copy(_data, destination, 0, destinationLength);
                 return destination;
             }
+
+            internal unsafe ReadOnlySpan<byte> Span => (_data != IntPtr.Zero && _length != 0) ?
+                new ReadOnlySpan<byte>(_data.ToPointer(), checked((int)_length)) :
+                default;
 
             public void Dispose()
             {

--- a/src/Common/src/Interop/Unix/System.Net.Security.Native/Interop.NetSecurityNative.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Security.Native/Interop.NetSecurityNative.cs
@@ -48,6 +48,11 @@ internal static partial class Interop
             out Status minorStatus,
             ref IntPtr inputName);
 
+        [DllImport(Interop.Libraries.NetSecurityNative, EntryPoint="NetSecurityNative_AcquireAcceptorCred")]
+        internal static extern Status AcquireAcceptorCred(
+            out Status minorStatus,
+            out SafeGssCredHandle outputCredHandle);
+
         [DllImport(Interop.Libraries.NetSecurityNative, EntryPoint="NetSecurityNative_InitiateCredSpNego")]
         internal static extern Status InitiateCredSpNego(
             out Status minorStatus,
@@ -101,11 +106,13 @@ internal static partial class Interop
         [DllImport(Interop.Libraries.NetSecurityNative, EntryPoint="NetSecurityNative_AcceptSecContext")]
         internal static extern Status AcceptSecContext(
             out Status minorStatus,
+            SafeGssCredHandle acceptorCredHandle,
             ref SafeGssContextHandle acceptContextHandle,
             byte[] inputBytes,
             int inputLength,
             ref GssBuffer token,
-            out uint retFlags);
+            out uint retFlags,
+            out bool isNtlmUsed);
 
         [DllImport(Interop.Libraries.NetSecurityNative, EntryPoint="NetSecurityNative_DeleteSecContext")]
         internal static extern Status DeleteSecContext(

--- a/src/Common/src/Microsoft/Win32/SafeHandles/GssSafeHandles.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/GssSafeHandles.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Win32.SafeHandles
             status = Interop.NetSecurityNative.AcquireAcceptorCred(out minorStatus, out retHandle);
             if (status != Interop.NetSecurityNative.Status.GSS_S_COMPLETE)
             {
-                throw new Interop.NetSecurityNative.GssApiException(status, minorStatus, null);
+                throw new Interop.NetSecurityNative.GssApiException(status, minorStatus);
             }
 
             return retHandle;
@@ -125,7 +125,7 @@ namespace Microsoft.Win32.SafeHandles
                 if (status != Interop.NetSecurityNative.Status.GSS_S_COMPLETE)
                 {
                     retHandle.Dispose();
-                    throw new Interop.NetSecurityNative.GssApiException(status, minorStatus, null);
+                    throw new Interop.NetSecurityNative.GssApiException(status, minorStatus);
                 }
             }
 

--- a/src/Common/src/Microsoft/Win32/SafeHandles/GssSafeHandles.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/GssSafeHandles.cs
@@ -74,6 +74,21 @@ namespace Microsoft.Win32.SafeHandles
     {
         private static readonly Lazy<bool> s_IsNtlmInstalled = new Lazy<bool>(InitIsNtlmInstalled);
 
+        public static SafeGssCredHandle CreateAcceptor()
+        {
+            SafeGssCredHandle retHandle = null;
+            Interop.NetSecurityNative.Status status;
+            Interop.NetSecurityNative.Status minorStatus;
+
+            status = Interop.NetSecurityNative.AcquireAcceptorCred(out minorStatus, out retHandle);
+            if (status != Interop.NetSecurityNative.Status.GSS_S_COMPLETE)
+            {
+                throw new Interop.NetSecurityNative.GssApiException(status, minorStatus, null);
+            }
+
+            return retHandle;
+        }
+
         /// <summary>
         ///  returns the handle for the given credentials.
         ///  The method returns an invalid handle if the username is null or empty.

--- a/src/Common/src/System/Net/Security/NegotiateStreamPal.Unix.cs
+++ b/src/Common/src/System/Net/Security/NegotiateStreamPal.Unix.cs
@@ -187,10 +187,14 @@ namespace System.Net.Security
 
         private static bool GssAcceptSecurityContext(
             ref SafeGssContextHandle context,
+            SafeGssCredHandle credential,
             byte[] buffer,
             out byte[] outputBuffer,
-            out uint outFlags)
+            out uint outFlags,
+            out bool isNtlmUsed)
         {
+            Debug.Assert(credential != null);
+
             bool newContext = false;
             if (context == null)
             {
@@ -205,11 +209,13 @@ namespace System.Net.Security
             {
                 Interop.NetSecurityNative.Status minorStatus;
                 status = Interop.NetSecurityNative.AcceptSecContext(out minorStatus,
+                                                                    credential,
                                                                     ref context,
                                                                     buffer,
                                                                     buffer?.Length ?? 0,
                                                                     ref token,
-                                                                    out outFlags);
+                                                                    out outFlags,
+                                                                    out isNtlmUsed);
 
                 if ((status != Interop.NetSecurityNative.Status.GSS_S_COMPLETE) &&
                     (status != Interop.NetSecurityNative.Status.GSS_S_CONTINUE_NEEDED))
@@ -249,7 +255,15 @@ namespace System.Net.Security
                     throw new Interop.NetSecurityNative.GssApiException(status, minorStatus);
                 }
 
-                return Encoding.UTF8.GetString(token.ToByteArray());
+                byte[] tokenBytes = token.ToByteArray();
+                int length = tokenBytes.Length;
+                if (length > 0 && tokenBytes[length - 1] == '\0')
+                {
+                    // Some GSS-API providers (gss-ntlmssp) include the terminating null with strings, so skip that.
+                    --length;
+                }
+
+                return Encoding.UTF8.GetString(tokenBytes, 0, length);
             }
             finally
             {
@@ -396,9 +410,11 @@ namespace System.Net.Security
                 SafeGssContextHandle contextHandle = negoContext.GssContext;
                 bool done = GssAcceptSecurityContext(
                    ref contextHandle,
+                   negoContext.AcceptorCredential,
                    incomingBlob,
                    out resultBlob,
-                   out uint outputFlags);
+                   out uint outputFlags,
+                   out bool isNtlmUsed);
 
                 Debug.Assert(resultBlob != null, "Unexpected null buffer returned by GssApi");
                 Debug.Assert(negoContext.GssContext == null || contextHandle == negoContext.GssContext);
@@ -413,9 +429,22 @@ namespace System.Net.Security
                 contextFlags = ContextFlagsAdapterPal.GetContextFlagsPalFromInterop(
                     (Interop.NetSecurityNative.GssFlags)outputFlags, isServer: true);
 
-                SecurityStatusPalErrorCode errorCode = done ?
-                    (negoContext.IsNtlmUsed && resultBlob.Length > 0 ? SecurityStatusPalErrorCode.OK : SecurityStatusPalErrorCode.CompleteNeeded) :
-                    SecurityStatusPalErrorCode.ContinueNeeded;
+                SecurityStatusPalErrorCode errorCode;
+                if (done)
+                {
+                    if (NetEventSource.IsEnabled)
+                    {
+                        string protocol = isNtlmUsed ? "SPNEGO-NTLM" : "SPNEGO-Kerberos";
+                        NetEventSource.Info(null, $"AcceptSecurityContext: actual protocol = {protocol}");
+                    }
+
+                    negoContext.SetAuthenticationPackage(isNtlmUsed);
+                    errorCode = (isNtlmUsed && resultBlob.Length > 0) ? SecurityStatusPalErrorCode.OK : SecurityStatusPalErrorCode.CompleteNeeded;
+                }
+                else
+                {
+                    errorCode = SecurityStatusPalErrorCode.ContinueNeeded;
+                }
 
                 return new SecurityStatusPal(errorCode);
             }

--- a/src/Common/src/System/Net/Security/NegotiateStreamPal.Unix.cs
+++ b/src/Common/src/System/Net/Security/NegotiateStreamPal.Unix.cs
@@ -255,15 +255,15 @@ namespace System.Net.Security
                     throw new Interop.NetSecurityNative.GssApiException(status, minorStatus);
                 }
 
-                byte[] tokenBytes = token.ToByteArray();
+                ReadOnlySpan<byte> tokenBytes = token.Span;
                 int length = tokenBytes.Length;
                 if (length > 0 && tokenBytes[length - 1] == '\0')
                 {
                     // Some GSS-API providers (gss-ntlmssp) include the terminating null with strings, so skip that.
-                    --length;
+                    tokenBytes = tokenBytes.Slice(0, length - 1);
                 }
 
-                return Encoding.UTF8.GetString(tokenBytes, 0, length);
+                return Encoding.UTF8.GetString(tokenBytes);
             }
             finally
             {
@@ -288,7 +288,7 @@ namespace System.Net.Security
                 if (NetEventSource.IsEnabled)
                 {
                     string protocol = isNtlmOnly ? "NTLM" : "SPNEGO";
-                    NetEventSource.Info(null, $"requested protocol = {protocol}, target = {targetName}");
+                    NetEventSource.Info(context, $"requested protocol = {protocol}, target = {targetName}");
                 }
 
                 context = new SafeDeleteNegoContext(credential, targetName);
@@ -319,7 +319,7 @@ namespace System.Net.Security
                     if (NetEventSource.IsEnabled)
                     {
                         string protocol = isNtlmOnly ? "NTLM" : isNtlmUsed ? "SPNEGO-NTLM" : "SPNEGO-Kerberos";
-                        NetEventSource.Info(null, $"actual protocol = {protocol}");
+                        NetEventSource.Info(context, $"actual protocol = {protocol}");
                     }
 
                     // Populate protocol used for authentication
@@ -435,7 +435,7 @@ namespace System.Net.Security
                     if (NetEventSource.IsEnabled)
                     {
                         string protocol = isNtlmUsed ? "SPNEGO-NTLM" : "SPNEGO-Kerberos";
-                        NetEventSource.Info(null, $"AcceptSecurityContext: actual protocol = {protocol}");
+                        NetEventSource.Info(securityContext, $"AcceptSecurityContext: actual protocol = {protocol}");
                     }
 
                     negoContext.SetAuthenticationPackage(isNtlmUsed);

--- a/src/Common/src/System/Net/Security/Unix/SafeDeleteNegoContext.cs
+++ b/src/Common/src/System/Net/Security/Unix/SafeDeleteNegoContext.cs
@@ -21,11 +21,7 @@ namespace System.Net.Security
         {
             get
             {
-                if (_acceptorCredential == null)
-                {
-                    _acceptorCredential = SafeGssCredHandle.CreateAcceptor();
-                }
-
+                _acceptorCredential ??= SafeGssCredHandle.CreateAcceptor();
                 return _acceptorCredential;
             }
         }

--- a/src/Common/src/System/Net/Security/Unix/SafeDeleteNegoContext.cs
+++ b/src/Common/src/System/Net/Security/Unix/SafeDeleteNegoContext.cs
@@ -12,9 +12,23 @@ namespace System.Net.Security
 {
     internal sealed class SafeDeleteNegoContext : SafeDeleteContext
     {
+        private SafeGssCredHandle _acceptorCredential;
         private SafeGssNameHandle _targetName;
         private SafeGssContextHandle _context;
         private bool _isNtlmUsed;
+
+        public SafeGssCredHandle AcceptorCredential
+        {
+            get
+            {
+                if (_acceptorCredential == null)
+                {
+                    _acceptorCredential = SafeGssCredHandle.CreateAcceptor();
+                }
+
+                return _acceptorCredential;
+            }
+        }
 
         public SafeGssNameHandle TargetName
         {
@@ -77,6 +91,12 @@ namespace System.Net.Security
                 {
                     _targetName.Dispose();
                     _targetName = null;
+                }
+
+                if (_acceptorCredential != null)
+                {
+                    _acceptorCredential.Dispose();
+                    _acceptorCredential = null;
                 }
             }
             base.Dispose(disposing);

--- a/src/Native/Unix/System.Net.Security.Native/pal_gssapi.c
+++ b/src/Native/Unix/System.Net.Security.Native/pal_gssapi.c
@@ -299,13 +299,16 @@ uint32_t NetSecurityNative_InitSecContextEx(uint32_t* minorStatus,
 }
 
 uint32_t NetSecurityNative_AcceptSecContext(uint32_t* minorStatus,
+                                            GssCredId* acceptorCredHandle,
                                             GssCtxId** contextHandle,
                                             uint8_t* inputBytes,
                                             uint32_t inputLength,
                                             PAL_GssBuffer* outBuffer,
-                                            uint32_t* retFlags)
+                                            uint32_t* retFlags,
+                                            int32_t* isNtlmUsed)
 {
     assert(minorStatus != NULL);
+    assert(acceptorCredHandle != NULL);
     assert(contextHandle != NULL);
     assert(inputBytes != NULL || inputLength == 0);
     assert(outBuffer != NULL);
@@ -314,17 +317,33 @@ uint32_t NetSecurityNative_AcceptSecContext(uint32_t* minorStatus,
     GssBuffer inputToken = {.length = inputLength, .value = inputBytes};
     GssBuffer gssBuffer = {.length = 0, .value = NULL};
 
+    gss_OID mechType = GSS_C_NO_OID;
     uint32_t majorStatus = gss_accept_sec_context(minorStatus,
                                                   contextHandle,
-                                                  GSS_C_NO_CREDENTIAL,
+                                                  acceptorCredHandle,
                                                   &inputToken,
                                                   GSS_C_NO_CHANNEL_BINDINGS,
                                                   NULL,
-                                                  NULL,
+                                                  &mechType,
                                                   &gssBuffer,
                                                   retFlags,
                                                   NULL,
                                                   NULL);
+
+#if HAVE_GSS_SPNEGO_MECHANISM
+    gss_OID ntlmMech = GSS_NTLM_MECHANISM;
+#else
+    gss_OID ntlmMech = &gss_mech_ntlm_OID_desc;
+#endif
+
+    *isNtlmUsed = (gss_oid_equal(mechType, ntlmMech) != 0) ? 1 : 0;
+
+    // The gss_ntlmssp provider doesn't support impersonation or delegation but fails to set the GSS_C_IDENTIFY_FLAG
+    // flag. So, we'll set it here to keep the behavior consistent with Windows platform.
+    if (*isNtlmUsed == 1)
+    {
+        *retFlags |= GSS_C_IDENTIFY_FLAG;
+    }
 
     NetSecurityNative_MoveBuffer(&gssBuffer, outBuffer);
     return majorStatus;
@@ -492,6 +511,19 @@ static uint32_t NetSecurityNative_AcquireCredWithPassword(uint32_t* minorStatus,
 #endif
 
     return majorStatus;
+}
+
+uint32_t NetSecurityNative_AcquireAcceptorCred(uint32_t* minorStatus,
+                                               GssCredId** outputCredHandle)
+{
+    return gss_acquire_cred(minorStatus,
+                            GSS_C_NO_NAME,
+                            GSS_C_INDEFINITE,
+                            GSS_C_NO_OID_SET,
+                            GSS_C_ACCEPT,
+                            outputCredHandle,
+                            NULL,
+                            NULL);
 }
 
 uint32_t NetSecurityNative_InitiateCredWithPassword(uint32_t* minorStatus,

--- a/src/Native/Unix/System.Net.Security.Native/pal_gssapi.c
+++ b/src/Native/Unix/System.Net.Security.Native/pal_gssapi.c
@@ -312,6 +312,7 @@ uint32_t NetSecurityNative_AcceptSecContext(uint32_t* minorStatus,
     assert(contextHandle != NULL);
     assert(inputBytes != NULL || inputLength == 0);
     assert(outBuffer != NULL);
+    assert(isNtlmUsed != NULL);
     // Note: *contextHandle is null only in the first call and non-null in the subsequent calls
 
     GssBuffer inputToken = {.length = inputLength, .value = inputBytes};

--- a/src/Native/Unix/System.Net.Security.Native/pal_gssapi.h
+++ b/src/Native/Unix/System.Net.Security.Native/pal_gssapi.h
@@ -90,6 +90,11 @@ Shims the gss_release_name method.
 DLLEXPORT uint32_t NetSecurityNative_ReleaseName(uint32_t* minorStatus, GssName** inputName);
 
 /*
+Shims the gss_acquire_cred method with GSS_C_ACCEPT.
+*/
+DLLEXPORT uint32_t NetSecurityNative_AcquireAcceptorCred(uint32_t* minorStatus, GssCredId** outputCredHandle);
+
+/*
 Shims the gss_acquire_cred method with SPNEGO oids with  GSS_C_INITIATE.
 */
 DLLEXPORT uint32_t
@@ -133,11 +138,13 @@ DLLEXPORT uint32_t NetSecurityNative_InitSecContextEx(uint32_t* minorStatus,
 Shims the gss_accept_sec_context method.
 */
 DLLEXPORT uint32_t NetSecurityNative_AcceptSecContext(uint32_t* minorStatus,
+                                                      GssCredId* acceptorCredHandle,
                                                       GssCtxId** contextHandle,
                                                       uint8_t* inputBytes,
                                                       uint32_t inputLength,
                                                       PAL_GssBuffer* outBuffer,
-                                                      uint32_t* retFlags);
+                                                      uint32_t* retFlags,
+                                                      int32_t* isNtlmUsed);
 
 /*
 


### PR DESCRIPTION
This PR is a follow up to PR #36827 which added support for Linux server-side
GSS-API (AcceptSecContext). This enabled NegotitateStream AuthenticateAsServer*
support. It also provided support for ASP.NET Core to allow Kestrel server to have
Negotiate authentication on Linux.

This PR fixes some problems with Negotiate (SPNEGO) fallback from Kerberos to NTLM.
Notably it passes in a correct GSS Acceptor credential so that fallback will work
correctly. As part of fixing that, I noticed some other problems with returning the
user-identity when NTLM is used.

This was tested in a separate enterprise testing environment that I have created.
It builds on technologies that we have started using like docker containers and Azure
pipelines (e.g. HttpStress). The environment is currently [here](
https://dev.azure.com/systemnetncl/Enterprise%20Testing). The extra Kerberos tests
and container support is [here]( https://github.com/davidsh/NetworkingTests/tree/master/Containers/SingleContainer).

When the repo merge is completed, I will work with the infra team to see what things
can be merged back into the main repo/CI pipeline and migrate the test sources to an
appropriate place in the new repo.

Contributes to #10041
Contributes to #24707
Contributes to #30150