### PR TITLE
Fixing regression caused by servicing of System.Data.SqlClient package

### DIFF
--- a/src/System.Data.SqlClient/Directory.Build.props
+++ b/src/System.Data.SqlClient/Directory.Build.props
@@ -4,6 +4,9 @@
     <!-- Must be kept in sync with pkg\Microsoft.Windows.Compatibility\Microsoft.Windows.Compatibility.pkgproj -->
     <PackageVersion>4.8.1</PackageVersion>
     <AssemblyVersion>4.6.1.1</AssemblyVersion>
+    <!-- Downgrade the Assembly Version to match RTM in order to have System.Data shim to still 
+    typeforward to RTM version instead of servicing version -->
+    <AssemblyVersion Condition="'$(TargetGroup)' == 'netcoreapp'">4.6.1.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IsUAP>true</IsUAP>
   </PropertyGroup>

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/UdtTest/UDTs/Address/Address.csproj
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/UdtTest/UDTs/Address/Address.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{D1392B54-998A-4F27-BC17-4CE149117BCC}</ProjectGuid>
-    <Configurations>netstandard-Debug;netstandard-Release</Configurations>
+    <Configurations>netstandard-Debug;netstandard-Release;netcoreapp-Debug;netcoreapp-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Address.cs" />

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/UdtTest/UDTs/Address/Configurations.props
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/UdtTest/UDTs/Address/Configurations.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       netstandard;
+      netcoreapp;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/UdtTest/UDTs/Circle/Circle.csproj
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/UdtTest/UDTs/Circle/Circle.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{6C88F00F-9597-43AD-9E5F-9B344DA3B16F}</ProjectGuid>
-    <Configurations>netstandard-Debug;netstandard-Release</Configurations>
+    <Configurations>netstandard-Debug;netstandard-Release;netcoreapp-Debug;netcoreapp-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Circle.cs" />

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/UdtTest/UDTs/Circle/Configurations.props
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/UdtTest/UDTs/Circle/Configurations.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       netstandard;
+      netcoreapp;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/UdtTest/UDTs/Shapes/Configurations.props
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/UdtTest/UDTs/Shapes/Configurations.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       netstandard;
+      netcoreapp;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/UdtTest/UDTs/Shapes/Shapes.csproj
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/UdtTest/UDTs/Shapes/Shapes.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{B73A7063-37C3-415D-AD53-BB3DA20ABD6E}</ProjectGuid>
-    <Configurations>netstandard-Debug;netstandard-Release</Configurations>
+    <Configurations>netstandard-Debug;netstandard-Release;netcoreapp-Debug;netcoreapp-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Line.cs" />

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/UdtTest/UDTs/Utf8String/Configurations.props
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/UdtTest/UDTs/Utf8String/Configurations.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       netstandard;
+      netcoreapp;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/UdtTest/UDTs/Utf8String/Utf8String.csproj
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/UdtTest/UDTs/Utf8String/Utf8String.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{E0A6BB21-574B-43D9-890D-6E1144F2EE9E}</ProjectGuid>
-    <Configurations>netstandard-Debug;netstandard-Release</Configurations>
+    <Configurations>netstandard-Debug;netstandard-Release;netcoreapp-Debug;netcoreapp-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Utf8String.cs" />


### PR DESCRIPTION
cc: @ericstj @danmosemsft @Pilchie @Anipik @wtgodbe 

For our 3.0 release (and 3.1) we made a major change on how we generate our compile and runtime .NET Framework shims (PR https://github.com/dotnet/corefx/pull/37550). We did this  in order to stop using assembly re-writing and instead to use source generation. Back when we did that, we didn't catch one diff which was that our desktop runtime shims would now reference the netcoreapp vertical contracts and their assembly versions, instead of just using 0.0.0.0 as we used to do with assembly re-writing. This caused an issue that if today we service one of our OOB packages and increase the assembly version, and this assembly happens to be referenced by one of our .NET Framework shims, then now the shims will have a hard dependency on that version of the OOB package and won't work with previous versions of the package. The first instance we've seen is now in 3.1.2 when we serviced System.Data.SqlClient (new assembly version is 4.6.1.1) and it is referenced by our System.Data shim. This means that if you need to load the System.Data shim, are running in 3.1.2 runtime, and reference a System.Data.SqlClient package which is older than 4.8.1 you will hit an exception like:

```
System.IO.FileLoadException: Could not load file or assembly 'System.Data.SqlClient, Version=4.6.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. The located assembly's manifest definition does not match the assembly reference. (0x80131040)
```

This will happen because the System.Data is trying to load System.Data.SqlClient new version, but the consuming app was referencing an older version of the package (for example: 4.8.0 which only contains 4.6.1.0 assembly)

This fix will address this regression only, by making System.Data shim to reference 4.6.1.0 version again so that package 4.8.0 will work again, however, older versions of the package will still not work (as was the case already since we initially shipped 3.0 and 3.1). There is a much larger list of assemblies that might hit this issue if they get serviced in the future, so after this regression is fixed, we will work in master branch in order to provide a future-proof fix that will work for all cases.