### PR TITLE
3.1: make sure we have big enough buffer to prevent endless spin while dumping route table on OSX

### DIFF
--- a/src/Native/Unix/System.Native/pal_interfaceaddresses.c
+++ b/src/Native/Unix/System.Native/pal_interfaceaddresses.c
@@ -180,6 +180,22 @@ int32_t SystemNative_EnumerateGatewayAddressesForInterface(uint32_t interfaceInd
 
     while (sysctl(routeDumpName, 6, buffer, &byteCount, NULL, 0) != 0)
     {
+        if (errno != ENOMEM)
+        {
+            return -1;
+        }
+
+        // If buffer is not big enough double size to avoid calling sysctl again
+        // as byteCount only gets estimated size when passed buffer is NULL.
+        // This only happens if routing table grows between first and second call.
+        size_t tmpEstimatedSize;
+        if (!multiply_s(byteCount, (size_t)2, &tmpEstimatedSize))
+        {
+            errno = ENOMEM;
+            return -1;
+        }
+
+        byteCount = tmpEstimatedSize;
         buffer = realloc(buffer, byteCount);
         if (buffer == NULL)
         {


### PR DESCRIPTION
**Description**
This is port of  https://github.com/dotnet/runtime/pull/591 to address `dotnet core 3 on macOS Catalina: NetworkInterface causes high CPU` #42634. Existing code assumes that when provided buffer is too small, `sysctl()` will update provided length. However that is happening only when NULL is passed in and we will en dup in endless spin trying to re-allocate to same size. 

**Impact**
This is race condition impacting OSX only. However, when it happens, we spin in native PAL code and there is no recovery or workaround. 

**Regression?**

No.

**Risk**

Small. Fix is in OSX pal code and does not impact other platforms. Fix was verified by impacted customer. 


fixes  #42634
