### PR TITLE
disabling publishing of stable packages on 3.1

### DIFF
--- a/src/packages.builds
+++ b/src/packages.builds
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <BuildAllPackages>true</BuildAllPackages>
+    <BuildAllPackages>false</BuildAllPackages>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(BuildAllPackages)' == 'true'">


### PR DESCRIPTION
I missed to disable the packages build in branding due to which internal build was failing