### PR TITLE
Addressing feedback, Documenting TranscodingWriteStream.MaxbyteBuffer Size and Replacing MediaTypeHeaderValue.Parse with .ctor since it performs better

### DIFF
--- a/src/System.Net.Http.Json/src/System/Net/Http/Json/HttpContentJsonExtensions.cs
+++ b/src/System.Net.Http.Json/src/System/Net/Http/Json/HttpContentJsonExtensions.cs
@@ -85,8 +85,9 @@ namespace System.Net.Http.Json
             int index = 0;
             int typeLength = mediaType.IndexOf('/');
 
+            ReadOnlySpan<char> type = mediaType.Slice(index, typeLength);
             if (typeLength < 0 ||
-                mediaType.Slice(index, typeLength).CompareTo(JsonContent.JsonType.AsSpan(), StringComparison.OrdinalIgnoreCase) != 0)
+                type.CompareTo(JsonContent.JsonType.AsSpan(), StringComparison.OrdinalIgnoreCase) != 0)
             {
                 return false;
             }
@@ -101,8 +102,8 @@ namespace System.Net.Http.Json
             }
 
             index += suffixStart + 1;
-            ReadOnlySpan<char> mediaTypeSuffix = mediaType.Slice(index);
-            if (mediaTypeSuffix.CompareTo(JsonContent.JsonSubtype.AsSpan(), StringComparison.OrdinalIgnoreCase) != 0)
+            ReadOnlySpan<char> suffix = mediaType.Slice(index);
+            if (suffix.CompareTo(JsonContent.JsonSubtype.AsSpan(), StringComparison.OrdinalIgnoreCase) != 0)
             {
                 return false;
             }

--- a/src/System.Net.Http.Json/src/System/Net/Http/Json/JsonContent.cs
+++ b/src/System.Net.Http.Json/src/System/Net/Http/Json/JsonContent.cs
@@ -18,7 +18,7 @@ namespace System.Net.Http.Json
         internal const string JsonType = "application";
         internal const string JsonSubtype = "json";
         private static MediaTypeHeaderValue DefaultMediaType
-            => MediaTypeHeaderValue.Parse(string.Format("{0}; charset={1}", JsonMediaType, Encoding.UTF8.WebName));
+            => new MediaTypeHeaderValue(JsonMediaType) { CharSet = "utf-8" };
 
         internal static JsonSerializerOptions DefaultSerializerOptions
             => new JsonSerializerOptions { PropertyNameCaseInsensitive = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase };

--- a/src/System.Net.Http.Json/src/System/Net/Http/Json/TranscodingWriteStream.cs
+++ b/src/System.Net.Http.Json/src/System/Net/Http/Json/TranscodingWriteStream.cs
@@ -14,7 +14,10 @@ namespace System.Net.Http.Json
 {
     internal sealed class TranscodingWriteStream : Stream
     {
+        // Default size of the char buffer that will hold the passed-in bytes when decoded from UTF-8.
+        // The buffer holds them and then they are encoded to the targetEncoding and written to the underlying stream.
         internal const int MaxCharBufferSize = 4096;
+        // Upper bound that limits the byte buffer size to prevent an encoding that has a very poor worst-case scenario.
         internal const int MaxByteBufferSize = 4 * MaxCharBufferSize;
         private readonly int _maxByteBufferSize;
 

--- a/src/System.Net.Http.Json/tests/FunctionalTests/HttpClientJsonExtensionsTests.cs
+++ b/src/System.Net.Http.Json/tests/FunctionalTests/HttpClientJsonExtensionsTests.cs
@@ -89,17 +89,17 @@ namespace System.Net.Http.Json.Functional.Tests
                     {
                         Person person = Person.Create();
 
-                        HttpResponseMessage response = await client.PostAsJsonAsync(uri.ToString(), person);
+                        using HttpResponseMessage response = await client.PostAsJsonAsync(uri.ToString(), person);
                         Assert.True(response.StatusCode == HttpStatusCode.OK);
 
-                        response = await client.PostAsJsonAsync(uri, person);
-                        Assert.True(response.StatusCode == HttpStatusCode.OK);
+                        using HttpResponseMessage response2 = await client.PostAsJsonAsync(uri, person);
+                        Assert.True(response2.StatusCode == HttpStatusCode.OK);
 
-                        response = await client.PostAsJsonAsync(uri.ToString(), person, CancellationToken.None);
-                        Assert.True(response.StatusCode == HttpStatusCode.OK);
+                        using HttpResponseMessage response3 = await client.PostAsJsonAsync(uri.ToString(), person, CancellationToken.None);
+                        Assert.True(response3.StatusCode == HttpStatusCode.OK);
 
-                        response = await client.PostAsJsonAsync(uri, person, CancellationToken.None);
-                        Assert.True(response.StatusCode == HttpStatusCode.OK);
+                        using HttpResponseMessage response4 = await client.PostAsJsonAsync(uri, person, CancellationToken.None);
+                        Assert.True(response4.StatusCode == HttpStatusCode.OK);
                     }
                 },
                 async server => {
@@ -125,17 +125,17 @@ namespace System.Net.Http.Json.Functional.Tests
                         Person person = Person.Create();
                         Type typePerson = typeof(Person);
 
-                        HttpResponseMessage response = await client.PutAsJsonAsync(uri.ToString(), person);
+                        using HttpResponseMessage response = await client.PutAsJsonAsync(uri.ToString(), person);
                         Assert.True(response.StatusCode == HttpStatusCode.OK);
 
-                        response = await client.PutAsJsonAsync(uri, person);
-                        Assert.True(response.StatusCode == HttpStatusCode.OK);
+                        using HttpResponseMessage response2 = await client.PutAsJsonAsync(uri, person);
+                        Assert.True(response2.StatusCode == HttpStatusCode.OK);
 
-                        response = await client.PutAsJsonAsync(uri.ToString(), person, CancellationToken.None);
-                        Assert.True(response.StatusCode == HttpStatusCode.OK);
+                        using HttpResponseMessage response3 = await client.PutAsJsonAsync(uri.ToString(), person, CancellationToken.None);
+                        Assert.True(response3.StatusCode == HttpStatusCode.OK);
 
-                        response = await client.PutAsJsonAsync(uri, person, CancellationToken.None);
-                        Assert.True(response.StatusCode == HttpStatusCode.OK);
+                        using HttpResponseMessage response4 = await client.PutAsJsonAsync(uri, person, CancellationToken.None);
+                        Assert.True(response4.StatusCode == HttpStatusCode.OK);
                     }
                 },
                 async server => {
@@ -150,31 +150,22 @@ namespace System.Net.Http.Json.Functional.Tests
         }
 
         [Fact]
-        public async Task TestHttpClientIsNullAsync()
+        public void TestHttpClientIsNullAsync()
         {
             HttpClient client = null;
             string uriString = "http://example.com";
             Uri uri = new Uri(uriString);
 
-            ArgumentNullException ex;
-            ex = await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetFromJsonAsync(uriString, typeof(Person)));
-            Assert.Equal("client", ex.ParamName);
-            ex = await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetFromJsonAsync(uri, typeof(Person)));
-            Assert.Equal("client", ex.ParamName);
-            ex = await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetFromJsonAsync<Person>(uriString));
-            Assert.Equal("client", ex.ParamName);
-            ex = await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetFromJsonAsync<Person>(uri));
-            Assert.Equal("client", ex.ParamName);
+            AssertExtensions.Throws<ArgumentNullException>("client", () => client.GetFromJsonAsync(uriString, typeof(Person)));
+            AssertExtensions.Throws<ArgumentNullException>("client", () => client.GetFromJsonAsync(uri, typeof(Person)));
+            AssertExtensions.Throws<ArgumentNullException>("client", () => client.GetFromJsonAsync<Person>(uriString));
+            AssertExtensions.Throws<ArgumentNullException>("client", () => client.GetFromJsonAsync<Person>(uri));
 
-            ex = await Assert.ThrowsAsync<ArgumentNullException>(() => client.PostAsJsonAsync<Person>(uriString, null));
-            Assert.Equal("client", ex.ParamName);
-            ex = await Assert.ThrowsAsync<ArgumentNullException>(() => client.PostAsJsonAsync<Person>(uri, null));
-            Assert.Equal("client", ex.ParamName);
+            AssertExtensions.Throws<ArgumentNullException>("client", () => client.PostAsJsonAsync<Person>(uriString, null));
+            AssertExtensions.Throws<ArgumentNullException>("client", () => client.PostAsJsonAsync<Person>(uri, null));
 
-            ex = await Assert.ThrowsAsync<ArgumentNullException>(() => client.PutAsJsonAsync<Person>(uriString, null));
-            Assert.Equal("client", ex.ParamName);
-            ex = await Assert.ThrowsAsync<ArgumentNullException>(() => client.PutAsJsonAsync<Person>(uri, null));
-            Assert.Equal("client", ex.ParamName);
+            AssertExtensions.Throws<ArgumentNullException>("client", () => client.PutAsJsonAsync<Person>(uriString, null));
+            AssertExtensions.Throws<ArgumentNullException>("client", () => client.PutAsJsonAsync<Person>(uri, null));
         }
 
         private void ValidateRequest(HttpRequestData requestData)

--- a/src/System.Net.Http.Json/tests/FunctionalTests/HttpContentJsonExtensionsTests.cs
+++ b/src/System.Net.Http.Json/tests/FunctionalTests/HttpContentJsonExtensionsTests.cs
@@ -18,11 +18,11 @@ namespace System.Net.Http.Json.Functional.Tests
         private readonly List<HttpHeaderData> _headers = new List<HttpHeaderData> { new HttpHeaderData("Content-Type", "application/json") };
 
         [Fact]
-        public async Task ThrowOnNull()
+        public void ThrowOnNull()
         {
             HttpContent content = null;
-            await Assert.ThrowsAsync<ArgumentNullException>(() => content.ReadFromJsonAsync<Person>());
-            await Assert.ThrowsAsync<ArgumentNullException>(() => content.ReadFromJsonAsync(typeof(Person)));
+            AssertExtensions.Throws<ArgumentNullException>("content", () => content.ReadFromJsonAsync<Person>());
+            AssertExtensions.Throws<ArgumentNullException>("content", () => content.ReadFromJsonAsync(typeof(Person)));
         }
 
         [Fact]
@@ -35,7 +35,7 @@ namespace System.Net.Http.Json.Functional.Tests
                     using (HttpClient client = new HttpClient())
                     {
                         var request = new HttpRequestMessage(HttpMethod.Get, uri);
-                        var response = await client.SendAsync(request);
+                        HttpResponseMessage response = await client.SendAsync(request);
                         object obj = await response.Content.ReadFromJsonAsync(typeof(Person));
                         Person per = Assert.IsType<Person>(obj);
                         per.Validate();
@@ -64,7 +64,7 @@ namespace System.Net.Http.Json.Functional.Tests
                     using (HttpClient client = new HttpClient())
                     {
                         var request = new HttpRequestMessage(HttpMethod.Get, uri);
-                        var response = await client.SendAsync(request);
+                        HttpResponseMessage response = await client.SendAsync(request);
                         object obj = await response.Content.ReadFromJsonAsync(typeof(Person));
                         Assert.Null(obj);
 
@@ -91,7 +91,7 @@ namespace System.Net.Http.Json.Functional.Tests
                     using (HttpClient client = new HttpClient())
                     {
                         var request = new HttpRequestMessage(HttpMethod.Get, uri);
-                        var response = await client.SendAsync(request);
+                        HttpResponseMessage response = await client.SendAsync(request);
 
                         // As of now, we pass the message body to the serializer even when its empty which causes the serializer to throw.
                         JsonException ex = await Assert.ThrowsAsync<JsonException>(() => response.Content.ReadFromJsonAsync(typeof(Person)));
@@ -110,7 +110,7 @@ namespace System.Net.Http.Json.Functional.Tests
                     using (HttpClient client = new HttpClient())
                     {
                         var request = new HttpRequestMessage(HttpMethod.Get, uri);
-                        var response = await client.SendAsync(request);
+                        HttpResponseMessage response = await client.SendAsync(request);
 
                         await Assert.ThrowsAsync<NotSupportedException>(() => response.Content.ReadFromJsonAsync<Person>());
                     }
@@ -132,7 +132,7 @@ namespace System.Net.Http.Json.Functional.Tests
                     using (HttpClient client = new HttpClient())
                     {
                         var request = new HttpRequestMessage(HttpMethod.Get, uri);
-                        var response = await client.SendAsync(request);
+                        HttpResponseMessage response = await client.SendAsync(request);
 
                         Person person = await response.Content.ReadFromJsonAsync<Person>();
                         person.Validate();
@@ -155,7 +155,7 @@ namespace System.Net.Http.Json.Functional.Tests
                     using (HttpClient client = new HttpClient())
                     {
                         var request = new HttpRequestMessage(HttpMethod.Get, uri);
-                        var response = await client.SendAsync(request);
+                        HttpResponseMessage response = await client.SendAsync(request);
 
                         InvalidOperationException ex = await Assert.ThrowsAsync<InvalidOperationException>(() => response.Content.ReadFromJsonAsync<Person>());
                         Assert.IsType<ArgumentException>(ex.InnerException);
@@ -175,7 +175,7 @@ namespace System.Net.Http.Json.Functional.Tests
                     using (HttpClient client = new HttpClient())
                     {
                         var request = new HttpRequestMessage(HttpMethod.Get, uri);
-                        var response = await client.SendAsync(request);
+                        HttpResponseMessage response = await client.SendAsync(request);
 
                         Person per = Assert.IsType<Person>(await response.Content.ReadFromJsonAsync(typeof(Person)));
                         per.Validate();
@@ -218,7 +218,7 @@ namespace System.Net.Http.Json.Functional.Tests
                     using (HttpClient client = new HttpClient())
                     {
                         var request = new HttpRequestMessage(HttpMethod.Get, uri);
-                        var response = await client.SendAsync(request);
+                        HttpResponseMessage response = await client.SendAsync(request);
                         await response.Content.ReadFromJsonAsync(typeof(EnsureDefaultOptions));
                     }
                 },
@@ -244,7 +244,7 @@ namespace System.Net.Http.Json.Functional.Tests
                     using (HttpClient client = new HttpClient())
                     {
                         var request = new HttpRequestMessage(HttpMethod.Get, uri);
-                        var response = await client.SendAsync(request);
+                        HttpResponseMessage response = await client.SendAsync(request);
 
                         Person person = await response.Content.ReadFromJsonAsync<Person>();
                         person.Validate();
@@ -274,7 +274,7 @@ namespace System.Net.Http.Json.Functional.Tests
                     using (HttpClient client = new HttpClient())
                     {
                         var request = new HttpRequestMessage(HttpMethod.Get, uri);
-                        var response = await client.SendAsync(request);
+                        HttpResponseMessage response = await client.SendAsync(request);
 
                         Exception ex = await Assert.ThrowsAsync<NotSupportedException>(() => response.Content.ReadFromJsonAsync<Person>());
                         Assert.Contains("application/json", ex.Message);

--- a/src/System.Net.Http.Json/tests/FunctionalTests/JsonContentTests.cs
+++ b/src/System.Net.Http.Json/tests/FunctionalTests/JsonContentTests.cs
@@ -69,18 +69,6 @@ namespace System.Net.Http.Json.Functional.Tests
         }
 
         [Fact]
-        public async Task SendQuotedCharsetAsync()
-        {
-            JsonContent content = JsonContent.Create<Foo>(null);
-            content.Headers.ContentType.CharSet = "\"utf-8\"";
-
-            HttpClient client = new HttpClient();
-            var request = new HttpRequestMessage(HttpMethod.Post, "http://example.com");
-            request.Content = content;
-            await client.SendAsync(request);
-        }
-
-        [Fact]
         public void TestJsonContentContentTypeIsNotTheSameOnMultipleInstances()
         {
             JsonContent jsonContent1 = JsonContent.Create<object>(null);
@@ -109,38 +97,24 @@ namespace System.Net.Http.Json.Functional.Tests
 
         [Fact]
         public void JsonContentInputTypeIsNull()
-        {
-            string foo = "test";
-
-            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => JsonContent.Create(foo, inputType: null, mediaType: null));
-            Assert.Equal("inputType", ex.ParamName);
-        }
+            => AssertExtensions.Throws<ArgumentNullException>("inputType", () => JsonContent.Create(null, inputType: null, mediaType: null));
 
         [Fact]
         public void JsonContentThrowsOnIncompatibleTypeAsync()
         {
-            HttpClient client = new HttpClient();
-            var foo = new Foo();
-            Type typeOfBar = typeof(Bar);
+            using (HttpClient client = new HttpClient())
+            {
+                var foo = new Foo();
+                Type typeOfBar = typeof(Bar);
 
-            Exception ex = Assert.Throws<ArgumentException>(() => JsonContent.Create(foo, typeOfBar));
+                Exception ex = Assert.Throws<ArgumentException>(() => JsonContent.Create(foo, typeOfBar));
 
-            string strTypeOfBar = typeOfBar.ToString();
-            Assert.Contains(strTypeOfBar, ex.Message);
+                string strTypeOfBar = typeOfBar.ToString();
+                Assert.Contains(strTypeOfBar, ex.Message);
 
-            string afterInputTypeMessage = ex.Message.Split(strTypeOfBar.ToCharArray())[1];
-            Assert.Contains(afterInputTypeMessage, ex.Message);
-        }
-
-        [Fact]
-        public async Task EnsureDefaultJsonSerializerOptionsAsync()
-        {
-            HttpClient client = new HttpClient();
-            EnsureDefaultOptions obj = new EnsureDefaultOptions();
-
-            var request = new HttpRequestMessage(HttpMethod.Post, "http://example.com");
-            request.Content = JsonContent.Create(obj);
-            await client.SendAsync(request);
+                string afterInputTypeMessage = ex.Message.Split(strTypeOfBar.ToCharArray())[1];
+                Assert.Contains(afterInputTypeMessage, ex.Message);
+            }
         }
     }
 }

--- a/src/System.Net.Http.Json/tests/UnitTests/TranscodingWriteStreamTests.cs
+++ b/src/System.Net.Http.Json/tests/UnitTests/TranscodingWriteStreamTests.cs
@@ -29,7 +29,7 @@ namespace System.Net.Http.Json.Functional.Tests
         [MemberData(nameof(WriteAsyncInputUnicode))]
         public Task WriteAsync_Works_WhenOutputIs_UTF32(string message)
         {
-            var targetEncoding = Encoding.UTF32;
+            Encoding targetEncoding = Encoding.UTF32;
             return WriteAsyncTest(targetEncoding, message);
         }
 
@@ -38,7 +38,7 @@ namespace System.Net.Http.Json.Functional.Tests
         [MemberData(nameof(WriteAsyncInputUnicode))]
         public Task WriteAsync_Works_WhenOutputIs_Unicode(string message)
         {
-            var targetEncoding = Encoding.Unicode;
+            Encoding targetEncoding = Encoding.Unicode;
             return WriteAsyncTest(targetEncoding, message);
         }
 
@@ -46,7 +46,7 @@ namespace System.Net.Http.Json.Functional.Tests
         [MemberData(nameof(WriteAsyncInputLatin))]
         public Task WriteAsync_Works_WhenOutputIs_UTF7(string message)
         {
-            var targetEncoding = Encoding.UTF7;
+            Encoding targetEncoding = Encoding.UTF7;
             return WriteAsyncTest(targetEncoding, message);
         }
 
@@ -55,7 +55,7 @@ namespace System.Net.Http.Json.Functional.Tests
         public Task WriteAsync_Works_WhenOutputIs_WesternEuropeanEncoding(string message)
         {
             // Arrange
-            var targetEncoding = Encoding.GetEncoding(28591);
+            Encoding targetEncoding = Encoding.GetEncoding(28591);
             return WriteAsyncTest(targetEncoding, message);
         }
 
@@ -65,7 +65,7 @@ namespace System.Net.Http.Json.Functional.Tests
         public Task WriteAsync_Works_WhenOutputIs_ASCII(string message)
         {
             // Arrange
-            var targetEncoding = Encoding.ASCII;
+            Encoding targetEncoding = Encoding.ASCII;
             return WriteAsyncTest(targetEncoding, message);
         }
 
@@ -84,7 +84,7 @@ namespace System.Net.Http.Json.Functional.Tests
             await transcodingStream.FinalWriteAsync(default);
             await transcodingStream.FlushAsync();
 
-            var actual = targetEncoding.GetString(stream.ToArray());
+            string actual = targetEncoding.GetString(stream.ToArray());
             Assert.Equal(expected, actual, StringComparer.OrdinalIgnoreCase);
         }
 


### PR DESCRIPTION
This is porting the last 3 commits that went into https://github.com/dotnet/runtime/pull/33459.

cc: @Jozkee @ericstj 