### PR TITLE
[release/3.1] Revert changes to EncoderNLS/DecoderNLS.Convert unit tests

### DIFF
--- a/src/System.Text.Encoding/tests/Decoder/DecoderConvert2.cs
+++ b/src/System.Text.Encoding/tests/Decoder/DecoderConvert2.cs
@@ -165,7 +165,7 @@ namespace System.Text.Tests
             }
 
             Decoder decoder = Encoding.Unicode.GetDecoder();
-            VerificationHelper(decoder, bytes, 0, bytes.Length, chars, 0, chars.Length, false, bytes.Length, chars.Length / 2, false, "006.1");
+            VerificationHelper(decoder, bytes, 0, bytes.Length, chars, 0, chars.Length, false, bytes.Length, chars.Length / 2, true, "006.1");
             decoder.Reset();
             // There will be 1 byte left unconverted after previous statement, and set flush = false should left this 1 byte in the buffer.
             VerificationHelper(decoder, bytes, 0, bytes.Length, chars, 0, chars.Length, true, bytes.Length, chars.Length / 2 + 1, true, "006.2");
@@ -288,8 +288,8 @@ namespace System.Text.Tests
             char[] chars = new char[32];
             Decoder decoder = Encoding.UTF8.GetDecoder();
 
-            VerificationHelper(decoder, bytes, 0, 1, chars, 0, 10, false, 1, 0, false, "011.1"); // incomplete since still state in Decoder
-            VerificationHelper(decoder, bytes, 1, 2, chars, 0, 10, false, 2, 1, false, "011.2"); // incomplete since still state in Decoder
+            VerificationHelper(decoder, bytes, 0, 1, chars, 0, 10, false, 1, 0, true, "011.1"); // complete since all source bytes consumed and no pending data for destination
+            VerificationHelper(decoder, bytes, 1, 2, chars, 0, 10, false, 2, 1, true, "011.2"); // complete since all source bytes consumed and no pending data for destination
             VerificationHelper(decoder, bytes, 3, 6, chars, 1, 1, false, 2, 1, false, "011.3"); // incomplete since not all bytes consumed
             VerificationHelper(decoder, bytes, 5, 4, chars, 2, 10, false, 4, 2, true, "011.4"); // complete since all bytes consumed and no leftover state
             VerificationHelper(decoder, bytes, 9, 1, chars, 4, 10, true, 1, 1, true, "011.5"); // complete since all bytes consumed and no leftover state

--- a/src/System.Text.Encoding/tests/Encoder/EncoderConvert2.cs
+++ b/src/System.Text.Encoding/tests/Encoder/EncoderConvert2.cs
@@ -224,7 +224,7 @@ namespace System.Text.Tests
             VerificationHelper(encoder, chars, 1, 3, bytes, 1, 3, false, 1, 3, expectedCompleted: false);
             VerificationHelper(encoder, chars, 1, 3, bytes, 1, 5, true, 3, 5, expectedCompleted: true);
 
-            VerificationHelper(encoder, chars, 0, 1, bytes, 0, bytes.Length, false, 1, 0, expectedCompleted: false);
+            VerificationHelper(encoder, chars, 0, 1, bytes, 0, bytes.Length, false, 1, 0, expectedCompleted: true);
             VerificationHelper(encoder, chars, 1, 1, bytes, 0, bytes.Length, true, 1, 4, expectedCompleted: true);
         }
  
@@ -259,7 +259,7 @@ namespace System.Text.Tests
             Encoder encoder = Encoding.UTF8.GetEncoder();
 
             VerificationHelper(encoder, chars, 0, 1, bytes, 0, 1, true, 1, 1, expectedCompleted: true);
-            VerificationHelper(encoder, chars, 0, 2, bytes, 0, 1, false, 2, 1, expectedCompleted: false);
+            VerificationHelper(encoder, chars, 0, 2, bytes, 0, 1, false, 2, 1, expectedCompleted: true);
             VerificationHelper(encoder, chars, 2, 1, bytes, 0, 5, false, 1, 4, expectedCompleted: true);
             VerificationHelper(encoder, chars, 1, 2, bytes, 0, 7, false, 2, 4, expectedCompleted: true);
             VerificationHelper(encoder, chars, 0, 5, bytes, 0, 7, false, 5, 7, expectedCompleted: true);
@@ -268,7 +268,7 @@ namespace System.Text.Tests
             VerificationHelper(encoder, chars, 1, 3, bytes, 1, 5, false, 3, 5, expectedCompleted: true);
             VerificationHelper(encoder, chars, 1, 3, bytes, 1, 5, true, 3, 5, expectedCompleted: true);
 
-            VerificationHelper(encoder, chars, 0, 2, bytes, 0, bytes.Length, false, 2, 1, expectedCompleted: false);
+            VerificationHelper(encoder, chars, 0, 2, bytes, 0, bytes.Length, false, 2, 1, expectedCompleted: true);
             VerificationHelper(encoder, chars, 2, 2, bytes, 0, bytes.Length, false, 2, 5, expectedCompleted: true);
             VerificationHelper(encoder, chars, 1, 1, bytes, 0, bytes.Length, true, 1, 3, expectedCompleted: true);
         }


### PR DESCRIPTION
These are the unit test changes to accompany https://github.com/dotnet/coreclr/pull/27996, which was committed to the __release/3.1__ branch in the _coreclr_ repo.

This _corefx_ PR isn't a functional product change. It's just updating the unit tests to reflect the incoming _coreclr_ changes. Once a nightly _coreclr_ build is created and it works its way into this repo, this PR will resolve the resulting unit test failures and will unblock future work in this repo.