### PR TITLE
Fix 3.0->3.1 regression in JSON serializing nested concurrent dictionaries

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNotNullable.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNotNullable.cs
@@ -130,7 +130,7 @@ namespace System.Text.Json
 
         public override void GetDictionaryKeyAndValueFromGenericDictionary(ref WriteStackFrame writeStackFrame, out string key, out object value)
         {
-            if (writeStackFrame.CollectionEnumerator is IEnumerator<KeyValuePair<string, TRuntimeProperty>> genericEnumerator)
+            if (writeStackFrame.CollectionEnumerator is IEnumerator<KeyValuePair<string, TDeclaredProperty>> genericEnumerator)
             {
                 key = genericEnumerator.Current.Key;
                 value = genericEnumerator.Current.Value;

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNotNullableContravariant.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNotNullableContravariant.cs
@@ -132,7 +132,7 @@ namespace System.Text.Json.Serialization
 
         public override void GetDictionaryKeyAndValueFromGenericDictionary(ref WriteStackFrame writeStackFrame, out string key, out object value)
         {
-            if (writeStackFrame.CollectionEnumerator is IEnumerator<KeyValuePair<string, TRuntimeProperty>> genericEnumerator)
+            if (writeStackFrame.CollectionEnumerator is IEnumerator<KeyValuePair<string, TDeclaredProperty>> genericEnumerator)
             {
                 key = genericEnumerator.Current.Key;
                 value = genericEnumerator.Current.Value;

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
@@ -254,11 +254,26 @@ namespace System.Text.Json
             else if (state.Current.IsProcessingDictionary())
             {
                 Debug.Assert(state.Current.ReturnValue != null);
-                IDictionary<string, TProperty> dictionary = (IDictionary<string, TProperty>)state.Current.JsonPropertyInfo.GetValueAsObject(state.Current.ReturnValue);
+
+                object currentDictionary = state.Current.JsonPropertyInfo.GetValueAsObject(state.Current.ReturnValue);
 
                 string key = state.Current.KeyName;
                 Debug.Assert(!string.IsNullOrEmpty(key));
-                dictionary[key] = value;
+
+                if (currentDictionary is IDictionary<string, TProperty> genericDict)
+                {
+                    Debug.Assert(!genericDict.IsReadOnly);
+                    genericDict[key] = value;
+                }
+                else if (currentDictionary is IDictionary dict)
+                {
+                    Debug.Assert(!dict.IsReadOnly);
+                    dict[key] = value;
+                }
+                else
+                {
+                    throw ThrowHelper.GetNotSupportedException_SerializationNotSupportedCollection(currentDictionary.GetType(), parentType: null, memberInfo: null);
+                }
             }
             else if (state.Current.IsProcessingIDictionaryConstructible())
             {

--- a/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
+++ b/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
@@ -997,6 +997,9 @@ namespace System.Text.Json.Serialization.Tests
             };
             baseDictionaryTypes.AddRange(nonGenericDictTypes);
 
+            // This method has exponential behavior which this depth value significantly impacts.
+            // Don't change this value without checking how many test cases are generated and
+            // how long the tests run for.
             int maxTestDepth = 4;
 
             HashSet<(Type, string)> tests = new HashSet<(Type, string)>();

--- a/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
+++ b/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
@@ -3,9 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Collections.Concurrent;
+using System.Collections.Specialized;
 using System.Reflection;
 using System.Text.Encodings.Web;
 using Xunit;
@@ -937,6 +938,8 @@ namespace System.Text.Json.Serialization.Tests
 
         private class MyClass : IClass { }
 
+        private class MyNonGenericDictionary : Dictionary<string, int> { }
+
         private class MyFactory : JsonConverterFactory
         {
             public override bool CanConvert(Type typeToConvert)
@@ -963,6 +966,10 @@ namespace System.Text.Json.Serialization.Tests
             }
         }
 
+        // This method generates 316 unique test cases for nested dictionaries up to 4
+        // levels deep, along with matching JSON, encompassing the various planes of
+        // dictionaries that can be combined: generic, non-generic, BCL, user-derived,
+        // immutable, mutable, readonly, concurrent, specialized.
         private static IEnumerable<(Type, string)> NestedDictionaryTypeData()
         {
             string testJson = @"{""Key"":1}";
@@ -970,22 +977,23 @@ namespace System.Text.Json.Serialization.Tests
             List<Type> genericDictTypes = new List<Type>()
             {
                 typeof(IDictionary<,>),
-                typeof(Dictionary<,>),
                 typeof(ConcurrentDictionary<,>),
+                typeof(GenericIDictionaryWrapper<,>),
             };
 
             List<Type> nonGenericDictTypes = new List<Type>()
             {
-                typeof(IDictionary),
                 typeof(Hashtable),
+                typeof(OrderedDictionary),
             };
 
             List<Type> baseDictionaryTypes = new List<Type>
             {
+                typeof(MyNonGenericDictionary),
                 typeof(IReadOnlyDictionary<string, MyClass>),
-                typeof(Dictionary<string, IClass>),
                 typeof(ConcurrentDictionary<string, int>),
-                typeof(ImmutableDictionary<string, object>),
+                typeof(ImmutableDictionary<string, IClass>),
+                typeof(GenericIDictionaryWrapper<string, int?>),
             };
             baseDictionaryTypes.AddRange(nonGenericDictTypes);
 

--- a/src/System.Text.Json/tests/Serialization/TestClasses.GenericCollections.cs
+++ b/src/System.Text.Json/tests/Serialization/TestClasses.GenericCollections.cs
@@ -936,6 +936,76 @@ namespace System.Text.Json.Serialization.Tests
         }
     }
 
+    public class GenericIDictionaryWrapper<TKey, TValue> : IDictionary<TKey, TValue>
+    {
+        private Dictionary<TKey, TValue> _dict = new Dictionary<TKey, TValue>();
+
+        public TValue this[TKey key] { get => ((IDictionary<TKey, TValue>)_dict)[key]; set => ((IDictionary<TKey, TValue>)_dict)[key] = value; }
+
+        public ICollection<TKey> Keys => ((IDictionary<TKey, TValue>)_dict).Keys;
+
+        public ICollection<TValue> Values => ((IDictionary<TKey, TValue>)_dict).Values;
+
+        public int Count => ((IDictionary<TKey, TValue>)_dict).Count;
+
+        public bool IsReadOnly => ((IDictionary<TKey, TValue>)_dict).IsReadOnly;
+
+        public void Add(TKey key, TValue value)
+        {
+            ((IDictionary<TKey, TValue>)_dict).Add(key, value);
+        }
+
+        public void Add(KeyValuePair<TKey, TValue> item)
+        {
+            ((IDictionary<TKey, TValue>)_dict).Add(item);
+        }
+
+        public void Clear()
+        {
+            ((IDictionary<TKey, TValue>)_dict).Clear();
+        }
+
+        public bool Contains(KeyValuePair<TKey, TValue> item)
+        {
+            return ((IDictionary<TKey, TValue>)_dict).Contains(item);
+        }
+
+        public bool ContainsKey(TKey key)
+        {
+            return ((IDictionary<TKey, TValue>)_dict).ContainsKey(key);
+        }
+
+        public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+        {
+            ((IDictionary<TKey, TValue>)_dict).CopyTo(array, arrayIndex);
+        }
+
+        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+        {
+            return ((IDictionary<TKey, TValue>)_dict).GetEnumerator();
+        }
+
+        public bool Remove(TKey key)
+        {
+            return ((IDictionary<TKey, TValue>)_dict).Remove(key);
+        }
+
+        public bool Remove(KeyValuePair<TKey, TValue> item)
+        {
+            return ((IDictionary<TKey, TValue>)_dict).Remove(item);
+        }
+
+        public bool TryGetValue(TKey key, out TValue value)
+        {
+            return ((IDictionary<TKey, TValue>)_dict).TryGetValue(key, out value);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return ((IDictionary<TKey, TValue>)_dict).GetEnumerator();
+        }
+    }
+
     public class StringToStringIReadOnlyDictionaryWrapper : IReadOnlyDictionary<string, string>
     {
         private Dictionary<string, string> _dictionary = new Dictionary<string, string>();


### PR DESCRIPTION
## Description

Fixes https://github.com/dotnet/runtime/issues/670, where there was a regression between 3.0 and 3.1 where serializing nested concurrent dictionaries went from supported to unsupported. The issue also exists in master/5.0. https://github.com/dotnet/runtime/pull/784 fixes it in master, and this PR ports the fix to 3.0.

In addition to the fix described above, this PR also also has a deserialization fix for an `InvalidCastException` thrown when a dictionary element type has a converter that returns a type different from the declared type, e.g. when you're deserializing `Dictionary<string, MyClass>`, where

```c#
private interface IClass { }

private class MyClass : IClass { }

private class MyFactory : JsonConverterFactory
{
    public override bool CanConvert(Type typeToConvert)
    {
        return typeToConvert == typeof(IClass) || typeToConvert == typeof(MyClass);
    }

    public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
    {
        return new MyStuffConverter();
    }
}

private class MyStuffConverter : JsonConverter<IClass>
{
    public override IClass Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
    {
        return new MyClass();
    }

    public override void Write(Utf8JsonWriter writer, IClass value, JsonSerializerOptions options)
    {
        writer.WriteNumberValue(1);
    }
}
```

In this case, the read method of the converter for `typeof(MyClass)` returns a type `IClass` (not the declared type, `MyClass`) which causes an `InvalidCastException` later in the deserialization flow.

## Customer Impact

The ability to serialize nested concurrent dictionaries is restored: https://github.com/dotnet/runtime/issues/670. 

The deserialization scenario is an edge case, but the fix defends against leaking exceptions were it to occur.

## Regression

No. The serialization change's tests are wide-ranging and covers various permutations of nested dictionaries, so a regression is unlikely.

The deserialization change adds more support without rescinding support. A regression is unlikely.

## Risk

Low, per the regression section above.