### PR TITLE
Bump branding to preview4 in 3.1-blazor branch

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,7 +7,7 @@
     <MinorVersion>8</MinorVersion>
     <!-- Always use shipping version instead of dummy version -->
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>
-    <PreReleaseVersionLabel>preview3</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>preview4</PreReleaseVersionLabel>
     <!--
         When StabilizePackageVersion is set to 'true', this branch will produce stable outputs for 'Shipping' packages
     -->


### PR DESCRIPTION
I looked at aspnetcore branding and they already moved to preview4.

https://github.com/dotnet/aspnetcore/blob/blazor-wasm/eng/Versions.props#L12