### PR TITLE
[release/3.1] Corresponding unit tests for dotnet/coreclr#28014

### DIFF
--- a/src/Common/tests/Tests/System/StringTests.cs
+++ b/src/Common/tests/Tests/System/StringTests.cs
@@ -20,6 +20,7 @@ namespace System.Tests
     public partial class StringTests
     {
         private const string SoftHyphen = "\u00AD";
+        private const string ZeroWidthJoiner = "\u200D"; // weightless in both ICU and NLS
         private static readonly char[] s_whiteSpaceCharacters = { '\u0009', '\u000a', '\u000b', '\u000c', '\u000d', '\u0020', '\u0085', '\u00a0', '\u1680' };
 
         [Theory]

--- a/src/System.Runtime/tests/System/StringTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/StringTests.netcoreapp.cs
@@ -745,6 +745,21 @@ namespace System.Tests
             AssertExtensions.Throws<ArgumentException>("oldValue", () => "abc".Replace("", "def", true, CultureInfo.CurrentCulture));
         }
 
+        [Fact]
+        public void Replace_StringComparison_WeightlessOldValue_WithOrdinalComparison_Succeeds()
+        {
+            Assert.Equal("abcdef", ("abc" + ZeroWidthJoiner).Replace(ZeroWidthJoiner, "def"));
+            Assert.Equal("abcdef", ("abc" + ZeroWidthJoiner).Replace(ZeroWidthJoiner, "def", StringComparison.Ordinal));
+            Assert.Equal("abcdef", ("abc" + ZeroWidthJoiner).Replace(ZeroWidthJoiner, "def", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Fact]
+        public void Replace_StringComparison_WeightlessOldValue_WithLinguisticComparison_TerminatesReplacement()
+        {
+            Assert.Equal("abc" + ZeroWidthJoiner + "def", ("abc" + ZeroWidthJoiner + "def").Replace(ZeroWidthJoiner, "xyz", StringComparison.CurrentCulture));
+            Assert.Equal("abc" + ZeroWidthJoiner + "def", ("abc" + ZeroWidthJoiner + "def").Replace(ZeroWidthJoiner, "xyz", true, CultureInfo.CurrentCulture));
+        }
+
         [Theory]
         [InlineData(StringComparison.CurrentCulture - 1)]
         [InlineData(StringComparison.OrdinalIgnoreCase + 1)]


### PR DESCRIPTION
These are the unit tests for https://github.com/dotnet/coreclr/pull/28014, which is a customer-reported infinite loop in `string.Replace`.

The unit tests will fail (by entering an infinite loop) until that PR is checked in to coreclr and the corresponding build flows to corefx.