### PR TITLE
Fix ReadOnlySequence GetFirstSpan

### DIFF
--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence.Helpers.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence.Helpers.cs
@@ -649,11 +649,11 @@ namespace System.Buffers
                     {
                         // Positive start and end index == ReadOnlySequenceSegment<T>
                         ReadOnlySequenceSegment<T> segment = (ReadOnlySequenceSegment<T>)startObject;
-                        next = new SequencePosition(segment.Next, 0);
                         first = segment.Memory.Span;
                         if (hasMultipleSegments)
                         {
                             first = first.Slice(startIndex);
+                            next = new SequencePosition(segment.Next, 0);
                         }
                         else
                         {

--- a/src/System.Memory/tests/SequenceReader/ReadTo.cs
+++ b/src/System.Memory/tests/SequenceReader/ReadTo.cs
@@ -198,5 +198,17 @@ namespace System.Memory.Tests.SequenceReader
                 Assert.Equal(i + 1, value);
             }
         }
+
+        [Fact]
+        public void TryReadTo_Span_At_Segments_Boundary()
+        {
+            Span<byte> delimiter = new byte[] { 13, 10 }; // \r\n
+            BufferSegment<byte> segment = new BufferSegment<byte>(Text.Encoding.ASCII.GetBytes("Hello\r"));
+            segment.Append(Text.Encoding.ASCII.GetBytes("\nWorld")); // add next segment
+            ReadOnlySequence<byte> inputSeq = new ReadOnlySequence<byte>(segment, 0, segment, 6); // span only the first segment!
+            SequenceReader<byte> sr = new SequenceReader<byte>(inputSeq);
+            bool r = sr.TryReadTo(out _, delimiter);
+            Assert.False(r);
+        }
     }
 }


### PR DESCRIPTION
Ports https://github.com/dotnet/runtime/pull/276 manually, to address https://github.com/dotnet/runtime/issues/2205.

**Description**

When getting the first span `GetFirstSpan` from a sequence that is made up of a single segment view of a sequence with multiple sequences the `next` `SequencePosition` is incorrect and will lead to failures trying to enumerate in `SequenceReader` (or anything else that tries to use the `GetFirstSpan` and the returned `SequencePosition`).

**Customer Impact**

Customers will see intermittent failures when sequences happen to align in this way. This issue has gotten multiple reports.

**Regression?**

No.

**Packaging reviewed?**

Bug fix, no API surface change.

**Risk**

Low. This fix has been in master for a few months and there are significant tests and upstream users.



