### PR TITLE
[release/3.1] Fix Connection Resiliency in SqlClient

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
@@ -912,7 +912,7 @@ namespace System.Data.SqlClient
                                             {
                                             }
                                             // use Task.Factory.StartNew with state overload instead of Task.Run to avoid anonymous closure context capture in method scope and avoid the unneeded allocation
-                                            runningReconnect = Task.Factory.StartNew(state => ReconnectAsync((int)state), timeout, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+                                            runningReconnect = Task.Factory.StartNew(state => ReconnectAsync((int)state), timeout, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default).Unwrap();
                                             // if current reconnect is not null, somebody already started reconnection task - some kind of race condition
                                             Debug.Assert(_currentReconnectionTask == null, "Duplicate reconnection tasks detected");
                                             _currentReconnectionTask = runningReconnect;


### PR DESCRIPTION
Port of: https://github.com/dotnet/runtime/pull/62 and https://github.com/dotnet/SqlClient/pull/310
Original issue https://github.com/dotnet/SqlClient/issues/304

### Summary
Connection Resiliency is an important feature in System.Data.SqlClient which stopped working post PR 
https://github.com/dotnet/corefx/pull/34047 (ie, in 3.0) as a breaking change got introduced.

### Customer Impact
Connections once idle cannot be restored and users start getting exceptions "The connection is closed".

### Regression?
Yes. Regression was introduced in System.Data.SqlClient **v4.7.0-preview.19073.11**.

### Testing

This feature was not being tested in CI hence the bug flowed over. We are working on adding tests in dotnet/sqlclient to test this feature and ensure it doesn't escape in future. Since all new changes will be made in dotnet/sqlclient repository, we'll be adding tests there in future.

### Risk
**Low**: The fix is to unwrap `Task.Factory.StartNew` call which was modified from `Task.Run`, has been tested and verified.

cc: @danmosemsft @David-Engel 