### PR TITLE
[release/3.1] Fix driver behavior of sending Attention signal for successful Bulk Copy operation

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlBulkCopy.cs
@@ -2561,7 +2561,7 @@ namespace System.Data.SqlClient
 
                 if (_stateObj != null)
                 {
-                    CleanUpStateObjectOnError();
+                    CleanUpStateObject();
                 }
             }
             catch (OutOfMemoryException)
@@ -2584,7 +2584,7 @@ namespace System.Data.SqlClient
         }
 
         // Cleans the stateobj. Used in a number of places, specially in  exceptions.
-        private void CleanUpStateObjectOnError()
+        private void CleanUpStateObject(bool isCancelRequested = true)
         {
             if (_stateObj != null)
             {
@@ -2594,7 +2594,7 @@ namespace System.Data.SqlClient
                     _stateObj.ResetBuffer();
                     _stateObj.ResetPacketCounters();
                     // If _parser is closed, sending attention will raise debug assertion, so we avoid it (but not calling CancelRequest).
-                    if (_parser.State == TdsParserState.OpenNotLoggedIn || _parser.State == TdsParserState.OpenLoggedIn)
+                    if (isCancelRequested && (_parser.State == TdsParserState.OpenNotLoggedIn || _parser.State == TdsParserState.OpenLoggedIn))
                     {
                         _stateObj.CancelRequest();
                     }
@@ -2655,7 +2655,7 @@ namespace System.Data.SqlClient
                                 _localColumnMappings = null;
                                 try
                                 {
-                                    CleanUpStateObjectOnError();
+                                    CleanUpStateObject();
                                 }
                                 finally
                                 {
@@ -2671,7 +2671,7 @@ namespace System.Data.SqlClient
                                 _localColumnMappings = null;
                                 try
                                 {
-                                    CleanUpStateObjectOnError();
+                                    CleanUpStateObject(isCancelRequested: false);
                                 }
                                 finally
                                 {
@@ -2698,11 +2698,11 @@ namespace System.Data.SqlClient
 
                     try
                     {
-                        CleanUpStateObjectOnError();
+                        CleanUpStateObject(isCancelRequested: false);
                     }
                     catch (Exception cleanupEx)
                     {
-                        Debug.Fail("Unexpected exception during CleanUpstateObjectOnError (ignored)", cleanupEx.ToString());
+                        Debug.Fail($"Unexpected exception during {nameof(CleanUpStateObject)} (ignored)", cleanupEx.ToString());
                     }
 
                     if (source != null)
@@ -2717,11 +2717,11 @@ namespace System.Data.SqlClient
 
                 try
                 {
-                    CleanUpStateObjectOnError();
+                    CleanUpStateObject();
                 }
                 catch (Exception cleanupEx)
                 {
-                    Debug.Fail("Unexpected exception during CleanUpstateObjectOnError (ignored)", cleanupEx.ToString());
+                    Debug.Fail($"Unexpected exception during {nameof(CleanUpStateObject)} (ignored)", cleanupEx.ToString());
                 }
 
                 if (source != null)

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/CopyAllFromReader.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/CopyAllFromReader.cs
@@ -62,7 +62,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                             DataTestUtility.AssertEqualsWithDescription((long)0, (long)stats["CursorOpens"], "Non-zero CursorOpens value: " + (long)stats["CursorOpens"]);
                             DataTestUtility.AssertEqualsWithDescription((long)0, (long)stats["IduRows"], "Non-zero IduRows value: " + (long)stats["IduRows"]);
 
-                            DataTestUtility.AssertEqualsWithDescription((long)4, stats["BuffersReceived"], "Unexpected BuffersReceived value.");
+                            DataTestUtility.AssertEqualsWithDescription((long)3, stats["BuffersReceived"], "Unexpected BuffersReceived value.");
                             DataTestUtility.AssertEqualsWithDescription((long)3, stats["BuffersSent"], "Unexpected BuffersSent value.");
                             DataTestUtility.AssertEqualsWithDescription((long)0, stats["IduCount"], "Unexpected IduCount value.");
                             DataTestUtility.AssertEqualsWithDescription((long)3, stats["SelectCount"], "Unexpected SelectCount value.");


### PR DESCRIPTION
Port of: https://github.com/dotnet/runtime/pull/61 and https://github.com/dotnet/SqlClient/pull/308

### Summary
Currently when performing Bulk Copy operations with SqlClient driver, on successful completion, an Attention Signal is sent to SQL Server which is not correct behavior and should not happen.

### Customer Impact

Reported by a .NET Framework customer.

Customers wouldn't notice these attention signals being sent and the transactions would only get impacted if the Abort bit is checked during transaction prepare/commit time. This case would be easily hit with HK tables when the transaction inserts a large number of rows, hence causing all the LCs to be filled up and  LC flush IO to fall behind LCs being requested for log serialization at transaction prepare time.

I would vote for getting the fix in 2.1 as this would result in unsuccessful Bulk Copy transactions for customers even though no error has occurred on their end as this was incorrect behavior by design.

Also to note, it's very likely to occur if customers are using Hekaton/memory-optimized tables. Log serialization in HK is done right at the end during the Hekaton transaction “preparation” phase, prior to commit. This implies that all required log records are generated/serialized into Log Cache at transaction prepare time. As a result, if there are a large number of log records to serialize, there could be a situation where Log Cache get filled up and need to be flushed while more log records are waiting to be serialized into Cache. However, if LC flush IO cannot keep up with the rate of LCs being requested for remaining log records, SQLServerLogMgr::WaitFlushOldestLC() is called, which will essentially wait for a free Log Cache. This function when executed also checks whether the task has an Abort bit set (which is set when the server receives the Attention packet), which ends up aborting the transaction commit itself.

### Regression?
No. The behavior is the original design ported from .NET Framework.

### Testing
When performing tests, the transactions would always commit successfully, hence this attention signal was not noticed. A special test case will be investigated and designed using HK tables in dotnet/sqlclient test lab to cover this scenario. Since all new changes will be made in dotnet/sqlclient repository, we'll be adding new tests there in future.

### Risk
**Low**: The fix is to not send attention signal when performing cleanups post Bulk Copy in successful scenarios.

cc: @danmosemsft @David-Engel @saurabh500 