### PR TITLE
HKDF implementation

### DIFF
--- a/src/Common/src/Internal/Cryptography/HashProviderCng.cs
+++ b/src/Common/src/Internal/Cryptography/HashProviderCng.cs
@@ -21,12 +21,16 @@ namespace Internal.Cryptography
         //
         //   - "key" activates MAC hashing if present. If null, this HashProvider performs a regular old hash.
         //
-        public HashProviderCng(string hashAlgId, byte[] key)
+        public HashProviderCng(string hashAlgId, byte[] key) : this(hashAlgId, key, isHmac: key != null)
+        {
+        }
+
+        internal HashProviderCng(string hashAlgId, ReadOnlySpan<byte> key, bool isHmac)
         {
             BCryptOpenAlgorithmProviderFlags dwFlags = BCryptOpenAlgorithmProviderFlags.None;
-            if (key != null)
+            if (isHmac)
             {
-                _key = key.CloneByteArray();
+                _key = key.ToArray();
                 dwFlags |= BCryptOpenAlgorithmProviderFlags.BCRYPT_ALG_HANDLE_HMAC_FLAG;
             }
 
@@ -63,7 +67,6 @@ namespace Internal.Cryptography
                     throw Interop.BCrypt.CreateCryptographicException(ntStatus);
                 _hashSize = hashSize;
             }
-            return;
         }
 
         public sealed override unsafe void AppendHashData(ReadOnlySpan<byte> source)

--- a/src/Common/src/Interop/Windows/BCrypt/Interop.BCryptCreateHash.cs
+++ b/src/Common/src/Interop/Windows/BCrypt/Interop.BCryptCreateHash.cs
@@ -12,16 +12,13 @@ internal partial class Interop
 {
     internal partial class BCrypt
     {
-        internal static unsafe NTSTATUS BCryptCreateHash(SafeBCryptAlgorithmHandle hAlgorithm, out SafeBCryptHashHandle phHash, IntPtr pbHashObject, int cbHashObject, ReadOnlySpan<byte> secret, int cbSecret, BCryptCreateHashFlags dwFlags)
+        internal static NTSTATUS BCryptCreateHash(SafeBCryptAlgorithmHandle hAlgorithm, out SafeBCryptHashHandle phHash, IntPtr pbHashObject, int cbHashObject, ReadOnlySpan<byte> secret, int cbSecret, BCryptCreateHashFlags dwFlags)
         {
-            fixed (byte* pbSecret = secret)
-            {
-                return BCryptCreateHash(hAlgorithm, out phHash, pbHashObject, cbHashObject, pbSecret, cbSecret, dwFlags);
-            }
+            return BCryptCreateHash(hAlgorithm, out phHash, pbHashObject, cbHashObject, ref MemoryMarshal.GetReference(secret), cbSecret, dwFlags);
         }
 
         [DllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
-        private static unsafe extern NTSTATUS BCryptCreateHash(SafeBCryptAlgorithmHandle hAlgorithm, out SafeBCryptHashHandle phHash, IntPtr pbHashObject, int cbHashObject, byte* pbSecret, int cbSecret, BCryptCreateHashFlags dwFlags);
+        private static extern NTSTATUS BCryptCreateHash(SafeBCryptAlgorithmHandle hAlgorithm, out SafeBCryptHashHandle phHash, IntPtr pbHashObject, int cbHashObject, ref byte pbSecret, int cbSecret, BCryptCreateHashFlags dwFlags);
 
         [Flags]
         internal enum BCryptCreateHashFlags : int

--- a/src/Common/src/Interop/Windows/BCrypt/Interop.BCryptCreateHash.cs
+++ b/src/Common/src/Interop/Windows/BCrypt/Interop.BCryptCreateHash.cs
@@ -12,8 +12,16 @@ internal partial class Interop
 {
     internal partial class BCrypt
     {
+        internal static unsafe NTSTATUS BCryptCreateHash(SafeBCryptAlgorithmHandle hAlgorithm, out SafeBCryptHashHandle phHash, IntPtr pbHashObject, int cbHashObject, ReadOnlySpan<byte> secret, int cbSecret, BCryptCreateHashFlags dwFlags)
+        {
+            fixed (byte* pbSecret = secret)
+            {
+                return BCryptCreateHash(hAlgorithm, out phHash, pbHashObject, cbHashObject, pbSecret, cbSecret, dwFlags);
+            }
+        }
+
         [DllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
-        internal static extern NTSTATUS BCryptCreateHash(SafeBCryptAlgorithmHandle hAlgorithm, out SafeBCryptHashHandle phHash, IntPtr pbHashObject, int cbHashObject, [In, Out] byte[] pbSecret, int cbSecret, BCryptCreateHashFlags dwFlags);
+        private static unsafe extern NTSTATUS BCryptCreateHash(SafeBCryptAlgorithmHandle hAlgorithm, out SafeBCryptHashHandle phHash, IntPtr pbHashObject, int cbHashObject, byte* pbSecret, int cbSecret, BCryptCreateHashFlags dwFlags);
 
         [Flags]
         internal enum BCryptCreateHashFlags : int

--- a/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
+++ b/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
@@ -332,6 +332,15 @@ namespace System.Security.Cryptography
         public byte[] X;
         public byte[] Y;
     }
+    public static class HKDF
+    {
+        public static byte[] Extract(HashAlgorithmName hashAlgorithmName, byte[] ikm, byte[] salt = null) { throw null; }
+        public static int Extract(HashAlgorithmName hashAlgorithmName, ReadOnlySpan<byte> ikm, ReadOnlySpan<byte> salt, Span<byte> prk) { throw null; }
+        public static byte[] Expand(HashAlgorithmName hashAlgorithmName, byte[] prk, int outputLength, byte[] info = null) { throw null; }
+        public static void Expand(HashAlgorithmName hashAlgorithmName, ReadOnlySpan<byte> prk, Span<byte> output, ReadOnlySpan<byte> info) { throw null; }
+        public static byte[] DeriveKey(HashAlgorithmName hashAlgorithmName, byte[] ikm, int outputLength, byte[] salt = null, byte[] info = null) { throw null; }
+        public static void DeriveKey(HashAlgorithmName hashAlgorithmName, ReadOnlySpan<byte> ikm, Span<byte> output, ReadOnlySpan<byte> salt, ReadOnlySpan<byte> info) { throw null; }
+    }
     public partial class HMACMD5 : System.Security.Cryptography.HMAC
     {
         public HMACMD5() { }

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HMACCommon.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HMACCommon.cs
@@ -17,20 +17,45 @@ namespace Internal.Cryptography
     //
     internal sealed class HMACCommon
     {
-        public HMACCommon(string hashAlgorithmId, byte[] key, int blockSize)
+        public HMACCommon(string hashAlgorithmId, byte[] key, int blockSize) : this(hashAlgorithmId, blockSize)
+        {
+            ChangeKey(key);
+        }
+
+        internal HMACCommon(string hashAlgorithmId, ReadOnlySpan<byte> key, int blockSize) : this(hashAlgorithmId, blockSize)
+        {
+            // note: will not set ActualKey if key size is smaller or equal than blockSize
+            //       this is to avoid extra allocation. ActualKey can still be used if key is generated.
+            //       Otherwise the ReadOnlySpan overload would actually be slower than byte array overload.
+            ChangeKey(key);
+        }
+
+        private HMACCommon(string hashAlgorithmId, int blockSize)
         {
             Debug.Assert(!string.IsNullOrEmpty(hashAlgorithmId));
             Debug.Assert(blockSize > 0 || blockSize == -1);
 
             _hashAlgorithmId = hashAlgorithmId;
             _blockSize = blockSize;
-            ChangeKey(key);
         }
 
         public int HashSizeInBits => _hMacProvider.HashSizeInBytes * 8;
 
         public void ChangeKey(byte[] key)
         {
+            ActualKey = ChangeKeyImpl(key) ?? key;
+        }
+
+        internal void ChangeKey(ReadOnlySpan<byte> key)
+        {
+            // note: does not set key when it's smaller than blockSize
+            ActualKey = ChangeKeyImpl(key);
+        }
+
+        private byte[] ChangeKeyImpl(ReadOnlySpan<byte> key)
+        {
+            byte[] modifiedKey = null;
+
             // If _blockSize is -1 the key isn't going to be extractable by the object holder,
             // so there's no point in recalculating it in managed code.
             if (key.Length > _blockSize && _blockSize > 0)
@@ -40,8 +65,8 @@ namespace Internal.Cryptography
                 {
                     _lazyHashProvider = HashProviderDispenser.CreateHashProvider(_hashAlgorithmId);
                 }
-                _lazyHashProvider.AppendHashData(key, 0, key.Length);
-                key = _lazyHashProvider.FinalizeHashAndReset();
+                _lazyHashProvider.AppendHashData(key);
+                modifiedKey = _lazyHashProvider.FinalizeHashAndReset();
             }
 
             HashProvider oldHashProvider = _hMacProvider;
@@ -49,7 +74,7 @@ namespace Internal.Cryptography
             oldHashProvider?.Dispose(true);
             _hMacProvider = HashProviderDispenser.CreateMacProvider(_hashAlgorithmId, key);
 
-            ActualKey = key;
+            return modifiedKey;
         }
 
         // The actual key used for hashing. This will not be the same as the original key passed to ChangeKey() if the original key exceeded the

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.OSX.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.OSX.cs
@@ -30,7 +30,7 @@ namespace Internal.Cryptography
             throw new CryptographicException(SR.Format(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithmId));
         }
 
-        public static HashProvider CreateMacProvider(string hashAlgorithmId, byte[] key)
+        public static HashProvider CreateMacProvider(string hashAlgorithmId, ReadOnlySpan<byte> key)
         {
             switch (hashAlgorithmId)
             {
@@ -62,9 +62,9 @@ namespace Internal.Cryptography
 
             public override int HashSizeInBytes { get; }
 
-            internal AppleHmacProvider(Interop.AppleCrypto.PAL_HashAlgorithm algorithm, byte[] key)
+            internal AppleHmacProvider(Interop.AppleCrypto.PAL_HashAlgorithm algorithm, ReadOnlySpan<byte> key)
             {
-                _key = key.CloneByteArray();
+                _key = key.ToArray();
                 int hashSizeInBytes = 0;
                 _ctx = Interop.AppleCrypto.HmacCreate(algorithm, ref hashSizeInBytes);
 

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.Unix.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.Unix.cs
@@ -30,7 +30,7 @@ namespace Internal.Cryptography
             throw new CryptographicException(SR.Format(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithmId));
         }
 
-        public static unsafe HashProvider CreateMacProvider(string hashAlgorithmId, byte[] key)
+        public static unsafe HashProvider CreateMacProvider(string hashAlgorithmId, ReadOnlySpan<byte> key)
         {
             switch (hashAlgorithmId)
             {
@@ -121,10 +121,9 @@ namespace Internal.Cryptography
             private readonly int _hashSize;
             private SafeHmacCtxHandle _hmacCtx;
 
-            public HmacHashProvider(IntPtr algorithmEvp, byte[] key)
+            public HmacHashProvider(IntPtr algorithmEvp, ReadOnlySpan<byte> key)
             {
                 Debug.Assert(algorithmEvp != IntPtr.Zero);
-                Debug.Assert(key != null);
 
                 _hashSize = Interop.Crypto.EvpMdSize(algorithmEvp);
                 if (_hashSize <= 0 || _hashSize > Interop.Crypto.EVP_MAX_MD_SIZE)
@@ -132,7 +131,7 @@ namespace Internal.Cryptography
                     throw new CryptographicException();
                 }
 
-                _hmacCtx = Interop.Crypto.HmacCreate(ref MemoryMarshal.GetReference(new Span<byte>(key)), key.Length, algorithmEvp);
+                _hmacCtx = Interop.Crypto.HmacCreate(ref MemoryMarshal.GetReference(key), key.Length, algorithmEvp);
                 Interop.Crypto.CheckValidOpenSslHandle(_hmacCtx);
             }
 

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.Windows.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.Windows.cs
@@ -18,9 +18,9 @@ namespace Internal.Cryptography
             return new HashProviderCng(hashAlgorithmId, null);
         }
 
-        public static HashProvider CreateMacProvider(string hashAlgorithmId, byte[] key)
+        public static HashProvider CreateMacProvider(string hashAlgorithmId, ReadOnlySpan<byte> key)
         {
-            return new HashProviderCng(hashAlgorithmId, key);
+            return new HashProviderCng(hashAlgorithmId, key, isHmac: true);
         }
     }
 }

--- a/src/System.Security.Cryptography.Algorithms/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Algorithms/src/Resources/Strings.resx
@@ -330,4 +330,10 @@
   <data name="Cryptography_WriteEncodedValue_OneValueAtATime" xml:space="preserve">
     <value>The input to WriteEncodedValue must represent a single encoded value with no trailing data.</value>
   </data>
+  <data name="Cryptography_Prk_TooSmall" xml:space="preserve">
+    <value>The pseudo-random key length must be {0} bytes.</value>
+  </data>
+  <data name="Cryptography_Okm_TooLarge" xml:space="preserve">
+    <value>Output keying material length can be at most {0} bytes (255 * hash length).</value>
+  </data>
 </root>

--- a/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);INTERNAL_ASYMMETRIC_IMPLEMENTATIONS</DefineConstants>
@@ -45,6 +45,7 @@
     <Compile Include="System\Security\Cryptography\ECDsa.Xml.cs" />
     <Compile Include="System\Security\Cryptography\ECParameters.cs" />
     <Compile Include="System\Security\Cryptography\ECPoint.cs" />
+    <Compile Include="System\Security\Cryptography\HKDF.cs" />
     <Compile Include="System\Security\Cryptography\MaskGenerationMethod.cs" />
     <Compile Include="System\Security\Cryptography\MD5.cs" />
     <Compile Include="System\Security\Cryptography\SHA1.cs" />
@@ -726,6 +727,6 @@
     <Reference Include="System.Runtime.Numerics" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="@(AsnXml)" /> 
+    <None Include="@(AsnXml)" />
   </ItemGroup>
 </Project>

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HKDF.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HKDF.cs
@@ -1,0 +1,255 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+namespace System.Security.Cryptography
+{
+    /// <summary>
+    /// RFC5869  HMAC-based Extract-and-Expand Key Derivation (HKDF)
+    /// </summary>
+    /// <remarks>
+    /// In situations where the input key material is already a uniformly random bitstring, the HKDF standard allows the Extract
+    /// phase to be skipped, and the master key to be used directly as the pseudorandom key.
+    /// See <a href="https://tools.ietf.org/html/rfc5869">RFC5869</a> for more information.
+    /// </remarks>
+    public static class HKDF
+    {
+        /// <summary>
+        /// Performs the HKDF-Extract function.
+        /// See section 2.2 of <a href="https://tools.ietf.org/html/rfc5869#section-2.2">RFC5869</a>
+        /// </summary>
+        /// <param name="hashAlgorithmName">Hash algorithm used for HMAC operations</param>
+        /// <param name="ikm">Input keying material</param>
+        /// <param name="salt">Optional salt value (a non-secret random value). If not provided it defaults to a byte array of <see cref="HashLength"/> zeros.</param>
+        /// <returns>Pseudo random key (prk)</returns>
+        public static byte[] Extract(HashAlgorithmName hashAlgorithmName, byte[] ikm, byte[] salt = null)
+        {
+            if (ikm == null)
+                throw new ArgumentNullException(nameof(ikm));
+
+            int hashLength = HashLength(hashAlgorithmName);
+            ReadOnlySpan<byte> saltSpan = salt ?? ReadOnlySpan<byte>.Empty;
+
+            byte[] prk = new byte[hashLength];
+
+            Extract(hashAlgorithmName, hashLength, ikm, saltSpan, prk);
+            return prk;
+        }
+
+        /// <summary>
+        /// Performs the HKDF-Extract function.
+        /// See section 2.2 of <a href="https://tools.ietf.org/html/rfc5869#section-2.2">RFC5869</a>
+        /// </summary>
+        /// <param name="hashAlgorithmName">Hash algorithm used for HMAC operations</param>
+        /// <param name="ikm">Input keying material</param>
+        /// <param name="salt">Salt value (a non-secret random value)</param>
+        /// <param name="prk">Buffer representing output pseudo-random key (prk)</param>
+        /// <returns>Number of bytes written to <paramref name="prk"/> buffer.</returns>
+        public static int Extract(HashAlgorithmName hashAlgorithmName, ReadOnlySpan<byte> ikm, ReadOnlySpan<byte> salt, Span<byte> prk)
+        {
+            int hashLength = HashLength(hashAlgorithmName);
+
+            if (prk.Length > hashLength)
+            {
+                prk = prk.Slice(0, hashLength);
+
+                // if it's too short we will throw later
+            }
+
+            Extract(hashAlgorithmName, hashLength, ikm, salt, prk);
+            return hashLength;
+        }
+
+        private static void Extract(HashAlgorithmName hashAlgorithmName, int hashLength, ReadOnlySpan<byte> ikm, ReadOnlySpan<byte> salt, Span<byte> prk)
+        {
+            if (prk.Length != hashLength)
+            {
+                throw new ArgumentException(nameof(prk));
+            }
+
+            Debug.Assert(HashLength(hashAlgorithmName) == hashLength);
+
+            using (IncrementalHash hmac = IncrementalHash.CreateHMAC(hashAlgorithmName, salt))
+            {
+                hmac.AppendData(ikm);
+                GetHashAndReset(hmac, prk);
+            }
+        }
+
+        /// <summary>
+        /// Performs the HKDF-Expand function
+        /// See section 2.3 of <a href="https://tools.ietf.org/html/rfc5869#section-2.3">RFC5869</a>
+        /// </summary>
+        /// <param name="hashAlgorithmName">Hash algorithm used for HMAC operations</param>
+        /// <param name="prk">Pseudorandom key of at least <see cref="HashLength"/> bytes (usually the output from Expand step)</param>
+        /// <param name="outputLength">Length of the output keying material</param>
+        /// <param name="info">Optional context and application specific information</param>
+        /// <returns>Output keying material</returns>
+        public static byte[] Expand(HashAlgorithmName hashAlgorithmName, byte[] prk, int outputLength, byte[] info = null)
+        {
+            if (prk == null)
+                throw new ArgumentNullException(nameof(prk));
+
+            int hashLength = HashLength(hashAlgorithmName);
+
+            if (outputLength <= 0 || outputLength > 255 * hashLength)
+                throw new ArgumentOutOfRangeException(nameof(outputLength));
+
+            info = info ?? Array.Empty<byte>();
+            byte[] result = new byte[outputLength];
+            Expand(hashAlgorithmName, hashLength, prk, result, info);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Performs the HKDF-Expand function
+        /// See section 2.3 of <a href="https://tools.ietf.org/html/rfc5869#section-2.3">RFC5869</a>
+        /// </summary>
+        /// <param name="hashAlgorithmName">Hash algorithm used for HMAC operations</param>
+        /// <param name="prk">Pseudorandom key of at least <see cref="HashLength"/> bytes (usually the output from Expand step)</param>
+        /// <param name="output">Output buffer representing output keying material</param>
+        /// <param name="info">Context and application specific information (can be an empty span)</param>
+        public static void Expand(HashAlgorithmName hashAlgorithmName, ReadOnlySpan<byte> prk, Span<byte> output, ReadOnlySpan<byte> info)
+        {
+            int hashLength = HashLength(hashAlgorithmName);
+
+            // We want to throw different exception type for this overload
+            if (output.Length > 255 * hashLength)
+                throw new ArgumentException(nameof(output));
+
+            Expand(hashAlgorithmName, hashLength, prk, output, info);
+        }
+
+        private static void Expand(HashAlgorithmName hashAlgorithmName, int hashLength, ReadOnlySpan<byte> prk, Span<byte> output, ReadOnlySpan<byte> info)
+        {
+            if (prk.Length < hashLength)
+                throw new ArgumentException(nameof(prk));
+
+            if (output.Length > 255 * hashLength)
+                throw new ArgumentOutOfRangeException(nameof(output));
+
+            Span<byte> counter = stackalloc byte[1];
+            Span<byte> t = Span<byte>.Empty;
+            Span<byte> remainingOutput = output;
+
+            using (IncrementalHash hmac = IncrementalHash.CreateHMAC(hashAlgorithmName, prk))
+            {
+                for (int i = 1; ; i++)
+                {
+                    hmac.AppendData(t);
+                    hmac.AppendData(info);
+                    counter[0] = (byte)i;
+                    hmac.AppendData(counter);
+
+                    if (remainingOutput.Length >= hashLength)
+                    {
+                        t = remainingOutput.Slice(0, hashLength);
+                        remainingOutput = remainingOutput.Slice(hashLength);
+                        GetHashAndReset(hmac, t);
+                    }
+                    else
+                    {
+                        if (remainingOutput.Length > 0)
+                        {
+                            Span<byte> lastChunk = stackalloc byte[hashLength];
+                            GetHashAndReset(hmac, lastChunk);
+                            lastChunk.Slice(0, remainingOutput.Length).CopyTo(remainingOutput);
+                        }
+
+                        break;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Performs the key derivation HKDF Expand and Extract functions
+        /// </summary>
+        /// <param name="hashAlgorithmName">Hash algorithm used for HMAC operations</param>
+        /// <param name="ikm">Input keying material</param>
+        /// <param name="outputLength">Length of the output keying material</param>
+        /// <param name="salt">Optional salt value (a non-secret random value). If not provided it defaults to a byte array of <see cref="HashLength"/> zeros.</param>
+        /// <param name="info">Optional context and application specific information</param>
+        /// <returns>Output keying material</returns>
+        public static byte[] DeriveKey(HashAlgorithmName hashAlgorithmName, byte[] ikm, int outputLength, byte[] salt = null, byte[] info = null)
+        {
+            if (ikm == null)
+                throw new ArgumentNullException(nameof(ikm));
+
+            int hashLength = HashLength(hashAlgorithmName);
+            Span<byte> prk = stackalloc byte[hashLength];
+            ReadOnlySpan<byte> saltSpan = salt ?? ReadOnlySpan<byte>.Empty;
+
+            Extract(hashAlgorithmName, hashLength, ikm, salt, prk);
+
+            byte[] result = new byte[outputLength];
+            Expand(hashAlgorithmName, hashLength, prk, result, info);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Performs the key derivation HKDF Expand and Extract functions
+        /// </summary>
+        /// <param name="hashAlgorithmName">Hash algorithm used for HMAC operations</param>
+        /// <param name="ikm">Input keying material</param>
+        /// <param name="output">Output buffer representing output keying material</param>
+        /// <param name="salt">Salt value (a non-secret random value)</param>
+        /// <param name="info">Context and application specific information (can be an empty span)</param>
+        public static void DeriveKey(HashAlgorithmName hashAlgorithmName, ReadOnlySpan<byte> ikm, Span<byte> output, ReadOnlySpan<byte> salt, ReadOnlySpan<byte> info)
+        {
+            int hashLength = HashLength(hashAlgorithmName);
+
+            // We want to throw different exception type for this overload
+            if (output.Length > 255 * hashLength)
+                throw new ArgumentException(nameof(output));
+
+            Span<byte> prk = stackalloc byte[hashLength];
+
+            Extract(hashAlgorithmName, hashLength, ikm, salt, prk);
+            Expand(hashAlgorithmName, hashLength, prk, output, info);
+        }
+
+        private static void GetHashAndReset(IncrementalHash hmac, Span<byte> output)
+        {
+            if (!hmac.TryGetHashAndReset(output, out int bytesWritten))
+            {
+                Debug.Assert(false, "HMAC operation failed unexpectedly");
+                throw new CryptographicException(SR.Arg_CryptographyException);
+            }
+
+            Debug.Assert(bytesWritten == output.Length, $"Bytes written is {bytesWritten} bytes which does not match output length ({output.Length} bytes)");
+        }
+
+        private static int HashLength(HashAlgorithmName hashAlgorithmName)
+        {
+            if (hashAlgorithmName == HashAlgorithmName.SHA1)
+            {
+                return 160 / 8;
+            }
+            else if (hashAlgorithmName == HashAlgorithmName.SHA256)
+            {
+                return 256 / 8;
+            }
+            else if (hashAlgorithmName == HashAlgorithmName.SHA384)
+            {
+                return 384 / 8;
+            }
+            else if (hashAlgorithmName == HashAlgorithmName.SHA512)
+            {
+                return 512 / 8;
+            }
+            else if (hashAlgorithmName == HashAlgorithmName.MD5)
+            {
+                return 128 / 8;
+            }
+            else
+            {
+                throw new ArgumentOutOfRangeException(nameof(hashAlgorithmName));
+            }
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/IncrementalHash.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/IncrementalHash.cs
@@ -209,6 +209,12 @@ namespace System.Security.Cryptography
         {
             if (key == null)
                 throw new ArgumentNullException(nameof(key));
+
+            return CreateHMAC(hashAlgorithm, (ReadOnlySpan<byte>)key);
+        }
+
+        internal static IncrementalHash CreateHMAC(HashAlgorithmName hashAlgorithm, ReadOnlySpan<byte> key)
+        {
             if (string.IsNullOrEmpty(hashAlgorithm.Name))
                 throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
 

--- a/src/System.Security.Cryptography.Algorithms/tests/HKDFTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/HKDFTests.cs
@@ -1,0 +1,611 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.DotNet.XUnitExtensions;
+using Test.Cryptography;
+using Xunit;
+
+namespace System.Security.Cryptography.Algorithms.Tests
+{
+    public class HKDFTests
+    {
+        [Theory]
+        [MemberData(nameof(GetRfc5869TestCases))]
+        public void Rfc5869ExtractByteArrayTests(Rfc5869TestCase test)
+        {
+            byte[] prk = HKDF.Extract(test.Hash, test.Ikm, test.Salt);
+            Assert.Equal(test.Prk, prk);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetRfc5869TestCases))]
+        public void Rfc5869ExtractByteArrayTamperHashTests(Rfc5869TestCase test)
+        {
+            byte[] prk = HKDF.Extract(HashAlgorithmName.MD5, test.Ikm, test.Salt);
+            Assert.NotEqual(test.Prk, prk);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetRfc5869TestCases))]
+        public void Rfc5869ExtractByteArrayTamperIkmTests(Rfc5869TestCase test)
+        {
+            test.Ikm[0] ^= 1;
+            byte[] prk = HKDF.Extract(test.Hash, test.Ikm, test.Salt);
+            Assert.NotEqual(test.Prk, prk);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetRfc5869TestCasesWithNonEmptySalt))]
+        public void Rfc5869ExtractByteArrayTamperSaltTests(Rfc5869TestCase test)
+        {
+            test.Salt[0] ^= 1;
+            byte[] prk = HKDF.Extract(test.Hash, test.Ikm, test.Salt);
+            Assert.NotEqual(test.Prk, prk);
+        }
+
+        [Fact]
+        public void Rfc5869ExtractByteArrayDefaultHash()
+        {
+            byte[] ikm = new byte[20];
+            byte[] salt = new byte[20];
+            Assert.Throws<ArgumentOutOfRangeException>(() => HKDF.Extract(default(HashAlgorithmName), ikm, salt));
+        }
+
+        [Fact]
+        public void Rfc5869ExtractByteArrayNonsensicalHash()
+        {
+            byte[] ikm = new byte[20];
+            byte[] salt = new byte[20];
+            Assert.Throws<ArgumentOutOfRangeException>(() => HKDF.Extract(new HashAlgorithmName("foo"), ikm, salt));
+        }
+
+        [Fact]
+        public void Rfc5869ExtractByteArrayNullIkm()
+        {
+            byte[] salt = new byte[20];
+            Assert.Throws<ArgumentNullException>(() => HKDF.Extract(HashAlgorithmName.SHA1, null, salt));
+        }
+
+        [Fact]
+        public void Rfc5869ExtractByteArrayEmptyIkm()
+        {
+            byte[] salt = new byte[20];
+            byte[] ikm = Array.Empty<byte>();
+
+            // Ensure does not throw
+            byte[] prk = HKDF.Extract(HashAlgorithmName.SHA1, ikm, salt);
+            Assert.Equal("FBDB1D1B18AA6C08324B7D64B71FB76370690E1D".HexToByteArray(), prk);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetRfc5869TestCases))]
+        public void Rfc5869ExtractSpanTests(Rfc5869TestCase test)
+        {
+            byte[] prk = new byte[test.Prk.Length];
+            Assert.Equal(test.Prk.Length, HKDF.Extract(test.Hash, test.Ikm, test.Salt, prk));
+            Assert.Equal(test.Prk, prk);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetRfc5869TestCases))]
+        public void Rfc5869ExtractSpanTamperIkmTests(Rfc5869TestCase test)
+        {
+            test.Ikm[0] ^= 1;
+            byte[] prk = new byte[test.Prk.Length];
+            HKDF.Extract(test.Hash, test.Ikm, test.Salt, prk);
+            Assert.NotEqual(test.Prk, prk);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetRfc5869TestCasesWithNonEmptySalt))]
+        public void Rfc5869ExtractSpanTamperSaltTests(Rfc5869TestCase test)
+        {
+            test.Salt[0] ^= 1;
+            byte[] prk = new byte[test.Prk.Length];
+            HKDF.Extract(test.Hash, test.Ikm, test.Salt, prk);
+            Assert.NotEqual(test.Prk, prk);
+        }
+
+        [Fact]
+        public void Rfc5869ExtractSpanDefaultHash()
+        {
+            byte[] prk = new byte[20];
+            byte[] ikm = new byte[20];
+            byte[] salt = new byte[20];
+            Assert.Throws<ArgumentOutOfRangeException>(() => HKDF.Extract(default(HashAlgorithmName), ikm, salt, prk));
+        }
+
+        [Fact]
+        public void Rfc5869ExtractSpanNonsensicalHash()
+        {
+            byte[] prk = new byte[20];
+            byte[] ikm = new byte[20];
+            byte[] salt = new byte[20];
+            Assert.Throws<ArgumentOutOfRangeException>(() => HKDF.Extract(new HashAlgorithmName("foo"), ikm, salt, prk));
+        }
+
+        [Fact]
+        public void Rfc5869ExtractSpanEmptyIkm()
+        {
+            byte[] prk = new byte[20];
+            byte[] ikm = Array.Empty<byte>();
+            byte[] salt = new byte[20];
+            Assert.Equal(20, HKDF.Extract(HashAlgorithmName.SHA1, ikm, salt, prk));
+            Assert.Equal("FBDB1D1B18AA6C08324B7D64B71FB76370690E1D".HexToByteArray(), prk);
+        }
+
+        [Fact]
+        public void Rfc5869ExtractSpanEmptySalt()
+        {
+            byte[] prk = new byte[20];
+            byte[] ikm = new byte[20];
+            byte[] salt = Array.Empty<byte>();
+            Assert.Equal(20, HKDF.Extract(HashAlgorithmName.SHA1, ikm, salt, prk));
+            Assert.Equal("A3CBF4A40F51A53E046F07397E52DF9286AE93A2".HexToByteArray(), prk);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(19)]
+        public void Rfc5869ExtractSpanPrkTooShort(int prkSize)
+        {
+            byte[] prk = new byte[prkSize];
+            byte[] ikm = new byte[20];
+            byte[] salt = new byte[20];
+            Assert.Throws<ArgumentException>(() => HKDF.Extract(HashAlgorithmName.SHA1, ikm, salt, prk));
+        }
+
+        [Fact]
+        public void Rfc5869ExtractSpanPrkTooLong()
+        {
+            byte[] prk = new byte[24];
+
+            for (int i = 0; i < 4; i++)
+            {
+                prk[20 + i] = (byte)(i + 5);
+            }
+
+            byte[] ikm = new byte[20];
+            byte[] salt = new byte[20];
+            Assert.Equal(20, HKDF.Extract(HashAlgorithmName.SHA1, ikm, salt, prk));
+            Assert.Equal("A3CBF4A40F51A53E046F07397E52DF9286AE93A2".HexToByteArray(), prk.Take(20).ToArray());
+
+            for (int i = 0; i < 4; i++)
+            {
+                // ensure we didn't modify anything further
+                Assert.Equal((byte)(i + 5), prk[20 + i]);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetRfc5869TestCases))]
+        public void Rfc5869ExpandByteArrayTests(Rfc5869TestCase test)
+        {
+            byte[] okm = HKDF.Expand(test.Hash, test.Prk, test.Okm.Length, test.Info);
+            Assert.Equal(test.Okm, okm);
+        }
+
+        [Fact]
+        public void Rfc5869ExpandByteArrayDefaultHash()
+        {
+            byte[] prk = new byte[20];
+            Assert.Throws<ArgumentOutOfRangeException>(() => HKDF.Expand(default(HashAlgorithmName), prk, 20, null));
+        }
+
+        [Fact]
+        public void Rfc5869ExpandByteArrayNonsensicalHash()
+        {
+            byte[] prk = new byte[20];
+            Assert.Throws<ArgumentOutOfRangeException>(() => HKDF.Expand(new HashAlgorithmName("foo"), prk, 20, null));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetRfc5869TestCases))]
+        public void Rfc5869ExpandByteArrayTamperPrkTests(Rfc5869TestCase test)
+        {
+            test.Prk[0] ^= 1;
+            byte[] okm = HKDF.Expand(test.Hash, test.Prk, test.Okm.Length, test.Info);
+            Assert.NotEqual(test.Okm, okm);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(19)]
+        public void Rfc5869ExpandByteArrayPrkTooSmall(int prkSize)
+        {
+            byte[] prk = new byte[prkSize];
+            Assert.Throws<ArgumentException>(() => HKDF.Expand(HashAlgorithmName.SHA1, prk, 17, Array.Empty<byte>()));
+        }
+
+        [Fact]
+        public void Rfc5869ExpandByteArrayOkmMaxSize()
+        {
+            byte[] prk = new byte[20];
+
+            // Does not throw
+            byte[] okm = HKDF.Expand(HashAlgorithmName.SHA1, prk, 20 * 255, Array.Empty<byte>());
+            Assert.Equal(20 * 255, okm.Length);
+        }
+
+        [Fact]
+        public void Rfc5869ExpandByteArrayOkmMaxSizePlusOne()
+        {
+            byte[] prk = new byte[20];
+            Assert.Throws<ArgumentOutOfRangeException>(() => HKDF.Expand(HashAlgorithmName.SHA1, prk, 20 * 255 + 1, Array.Empty<byte>()));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetRfc5869TestCases))]
+        public void Rfc5869ExpandSpanTests(Rfc5869TestCase test)
+        {
+            byte[] okm = new byte[test.Okm.Length];
+            HKDF.Expand(test.Hash, test.Prk, okm, test.Info);
+            Assert.Equal(test.Okm, okm);
+        }
+
+        [Fact]
+        public void Rfc5869ExpandSpanDefaultHash()
+        {
+            byte[] prk = new byte[20];
+            byte[] okm = new byte[20];
+            Assert.Throws<ArgumentOutOfRangeException>(() => HKDF.Expand(default(HashAlgorithmName), prk, okm, null));
+        }
+
+        [Fact]
+        public void Rfc5869ExpandSpanNonsensicalHash()
+        {
+            byte[] prk = new byte[20];
+            byte[] okm = new byte[20];
+            Assert.Throws<ArgumentOutOfRangeException>(() => HKDF.Expand(new HashAlgorithmName("foo"), prk, okm, null));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetRfc5869TestCases))]
+        public void Rfc5869ExpandSpanTamperPrkTests(Rfc5869TestCase test)
+        {
+            test.Prk[0] ^= 1;
+            byte[] okm = new byte[test.Okm.Length];
+            HKDF.Expand(test.Hash, test.Prk, okm, test.Info);
+            Assert.NotEqual(test.Okm, okm);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(19)]
+        public void Rfc5869ExpandSpanPrkTooSmall(int prkSize)
+        {
+            byte[] prk = new byte[prkSize];
+            byte[] okm = new byte[17];
+            Assert.Throws<ArgumentException>(() => HKDF.Expand(HashAlgorithmName.SHA1, prk, okm, Array.Empty<byte>()));
+        }
+
+        [Fact]
+        public void Rfc5869ExpandSpanOkmMaxSize()
+        {
+            byte[] prk = new byte[20];
+            byte[] okm = new byte[20 * 255];
+
+            // Does not throw
+            HKDF.Expand(HashAlgorithmName.SHA1, prk, okm, Array.Empty<byte>());
+        }
+
+        [Fact]
+        public void Rfc5869ExpandSpanOkmMaxSizePlusOne()
+        {
+            byte[] prk = new byte[20];
+            byte[] okm = new byte[20 * 255 + 1];
+            // Note: We expect ArgumentOutOfRangeException for byte array version since it takes a size
+            Assert.Throws<ArgumentException>(() => HKDF.Expand(HashAlgorithmName.SHA1, prk, okm, Array.Empty<byte>()));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetRfc5869TestCases))]
+        public void Rfc5869DeriveKeyByteArrayTests(Rfc5869TestCase test)
+        {
+            byte[] okm = HKDF.DeriveKey(test.Hash, test.Ikm, test.Okm.Length, test.Salt, test.Info);
+            Assert.Equal(test.Okm, okm);
+        }
+
+        [Fact]
+        public void Rfc5869DeriveKeyByteArrayDefaultHash()
+        {
+            byte[] ikm = new byte[20];
+            Assert.Throws<ArgumentOutOfRangeException>(() => HKDF.DeriveKey(default(HashAlgorithmName), ikm, 20, Array.Empty<byte>(), Array.Empty<byte>()));
+        }
+
+        [Fact]
+        public void Rfc5869DeriveKeyByteArrayNonSensicalHash()
+        {
+            byte[] ikm = new byte[20];
+            Assert.Throws<ArgumentOutOfRangeException>(() => HKDF.DeriveKey(new HashAlgorithmName("foo"), ikm, 20, Array.Empty<byte>(), Array.Empty<byte>()));
+        }
+
+        [Fact]
+        public void Rfc5869DeriveKeyByteArrayNullIkm()
+        {
+            Assert.Throws<ArgumentNullException>(() => HKDF.DeriveKey(HashAlgorithmName.SHA1, null, 20, Array.Empty<byte>(), Array.Empty<byte>()));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetRfc5869TestCases))]
+        public void Rfc5869DeriveKeyByteArrayTamperIkmTests(Rfc5869TestCase test)
+        {
+            test.Ikm[0] ^= 1;
+            byte[] okm = HKDF.DeriveKey(test.Hash, test.Ikm, test.Okm.Length, test.Salt, test.Info);
+            Assert.NotEqual(test.Okm, okm);
+        }
+
+        [Fact]
+        public void Rfc5869DeriveKeyByteArrayOkmMaxSizePlusOne()
+        {
+            byte[] ikm = new byte[20];
+            Assert.Throws<ArgumentOutOfRangeException>(() => HKDF.DeriveKey(HashAlgorithmName.SHA1, ikm, 20 * 255 + 1, Array.Empty<byte>(), Array.Empty<byte>()));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetRfc5869TestCasesWithNonEmptySalt))]
+        public void Rfc5869DeriveKeyByteArrayTamperSaltTests(Rfc5869TestCase test)
+        {
+            test.Salt[0] ^= 1;
+            byte[] okm = HKDF.DeriveKey(test.Hash, test.Ikm, test.Okm.Length, test.Salt, test.Info);
+            Assert.NotEqual(test.Okm, okm);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetRfc5869TestCasesWithNonEmptyInfo))]
+        public void Rfc5869DeriveKeyByteArrayTamperInfoTests(Rfc5869TestCase test)
+        {
+            test.Info[0] ^= 1;
+            byte[] okm = HKDF.DeriveKey(test.Hash, test.Ikm, test.Okm.Length, test.Salt, test.Info);
+            Assert.NotEqual(test.Okm, okm);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetRfc5869TestCases))]
+        public void Rfc5869DeriveKeySpanTests(Rfc5869TestCase test)
+        {
+            byte[] okm = new byte[test.Okm.Length];
+            HKDF.DeriveKey(test.Hash, test.Ikm, okm, test.Salt, test.Info);
+            Assert.Equal(test.Okm, okm);
+        }
+
+        [Fact]
+        public void Rfc5869DeriveKeySpanDefaultHash()
+        {
+            byte[] ikm = new byte[20];
+            byte[] okm = new byte[17];
+            Assert.Throws<ArgumentOutOfRangeException>(() => HKDF.DeriveKey(default(HashAlgorithmName), ikm, okm, Array.Empty<byte>(), Array.Empty<byte>()));
+        }
+
+        [Fact]
+        public void Rfc5869DeriveKeySpanNonSensicalHash()
+        {
+            byte[] ikm = new byte[20];
+            byte[] okm = new byte[17];
+            Assert.Throws<ArgumentOutOfRangeException>(() => HKDF.DeriveKey(new HashAlgorithmName("foo"), ikm, okm, Array.Empty<byte>(), Array.Empty<byte>()));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetRfc5869TestCases))]
+        public void Rfc5869DeriveKeySpanTamperIkmTests(Rfc5869TestCase test)
+        {
+            test.Ikm[0] ^= 1;
+            byte[] okm = new byte[test.Okm.Length];
+            HKDF.DeriveKey(test.Hash, test.Ikm, okm, test.Salt, test.Info);
+            Assert.NotEqual(test.Okm, okm);
+        }
+
+        [Fact]
+        public void Rfc5869DeriveKeySpanOkmMaxSizePlusOne()
+        {
+            byte[] ikm = new byte[20];
+            byte[] okm = new byte[20 * 255 + 1];
+            Assert.Throws<ArgumentException>(() => HKDF.DeriveKey(HashAlgorithmName.SHA1, ikm, okm, Array.Empty<byte>(), Array.Empty<byte>()));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetRfc5869TestCasesWithNonEmptySalt))]
+        public void Rfc5869DeriveKeySpanTamperSaltTests(Rfc5869TestCase test)
+        {
+            test.Salt[0] ^= 1;
+            byte[] okm = new byte[test.Okm.Length];
+            HKDF.DeriveKey(test.Hash, test.Ikm, okm, test.Salt, test.Info);
+            Assert.NotEqual(test.Okm, okm);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetRfc5869TestCasesWithNonEmptyInfo))]
+        public void Rfc5869DeriveKeySpanTamperInfoTests(Rfc5869TestCase test)
+        {
+            test.Info[0] ^= 1;
+            byte[] okm = new byte[test.Okm.Length];
+            HKDF.DeriveKey(test.Hash, test.Ikm, okm, test.Salt, test.Info);
+            Assert.NotEqual(test.Okm, okm);
+        }
+
+        public static IEnumerable<object[]> GetRfc5869TestCases()
+        {
+            foreach (Rfc5869TestCase test in Rfc5869TestCases)
+            {
+                yield return new object[] { test };
+            }
+        }
+
+        public static IEnumerable<object[]> GetRfc5869TestCasesWithNonEmptySalt()
+        {
+            foreach (Rfc5869TestCase test in Rfc5869TestCases)
+            {
+                if (test.Salt != null && test.Salt.Length != 0)
+                {
+                    yield return new object[] { test };
+                }
+            }
+        }
+
+        public static IEnumerable<object[]> GetRfc5869TestCasesWithNonEmptyInfo()
+        {
+            foreach (Rfc5869TestCase test in Rfc5869TestCases)
+            {
+                if (test.Info != null && test.Info.Length != 0)
+                {
+                    yield return new object[] { test };
+                }
+            }
+        }
+
+        private static Rfc5869TestCase[] Rfc5869TestCases => new Rfc5869TestCase[7]
+        {
+            new Rfc5869TestCase()
+            {
+                Name = "Basic test case with SHA-256",
+                Hash = HashAlgorithmName.SHA256,
+                Ikm = "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b".HexToByteArray(),
+                Salt = "000102030405060708090a0b0c".HexToByteArray(),
+                Info = "f0f1f2f3f4f5f6f7f8f9".HexToByteArray(),
+                Prk = (
+                    "077709362c2e32df0ddc3f0dc47bba63" +
+                    "90b6c73bb50f9c3122ec844ad7c2b3e5").HexToByteArray(),
+                Okm = (
+                    "3cb25f25faacd57a90434f64d0362f2a" +
+                    "2d2d0a90cf1a5a4c5db02d56ecc4c5bf" +
+                    "34007208d5b887185865").HexToByteArray(),
+            },
+            new Rfc5869TestCase()
+            {
+                Name = "Test with SHA-256 and longer inputs/outputs",
+                Hash = HashAlgorithmName.SHA256,
+                Ikm = (
+                    "000102030405060708090a0b0c0d0e0f" +
+                    "101112131415161718191a1b1c1d1e1f" +
+                    "202122232425262728292a2b2c2d2e2f" +
+                    "303132333435363738393a3b3c3d3e3f" +
+                    "404142434445464748494a4b4c4d4e4f").HexToByteArray(),
+                Salt = (
+                    "606162636465666768696a6b6c6d6e6f" +
+                    "707172737475767778797a7b7c7d7e7f" +
+                    "808182838485868788898a8b8c8d8e8f" +
+                    "909192939495969798999a9b9c9d9e9f" +
+                    "a0a1a2a3a4a5a6a7a8a9aaabacadaeaf").HexToByteArray(),
+                Info = (
+                    "b0b1b2b3b4b5b6b7b8b9babbbcbdbebf" +
+                    "c0c1c2c3c4c5c6c7c8c9cacbcccdcecf" +
+                    "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf" +
+                    "e0e1e2e3e4e5e6e7e8e9eaebecedeeef" +
+                    "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff").HexToByteArray(),
+                Prk = (
+                    "06a6b88c5853361a06104c9ceb35b45c" +
+                    "ef760014904671014a193f40c15fc244").HexToByteArray(),
+                Okm = (
+                    "b11e398dc80327a1c8e7f78c596a4934" +
+                    "4f012eda2d4efad8a050cc4c19afa97c" +
+                    "59045a99cac7827271cb41c65e590e09" +
+                    "da3275600c2f09b8367793a9aca3db71" +
+                    "cc30c58179ec3e87c14c01d5c1f3434f" +
+                    "1d87").HexToByteArray(),
+            },
+            new Rfc5869TestCase()
+            {
+                Name = "Test with SHA-256 and zero-length salt/info",
+                Hash = HashAlgorithmName.SHA256,
+                Ikm = "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b".HexToByteArray(),
+                Salt = Array.Empty<byte>(),
+                Info = Array.Empty<byte>(),
+                Prk = (
+                    "19ef24a32c717b167f33a91d6f648bdf" +
+                    "96596776afdb6377ac434c1c293ccb04").HexToByteArray(),
+                Okm = (
+                    "8da4e775a563c18f715f802a063c5a31" +
+                    "b8a11f5c5ee1879ec3454e5f3c738d2d" +
+                    "9d201395faa4b61a96c8").HexToByteArray(),
+            },
+            new Rfc5869TestCase()
+            {
+                Name = "Basic test case with SHA-1",
+                Hash = HashAlgorithmName.SHA1,
+                Ikm = "0b0b0b0b0b0b0b0b0b0b0b".HexToByteArray(),
+                Salt = "000102030405060708090a0b0c".HexToByteArray(),
+                Info = "f0f1f2f3f4f5f6f7f8f9".HexToByteArray(),
+                Prk = "9b6c18c432a7bf8f0e71c8eb88f4b30baa2ba243".HexToByteArray(),
+                Okm = (
+                    "085a01ea1b10f36933068b56efa5ad81" +
+                    "a4f14b822f5b091568a9cdd4f155fda2" +
+                    "c22e422478d305f3f896").HexToByteArray(),
+            },
+            new Rfc5869TestCase()
+            {
+                Name = "Test with SHA-1 and longer inputs/outputs",
+                Hash = HashAlgorithmName.SHA1,
+                Ikm = (
+                    "000102030405060708090a0b0c0d0e0f" +
+                    "101112131415161718191a1b1c1d1e1f" +
+                    "202122232425262728292a2b2c2d2e2f" +
+                    "303132333435363738393a3b3c3d3e3f" +
+                    "404142434445464748494a4b4c4d4e4f").HexToByteArray(),
+                Salt = (
+                    "606162636465666768696a6b6c6d6e6f" +
+                    "707172737475767778797a7b7c7d7e7f" +
+                    "808182838485868788898a8b8c8d8e8f" +
+                    "909192939495969798999a9b9c9d9e9f" +
+                    "a0a1a2a3a4a5a6a7a8a9aaabacadaeaf").HexToByteArray(),
+                Info = (
+                    "b0b1b2b3b4b5b6b7b8b9babbbcbdbebf" +
+                    "c0c1c2c3c4c5c6c7c8c9cacbcccdcecf" +
+                    "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf" +
+                    "e0e1e2e3e4e5e6e7e8e9eaebecedeeef" +
+                    "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff").HexToByteArray(),
+                Prk = "8adae09a2a307059478d309b26c4115a224cfaf6".HexToByteArray(),
+                Okm = (
+                    "0bd770a74d1160f7c9f12cd5912a06eb" +
+                    "ff6adcae899d92191fe4305673ba2ffe" +
+                    "8fa3f1a4e5ad79f3f334b3b202b2173c" +
+                    "486ea37ce3d397ed034c7f9dfeb15c5e" +
+                    "927336d0441f4c4300e2cff0d0900b52" +
+                    "d3b4").HexToByteArray(),
+            },
+            new Rfc5869TestCase()
+            {
+                Name = "Test with SHA-1 and zero-length salt/info",
+                Hash = HashAlgorithmName.SHA1,
+                Ikm = "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b".HexToByteArray(),
+                Salt = Array.Empty<byte>(),
+                Info = Array.Empty<byte>(),
+                Prk = "da8c8a73c7fa77288ec6f5e7c297786aa0d32d01".HexToByteArray(),
+                Okm = (
+                    "0ac1af7002b3d761d1e55298da9d0506" +
+                    "b9ae52057220a306e07b6b87e8df21d0" +
+                    "ea00033de03984d34918").HexToByteArray(),
+            },
+            new Rfc5869TestCase()
+            {
+                Name = "Test with SHA-1, salt not provided (defaults to HashLen zero octets), zero-length info",
+                Hash = HashAlgorithmName.SHA1,
+                Ikm = "0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c".HexToByteArray(),
+                Salt = null,
+                Info = Array.Empty<byte>(),
+                Prk = "2adccada18779e7c2077ad2eb19d3f3e731385dd".HexToByteArray(),
+                Okm = (
+                    "2c91117204d745f3500d636a62f64f0a" +
+                    "b3bae548aa53d423b0d1f27ebba6f5e5" +
+                    "673a081d70cce7acfc48").HexToByteArray(),
+            },
+        };
+
+        public struct Rfc5869TestCase
+        {
+            public string Name { get; set; }
+            public HashAlgorithmName Hash { get; set; }
+            public byte[] Ikm { get; set; }
+            public byte[] Salt { get; set; }
+            public byte[] Info { get; set; }
+            public byte[] Prk { get; set; }
+            public byte[] Okm { get; set; }
+
+            public override string ToString() => Name;
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/tests/HKDFTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/HKDFTests.cs
@@ -501,7 +501,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
                 byte[] ikm = new byte[20];
                 byte[] salt = new byte[20];
                 Assert.Equal(20, HKDF.Extract(HashAlgorithmName.SHA1, ikm, salt, prk));
-                Assert.Equal("A3CBF4A40F51A53E046F07397E52DF9286AE93A2".HexToByteArray(), prk.Take(20).ToArray());
+                Assert.Equal("A3CBF4A40F51A53E046F07397E52DF9286AE93A2", prk.AsSpan(0, 20).ByteArrayToHex());
 
                 for (int i = 0; i < 4; i++)
                 {

--- a/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
+++ b/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
@@ -268,5 +268,6 @@
     <Compile Include="AesAEADTests.cs" />
     <Compile Include="AesCcmTests.cs" />
     <Compile Include="AesGcmTests.cs" />
+    <Compile Include="HKDFTests.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/29660

Provides HKDF implementation according to [Rfc5869](https://tools.ietf.org/html/rfc5869)

Also couple of changes to HMAC in order to be able to use Span without extra allocations