### PR TITLE
[release/2.1] Suppress the GrayListedLeaf error code on macOS X509Chain

### DIFF
--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509chain.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509chain.cpp
@@ -187,7 +187,7 @@ static void MergeStatusCodes(CFTypeRef key, CFTypeRef value, void* context)
         // just ignore it for now.
     }
     else if (CFEqual(keyString, CFSTR("NonEmptySubject")) || CFEqual(keyString, CFSTR("GrayListedKey")) ||
-             CFEqual(keyString, CFSTR("CTRequired")))
+             CFEqual(keyString, CFSTR("CTRequired")) || CFEqual(keyString, CFSTR("GrayListedLeaf")))
     {
         // Not a "problem" that we report.
     }


### PR DESCRIPTION
This is a port of https://github.com/dotnet/runtime/pull/32895.

#### Description

Recent change to macOS has caused a new error code to appear during X509Chain building. Since this error code has been identified as not having impact on the .NET X509Chain class, ignore it.

#### Customer Impact

Without this fix, customers who upgrade their macOS version and build X509Chains against certificates/certificate-authorities which result in the GrayListedLeaf code will get a `CryptographicException` due to the unmapped error.

#### Regression?

No, reaction to OS update.

#### Packaging reviewed?

Required shim library, no packaging impact.

#### Risk

**Low**, covered by unit tests (which originally discovered the issue).