### PR TITLE
Backport attribute to support inline namespaces in C++/CLI 

### DIFF
--- a/src/System.Runtime.CompilerServices.VisualC/ref/System.Runtime.CompilerServices.VisualC.cs
+++ b/src/System.Runtime.CompilerServices.VisualC/ref/System.Runtime.CompilerServices.VisualC.cs
@@ -66,6 +66,11 @@ namespace System.Runtime.CompilerServices
     {
         public NativeCppClassAttribute() { }
     }
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple=true)]
+    public sealed class CppInlineNamespaceAttribute : Attribute
+    {
+        public CppInlineNamespaceAttribute(string dottedName) {}
+    }
     [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Enum | System.AttributeTargets.Interface | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
     public sealed partial class RequiredAttributeAttribute : System.Attribute
     {

--- a/src/System.Runtime.CompilerServices.VisualC/src/System/Runtime/CompilerServices/Attributes.cs
+++ b/src/System.Runtime.CompilerServices.VisualC/src/System/Runtime/CompilerServices/Attributes.cs
@@ -121,6 +121,12 @@ namespace System.Runtime.CompilerServices
         public NativeCppClassAttribute() { }
     }
 
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple=true)]
+    public sealed class CppInlineNamespaceAttribute : Attribute
+    {
+        public CppInlineNamespaceAttribute(string dottedName) {}
+    }
+
     [AttributeUsage (AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Interface,AllowMultiple=true, Inherited=false)]
     public sealed class RequiredAttributeAttribute : Attribute
     {


### PR DESCRIPTION
Port commit cef57de93bab815726f860f79195227c65e4fce5 from dotnet/runtime (5.0) to dotnet/corefx (3.1).

commit cef57de93bab815726f860f79195227c65e4fce5
Author: Tanveer Gani <45886079+tgani-msft@users.noreply.github.com>
Date:   Thu Jan 30 10:28:26 2020 -0800

    Add attribute to support inline namespaces in C++/CLI. (#781)

    * Add attribute to support inline namespaces in C++/CLI.

    A new assembly-scope custom attribute

    [CppInlineNamespace(string dottedName)]

    has been added to implement inline namespaces in C++/CLI. For every
    inline namespace encountered in a translation unit, the C++ compiler
    will emit this attribute with the fully scoped name, in CLR dotted
    form, as the argument for the attribute.

    * Add [CppInlineNamespace] to refs.