### PR TITLE
[release/3.1] Permit incorrectly DER sorted SET for decoding X500 names.

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/X500NameEncoder.ManagedDecode.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/X500NameEncoder.ManagedDecode.cs
@@ -29,7 +29,9 @@ namespace Internal.Cryptography.Pal
 
             while (x500NameSequenceReader.HasData)
             {
-                rdnReaders.Add(x500NameSequenceReader.ReadSetOf());
+                // To match Windows' behavior, permit multi-value RDN SETs to not
+                // be DER sorted.
+                rdnReaders.Add(x500NameSequenceReader.ReadSetOf(skipSortOrderValidation: true));
             }
 
             // We need to allocate a StringBuilder to hold the data as we're building it, and there's the usual

--- a/src/System.Security.Cryptography.X509Certificates/tests/X500DistinguishedNameTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X500DistinguishedNameTests.cs
@@ -210,6 +210,15 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             Assert.Equal("OID.1.1.1.2.2.3=123 654 7890, CN=Test", dn.Decode(X500DistinguishedNameFlags.None));
         }
 
+        [Fact]
+        public static void OrganizationUnitMultiValueWithIncorrectlySortedDerSet()
+        {
+            X500DistinguishedName dn = new X500DistinguishedName(
+                "301C311A300B060355040B13047A7A7A7A300B060355040B130461616161".HexToByteArray());
+
+            Assert.Equal("OU=zzzz + OU=aaaa", dn.Decode(X500DistinguishedNameFlags.None));
+        }
+
         public static readonly object[][] WhitespaceBeforeCases =
         {
             // Regular space.


### PR DESCRIPTION
This is a cherry-pick of https://github.com/dotnet/runtime/commit/b12c90179f115f9b7979263da529921607412f6d to port the fix from dotnet/runtime#32558 in to the 3.1 release branch.

/cc @bartonjs @danmosemsft 

## Description

`X500DistinguishedName` values that do not follow the specified sort order decode as the empty string on .NET Core 3.0+ on Linux, but work on Windows.   This change makes the Linux build match the Windows behavior.

The fix is to simply skip a specific data conformance validation check, which only has a visible impact on non-conforming values now being accepted.

## Customer Impact

Reported by Pivotal. Customers that encounter X.509 certificates with a subject name, or issuer name, that contains a segment that is not canonically encoded will see that subject name (or issuer name) as the empty string on .NET Core 3.1 on Linux.

This problem only applies to X500DistinguishedName values that use a "multi-RDN" value, which is not very common (the CA/Browser forum Baseline Recommendations do not explicitly say to not use this encoding, but their description of distinguished name values uses "single-value" terminology).

## Regression

Yes, from 2.1.  The underlying data reader was replaced during 3.0, with the new reader validating by default and the old reader not validating.

### Testing

Added a unit test to verify that non-conforming data decodes the same on all platforms.

## Risk

**Low**.  The change merely bypasses a conformance check, explicitly choosing to accept non-conforming data. The unit tests confirms that the same answer is given for Windows and Linux.