### PR TITLE
[release/3.1] Update SslClientAuthenticationOptionsExtensions.ShallowClone to copy CipherSuitesPolicy

### DIFF
--- a/src/Common/src/System/Net/Security/SslClientAuthenticationOptionsExtensions.cs
+++ b/src/Common/src/System/Net/Security/SslClientAuthenticationOptionsExtensions.cs
@@ -2,16 +2,25 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+#if DEBUG
+using System.Collections;
+using System.Diagnostics;
+using System.Reflection;
+#endif
+
 namespace System.Net.Security
 {
     internal static class SslClientAuthenticationOptionsExtensions
     {
-        public static SslClientAuthenticationOptions ShallowClone(this SslClientAuthenticationOptions options) =>
-            new SslClientAuthenticationOptions()
+        public static SslClientAuthenticationOptions ShallowClone(this SslClientAuthenticationOptions options)
+        {
+            var clone = new SslClientAuthenticationOptions()
             {
                 AllowRenegotiation = options.AllowRenegotiation,
-                ApplicationProtocols = options.ApplicationProtocols,
+                ApplicationProtocols = options.ApplicationProtocols != null ? new List<SslApplicationProtocol>(options.ApplicationProtocols) : null,
                 CertificateRevocationCheckMode = options.CertificateRevocationCheckMode,
+                CipherSuitesPolicy = options.CipherSuitesPolicy,
                 ClientCertificates = options.ClientCertificates,
                 EnabledSslProtocols = options.EnabledSslProtocols,
                 EncryptionPolicy = options.EncryptionPolicy,
@@ -19,5 +28,50 @@ namespace System.Net.Security
                 RemoteCertificateValidationCallback = options.RemoteCertificateValidationCallback,
                 TargetHost = options.TargetHost
             };
+
+#if DEBUG
+            // Try to detect if a property gets added that we're not copying correctly.
+            foreach (PropertyInfo pi in options.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+            {
+                object origValue = pi.GetValue(options);
+                object cloneValue = pi.GetValue(clone);
+
+                if (origValue is IEnumerable origEnumerable)
+                {
+                    IEnumerable cloneEnumerable = cloneValue as IEnumerable;
+                    Debug.Assert(cloneEnumerable != null, $"{pi.Name}. Expected enumerable cloned value.");
+
+                    IEnumerator e1 = origEnumerable.GetEnumerator();
+                    try
+                    {
+                        IEnumerator e2 = cloneEnumerable.GetEnumerator();
+                        try
+                        {
+                            while (e1.MoveNext())
+                            {
+                                Debug.Assert(e2.MoveNext(), $"{pi.Name}. Cloned enumerator too short.");
+                                Debug.Assert(Equals(e1.Current, e2.Current), $"{pi.Name}. Cloned enumerator's values don't match.");
+                            }
+                            Debug.Assert(!e2.MoveNext(), $"{pi.Name}. Cloned enumerator too long.");
+                        }
+                        finally
+                        {
+                            (e2 as IDisposable)?.Dispose();
+                        }
+                    }
+                    finally
+                    {
+                        (e1 as IDisposable)?.Dispose();
+                    }
+                }
+                else
+                {
+                    Debug.Assert(Equals(origValue, cloneValue), $"{pi.Name}. Expected: {origValue}, Actual: {cloneValue}");
+                }
+            }
+#endif
+
+            return clone;
+        }
     }
 }


### PR DESCRIPTION
Port https://github.com/dotnet/runtime/pull/211 to release/3.1
Fixes https://github.com/dotnet/corefx/issues/42670

## Description

SocketsHttpHandler allows for an SslClientAuthenticationOptions to be set onto it, and those settings are then passed along to the SslStream it creates under the covers.  Because SslClientAuthenticationOptions is mutable and SocketsHttpHandler uses it repeatedly in order to create every SslStream it creates, it makes a copy of the instance.  But the type doesn't currently expose any kind of clone method or copy constructor, so SocketsHttpHandler has to manually copy each property.  In .NET Core 3.0 a new property was added to SslClientAuthenticationOptions, for configuring the cipher suites to be used, but we neglected to add that new property to the set of those getting copied.  That means SocketsHttpHandler completely ignores the cipher suites configured on the SslClientAuthenticationOptions.

## Customer Impact

The cipher suite options selected by the developer are ignored.

## Regression?

No

## Testing

All existing tests, plus some new debug-only code that validates all properties on the instance are being copied.

## Risk

Minimal.

cc: @danmosemsft, @davidsh