### PR TITLE
Publish only on all configurations and only publish Json package

### DIFF
--- a/eng/pipelines/corefx-base.yml
+++ b/eng/pipelines/corefx-base.yml
@@ -208,10 +208,19 @@ jobs:
                   helixToken: ''
 
           - ${{ if eq(parameters.isOfficialBuild, 'true') }}:
+            - task: CopyFiles@2
+              displayName: Prepare artifacts packages folder to publish
+              inputs:
+                sourceFolder: $(Build.SourcesDirectory)/artifacts/packages
+                targetFolder: $(Build.ArtifactStagingDirectory)/artifacts/packages
+                contents: |
+                  **/System.Net.Http.Json*.nupkg
+              condition: and(succeeded(), eq(variables['_publishPackages'], true))
+
             - task: PublishBuildArtifacts@1
               displayName: Publish packages to artifacts container
               inputs:
-                pathToPublish: $(Build.SourcesDirectory)/artifacts/packages
+                pathToPublish: $(Build.ArtifactStagingDirectory)/artifacts/packages
                 artifactName: packages
                 artifactType: container
-              condition: and(succeeded(), ne(variables['_skipPublishPackages'], 'true'))
+              condition: and(succeeded(), eq(variables['_publishPackages'], 'true'))

--- a/eng/pipelines/windows.yml
+++ b/eng/pipelines/windows.yml
@@ -75,28 +75,24 @@ stages:
                 _architecture: x86
                 _framework: netfx
                 _helixQueues: $(uapNetfxQueues)
-                _skipPublishPackages: true # In NETFX leg we don't produce packages
 
               NETFX_x64_Release:
                 _BuildConfig: Release
                 _architecture: x64
                 _framework: netfx
                 _helixQueues: $(uapNetfxQueues)
-                _skipPublishPackages: true # In NETFX leg we don't produce packages
 
               UAP_x64_Release:
                 _BuildConfig: Release
                 _architecture: x64
                 _framework: uap
                 _helixQueues: $(uapNetfxQueues)
-                _skipPublishPackages: true # In UWP we don't produce packages
 
               UAP_x86_Release:
                 _BuildConfig: Release
                 _architecture: x86
                 _framework: uap
                 _helixQueues: $(uapNetfxQueues)
-                _skipPublishPackages: true # In UWP we don't produce packages
 
               arm64_Release:
                 _BuildConfig: Release
@@ -144,6 +140,7 @@ stages:
                   _architecture: x64
                   _framework: allConfigurations
                   _helixQueues: $(allConfigurationsQueues)
+                  _publishPackages: true
 
           pool:
             ${{ if ne(variables['System.TeamProject'], 'public') }}:


### PR DESCRIPTION
This prevents us from publishing any transport packages in release/3.1-blazor package, and will only publish the json package added in: https://github.com/dotnet/corefx/pull/42889

Once that PR is merged, I'll test this on an official build and if green add the default channel and then merge.

cc: @joperezr @ericstj