### PR TITLE
Improve documentation for intrinsics

### DIFF
--- a/src/Common/src/CoreLib/System/Runtime/Intrinsics/Vector256.cs
+++ b/src/Common/src/CoreLib/System/Runtime/Intrinsics/Vector256.cs
@@ -675,6 +675,7 @@ namespace System.Runtime.Intrinsics
         /// <param name="e29">The value that element 29 will be initialized to.</param>
         /// <param name="e30">The value that element 30 will be initialized to.</param>
         /// <param name="e31">The value that element 31 will be initialized to.</param>
+        /// <remarks>This method corresponds to __m256i _mm256_setr_epi8</remarks>
         /// <returns>A new <see cref="Vector256{Byte}" /> with each element initialized to corresponding specified value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe Vector256<byte> Create(byte e0, byte e1, byte e2, byte e3, byte e4, byte e5, byte e6, byte e7, byte e8, byte e9, byte e10, byte e11, byte e12, byte e13, byte e14, byte e15, byte e16, byte e17, byte e18, byte e19, byte e20, byte e21, byte e22, byte e23, byte e24, byte e25, byte e26, byte e27, byte e28, byte e29, byte e30, byte e31)
@@ -735,6 +736,7 @@ namespace System.Runtime.Intrinsics
         /// <param name="e1">The value that element 1 will be initialized to.</param>
         /// <param name="e2">The value that element 2 will be initialized to.</param>
         /// <param name="e3">The value that element 3 will be initialized to.</param>
+        /// <remarks>This method corresponds to __m256d _mm256_setr_pd</remarks>
         /// <returns>A new <see cref="Vector256{Double}" /> with each element initialized to corresponding specified value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe Vector256<double> Create(double e0, double e1, double e2, double e3)
@@ -779,6 +781,7 @@ namespace System.Runtime.Intrinsics
         /// <param name="e13">The value that element 13 will be initialized to.</param>
         /// <param name="e14">The value that element 14 will be initialized to.</param>
         /// <param name="e15">The value that element 15 will be initialized to.</param>
+        /// <remarks>This method corresponds to __m256i _mm256_setr_epi16</remarks>
         /// <returns>A new <see cref="Vector256{Int16}" /> with each element initialized to corresponding specified value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe Vector256<short> Create(short e0, short e1, short e2, short e3, short e4, short e5, short e6, short e7, short e8, short e9, short e10, short e11, short e12, short e13, short e14, short e15)
@@ -827,6 +830,7 @@ namespace System.Runtime.Intrinsics
         /// <param name="e5">The value that element 5 will be initialized to.</param>
         /// <param name="e6">The value that element 6 will be initialized to.</param>
         /// <param name="e7">The value that element 7 will be initialized to.</param>
+        /// <remarks>This method corresponds to __m256i _mm256_setr_epi32</remarks>
         /// <returns>A new <see cref="Vector256{Int32}" /> with each element initialized to corresponding specified value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe Vector256<int> Create(int e0, int e1, int e2, int e3, int e4, int e5, int e6, int e7)
@@ -863,6 +867,7 @@ namespace System.Runtime.Intrinsics
         /// <param name="e1">The value that element 1 will be initialized to.</param>
         /// <param name="e2">The value that element 2 will be initialized to.</param>
         /// <param name="e3">The value that element 3 will be initialized to.</param>
+        /// <remarks>This method corresponds to __m256i _mm256_setr_epi64x</remarks>
         /// <returns>A new <see cref="Vector256{Int64}" /> with each element initialized to corresponding specified value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe Vector256<long> Create(long e0, long e1, long e2, long e3)
@@ -988,6 +993,7 @@ namespace System.Runtime.Intrinsics
         /// <param name="e5">The value that element 5 will be initialized to.</param>
         /// <param name="e6">The value that element 6 will be initialized to.</param>
         /// <param name="e7">The value that element 7 will be initialized to.</param>
+        /// <remarks>This method corresponds to __m256 _mm256_setr_ps</remarks>
         /// <returns>A new <see cref="Vector256{Single}" /> with each element initialized to corresponding specified value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe Vector256<float> Create(float e0, float e1, float e2, float e3, float e4, float e5, float e6, float e7)
@@ -1180,6 +1186,7 @@ namespace System.Runtime.Intrinsics
         /// <summary>Creates a new <see cref="Vector256{Double}" /> instance from two <see cref="Vector128{Double}" /> instances.</summary>
         /// <param name="lower">The value that the lower 128-bits will be initialized to.</param>
         /// <param name="upper">The value that the upper 128-bits will be initialized to.</param>
+        /// <remarks>This method corresponds to __m256d _mm256_setr_m128d</remarks>
         /// <returns>A new <see cref="Vector256{Double}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe Vector256<double> Create(Vector128<double> lower, Vector128<double> upper)
@@ -1316,6 +1323,7 @@ namespace System.Runtime.Intrinsics
         /// <summary>Creates a new <see cref="Vector256{Single}" /> instance from two <see cref="Vector128{Single}" /> instances.</summary>
         /// <param name="lower">The value that the lower 128-bits will be initialized to.</param>
         /// <param name="upper">The value that the upper 128-bits will be initialized to.</param>
+        /// <remarks>This method corresponds to __m256 _mm256_setr_m128</remarks>
         /// <returns>A new <see cref="Vector256{Single}" /> initialized from <paramref name="lower" /> and <paramref name="upper" />.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe Vector256<float> Create(Vector128<float> lower, Vector128<float> upper)

--- a/src/Common/src/CoreLib/System/Runtime/Intrinsics/X86/Sse3.cs
+++ b/src/Common/src/CoreLib/System/Runtime/Intrinsics/X86/Sse3.cs
@@ -61,12 +61,40 @@ namespace System.Runtime.Intrinsics.X86
         ///   LDDQU xmm, m128
         /// </summary>
         public static unsafe Vector128<sbyte> LoadDquVector128(sbyte* address) => LoadDquVector128(address);
+        /// <summary>
+        /// __m128i _mm_lddqu_si128 (__m128i const* mem_addr)
+        ///   LDDQU xmm, m128
+        /// </summary>
         public static unsafe Vector128<byte> LoadDquVector128(byte* address) => LoadDquVector128(address);
+        /// <summary>
+        /// __m128i _mm_lddqu_si128 (__m128i const* mem_addr)
+        ///   LDDQU xmm, m128
+        /// </summary>
         public static unsafe Vector128<short> LoadDquVector128(short* address) => LoadDquVector128(address);
+        /// <summary>
+        /// __m128i _mm_lddqu_si128 (__m128i const* mem_addr)
+        ///   LDDQU xmm, m128
+        /// </summary>
         public static unsafe Vector128<ushort> LoadDquVector128(ushort* address) => LoadDquVector128(address);
+        /// <summary>
+        /// __m128i _mm_lddqu_si128 (__m128i const* mem_addr)
+        ///   LDDQU xmm, m128
+        /// </summary>
         public static unsafe Vector128<int> LoadDquVector128(int* address) => LoadDquVector128(address);
+        /// <summary>
+        /// __m128i _mm_lddqu_si128 (__m128i const* mem_addr)
+        ///   LDDQU xmm, m128
+        /// </summary>
         public static unsafe Vector128<uint> LoadDquVector128(uint* address) => LoadDquVector128(address);
+        /// <summary>
+        /// __m128i _mm_lddqu_si128 (__m128i const* mem_addr)
+        ///   LDDQU xmm, m128
+        /// </summary>
         public static unsafe Vector128<long> LoadDquVector128(long* address) => LoadDquVector128(address);
+        /// <summary>
+        /// __m128i _mm_lddqu_si128 (__m128i const* mem_addr)
+        ///   LDDQU xmm, m128
+        /// </summary>
         public static unsafe Vector128<ulong> LoadDquVector128(ulong* address) => LoadDquVector128(address);
 
         /// <summary>

--- a/src/Common/src/CoreLib/System/Runtime/Intrinsics/X86/Sse41.cs
+++ b/src/Common/src/CoreLib/System/Runtime/Intrinsics/X86/Sse41.cs
@@ -676,12 +676,40 @@ namespace System.Runtime.Intrinsics.X86
         ///   PTEST xmm, xmm/m128
         /// </summary>
         public static bool TestC(Vector128<sbyte> left, Vector128<sbyte> right) => TestC(left, right);
+        /// <summary>
+        /// int _mm_testc_si128 (__m128i a, __m128i b)
+        ///   PTEST xmm, xmm/m128
+        /// </summary>
         public static bool TestC(Vector128<byte> left, Vector128<byte> right) => TestC(left, right);
+        /// <summary>
+        /// int _mm_testc_si128 (__m128i a, __m128i b)
+        ///   PTEST xmm, xmm/m128
+        /// </summary>
         public static bool TestC(Vector128<short> left, Vector128<short> right) => TestC(left, right);
+        /// <summary>
+        /// int _mm_testc_si128 (__m128i a, __m128i b)
+        ///   PTEST xmm, xmm/m128
+        /// </summary>
         public static bool TestC(Vector128<ushort> left, Vector128<ushort> right) => TestC(left, right);
+        /// <summary>
+        /// int _mm_testc_si128 (__m128i a, __m128i b)
+        ///   PTEST xmm, xmm/m128
+        /// </summary>
         public static bool TestC(Vector128<int> left, Vector128<int> right) => TestC(left, right);
+        /// <summary>
+        /// int _mm_testc_si128 (__m128i a, __m128i b)
+        ///   PTEST xmm, xmm/m128
+        /// </summary>
         public static bool TestC(Vector128<uint> left, Vector128<uint> right) => TestC(left, right);
+        /// <summary>
+        /// int _mm_testc_si128 (__m128i a, __m128i b)
+        ///   PTEST xmm, xmm/m128
+        /// </summary>
         public static bool TestC(Vector128<long> left, Vector128<long> right) => TestC(left, right);
+        /// <summary>
+        /// int _mm_testc_si128 (__m128i a, __m128i b)
+        ///   PTEST xmm, xmm/m128
+        /// </summary>
         public static bool TestC(Vector128<ulong> left, Vector128<ulong> right) => TestC(left, right);
 
         /// <summary>
@@ -689,12 +717,40 @@ namespace System.Runtime.Intrinsics.X86
         ///   PTEST xmm, xmm/m128
         /// </summary>
         public static bool TestNotZAndNotC(Vector128<sbyte> left, Vector128<sbyte> right) => TestNotZAndNotC(left, right);
+        /// <summary>
+        /// int _mm_testnzc_si128 (__m128i a, __m128i b)
+        ///   PTEST xmm, xmm/m128
+        /// </summary>
         public static bool TestNotZAndNotC(Vector128<byte> left, Vector128<byte> right) => TestNotZAndNotC(left, right);
+        /// <summary>
+        /// int _mm_testnzc_si128 (__m128i a, __m128i b)
+        ///   PTEST xmm, xmm/m128
+        /// </summary>
         public static bool TestNotZAndNotC(Vector128<short> left, Vector128<short> right) => TestNotZAndNotC(left, right);
+        /// <summary>
+        /// int _mm_testnzc_si128 (__m128i a, __m128i b)
+        ///   PTEST xmm, xmm/m128
+        /// </summary>
         public static bool TestNotZAndNotC(Vector128<ushort> left, Vector128<ushort> right) => TestNotZAndNotC(left, right);
+        /// <summary>
+        /// int _mm_testnzc_si128 (__m128i a, __m128i b)
+        ///   PTEST xmm, xmm/m128
+        /// </summary>
         public static bool TestNotZAndNotC(Vector128<int> left, Vector128<int> right) => TestNotZAndNotC(left, right);
+        /// <summary>
+        /// int _mm_testnzc_si128 (__m128i a, __m128i b)
+        ///   PTEST xmm, xmm/m128
+        /// </summary>
         public static bool TestNotZAndNotC(Vector128<uint> left, Vector128<uint> right) => TestNotZAndNotC(left, right);
+        /// <summary>
+        /// int _mm_testnzc_si128 (__m128i a, __m128i b)
+        ///   PTEST xmm, xmm/m128
+        /// </summary>
         public static bool TestNotZAndNotC(Vector128<long> left, Vector128<long> right) => TestNotZAndNotC(left, right);
+        /// <summary>
+        /// int _mm_testnzc_si128 (__m128i a, __m128i b)
+        ///   PTEST xmm, xmm/m128
+        /// </summary>
         public static bool TestNotZAndNotC(Vector128<ulong> left, Vector128<ulong> right) => TestNotZAndNotC(left, right);
 
         /// <summary>
@@ -702,12 +758,40 @@ namespace System.Runtime.Intrinsics.X86
         ///   PTEST xmm, xmm/m128
         /// </summary>
         public static bool TestZ(Vector128<sbyte> left, Vector128<sbyte> right) => TestZ(left, right);
+        /// <summary>
+        /// int _mm_testz_si128 (__m128i a, __m128i b)
+        ///   PTEST xmm, xmm/m128
+        /// </summary>
         public static bool TestZ(Vector128<byte> left, Vector128<byte> right) => TestZ(left, right);
+        /// <summary>
+        /// int _mm_testz_si128 (__m128i a, __m128i b)
+        ///   PTEST xmm, xmm/m128
+        /// </summary>
         public static bool TestZ(Vector128<short> left, Vector128<short> right) => TestZ(left, right);
+        /// <summary>
+        /// int _mm_testz_si128 (__m128i a, __m128i b)
+        ///   PTEST xmm, xmm/m128
+        /// </summary>
         public static bool TestZ(Vector128<ushort> left, Vector128<ushort> right) => TestZ(left, right);
+        /// <summary>
+        /// int _mm_testz_si128 (__m128i a, __m128i b)
+        ///   PTEST xmm, xmm/m128
+        /// </summary>
         public static bool TestZ(Vector128<int> left, Vector128<int> right) => TestZ(left, right);
+        /// <summary>
+        /// int _mm_testz_si128 (__m128i a, __m128i b)
+        ///   PTEST xmm, xmm/m128
+        /// </summary>
         public static bool TestZ(Vector128<uint> left, Vector128<uint> right) => TestZ(left, right);
+        /// <summary>
+        /// int _mm_testz_si128 (__m128i a, __m128i b)
+        ///   PTEST xmm, xmm/m128
+        /// </summary>
         public static bool TestZ(Vector128<long> left, Vector128<long> right) => TestZ(left, right);
+        /// <summary>
+        /// int _mm_testz_si128 (__m128i a, __m128i b)
+        ///   PTEST xmm, xmm/m128
+        /// </summary>
         public static bool TestZ(Vector128<ulong> left, Vector128<ulong> right) => TestZ(left, right);
     }
 }


### PR DESCRIPTION
This is for issue #42207 
I was following [Intel Guide](https://software.intel.com/sites/landingpage/IntrinsicsGuide/)

@tannergooding 
Does that look good ? If so I'd like to proceed with Vector64 and Vector128. I have no idea however to what instruction are translated Create methods for unsigned numbers/sbyte as well as methods like that : 
```csharp
public static unsafe Vector256<byte> Create(byte value)
```
they kind of look like standard methods / not intrinsic ones