### PR TITLE
Preemptively correct the restore project style

### DIFF
--- a/eng/restore/repoRestore.targets
+++ b/eng/restore/repoRestore.targets
@@ -1,7 +1,7 @@
 <Project InitialTargets="_ClearResolvePackageAssets" TreatAsLocalProperty="ExcludeRestorePackageImports">
   <PropertyGroup>
     <!-- Disable restoring of package references in our projects -->
-    <RestoreProjectStyle Condition="'$(MSBuildProjectExtension)' != '.depproj'">None</RestoreProjectStyle>
+    <RestoreProjectStyle Condition="'$(MSBuildProjectExtension)' != '.depproj'">Unknown</RestoreProjectStyle>
   </PropertyGroup>
 
   <Import Project="$(RepositoryEngineeringDir)codeAnalysis.targets" />


### PR DESCRIPTION
https://github.com/NuGet/NuGet.Client/pull/3131 might add a warning when a bad project style is used. 

That will get elevated to an error due to treat warnings as error being enabled and fail the restore. 

This preemptively addresses that. 

For reference, these are the valid project types: https://github.com/NuGet/NuGet.Client/blob/a66ebed83647727d157dc37f14685cbfd2a4adf4/src/NuGet.Core/NuGet.ProjectModel/ProjectStyle.cs