### PR TITLE
Initialize Delimiter from Attributes

### DIFF
--- a/src/System.Diagnostics.TextWriterTraceListener/src/System.Diagnostics.TextWriterTraceListener.csproj
+++ b/src/System.Diagnostics.TextWriterTraceListener/src/System.Diagnostics.TextWriterTraceListener.csproj
@@ -42,6 +42,7 @@
     <Reference Include="System.ComponentModel.Primitives" />
     <Reference Include="System.Console" />
     <Reference Include="System.Collections.NonGeneric" />
+    <Reference Include="System.Collections.Specialized" />
     <Reference Include="System.Diagnostics.Process" />
     <Reference Include="System.Diagnostics.Tools" />
     <Reference Include="System.Diagnostics.TraceSource" />

--- a/src/System.Diagnostics.TextWriterTraceListener/src/System/Diagnostics/DelimitedListTraceListener.cs
+++ b/src/System.Diagnostics.TextWriterTraceListener/src/System/Diagnostics/DelimitedListTraceListener.cs
@@ -14,6 +14,7 @@ namespace System.Diagnostics
     {
         private string _delimiter = ";";
         private string _secondaryDelim = ",";
+        private bool _initializedDelim = false;
 
         public DelimitedListTraceListener(Stream stream) : base(stream)
         {
@@ -43,6 +44,17 @@ namespace System.Diagnostics
         {
             get
             {
+                lock (this)
+                {
+                    if (!_initializedDelim)
+                    {
+                        if (Attributes.ContainsKey("delimiter"))
+                        {
+                            _delimiter = Attributes["delimiter"];
+                        }
+                        _initializedDelim = true;
+                    }
+                }
                 return _delimiter;
             }
             set
@@ -56,6 +68,7 @@ namespace System.Diagnostics
                 lock (this)
                 {
                     _delimiter = value;
+                    _initializedDelim = true;
                 }
 
                 if (_delimiter == ",")

--- a/src/System.Diagnostics.TextWriterTraceListener/tests/CommonUtilities.cs
+++ b/src/System.Diagnostics.TextWriterTraceListener/tests/CommonUtilities.cs
@@ -11,7 +11,7 @@ namespace System.Diagnostics.TextWriterTraceListenerTests
 {
     internal static class CommonUtilities
     {
-        private const string DefaultDelimiter = ";";
+        internal const string DefaultDelimiter = ";";
 
         internal static void DeleteFile(string fileName)
         {


### PR DESCRIPTION
If a DelimitedListTraceListener has a Delimiter attribute, use it
to initialize the Delimiter unless (and until) a delimiter is set
explicitly.

Also add unit tests for these scenarios.

Fix #39363