### PR TITLE
Simplified `string.Concat(object? arg0, object? arg1)`

### DIFF
--- a/src/Common/src/CoreLib/System/String.Manipulation.cs
+++ b/src/Common/src/CoreLib/System/String.Manipulation.cs
@@ -36,12 +36,12 @@ namespace System
         {
             if (arg0 == null)
             {
-                arg0 = string.Empty;
+                return arg1?.ToString() ?? string.Empty;
             }
 
             if (arg1 == null)
             {
-                arg1 = string.Empty;
+                return arg0?.ToString() ?? string.Empty;
             }
             return Concat(arg0.ToString(), arg1.ToString());
         }


### PR DESCRIPTION
Similar to `string.Concat(object? arg0)` only the other value is returned in case of a `null` value.
This saves the additional functions `.Concat(params object?[] args)` call and additional `.ToString()` calls.