### PR TITLE
QUIC: Change constructor overloads for passing QuicImplementationProvider

### DIFF
--- a/src/System.Net.Quic/ref/System.Net.Quic.Temporary.cs
+++ b/src/System.Net.Quic/ref/System.Net.Quic.Temporary.cs
@@ -20,6 +20,8 @@ namespace System.Net.Quic
     public static class QuicImplementationProviders
     {
         public static System.Net.Quic.Implementations.QuicImplementationProvider Mock { get { throw null; } }
+
+        public static System.Net.Quic.Implementations.QuicImplementationProvider Default { get { throw null; } }
     }
 }
 namespace System.Net.Quic.Implementations

--- a/src/System.Net.Quic/ref/System.Net.Quic.Temporary.cs
+++ b/src/System.Net.Quic/ref/System.Net.Quic.Temporary.cs
@@ -11,11 +11,11 @@ namespace System.Net.Quic
 {
     public sealed partial class QuicConnection : System.IDisposable
     {
-        public QuicConnection(IPEndPoint remoteEndPoint, System.Net.Security.SslClientAuthenticationOptions sslClientAuthenticationOptions, IPEndPoint localEndPoint = null, System.Net.Quic.Implementations.QuicImplementationProvider implementationProvider = null) { }
+        public QuicConnection(System.Net.Quic.Implementations.QuicImplementationProvider implementationProvider, IPEndPoint remoteEndPoint, System.Net.Security.SslClientAuthenticationOptions sslClientAuthenticationOptions, IPEndPoint localEndPoint = null) { }
     }
     public sealed partial class QuicListener : IDisposable
     {
-        public QuicListener(IPEndPoint listenEndPoint, System.Net.Security.SslServerAuthenticationOptions sslServerAuthenticationOptions, System.Net.Quic.Implementations.QuicImplementationProvider implementationProvider = null) { }
+        public QuicListener(System.Net.Quic.Implementations.QuicImplementationProvider implementationProvider, IPEndPoint listenEndPoint, System.Net.Security.SslServerAuthenticationOptions sslServerAuthenticationOptions) { }
     }
     public static class QuicImplementationProviders
     {

--- a/src/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -20,7 +20,7 @@ namespace System.Net.Quic
         /// <param name="sslClientAuthenticationOptions">TLS options</param>
         /// <param name="localEndPoint">The local endpoint to connect from.</param>
         public QuicConnection(IPEndPoint remoteEndPoint, SslClientAuthenticationOptions sslClientAuthenticationOptions, IPEndPoint localEndPoint = null)
-            : this(null, remoteEndPoint, sslClientAuthenticationOptions, localEndPoint)
+            : this(QuicImplementationProviders.Default, remoteEndPoint, sslClientAuthenticationOptions, localEndPoint)
         {
         }
 

--- a/src/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -20,12 +20,12 @@ namespace System.Net.Quic
         /// <param name="sslClientAuthenticationOptions">TLS options</param>
         /// <param name="localEndPoint">The local endpoint to connect from.</param>
         public QuicConnection(IPEndPoint remoteEndPoint, SslClientAuthenticationOptions sslClientAuthenticationOptions, IPEndPoint localEndPoint = null)
-            : this(remoteEndPoint, sslClientAuthenticationOptions, localEndPoint, implementationProvider: null)
+            : this(null, remoteEndPoint, sslClientAuthenticationOptions, localEndPoint)
         {
         }
 
         // !!! TEMPORARY: Remove "implementationProvider" before shipping
-        public QuicConnection(IPEndPoint remoteEndPoint, SslClientAuthenticationOptions sslClientAuthenticationOptions, IPEndPoint localEndPoint = null, QuicImplementationProvider implementationProvider = null)
+        public QuicConnection(QuicImplementationProvider implementationProvider, IPEndPoint remoteEndPoint, SslClientAuthenticationOptions sslClientAuthenticationOptions, IPEndPoint localEndPoint = null)
         {
             _provider = implementationProvider.CreateConnection(remoteEndPoint, sslClientAuthenticationOptions, localEndPoint);
         }

--- a/src/System.Net.Quic/src/System/Net/Quic/QuicImplementationProviders.cs
+++ b/src/System.Net.Quic/src/System/Net/Quic/QuicImplementationProviders.cs
@@ -8,6 +8,6 @@ namespace System.Net.Quic
     {
         public static Implementations.QuicImplementationProvider Mock { get; } = new Implementations.Mock.MockImplementationProvider();
 
-        public static Implementations.QuicImplementationProvider Default { get; } = Mock;
+        public static Implementations.QuicImplementationProvider Default => Mock;
     }
 }

--- a/src/System.Net.Quic/src/System/Net/Quic/QuicImplementationProviders.cs
+++ b/src/System.Net.Quic/src/System/Net/Quic/QuicImplementationProviders.cs
@@ -7,5 +7,7 @@ namespace System.Net.Quic
     public static class QuicImplementationProviders
     {
         public static Implementations.QuicImplementationProvider Mock { get; } = new Implementations.Mock.MockImplementationProvider();
+
+        public static Implementations.QuicImplementationProvider Default { get; } = Mock;
     }
 }

--- a/src/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
+++ b/src/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
@@ -19,12 +19,12 @@ namespace System.Net.Quic
         /// <param name="listenEndPoint">The local endpoint to listen on.</param>
         /// <param name="sslServerAuthenticationOptions">TLS options for the listener.</param>
         public QuicListener(IPEndPoint listenEndPoint, SslServerAuthenticationOptions sslServerAuthenticationOptions)
-            : this(listenEndPoint, sslServerAuthenticationOptions, implementationProvider: null)
+            : this(null, listenEndPoint, sslServerAuthenticationOptions)
         {
         }
 
         // !!! TEMPORARY: Remove "implementationProvider" before shipping
-        public QuicListener(IPEndPoint listenEndPoint, SslServerAuthenticationOptions sslServerAuthenticationOptions, QuicImplementationProvider implementationProvider = null)
+        public QuicListener(QuicImplementationProvider implementationProvider, IPEndPoint listenEndPoint, SslServerAuthenticationOptions sslServerAuthenticationOptions)
         {
             _provider = implementationProvider.CreateListener(listenEndPoint, sslServerAuthenticationOptions);
         }

--- a/src/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
+++ b/src/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
@@ -19,7 +19,7 @@ namespace System.Net.Quic
         /// <param name="listenEndPoint">The local endpoint to listen on.</param>
         /// <param name="sslServerAuthenticationOptions">TLS options for the listener.</param>
         public QuicListener(IPEndPoint listenEndPoint, SslServerAuthenticationOptions sslServerAuthenticationOptions)
-            : this(null, listenEndPoint, sslServerAuthenticationOptions)
+            : this(QuicImplementationProviders.Default, listenEndPoint, sslServerAuthenticationOptions)
         {
         }
 

--- a/src/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
+++ b/src/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
@@ -18,7 +18,7 @@ namespace System.Net.Quic.Tests
         [Fact]
         public async Task BasicTest()
         {
-            using (QuicListener listener = new QuicListener(new IPEndPoint(IPAddress.Loopback, 0), sslServerAuthenticationOptions: null, implementationProvider: QuicImplementationProviders.Mock))
+            using (QuicListener listener = new QuicListener(QuicImplementationProviders.Mock, new IPEndPoint(IPAddress.Loopback, 0), sslServerAuthenticationOptions: null))
             {
                 IPEndPoint listenEndPoint = listener.ListenEndPoint;
 
@@ -26,7 +26,7 @@ namespace System.Net.Quic.Tests
                     Task.Run(async () =>
                         {
                             // Client code
-                            using (QuicConnection connection = new QuicConnection(listenEndPoint, sslClientAuthenticationOptions: null, implementationProvider: QuicImplementationProviders.Mock))
+                            using (QuicConnection connection = new QuicConnection(QuicImplementationProviders.Mock, listenEndPoint, sslClientAuthenticationOptions: null))
                             {
                                 await connection.ConnectAsync();
                                 using (QuicStream stream = connection.OpenBidirectionalStream())
@@ -55,11 +55,11 @@ namespace System.Net.Quic.Tests
         [Fact]
         public async Task TestStreams()
         {
-            using (QuicListener listener = new QuicListener(new IPEndPoint(IPAddress.Loopback, 0), sslServerAuthenticationOptions: null, implementationProvider: QuicImplementationProviders.Mock))
+            using (QuicListener listener = new QuicListener(QuicImplementationProviders.Mock, new IPEndPoint(IPAddress.Loopback, 0), sslServerAuthenticationOptions: null))
             {
                 IPEndPoint listenEndPoint = listener.ListenEndPoint;
 
-                using (QuicConnection clientConnection = new QuicConnection(listenEndPoint, sslClientAuthenticationOptions: null, implementationProvider: QuicImplementationProviders.Mock))
+                using (QuicConnection clientConnection = new QuicConnection(QuicImplementationProviders.Mock, listenEndPoint, sslClientAuthenticationOptions: null))
                 {
                     Assert.False(clientConnection.Connected);
                     Assert.Equal(listenEndPoint, clientConnection.RemoteEndPoint);


### PR DESCRIPTION
Currently, the constructors without the QuicImplementationProvider arg can't be called because the optional parameters make the call ambiguous.

Fix this by changing the QuicImplementationProvider arg to be first and required.

@dotnet/http3 