### PR TITLE
Throwing DirectoryNotFoundException when part of image path does not exist

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/Image.Windows.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Image.Windows.cs
@@ -134,6 +134,8 @@ namespace System.Drawing
                 throw new ArgumentNullException(nameof(filename));
             if (encoder == null)
                 throw new ArgumentNullException(nameof(encoder));
+            if (!Directory.Exists(Path.GetDirectoryName(filename)))
+                throw new DirectoryNotFoundException(nameof(filename));
 
             IntPtr encoderParamsMemory = IntPtr.Zero;
 


### PR DESCRIPTION
Fixes #42294. 