### PR TITLE
Disable machine related or flaky tests

### DIFF
--- a/src/System.Drawing.Common/tests/BitmapTests.cs
+++ b/src/System.Drawing.Common/tests/BitmapTests.cs
@@ -546,6 +546,7 @@ namespace System.Drawing.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => bitmap.Clone(new RectangleF(0, 0, 1, 1), PixelFormat.Format32bppArgb));
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.OSX)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GetFrameCount_NewBitmap_ReturnsZero()
         {

--- a/src/System.Drawing.Common/tests/IconTests.cs
+++ b/src/System.Drawing.Common/tests/IconTests.cs
@@ -829,6 +829,7 @@ namespace System.Drawing.Tests
             }
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.OSX)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void CorrectColorDepthExtracted()
         {

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
@@ -86,6 +86,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/1332")]
         [PlatformSpecific(TestPlatforms.OSX|TestPlatforms.FreeBSD)]
         public void BasicTest_AccessInstanceProperties_NoExceptions_Bsd()
         {


### PR DESCRIPTION
System.DrawingTest are failing on mac because the machines are being updated.
 BasicTest_AccessInstanceProperties_NoExceptions_Bsd failure is known and we are working on fixing it. 