### PR TITLE
[release/3.1] Improve Expression.Lambda<TDelegate> performance (dotnet/runtime#32768)

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
@@ -695,7 +695,11 @@ namespace System.Linq.Expressions
         {
             ReadOnlyCollection<ParameterExpression> parameterList = parameters.ToReadOnly();
             ValidateLambdaArgs(typeof(TDelegate), ref body, parameterList, nameof(TDelegate));
-            return (Expression<TDelegate>)CreateLambda(typeof(TDelegate), body, name, tailCall, parameterList);
+#if FEATURE_COMPILE
+            return Expression<TDelegate>.Create(body, name, tailCall, parameterList);
+#else
+            return ExpressionCreator<TDelegate>.CreateExpressionFunc(body, name, tailCall, parameterList);
+#endif
         }
 
         /// <summary>


### PR DESCRIPTION
Port of https://github.com/dotnet/runtime/pull/32768
Fixes https://github.com/dotnet/runtime/issues/32767

### Description
An `Expression` lambda delegate cache was added in .NET Core 2.0. If there are many calls to `Expression.Lambda<TDelegate>()` overloads with distinct delegate types which result in cache misses, the result is a performance regression. 

### Customer Impact
Performance regression with many calls to `Expression.Lambda<TDelegate>()` with distinct delegate types. Customer reported this impact in a migration from .NET Framework to .NET Core.

### Packaging Impact
None

### Regression
Regression from .NET Core 1.0, and .NET Framework.
 
### Testing
See benchmark testing in https://github.com/dotnet/runtime/issues/32767.

### Risk
Low. The change avoids the cache and allocates a distinct `Expression<TDelegate>` each time.

cc @ericstj