### PR TITLE
[release/3.1] Switch to using 3.1100 SDK to build 3.1

### DIFF
--- a/eng/depProj.targets
+++ b/eng/depProj.targets
@@ -68,7 +68,7 @@ See the LICENSE file in the project root for more information.
           BeforeTargets="ResolvePackageAssets"
           Condition="'$(VSDesignTimeBuild)' != 'true'" />
 
-  <Target Name="CoreCompile" Condition="'@(PackageReference)' != '' Or '@(PackageDownload)' == ''">
+  <Target Name="CoreCompile">
 
     <Error Condition="'$(NuGetDeploySourceItem)' != 'ReferenceCopyLocalPaths' AND
                       '$(NuGetDeploySourceItem)' != 'Reference' AND
@@ -98,8 +98,12 @@ See the LICENSE file in the project root for more information.
       </ContentWithTargetPath>
     </ItemGroup>
 
-    <Error Condition="'@(NuGetDeploy)' == ''" Text="Error no assets were resolved from NuGet packages." />
-    <Message Importance="High" Text="%(FullPath) (%(NuGetPackageId).%(NuGetPackageVersion)) -&gt; @(NuGetDeploy->'$(TargetDir)%(SubFolder)%(FileName)%(Extension)')" />
+    <Message Importance="High"
+             Condition="'@(NuGetDeploy)' == ''"
+             Text="$(MSBuildProjectFile): No assets were resolved from NuGet packages." />
+    <Message Importance="High"
+             Condition="'@(NuGetDeploy)' != ''"
+             Text="%(FullPath) (%(NuGetPackageId).%(NuGetPackageVersion)) -&gt; @(NuGetDeploy->'$(TargetDir)%(SubFolder)%(FileName)%(Extension)')" />
 
     <!-- Include marker files if an extension has been provided -->
     <!-- internal builds use this to distinguish files which have already been signed -->

--- a/global.json
+++ b/global.json
@@ -1,10 +1,10 @@
 {
   "sdk": {
-    "version": "3.0.101",
+    "version": "3.1.100",
     "rollforward": "major"
   },
   "tools": {
-    "dotnet": "3.0.101"
+    "dotnet": "3.1.1010"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19577.5",

--- a/global.json
+++ b/global.json
@@ -4,7 +4,7 @@
     "rollforward": "major"
   },
   "tools": {
-    "dotnet": "3.1.1010"
+    "dotnet": "3.1.100"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19577.5",


### PR DESCRIPTION
Required for upstack components, so this is for consistency.