### PR TITLE
disable ferebsd setial port changes

### DIFF
--- a/src/System.IO.Ports/src/Configurations.props
+++ b/src/System.IO.Ports/src/Configurations.props
@@ -4,12 +4,12 @@
       netstandard2.0-Windows_NT;
       netstandard2.0-Linux;
       netstandard2.0-OSX;
-      netstandard2.0-FreeBSD;
       netstandard2.0;
       net461-Windows_NT;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations)
+      netstandard2.0-FreeBSD;
       netfx-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/pkg/runtime.native.System.IO.Ports/netcoreapp.rids.props
+++ b/src/pkg/runtime.native.System.IO.Ports/netcoreapp.rids.props
@@ -8,6 +8,5 @@
     </BuildRID>
     <BuildRID Include="linux-x64" />
     <BuildRID Include="osx-x64" />
-    <BuildRID Include="freebsd-x64" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Port of https://github.com/dotnet/runtime/pull/53/ to stabilize master for remaining time. 