### PR TITLE
SmtpConnection: add _aborted field for debugging SmtpClientTest.TestZeroTimeout hang

### DIFF
--- a/src/System.Net.Mail/src/System/Net/Mail/SmtpConnection.cs
+++ b/src/System.Net.Mail/src/System/Net/Mail/SmtpConnection.cs
@@ -40,6 +40,9 @@ namespace System.Net.Mail
         private readonly ChannelBinding _channelBindingToken = null;
         private bool _enableSsl;
         private X509CertificateCollection _clientCertificates;
+#pragma warning disable CS0414
+        private bool _aborted; // Tracks whether Abort was called, for debugging https://github.com/dotnet/corefx/issues/40711.
+#pragma warning restore CS0414
 
         internal SmtpConnection(SmtpTransport parent, SmtpClient client, ICredentialsByHost credentials, ISmtpAuthenticationModule[] authenticationModules)
         {
@@ -151,6 +154,8 @@ namespace System.Net.Mail
 
         internal void Abort()
         {
+            _aborted = true;
+
             if (!_isClosed)
             {
                 lock (this)


### PR DESCRIPTION
To debug https://github.com/dotnet/corefx/issues/40711.

cc @dotnet/ncl 