### PR TITLE
[release/3.1] Client certificate authentication on HTTP/2 in WinHttpHandler

### DIFF
--- a/src/Common/src/Interop/Windows/WinHttp/Interop.winhttp_types.cs
+++ b/src/Common/src/Interop/Windows/WinHttp/Interop.winhttp_types.cs
@@ -148,9 +148,11 @@ internal partial class Interop
 
         public const uint WINHTTP_OPTION_ASSURED_NON_BLOCKING_CALLBACKS = 111;
 
+        public const uint WINHTTP_OPTION_ENABLE_HTTP2_PLUS_CLIENT_CERT = 161;
         public const uint WINHTTP_OPTION_ENABLE_HTTP_PROTOCOL = 133;
         public const uint WINHTTP_OPTION_HTTP_PROTOCOL_USED = 134;
         public const uint WINHTTP_PROTOCOL_FLAG_HTTP2 = 0x1;
+        public const uint WINHTTP_HTTP2_PLUS_CLIENT_CERT_FLAG = 0x1;
 
         public const uint WINHTTP_OPTION_UPGRADE_TO_WEB_SOCKET = 114;
         public const uint WINHTTP_OPTION_WEB_SOCKET_CLOSE_TIMEOUT = 115;


### PR DESCRIPTION
This is port of dotnet/runtime#33158.

**Description**
Pre-release WinHTTP's version supports client certificate-based authentication over HTTP/2, but the feature must be explicitly opted-in. PR sets WINHTTP_OPTION_ENABLE_HTTP2_PLUS_CLIENT_CERT to TRUE before invoking WinHttpConnect if the request's protocol is HTTP/2 and scheme is HTTPS.

**Customer impact**
Without this change, it's not possible to use client certificate-based authentication on HTTP/2 in .Net Framework 4.7.2 and 4.8.

**Regression?**
No

**Packaging review**
Change affects System.Net.Http.WinHttpHandler.dll which is distributed in System.Net.Http.WinHttpHandler package.

**Risk**
**Low**, covered by functional tests in master branch, but only manually tested for 3.1