### PR TITLE
Make UriTypeConverter better handle relative URIs

### DIFF
--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/UriTypeConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/UriTypeConverter.cs
@@ -52,7 +52,7 @@ namespace System
 
             if (value is Uri uri)
             {
-                return new Uri(uri.OriginalString); // return new instance
+                return new Uri(uri.OriginalString, GetUriKind(uri));
             }
 
             throw GetConvertFromException(value);
@@ -75,7 +75,7 @@ namespace System
                 {
                     ConstructorInfo ctor = typeof(Uri).GetConstructor(BindingFlags.Public | BindingFlags.Instance, null, new Type[] { typeof(string), typeof(UriKind) }, null);
                     Debug.Assert(ctor != null, "Couldn't find constructor");
-                    return new InstanceDescriptor(ctor, new object[] { uri.OriginalString, uri.IsAbsoluteUri ? UriKind.Absolute : UriKind.Relative });
+                    return new InstanceDescriptor(ctor, new object[] { uri.OriginalString, GetUriKind(uri) });
                 }
 
                 if (destinationType == typeof(string))
@@ -85,7 +85,7 @@ namespace System
 
                 if (destinationType == typeof(Uri))
                 {
-                    return new Uri(uri.OriginalString, UriKind.RelativeOrAbsolute);
+                    return new Uri(uri.OriginalString, GetUriKind(uri));
                 }
             }
 
@@ -100,5 +100,7 @@ namespace System
             }
             return value is Uri;
         }
+
+        private static UriKind GetUriKind(Uri uri) => uri.IsAbsoluteUri ? UriKind.Absolute : UriKind.Relative;
     }
 }

--- a/src/System.ComponentModel.TypeConverter/tests/UriTypeConverterTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/UriTypeConverterTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.ComponentModel.Design.Serialization;
 using System.Globalization;
 using Xunit;
@@ -39,9 +40,12 @@ namespace System.ComponentModel.Tests
         [Fact]
         public static void ConvertFrom_WithContext()
         {
-            ConvertFrom_WithContext(new object[2, 3]
+            ConvertFrom_WithContext(new object[5, 3]
                 {
                     {"http://www.Microsoft.com/", new Uri("http://www.Microsoft.com/"),  CultureInfo.InvariantCulture},
+                    {"/relative",  new Uri("/relative", UriKind.Relative),  CultureInfo.InvariantCulture},
+                    {new Uri("http://www.Microsoft.com/"), new Uri("http://www.Microsoft.com/"),  null},
+                    {new Uri("/relative", UriKind.Relative), new Uri("/relative", UriKind.Relative),  null},
                     {"mailto:?to=User2@Host2.com;cc=User3@Host3com", new Uri("mailto:?to=User2@Host2.com;cc=User3@Host3com"),  null}
                 },
                 UriTypeConverterTests.s_converter);
@@ -50,9 +54,10 @@ namespace System.ComponentModel.Tests
         [Fact]
         public static void ConvertTo_WithContext()
         {
-            ConvertTo_WithContext(new object[2, 3]
+            ConvertTo_WithContext(new object[3, 3]
                 {
                     {new Uri("http://www.Microsoft.com/"), "http://www.Microsoft.com/", CultureInfo.InvariantCulture},
+                    {new Uri("/relative", UriKind.Relative), "/relative", CultureInfo.InvariantCulture},
                     {new Uri("mailto:?to=User2@Host2.com;cc=User3@Host3com"), "mailto:?to=User2@Host2.com;cc=User3@Host3com",  null}
                 },
                 UriTypeConverterTests.s_converter);


### PR DESCRIPTION
We missed one case in handling relative URIs:
  ConvertTo(..., relativeUri, typeof(Uri))

Fix this, add tests, and share the UriKind calculation.

Fixes #42438 
/cc @iSazonov 