### PR TITLE
[release/3.1] Fix HTTP Digest authentication

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.Digest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.Digest.cs
@@ -414,7 +414,8 @@ namespace System.Net.Http
                     // Get the value.
                     string value = GetNextValue(challenge, parsedIndex, MustValueBeQuoted(key), out parsedIndex);
                     // Ensure value is valid.
-                    if (string.IsNullOrEmpty(value))
+                    if (string.IsNullOrEmpty(value)
+                        && (value == null || !key.Equals(Opaque, StringComparison.OrdinalIgnoreCase)))
                         break;
 
                     // Add the key-value pair to Parameters.

--- a/src/System.Net.Http/tests/UnitTests/DigestAuthenticationTests.cs
+++ b/src/System.Net.Http/tests/UnitTests/DigestAuthenticationTests.cs
@@ -81,6 +81,8 @@ namespace System.Net.Http.Tests
             yield return new object[] { "realm=\"NetCore\", nonce=\"qMRqWgAAAAAQMjIABgAAAFwEiEwAAAAA\", qop=\"auth\", stale=false, opaque=\"qMRqWgAAAAAA\"", "(?=.*username=)(?=.*realm=)(?=.*nonce=)(?=.*uri=)(?=.*response=)(?=.*qop=)(?=.*nc=)(?=.*cnonce=)(?=.*opaque=)", "(algorithm=)", 9 };
             yield return new object[] { "realm=\"NetCore\", nonce=\"qMRqWgAAAAAQMjIABgAAAFwEiEwAAAAA\", stale=false, opaque=\"qMRqWgAAAAAA\"", "(?=.*username=)(?=.*realm=)(?=.*nonce=)(?=.*uri=)(?=.*response=)(?=.*opaque=)", "(algorithm=)", 6 };
             yield return new object[] { "realm=\"NetCore\", nonce=\"qMRqWgAAAAAQMjIABgAAAFwEiEwAAAAA\", stale=false, algorithm=MD5-sess, qop=\"auth\"", "(?=.*username=)(?=.*realm=)(?=.*nonce=)(?=.*uri=)(?=.*response=)(?=.*qop=)(?=.*nc=)(?=.*cnonce=)(?=.*algorithm=)", null, 9 };
+            yield return new object[] { "realm=\"NetCore\", nonce=\"qMRqWgAAAAAQMjIABgAAAFwEiEwAAAAA\", opaque=\"qMRqWgAAAAAA\", stale=false, algorithm=MD5-sess, qop=\"auth\"", "(?=.*username=)(?=.*realm=)(?=.*nonce=)(?=.*uri=)(?=.*response=)(?=.*qop=)(?=.*nc=)(?=.*cnonce=)(?=.*algorithm=)(?=.*opaque=)", null, 10 };
+            yield return new object[] { "realm=\"NetCore\", nonce=\"qMRqWgAAAAAQMjIABgAAAFwEiEwAAAAA\", opaque=\"\", stale=false, algorithm=MD5, qop=\"auth\"", "(?=.*username=)(?=.*realm=)(?=.*nonce=)(?=.*uri=)(?=.*response=)(?=.*qop=)(?=.*nc=)(?=.*cnonce=)(?=.*algorithm=)(?=.*opaque=)", null, 10 };
         }
 
         [Theory]


### PR DESCRIPTION
This is a port of https://github.com/dotnet/runtime/pull/32983. Original issue: https://github.com/dotnet/runtime/issues/32943

#### Description

This bug was found in testing http requests with a Bosch IP Camera that supports the ONVIF protocol. Bosch is a large manufacturer in the realm of ONVIF compliant cameras. A Bosch camera that was being tested sent a digest challenge with the opaque value as an empty-string. The current dotnet core library fails to use the correct digest scheme because it breaks on parsing the empty string. 

#### Customer Impact

Without this fix, customers can not communicate with the Bosch IP Cameras which use HTTP Digest communications.

#### Regression?

No

#### Packaging reviewed?

Change needed to System.Net.Http.dll which is part of the shared framework Microsoft.NETCore.App package.

#### Risk

**Low**, covered by unit tests