### PR TITLE
[release/3.1] Do not null ref or throw index out of range exception when deserializing to char.

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterChar.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterChar.cs
@@ -10,7 +10,12 @@ namespace System.Text.Json.Serialization.Converters
     {
         public override char Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return reader.GetString()[0];
+            string str = reader.GetString();
+            if (string.IsNullOrEmpty(str))
+            {
+                throw ThrowHelper.GetInvalidOperationException_ExpectedChar(reader.TokenType);
+            }
+            return str[0];
         }
 
         public override void Write(Utf8JsonWriter writer, char value, JsonSerializerOptions options)

--- a/src/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
+++ b/src/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
@@ -592,6 +592,11 @@ namespace System.Text.Json
             ex.Source = ExceptionSourceValueToRethrowAsJsonException;
             return ex;
         }
+
+        public static InvalidOperationException GetInvalidOperationException_ExpectedChar(JsonTokenType tokenType)
+        {
+            return GetInvalidOperationException("char", tokenType);
+        }
     }
 
     internal enum ExceptionResource

--- a/src/System.Text.Json/tests/Serialization/Null.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Null.ReadTests.cs
@@ -152,5 +152,16 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Null(obj);
             }
         }
+
+        [Fact]
+        public static void NullReadTestChar()
+        {
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<char>("null"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<char>("\"\""));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<char>(""));   // Empty JSON is invalid
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<char>("1234")); // Can't convert a JSON number to JSON string/char
+            Assert.Equal('a', JsonSerializer.Deserialize<char>("\"a\""));
+            Assert.Equal('Y', JsonSerializer.Deserialize<char>("\"\u0059\""));
+        }
     }
 }


### PR DESCRIPTION
Get the changes from 5.0/master found in https://github.com/dotnet/runtime/pull/528 

## Description

Add a null/empty string check when deserializing JSON strings into a `char` property so that we don't null ref or throw an index of out of range exception. Intentionally left out the `string.length > 1` check as that could potentially break someone.

## Customer Impact

Most people are very unlikely to have a catch handler for NullReferenceException, IndexOutOfRangeException, or InvalidOperationException (and in the first two, it certainly doesn't make sense for them to). So in server scenarios customers still get an HTTP 500.
Now, the the `JsonConverter<char>` throws an `InvalidOperationException` which the wraps the into an outer `JsonException` so that customers can have handlers to catch that. For them, we’d turn a crash into success.

Deserializing into a char is now more reliable when the input JSON payload is unknown/provided by the user which may contain unexpected values.
```C#
public class MyPoco
{
    public char Character { get; set; }
}

public static void TestDeserializeToChar()
{
    // Before (3.1): NullReferenceException
    // After (5.0): JsonException
    JsonSerializer.Deserialize<MyPoco>("{\"Character\": null}");

    // Before (3.1): IndexOutOfRangeException
    // After (5.0): JsonException
    JsonSerializer.Deserialize<MyPoco>("{\"Character\": \"\"}");
}
```

There is a workaround for the user today, where they could create and register their own `JsonConverter<char>` which does the right checks. However, doing so, in all the entry points of the JsonSerializer (including within ASP.NET web app) would become cumbersome.

## Regression

No. The bug existed in the deserialization behavior since the initial release of S.T.Json as part of 3.0.

### Testing

Added appropriate unit tests and the behavior in master meets user expectations such as https://github.com/dotnet/runtime/issues/32429
This only affects deserialization/reading.

## Risk

**Low** given it is a very targeted fix with no regression. We are going from an unrecoverable/less user friendly exception to a more user-friendly exception that the caller can reason about. There is no breaking change here.

cc @ericstj 