### PR TITLE
Remove unnecessary assert in File_Move_Multiple_From_Watched_To_Unwatched_Mac

### DIFF
--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Move.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.Move.cs
@@ -36,7 +36,6 @@ namespace System.IO.Tests
         [InlineData(1)]
         [InlineData(2)]
         [InlineData(3)]
-        [ActiveIssue(42507, TestPlatforms.OSX)]
         public void File_Move_Multiple_From_Watched_To_Unwatched_Mac(int filesCount)
         {
             // On Mac, the FSStream aggregate old events caused by the test setup.

--- a/src/System.IO.FileSystem.Watcher/tests/Utility/FileSystemWatcherTest.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/Utility/FileSystemWatcherTest.cs
@@ -597,7 +597,6 @@ namespace System.IO.Tests
             {
                 Assert.False(true, $"Filewatcher error event triggered: { error.GetException()?.Message ?? "Unknow error" }");
             }
-            Assert.True(eventsOrrures == expectedEvents, $"Expected events ({expectedEvents}) count doesn't match triggered events count ({eventsOrrures}):{Environment.NewLine}{String.Join(Environment.NewLine, events)}");
 
             return events;
 


### PR DESCRIPTION
Assert in ExpectEvents method is not necessary as events should be evaluated in the test case, not in the utility method.

Fixes #42507 