### PR TITLE
[release/3.1] Fix cast in CacheMemoryMonitor (#41776)

### DIFF
--- a/src/System.Runtime.Caching/src/System/Runtime/Caching/CacheMemoryMonitor.cs
+++ b/src/System.Runtime.Caching/src/System/Runtime/Caching/CacheMemoryMonitor.cs
@@ -236,7 +236,7 @@ namespace System.Runtime.Caching
         internal void SetLimit(int cacheMemoryLimitMegabytes)
         {
             long cacheMemoryLimit = cacheMemoryLimitMegabytes;
-            cacheMemoryLimit = cacheMemoryLimit << MEGABYTE_SHIFT;
+            cacheMemoryLimit = ((long)cacheMemoryLimit) << MEGABYTE_SHIFT;
 
             _memoryLimit = 0;
 


### PR DESCRIPTION
Avoid overflow.

cc @stephentoub 