### PR TITLE
update missing docs for System.IO.UnmanagedMemoryStream

### DIFF
--- a/src/Common/src/CoreLib/System/IO/UnmanagedMemoryStream.cs
+++ b/src/Common/src/CoreLib/System/IO/UnmanagedMemoryStream.cs
@@ -72,9 +72,9 @@ namespace System.IO
         /// <summary>
         /// Creates a stream over a SafeBuffer.
         /// </summary>
-        /// <param name="buffer"></param>
-        /// <param name="offset"></param>
-        /// <param name="length"></param>
+        /// <param name="buffer">The buffer to contain the unmanaged memory stream.</param>
+        /// <param name="offset">The byte position in the buffer at which to start the unmanaged memory stream.</param>
+        /// <param name="length">The length of the unmanaged memory stream.</param>
         public UnmanagedMemoryStream(SafeBuffer buffer, long offset, long length)
         {
             Initialize(buffer, offset, length, FileAccess.Read);
@@ -91,10 +91,10 @@ namespace System.IO
         /// <summary>
         /// Subclasses must call this method (or the other overload) to properly initialize all instance fields.
         /// </summary>
-        /// <param name="buffer"></param>
-        /// <param name="offset"></param>
-        /// <param name="length"></param>
-        /// <param name="access"></param>
+        /// <param name="buffer">The buffer to contain the unmanaged memory stream.</param>
+        /// <param name="offset">The byte position in the buffer at which to start the unmanaged memory stream.</param>
+        /// <param name="length">The length of the unmanaged memory stream.</param>
+        /// <param name="access">The mode of file access to the unmanaged memory stream.</param>
         protected void Initialize(SafeBuffer buffer, long offset, long length, FileAccess access)
         {
             if (buffer == null)
@@ -521,7 +521,7 @@ namespace System.IO
         /// <summary>
         /// Returns the byte at the stream current Position and advances the Position.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>The unsigned byte cast to an Int32, or -1 if at the end of the stream.</returns>
         public override int ReadByte()
         {
             EnsureNotClosed();
@@ -568,7 +568,7 @@ namespace System.IO
         /// </summary>
         /// <param name="offset">Offset from the loc parameter.</param>
         /// <param name="loc">Origin for the offset parameter.</param>
-        /// <returns></returns>
+        /// <returns>The new position in the stream.</returns>
         public override long Seek(long offset, SeekOrigin loc)
         {
             EnsureNotClosed();
@@ -607,7 +607,7 @@ namespace System.IO
         /// <summary>
         /// Sets the Length of the stream.
         /// </summary>
-        /// <param name="value"></param>
+        /// <param name="value">The length of the stream.</param>
         public override void SetLength(long value)
         {
             if (value < 0)
@@ -811,7 +811,7 @@ namespace System.IO
         /// <summary>
         /// Writes a byte to the stream and advances the current Position.
         /// </summary>
-        /// <param name="value"></param>
+        /// <param name="value">A byte value written to the stream.</param>
         public override void WriteByte(byte value)
         {
             EnsureNotClosed();


### PR DESCRIPTION
Was looking into System.IO.UnmanagedMemoryStream.ReadByte() return documentation because apparently it has some encoded meaning to it. Updated that one + some other docs while looking around.