### PR TITLE
[release/3.1] Make sure original Utf8JsonReader options are honored when re-creating the reader.

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Utf8JsonReader.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Utf8JsonReader.cs
@@ -299,7 +299,9 @@ namespace System.Text.Json
                     valueSpan.CopyTo(rentedSpan);
                 }
 
-                var newReader = new Utf8JsonReader(rentedSpan, isFinalBlock: true, state: default);
+                JsonReaderOptions originalReaderOptions = state.Options;
+
+                var newReader = new Utf8JsonReader(rentedSpan, originalReaderOptions);
 
                 ReadCore(options, ref newReader, ref readStack);
 

--- a/src/System.Text.Json/tests/Serialization/WriteValueTests.cs
+++ b/src/System.Text.Json/tests/Serialization/WriteValueTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
+using System.Text.Encodings.Web;
 using Xunit;
 
 namespace System.Text.Json.Serialization.Tests
@@ -31,6 +32,222 @@ namespace System.Text.Json.Serialization.Tests
 
             string json = Encoding.UTF8.GetString(memoryStream.ToArray());
             Assert.Equal("{\"test\":[1]}", json);
+        }
+
+        [Fact]
+        public static void WriterOptionsWinIndented()
+        {
+            int[] input = new int[3] { 1, 2, 3 };
+
+            var serializerOptions = new JsonSerializerOptions
+            {
+                WriteIndented = true,
+            };
+
+            using (var stream = new MemoryStream())
+            {
+                using (var writer = new Utf8JsonWriter(stream))
+                {
+                    JsonSerializer.Serialize(writer, input, serializerOptions);
+                }
+                Assert.Equal("[1,2,3]", Encoding.UTF8.GetString(stream.ToArray()));
+            }
+
+            using (var stream = new MemoryStream())
+            {
+                using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = false }))
+                {
+                    JsonSerializer.Serialize(writer, input, serializerOptions);
+                }
+                Assert.Equal("[1,2,3]", Encoding.UTF8.GetString(stream.ToArray()));
+            }
+
+            using (var stream = new MemoryStream())
+            {
+                using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true }))
+                {
+                    JsonSerializer.Serialize(writer, input);
+                }
+                Assert.Equal($"[{Environment.NewLine}  1,{Environment.NewLine}  2,{Environment.NewLine}  3{Environment.NewLine}]", Encoding.UTF8.GetString(stream.ToArray()));
+            }
+        }
+
+        [Fact]
+        public static void WriterOptionsWinEncoder()
+        {
+            string input = "abcd+<>&";
+
+            var serializerOptions = new JsonSerializerOptions
+            {
+                Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+            };
+
+            using (var stream = new MemoryStream())
+            {
+                using (var writer = new Utf8JsonWriter(stream))
+                {
+                    JsonSerializer.Serialize(writer, input, serializerOptions);
+                }
+                Assert.Equal("\"abcd\\u002B\\u003C\\u003E\\u0026\"", Encoding.UTF8.GetString(stream.ToArray()));
+            }
+
+            using (var stream = new MemoryStream())
+            {
+                using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Encoder = JavaScriptEncoder.Default }))
+                {
+                    JsonSerializer.Serialize(writer, input, serializerOptions);
+                }
+                Assert.Equal("\"abcd\\u002B\\u003C\\u003E\\u0026\"", Encoding.UTF8.GetString(stream.ToArray()));
+            }
+
+            using (var stream = new MemoryStream())
+            {
+                using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping }))
+                {
+                    JsonSerializer.Serialize(writer, input);
+                }
+                Assert.Equal("\"abcd+<>&\"", Encoding.UTF8.GetString(stream.ToArray()));
+            }
+        }
+
+        [Fact]
+        public static void WriterOptionsSkipValidation()
+        {
+            int[] input = new int[3] { 1, 2, 3 };
+
+            using (var stream = new MemoryStream())
+            {
+                using (var writer = new Utf8JsonWriter(stream))
+                {
+                    writer.WriteStartObject();
+                    Assert.Throws<JsonException>(() => JsonSerializer.Serialize(writer, input));
+                }
+            }
+
+            using (var stream = new MemoryStream())
+            {
+                using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { SkipValidation = true }))
+                {
+                    writer.WriteStartObject();
+                    JsonSerializer.Serialize(writer, input);
+                }
+                Assert.Equal("{[1,2,3]", Encoding.UTF8.GetString(stream.ToArray()));
+            }
+
+            var serializerOptions = new JsonSerializerOptions
+            {
+                Converters = { new InvalidArrayConverter() },
+            };
+
+            using (var stream = new MemoryStream())
+            {
+                using (var writer = new Utf8JsonWriter(stream))
+                {
+                    Assert.Throws<JsonException>(() => JsonSerializer.Serialize(writer, input, serializerOptions));
+                }
+            }
+
+            using (var stream = new MemoryStream())
+            {
+                using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { SkipValidation = true }))
+                {
+                    JsonSerializer.Serialize(writer, input, serializerOptions);
+                }
+                Assert.Equal("[}", Encoding.UTF8.GetString(stream.ToArray()));
+            }
+        }
+
+        public class InvalidArrayConverter : JsonConverter<int[]>
+        {
+            public override int[] Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void Write(Utf8JsonWriter writer, int[] value, JsonSerializerOptions options)
+            {
+                writer.WriteStartArray();
+                writer.WriteEndObject();
+            }
+        }
+
+        [Fact]
+        public static void OptionsFollowToConverter()
+        {
+            string json = "{\"type\":\"array\",\"array\":[1]}";
+            string jsonFormatted =
+@"{
+  ""type"": ""array"",
+  ""array"": [
+    1
+  ]
+}";
+            string expectedInner = "{\"array\":[1]}";
+
+            var tempOptions = new JsonSerializerOptions();
+            tempOptions.Converters.Add(new CustomConverter());
+            DeepArray direct = JsonSerializer.Deserialize<DeepArray>(json, tempOptions);
+            IContent custom = JsonSerializer.Deserialize<IContent>(json, tempOptions);
+
+            {
+                var options = new JsonSerializerOptions();
+                options.Converters.Add(new CustomConverter());
+
+                Assert.Equal(expectedInner, JsonSerializer.Serialize(direct, options));
+                Assert.Equal(json, JsonSerializer.Serialize(custom, options));
+            }
+
+            {
+                var options = new JsonSerializerOptions
+                {
+                    Converters = { new CustomConverter() }
+                };
+                WriteAndValidate(direct, typeof(DeepArray), expectedInner, options, writerOptions: default);
+                WriteAndValidate(custom, typeof(IContent), json, options, writerOptions: default);
+            }
+
+            {
+                var options = new JsonSerializerOptions
+                {
+                    WriteIndented = true,
+                    Converters = { new CustomConverter() }
+                };
+                var writerOptions = new JsonWriterOptions { Indented = false };
+                WriteAndValidate(direct, typeof(DeepArray), expectedInner, options, writerOptions);
+                WriteAndValidate(custom, typeof(IContent), json, options, writerOptions);
+            }
+
+            {
+                var options = new JsonSerializerOptions
+                {
+                    WriteIndented = true,
+                    Converters = { new CustomConverter() }
+                };
+                WriteAndValidate(direct, typeof(DeepArray), expectedInner, options, writerOptions: default);
+                WriteAndValidate(custom, typeof(IContent), json, options, writerOptions: default);
+            }
+
+            {
+                var options = new JsonSerializerOptions
+                {
+                    Converters = { new CustomConverter() }
+                };
+                var writerOptions = new JsonWriterOptions { Indented = true };
+                WriteAndValidate(direct, typeof(DeepArray), $"{{{Environment.NewLine}  \"array\": [{Environment.NewLine}    1{Environment.NewLine}  ]{Environment.NewLine}}}", options, writerOptions);
+                WriteAndValidate(custom, typeof(IContent), jsonFormatted, options, writerOptions);
+            }
+
+            static void WriteAndValidate(object input, Type type, string expected, JsonSerializerOptions options, JsonWriterOptions writerOptions)
+            {
+                using (var stream = new MemoryStream())
+                {
+                    using (var writer = new Utf8JsonWriter(stream, writerOptions))
+                    {
+                        JsonSerializer.Serialize(writer, input, type, options);
+                    }
+                    Assert.Equal(expected, Encoding.UTF8.GetString(stream.ToArray()));
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Ports https://github.com/dotnet/runtime/pull/31791 from 5.0/master
Fixes https://github.com/dotnet/runtime/issues/882

## Description

Generate the `JsonReaderOptions` from the the user-defined, passed-in `JsonSerializerOptions`, and use that to create the `Utf8JsonReader`, rather than the default options. The fix is a couple of lines, with the rest of the PR adding tests and test enhancement.

## Customer Impact

This bug was initially reported in user-defined `JsonConverter<T>` where the user couldn't deserialize a deeply nested object graph (beyond the default max depth of 64). The issue, however, is not just specific to converters (nor just to `MaxDepth`) and will be hit whenever the caller passes in a `Utf8JsonReader` to the `JsonSerializer.Deserialize` method with non-default `JsonReaderOptions` set (which currently includes `MaxDepth`, `JsonCommentHandling`, and `AllowTrailingCommas`).

For example, this code snippet incorrectly fails with an exception:
```C#
var localReader = new Utf8JsonReader(Encoding.UTF8.GetBytes("[null,]"), 
                                       new JsonReaderOptions { AllowTrailingCommas = true });

string[] returnedValue = JsonSerializer.Deserialize<string[]>(ref localReader);

// System.Text.Json.JsonException : The JSON array contains a trailing comma at the end 
// which is not supported in this mode. Change the reader options. Path: $[1] | 
// LineNumber: 0 | BytePositionInLine: 6.
```

It is clear that we should be honoring the user-defined options. Otherwise, there is no way for callers to deserialize payloads containing trailing commas or comments when using the `Utf8JsonReader` with the `JsonSerializer`. We should make sure to meet user expectations here (otherwise, even debugging the issue would become difficult for them).

There is no reasonable workaround for the user. In fact, the `JsonConverter<T>` extension point is the primary workaround to change default serialization behavior, which increases the need for this fix since that isn't working as expected.

## Regression

No. The bug existed in the deserialization behavior since the initial release of S.T.Json as part of 3.0.

### Testing

Added several permutations within the test including customer reported scenario. The fix for the bug is only a couple of lines and only affects the read/deserialize, but I wanted to make sure we add tests to exercise the various options for both read and write. We already have decent negative test cases (where the default options throw for invalid JSON), but were missing positive test cases (where custom options worked to make the reader more flexible).

The writer tests are only there for completeness and fill a gap from when the `JsonSerializer` APIs that accept a writer were originally added (see https://github.com/dotnet/corefx/pull/38700#issuecomment-503763061). Those tests pass in master and 3.1 already with no source changes.

## Risk

**Low** given it is a very targeted fix with no regression. This fix only affects the deserialization behavior. One scenario where a customer could be impacted is if they accidentally relied on the default reader options to catch/throw for JSON that might contain comments/trailing commas, even when they were setting the options to be flexible. The fix for that would be to make sure the options match what you expect.

cc @ericstj 