### PR TITLE
[release/3.1] Fix corefx to build on clang 10

### DIFF
--- a/src/Native/Unix/CMakeLists.txt
+++ b/src/Native/Unix/CMakeLists.txt
@@ -247,6 +247,13 @@ endfunction()
 
 include(configure.cmake)
 
+if (HAVE_WNO_ALLOCA)
+    add_compile_options(-Wno-alloca)
+endif()
+if (HAVE_WNO_IMPLICIT_INT_FLOAT_CONVERSION)
+    add_compile_options(-Wno-implicit-int-float-conversion)
+endif()
+
 if (NOT CLR_CMAKE_PLATFORM_WASM)
     add_subdirectory(System.IO.Compression.Native)
 	add_subdirectory(System.IO.Ports.Native)

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -1,3 +1,4 @@
+include(CheckCCompilerFlag)
 include(CheckCSourceCompiles)
 include(CheckCSourceRuns)
 include(CheckFunctionExists)
@@ -30,6 +31,9 @@ endif ()
 # Older CMake versions (3.8) do not assign the result of their tests, causing unused-value errors
 # which are not distinguished from the test failing. So no error for that one.
 set(CMAKE_REQUIRED_FLAGS "-Werror -Wno-error=unused-value")
+
+check_c_compiler_flag(-Wno-alloca HAVE_WNO_ALLOCA)
+check_c_compiler_flag(-Wno-implicit-int-float-conversion HAVE_WNO_IMPLICIT_INT_FLOAT_CONVERSION)
 
 # in_pktinfo: Find whether this struct exists
 check_include_files(


### PR DESCRIPTION
Clang 10 adds/enables new warnings, some of which is affecting the corefx code.

Clang 10 has added `-Walloca` to warn about uses of `alloca()`. Clang 10 has also added `-Wimplicit-int-float-conversion`. This commit disables those warnings where applicable.

This is a backport of dotnet/runtime#33734 to corefx.

After this commit, I can build all of corefx with Clang 10.