### PR TITLE
[Release/2.1] Adding .NET Framework asset on OOB packages

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -607,7 +607,7 @@
         "4.4.0",
         "4.5.0"
       ],
-      "BaselineVersion": "4.4.0",
+      "BaselineVersion": "4.5.1",
       "InboxOn": {
         "netcoreapp2.0": "4.0.2.0",
         "netcoreapp2.1": "4.0.3.0",
@@ -2500,6 +2500,7 @@
         "4.5.2",
         "4.5.3"
       ],
+      "BaselineVersion": "4.5.4",
       "InboxOn": {
         "netcoreapp2.1": "4.1.0.0"
       },
@@ -3642,6 +3643,7 @@
         "4.5.1",
         "4.5.2"
       ],
+      "BaselineVersion": "4.5.3",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.4.0": "4.5.1",

--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -5052,7 +5052,7 @@
         "4.5.2",
         "4.5.3"
       ],
-      "BaselineVersion": "4.4.0",
+      "BaselineVersion": "4.5.4",
       "InboxOn": {
         "netcoreapp2.0": "4.1.1.0",
         "netcoreapp2.1": "4.3.0.0",

--- a/src/System.Buffers/dir.props
+++ b/src/System.Buffers/dir.props
@@ -2,6 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
+  	<PackageVersion>4.5.1</PackageVersion>
     <AssemblyVersion>4.0.3.0</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
     <IsNETCoreApp>true</IsNETCoreApp>

--- a/src/System.Buffers/src/Configurations.props
+++ b/src/System.Buffers/src/Configurations.props
@@ -4,6 +4,7 @@
     <PackageConfigurations>
       netstandard1.1;
       netstandard;
+      netfx;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);

--- a/src/System.Buffers/src/System.Buffers.csproj
+++ b/src/System.Buffers/src/System.Buffers.csproj
@@ -5,7 +5,7 @@
     <ProjectGuid>{2ADDB484-6F57-4D71-A3FE-A57EC6329A2B}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DocumentationFile>$(OutputPath)$(MSBuildProjectName).xml</DocumentationFile>
-    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' != 'netstandard' and '$(TargetGroup)' != 'netstandard1.1' and '$(TargetGroup)' != 'uap10.0.16299'">true</IsPartialFacadeAssembly>
+    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' != 'netstandard' and '$(TargetGroup)' != 'netstandard1.1' and '$(TargetGroup)' != 'uap10.0.16299' and '$(TargetGroup)' != 'netfx'">true</IsPartialFacadeAssembly>
     <ExcludeResourcesImport Condition="'$(IsPartialFacadeAssembly)'=='true'">true</ExcludeResourcesImport>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Unix-Debug|AnyCPU'" />
@@ -16,6 +16,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.1-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.1-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uapaot-Windows_NT-Debug|AnyCPU'" />
@@ -36,6 +38,10 @@
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Threading" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netfx'">
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Memory/dir.props
+++ b/src/System.Memory/dir.props
@@ -2,8 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.1.1</AssemblyVersion>
-    <PackageVersion>4.5.1</PackageVersion>
+    <AssemblyVersion>4.0.1.2</AssemblyVersion>
     <!-- System.Memory has forwarded types into the runtime on netcoreapp/uap
          It must win over assemblies versioned at 4.0.* -->
     <AssemblyVersion Condition="'$(TargetGroup)' == 'netcoreapp' OR '$(TargetGroup)' == 'uap' ">4.1.0.0</AssemblyVersion>

--- a/src/System.Memory/dir.props
+++ b/src/System.Memory/dir.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.1.2</AssemblyVersion>
+    <AssemblyVersion>4.0.1.1</AssemblyVersion>
     <!-- System.Memory has forwarded types into the runtime on netcoreapp/uap
          It must win over assemblies versioned at 4.0.* -->
     <AssemblyVersion Condition="'$(TargetGroup)' == 'netcoreapp' OR '$(TargetGroup)' == 'uap' ">4.1.0.0</AssemblyVersion>

--- a/src/System.Memory/pkg/System.Memory.pkgproj
+++ b/src/System.Memory/pkg/System.Memory.pkgproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <PackageVersion>4.5.3</PackageVersion>
+    <PackageVersion>4.5.4</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageIndex Include="$(ProjectDir)\pkg\baseline\packageBaseline.1.1.json" />

--- a/src/System.Memory/ref/Configurations.props
+++ b/src/System.Memory/ref/Configurations.props
@@ -4,6 +4,7 @@
     <PackageConfigurations>
       netstandard1.1;
       netstandard;
+      netfx;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);

--- a/src/System.Memory/ref/System.Memory.csproj
+++ b/src/System.Memory/ref/System.Memory.csproj
@@ -29,5 +29,9 @@
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.InteropServices" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netfx'">
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Memory/src/Configurations.props
+++ b/src/System.Memory/src/Configurations.props
@@ -4,6 +4,7 @@
     <PackageConfigurations>
       netstandard1.1;
       netstandard;
+      netfx;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);

--- a/src/System.Memory/src/System.Memory.csproj
+++ b/src/System.Memory/src/System.Memory.csproj
@@ -154,6 +154,10 @@
     <Reference Include="System.Threading" />
     <Reference Condition="'$(TargetGroup)' != 'netstandard1.1'" Include="System.Numerics.Vectors" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netfx'">
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+  </ItemGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' == 'true'">
     <ReferenceFromRuntime Include="System.Private.CoreLib" />
     <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj" />

--- a/src/System.Runtime.CompilerServices.Unsafe/dir.props
+++ b/src/System.Runtime.CompilerServices.Unsafe/dir.props
@@ -3,7 +3,7 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.4.1</AssemblyVersion>
-    <PackageVersion>4.5.2</PackageVersion>
+    <PackageVersion>4.5.3</PackageVersion>
     <AssemblyKey>MSFT</AssemblyKey>
     <IsUAP>true</IsUAP>
   </PropertyGroup>

--- a/src/System.Runtime.CompilerServices.Unsafe/ref/Configurations.props
+++ b/src/System.Runtime.CompilerServices.Unsafe/ref/Configurations.props
@@ -4,6 +4,7 @@
     <BuildConfigurations>
       netstandard1.0;
       netstandard;
+      netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.CompilerServices.Unsafe/ref/System.Runtime.CompilerServices.Unsafe.csproj
+++ b/src/System.Runtime.CompilerServices.Unsafe/ref/System.Runtime.CompilerServices.Unsafe.csproj
@@ -8,11 +8,16 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.0-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.0-Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="System.Runtime.CompilerServices.Unsafe.cs" />
     <Reference Include="System.Runtime" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netfx'">
+    <Reference Include="mscorlib" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime.CompilerServices.Unsafe/src/Configurations.props
+++ b/src/System.Runtime.CompilerServices.Unsafe/src/Configurations.props
@@ -5,6 +5,7 @@
       netcoreapp2.0;
       netstandard1.0;
       netstandard;
+      netfx;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);

--- a/src/System.Runtime.CompilerServices.Unsafe/src/include/netfx/coreassembly.h
+++ b/src/System.Runtime.CompilerServices.Unsafe/src/include/netfx/coreassembly.h
@@ -3,6 +3,6 @@
 // Metadata version: v4.0.30319
 .assembly extern CORE_ASSEMBLY
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .?_....:
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
   .ver 4:0:0:0
 }

--- a/src/System.Runtime.CompilerServices.Unsafe/src/include/netfx/coreassembly.h
+++ b/src/System.Runtime.CompilerServices.Unsafe/src/include/netfx/coreassembly.h
@@ -1,0 +1,8 @@
+#define CORE_ASSEMBLY "mscorlib"
+
+// Metadata version: v4.0.30319
+.assembly extern CORE_ASSEMBLY
+{
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .?_....:
+  .ver 4:0:0:0
+}

--- a/src/System.Threading.Tasks.Extensions/dir.props
+++ b/src/System.Threading.Tasks.Extensions/dir.props
@@ -3,7 +3,7 @@
   <Import Project="..\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.2.0.1</AssemblyVersion>
-    <PackageVersion>4.5.3</PackageVersion>
+    <PackageVersion>4.5.4</PackageVersion>
     <!-- System.Threading.Tasks.Extensions has forwarded types into the runtime on netcoreapp/uap
          It must win over assemblies versioned at 4.2.* -->
     <AssemblyVersion Condition="'$(TargetGroup)' == 'netcoreapp' OR '$(TargetGroup)' == 'uap' ">4.3.0.0</AssemblyVersion>

--- a/src/System.Threading.Tasks.Extensions/ref/Configurations.props
+++ b/src/System.Threading.Tasks.Extensions/ref/Configurations.props
@@ -4,6 +4,7 @@
     <PackageConfigurations>
       netstandard1.0;
       netstandard;
+      netfx;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);

--- a/src/System.Threading.Tasks.Extensions/ref/System.Threading.Tasks.Extensions.csproj
+++ b/src/System.Threading.Tasks.Extensions/ref/System.Threading.Tasks.Extensions.csproj
@@ -11,6 +11,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.0-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.0-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Release|AnyCPU'" />
   <ItemGroup>
@@ -23,6 +25,9 @@
   <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.0'">
     <Reference Include="System.Runtime" />
     <Reference Include="System.Threading.Tasks" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netfx'">
+    <Reference Include="mscorlib" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Threading.Tasks.Extensions/src/Configurations.props
+++ b/src/System.Threading.Tasks.Extensions/src/Configurations.props
@@ -4,6 +4,7 @@
     <PackageConfigurations>
       netstandard1.0;
       netstandard;
+      netfx;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);

--- a/src/System.Threading.Tasks.Extensions/src/System.Threading.Tasks.Extensions.csproj
+++ b/src/System.Threading.Tasks.Extensions/src/System.Threading.Tasks.Extensions.csproj
@@ -5,7 +5,7 @@
     <ProjectGuid>{DE90AD0B-649D-4062-B8D9-9658DE140532}</ProjectGuid>
     <DocumentationFile>$(OutputPath)$(MSBuildProjectName).xml</DocumentationFile>
     <PackageTargetFramework Condition="'$(TargetGroup)' == 'netstandard1.0'">netstandard1.0;portable-net45+win8+wp8+wpa81</PackageTargetFramework>
-    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' != 'netstandard' and '$(TargetGroup)' != 'netstandard1.0'">true</IsPartialFacadeAssembly>
+    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' != 'netstandard' and '$(TargetGroup)' != 'netstandard1.0' and '$(TargetGroup)' != 'netfx'">true</IsPartialFacadeAssembly>
     <DefineConstants Condition="'$(IsPartialFacadeAssembly)' != 'true'">$(DefineConstants);netstandard</DefineConstants>
     <ExcludeResourcesImport Condition="'$(IsPartialFacadeAssembly)'=='true'">true</ExcludeResourcesImport>
   </PropertyGroup>
@@ -15,6 +15,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcoreapp-Windows_NT-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard-Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.0-Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netstandard1.0-Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'uap-Windows_NT-Debug|AnyCPU'" />
@@ -51,6 +53,10 @@
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.CompilerServices.Unsafe" />
     <Reference Include="System.Threading.Tasks" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netfx'">
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -33,6 +33,12 @@
     <Project Include="$(MSBuildThisFileDirectory)System.Buffers\pkg\System.Buffers.pkgproj">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
+    <Project Include="$(MSBuildThisFileDirectory)System.Runtime.CompilerServices.Unsafe\pkg\System.Runtime.CompilerServices.Unsafe.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="$(MSBuildThisFileDirectory)System.Threading.Tasks.Extensions\pkg\System.Threading.Tasks.Extensions.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
   </ItemGroup>
 
   <!-- Need the PackageIndexFile file property from baseline.props -->

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -26,7 +26,10 @@
     <!-- add specific builds / pkgproj's here to include in servicing builds -->
     <Project Include="$(MSBuildThisFileDirectory)..\pkg\Microsoft.NETCore.Platforms\Microsoft.NETCore.Platforms.builds">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
-     </Project>
+    </Project>
+    <Project Include="$(MSBuildThisFileDirectory)System.Memory\pkg\System.Memory.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
   </ItemGroup>
 
   <!-- Need the PackageIndexFile file property from baseline.props -->

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -30,6 +30,9 @@
     <Project Include="$(MSBuildThisFileDirectory)System.Memory\pkg\System.Memory.pkgproj">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
+    <Project Include="$(MSBuildThisFileDirectory)System.Buffers\pkg\System.Buffers.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
   </ItemGroup>
 
   <!-- Need the PackageIndexFile file property from baseline.props -->


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/1625

PTAL: @ericstj @ahsonkhan 

FYI: @Dmitry-Matveev after this fix is in and shipped, then App Insights will be able to depend on the new version of System.Memory which will stop requiring facades to get binplaced and binding redirects to be required.

The changes included in this PR will fix all packages that are supported in .Net Framework, currently provide a .NET Standard asset for one .NET Framework version, and we no longer build on other branches (master or release/3.1). The thing left to do before this goes in, is to analyze the packages that had a reference to one of these and no longer build on other branches, so that we produce a new version of them referencing the new packages.