### PR TITLE
[release/3.1] Port dotnet/runtime#32104 fix for Thread.CurrentPrincipal regression

### DIFF
--- a/src/Common/src/CoreLib/System/Threading/Thread.cs
+++ b/src/Common/src/CoreLib/System/Threading/Thread.cs
@@ -136,11 +136,12 @@ namespace System.Threading
         {
             get
             {
-                if (s_asyncLocalPrincipal is null)
+                IPrincipal? principal = s_asyncLocalPrincipal?.Value;
+                if (principal is null)
                 {
-                    CurrentPrincipal = AppDomain.CurrentDomain.GetThreadPrincipal();
+                    CurrentPrincipal = (principal = AppDomain.CurrentDomain.GetThreadPrincipal());
                 }
-                return s_asyncLocalPrincipal?.Value;
+                return principal;
             }
             set
             {


### PR DESCRIPTION
Backports a fix for issue https://github.com/dotnet/runtime/issues/31717 which concerns a regression in the behaviour of the `Thread.CurrentPrincipal` property, introduced in 3.0.

This has already been fixed in .NET 5 (see https://github.com/dotnet/runtime/pull/32104). This PR ports that fix down to _release/3.1_.

## Customer Impact
Assigning a PrincipalPolicy to the current AppDomain results in the first thread correctly returning `Thread.CurrentPrincipal`. However it will consistently return `null` for any subsequent threads. There are no known workarounds to this issue.

## Regression?
Functional regression between 2.1 and 3.0. Reported by 2 customers.

## Testing
The .NET 5 fix at https://github.com/dotnet/runtime/pull/32104 includes tests for the fix.

## Risk
Moderate. The regression was introduced in an attempt to introduce new behaviour (i.e. flowing the principal with ExecutionContext), but this was broken in all but the most trivial scenaria (using just one thread). It is conceivable that fixing this might expose other problems, or in the very least break applications written against 3.0 that implicitly depend on the current behaviour of the property.

## Code Reviewer
@jkotas 