### PR TITLE
SequenceReader nextPosition fix

### DIFF
--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence.Helpers.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence.Helpers.cs
@@ -649,11 +649,11 @@ namespace System.Buffers
                     {
                         // Positive start and end index == ReadOnlySequenceSegment<T>
                         ReadOnlySequenceSegment<T> segment = (ReadOnlySequenceSegment<T>)startObject;
-                        next = new SequencePosition(segment.Next, 0);
                         first = segment.Memory.Span;
                         if (hasMultipleSegments)
                         {
                             first = first.Slice(startIndex);
+                            next = new SequencePosition(segment.Next, 0);
                         }
                         else
                         {

--- a/src/System.Memory/tests/SequenceReader/ReadTo.cs
+++ b/src/System.Memory/tests/SequenceReader/ReadTo.cs
@@ -200,12 +200,12 @@ namespace System.Memory.Tests.SequenceReader
         }
 
         [Fact]
-        public void TryReadTo_Span_At_Segmet_Boundary()
+        public void TryReadTo_Span_At_Segments_Boundary()
         {
             Span<byte> delimiter = new byte[] { 13, 10 }; // \r\n
-            BufferSegment<byte> bufSeq = new BufferSegment<byte>(Text.Encoding.ASCII.GetBytes("Hello\r"));
-            bufSeq.Append(Text.Encoding.ASCII.GetBytes("\nWorld"));
-            ReadOnlySequence<byte> inputSeq = new ReadOnlySequence<byte>(bufSeq, 0, bufSeq, 6); // span only the first segment!
+            BufferSegment<byte> segment = new BufferSegment<byte>(Text.Encoding.ASCII.GetBytes("Hello\r"));
+            segment.Append(Text.Encoding.ASCII.GetBytes("\nWorld")); // add next segment
+            ReadOnlySequence<byte> inputSeq = new ReadOnlySequence<byte>(segment, 0, segment, 6); // span only the first segment!
             SequenceReader<byte> sr = new SequenceReader<byte>(inputSeq);
             bool r = sr.TryReadTo(out _, delimiter);
             Assert.False(r);

--- a/src/System.Memory/tests/SequenceReader/ReadTo.cs
+++ b/src/System.Memory/tests/SequenceReader/ReadTo.cs
@@ -198,5 +198,17 @@ namespace System.Memory.Tests.SequenceReader
                 Assert.Equal(i + 1, value);
             }
         }
+
+        [Fact]
+        public void TryReadTo_Span_At_Segmet_Boundary()
+        {
+            Span<byte> delimiter = new byte[] { 13, 10 }; // \r\n
+            BufferSegment<byte> bufSeq = new BufferSegment<byte>(Text.Encoding.ASCII.GetBytes("Hello\r"));
+            bufSeq.Append(Text.Encoding.ASCII.GetBytes("\nWorld"));
+            ReadOnlySequence<byte> inputSeq = new ReadOnlySequence<byte>(bufSeq, 0, bufSeq, 6); // span only the first segment!
+            SequenceReader<byte> sr = new SequenceReader<byte>(inputSeq);
+            bool r = sr.TryReadTo(out _, delimiter);
+            Assert.False(r);
+        }
     }
 }


### PR DESCRIPTION
While working with `PipeReader` I ran into a rare issue when using `SequenceReader` with the returned `ReadOnlySequence`. In my code I'm splitting incoming data by newlines (\r\n) like this : 
```c#
var rr = await reader.ReadAsync();
var sr = new SequenceReader<byte>(rr.Buffer);
var r = sr.TryReadTo(out line, M_CRNL.Span);
```
On rare occasions last line of this code throws following exception:
```
System.InvalidOperationException: End position was not reached during enumeration.
   at System.ThrowHelper.ThrowInvalidOperationException_EndPositionNotReached()
   at System.Buffers.SequenceReader`1.IsNextSlow(ReadOnlySpan`1 next, Boolean advancePast)
   at System.Buffers.SequenceReader`1.TryReadTo(ReadOnlySequence`1& sequence, ReadOnlySpan`1 delimiter, Boolean advancePastDelimiter)
...
```

After extensive investigation I have determined the true StackTrace was:
```
   at System.ThrowHelper.ThrowInvalidOperationException_EndPositionNotReached()
   at System.Buffers.ReadOnlySequence.TryGetBuffer(in SequencePosition position, out ReadOnlyMemory<T> memory, out SequencePosition next) line 42 (ReadOnlySequence.Helpers.cs)
   at System.Buffers.ReadOnlySequence.TryGet(ref SequencePosition position, out ReadOnlyMemory<T> memory, bool advance = true) line 549
   at System.Buffers.SequenceReader.IsNextSlow(ReadOnlySpan<T> next, Boolean advancePast) line 752
   at System.Buffers.SequenceReader.IsNext(ReadOnlySpan<T> next, bool advancePast = false) line 724
   at System.Buffers.SequenceReader.TryReadTo(out ReadOnlySequence<T> sequence, ReadOnlySpan<T> delimiter, bool advancePastDelimiter = true) line 444
...
```
and that this issue only happened when the Sequence was spanning only one segment (but this segment references another segment (next)) and the first segment's memory ends exactly with the first byte of the delimiter.

I believe constructor `public SequenceReader(ReadOnlySequence<T> sequence)` incorrectly sets `_nextPosition` trough `ReadOnlySequence.GetFirstSpan(out ReadOnlySpan<T> first, out SequencePosition next)` where `next` is set to segment's Next (`next = new SequencePosition(segment.Next, 0);`) regardless of whether or not the sequence actually spans this segment. This ultimately causes fail inside `ReadOnlySequence.TryGetBuffer()` when `SequenceReader.IsNextSlow` tries to search outside the sequence's boundary.

This PR aimes to fix this issue and it adds a test which would fail with the old code (and thus can serve as repro).