### PR TITLE
Adding .NET Framework configurations to OOB packages so that they won't require the netstandard shims when targeting .NET Framework

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -764,9 +764,10 @@
         "4.0.0",
         "4.3.0",
         "4.4.0",
-        "4.5.0"
+        "4.5.0",
+        "4.5.1"
       ],
-      "BaselineVersion": "4.5.0",
+      "BaselineVersion": "4.5.1",
       "InboxOn": {
         "netcoreapp2.0": "4.0.2.0",
         "netcoreapp2.1": "4.0.3.0",
@@ -891,7 +892,7 @@
         "1.6.0",
         "1.7.0"
       ],
-      "BaselineVersion": "1.7.0",
+      "BaselineVersion": "1.7.1",
       "InboxOn": {
         "netcoreapp2.0": "1.2.2.0",
         "netcoreapp2.1": "1.2.3.0",
@@ -1217,7 +1218,7 @@
         "1.3.0",
         "1.4.0"
       ],
-      "BaselineVersion": "1.4.0",
+      "BaselineVersion": "1.4.1",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "1.0.31.0": "1.0.31",
@@ -1253,7 +1254,7 @@
         "1.3.0",
         "1.4.0"
       ],
-      "BaselineVersion": "1.4.0",
+      "BaselineVersion": "1.4.1",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "1.0.31.0": "1.0.31",
@@ -1271,7 +1272,7 @@
         "1.3.0",
         "1.4.0"
       ],
-      "BaselineVersion": "1.4.0",
+      "BaselineVersion": "1.4.1",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "1.0.31.0": "1.0.31",
@@ -2870,9 +2871,10 @@
         "4.5.0",
         "4.5.1",
         "4.5.2",
-        "4.5.3"
+        "4.5.3",
+        "4.5.4"
       ],
-      "BaselineVersion": "4.5.3",
+      "BaselineVersion": "4.5.4",
       "InboxOn": {
         "netcoreapp2.1": "4.1.0.0",
         "netcoreapp3.0": "4.2.0.0",
@@ -3894,7 +3896,7 @@
         "1.7.0",
         "1.8.0"
       ],
-      "BaselineVersion": "1.8.0",
+      "BaselineVersion": "1.8.1",
       "InboxOn": {
         "netcoreapp2.0": "1.4.2.0",
         "netcoreapp2.1": "1.4.3.0",
@@ -4191,7 +4193,7 @@
         "4.7.0",
         "4.7.1"
       ],
-      "BaselineVersion": "4.7.0",
+      "BaselineVersion": "4.7.1",
       "InboxOn": {
         "netcoreapp3.0": "4.0.5.0",
         "netcoreapp3.1": "4.0.6.0",
@@ -5512,7 +5514,7 @@
         "4.6.0",
         "4.7.0"
       ],
-      "BaselineVersion": "4.7.0",
+      "BaselineVersion": "4.7.1",
       "InboxOn": {
         "netcoreapp3.0": "4.0.4.0",
         "netcoreapp3.1": "4.0.5.0",
@@ -5786,9 +5788,10 @@
         "4.5.0",
         "4.5.1",
         "4.5.2",
-        "4.5.3"
+        "4.5.3",
+        "4.5.4"
       ],
-      "BaselineVersion": "4.5.2",
+      "BaselineVersion": "4.5.4",
       "InboxOn": {
         "netcoreapp2.0": "4.1.1.0",
         "netcoreapp2.1": "4.3.0.0",

--- a/pkg/test/packageSettings/System.Runtime.WindowsRuntime.UI.Xaml/net461/disableTest.targets
+++ b/pkg/test/packageSettings/System.Runtime.WindowsRuntime.UI.Xaml/net461/disableTest.targets
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <!-- This package is special because it uses targets to include assemblies to referencePath, so 
+    it will still require the netstandard facades. -->
+    <DisableVerifyNotDependsOnNetStandardTest>true</DisableVerifyNotDependsOnNetStandardTest>
+  </PropertyGroup>
+</Project>

--- a/pkg/test/packageSettings/System.Runtime.WindowsRuntime.UI.Xaml/net462/disableTest.targets
+++ b/pkg/test/packageSettings/System.Runtime.WindowsRuntime.UI.Xaml/net462/disableTest.targets
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <!-- This package is special because it uses targets to include assemblies to referencePath, so 
+    it will still require the netstandard facades. -->
+    <DisableVerifyNotDependsOnNetStandardTest>true</DisableVerifyNotDependsOnNetStandardTest>
+  </PropertyGroup>
+</Project>

--- a/pkg/test/packageSettings/System.Runtime.WindowsRuntime.UI.Xaml/net471/disableTest.targets
+++ b/pkg/test/packageSettings/System.Runtime.WindowsRuntime.UI.Xaml/net471/disableTest.targets
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <!-- This package is special because it uses targets to include assemblies to referencePath, so 
+    it will still require the netstandard facades. -->
+    <DisableVerifyNotDependsOnNetStandardTest>true</DisableVerifyNotDependsOnNetStandardTest>
+  </PropertyGroup>
+</Project>

--- a/pkg/test/packageSettings/System.Runtime.WindowsRuntime/net461/disableTest.targets
+++ b/pkg/test/packageSettings/System.Runtime.WindowsRuntime/net461/disableTest.targets
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <!-- This package is special because it uses targets to include assemblies to referencePath, so 
+    it will still require the netstandard facades. -->
+    <DisableVerifyNotDependsOnNetStandardTest>true</DisableVerifyNotDependsOnNetStandardTest>
+  </PropertyGroup>
+</Project>

--- a/pkg/test/packageSettings/System.Runtime.WindowsRuntime/net462/disableTest.targets
+++ b/pkg/test/packageSettings/System.Runtime.WindowsRuntime/net462/disableTest.targets
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <!-- This package is special because it uses targets to include assemblies to referencePath, so 
+    it will still require the netstandard facades. -->
+    <DisableVerifyNotDependsOnNetStandardTest>true</DisableVerifyNotDependsOnNetStandardTest>
+  </PropertyGroup>
+</Project>

--- a/pkg/test/packageSettings/System.Runtime.WindowsRuntime/net471/disableTest.targets
+++ b/pkg/test/packageSettings/System.Runtime.WindowsRuntime/net471/disableTest.targets
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <!-- This package is special because it uses targets to include assemblies to referencePath, so 
+    it will still require the netstandard facades. -->
+    <DisableVerifyNotDependsOnNetStandardTest>true</DisableVerifyNotDependsOnNetStandardTest>
+  </PropertyGroup>
+</Project>

--- a/pkg/test/packageTest.targets
+++ b/pkg/test/packageTest.targets
@@ -92,9 +92,16 @@
                  IgnoredTypes="@(IgnoredTypes)" />
   </Target>
 
+  <Target Name="VerifyNotDependsOnNetStandard"
+          DependsOnTargets="ResolveReferences"
+          Condition="'$(_ShortFrameworkIdentifier)' == 'net' AND '$(_TargetFrameworkVersionWithoutV)' &gt;= '4.6.1' AND '$(RuntimeIdentifier)' == '' AND '$(DisableVerifyNotDependsOnNetStandardTest)' != 'true'">
+    <Error Condition="'$(DependsOnNetStandard)' == 'true'" Text="Package $(TestPackageId) requires netstandard shims when targeting $(TargetFramework)" />
+  </Target>
+
   <PropertyGroup>
     <_testDependsOn>
       LogBeginTest;
+      VerifyNotDependsOnNetStandard;
       VerifyReferenceClosure;
       VerifyReferenceTypes;
       VerifyRuntimeClosure;

--- a/src/Common/src/CoreLib/System/IO/PinnedBufferMemoryStream.cs
+++ b/src/Common/src/CoreLib/System/IO/PinnedBufferMemoryStream.cs
@@ -38,7 +38,7 @@ namespace System.IO
                 Initialize(ptr, len, len, FileAccess.Read);
         }
 
-#if !netstandard
+#if (!netstandard && !netfx)
         public override int Read(Span<byte> buffer) => ReadCore(buffer);
 
         public override void Write(ReadOnlySpan<byte> buffer) => WriteCore(buffer);

--- a/src/Common/src/CoreLib/System/Resources/RuntimeResourceSet.cs
+++ b/src/Common/src/CoreLib/System/Resources/RuntimeResourceSet.cs
@@ -210,7 +210,11 @@ namespace System.Resources
             Reader = _defaultReader;
         }
 #else
-        private IResourceReader Reader => _defaultReader!;
+        private
+#if HIDE_READER
+        new
+#endif
+        IResourceReader Reader => _defaultReader!;
 
         internal RuntimeResourceSet(IResourceReader reader) :
             // explicitly do not call IResourceReader constructor since it caches all resources

--- a/src/Common/src/CoreLib/System/Resources/RuntimeResourceSet.cs
+++ b/src/Common/src/CoreLib/System/Resources/RuntimeResourceSet.cs
@@ -211,7 +211,7 @@ namespace System.Resources
         }
 #else
         private
-#if HIDE_READER
+#if netfx
         new
 #endif
         IResourceReader Reader => _defaultReader!;

--- a/src/Microsoft.Bcl.AsyncInterfaces/Directory.Build.props
+++ b/src/Microsoft.Bcl.AsyncInterfaces/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <PackageVersion>1.1.0</PackageVersion>
+    <PackageVersion>1.2.0</PackageVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <!-- This assembly should never be placed inbox as it is only for downlevel compatibility. -->
   </PropertyGroup>

--- a/src/Microsoft.Bcl.AsyncInterfaces/Directory.Build.props
+++ b/src/Microsoft.Bcl.AsyncInterfaces/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <PackageVersion>1.2.0</PackageVersion>
+    <PackageVersion>1.1.1</PackageVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <!-- This assembly should never be placed inbox as it is only for downlevel compatibility. -->
   </PropertyGroup>

--- a/src/Microsoft.XmlSerializer.Generator/Directory.Build.props
+++ b/src/Microsoft.XmlSerializer.Generator/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>2.2.0</PackageVersion>
+    <PackageVersion>2.3.0</PackageVersion>
     <SkipValidatePackage>true</SkipValidatePackage>
     <AssemblyVersion>2.0.1.0</AssemblyVersion>
     <AssemblyFileVersion>$(AssemblyVersion)</AssemblyFileVersion>

--- a/src/Microsoft.XmlSerializer.Generator/Directory.Build.props
+++ b/src/Microsoft.XmlSerializer.Generator/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>2.3.0</PackageVersion>
+    <PackageVersion>2.2.1</PackageVersion>
     <SkipValidatePackage>true</SkipValidatePackage>
     <AssemblyVersion>2.0.1.0</AssemblyVersion>
     <AssemblyFileVersion>$(AssemblyVersion)</AssemblyFileVersion>

--- a/src/Microsoft.XmlSerializer.Generator/src/Configurations.props
+++ b/src/Microsoft.XmlSerializer.Generator/src/Configurations.props
@@ -1,7 +1,12 @@
 ﻿<Project>
   <PropertyGroup>
-    <BuildConfigurations>
+    <PackageConfigurations>
       netstandard;
+      net461;
+    </PackageConfigurations>
+    <BuildConfigurations>
+      $(PackageConfigurations);
+      netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.XmlSerializer.Generator/src/Microsoft.XmlSerializer.Generator.csproj
+++ b/src/Microsoft.XmlSerializer.Generator/src/Microsoft.XmlSerializer.Generator.csproj
@@ -6,10 +6,15 @@
     <StringResourcesPath>..\..\System.Private.Xml\src\Resources\Strings.resx</StringResourcesPath>
     <StringResourcesName>FxResources.$(AssemblyName.Replace('-', '_')).SR</StringResourcesName>
     <OutputType>Exe</OutputType>
-    <Configurations>netstandard-Debug;netstandard-Release</Configurations>
+    <Configurations>netstandard-Debug;netstandard-Release;net461-Debug;net461-Release;netfx-Debug;netfx-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Sgen.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
+    <Reference Include="mscorlib" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System" />
   </ItemGroup>
   <Import Project=".\GenerateThisAssemblyCs.targets" />
 </Project>

--- a/src/System.Collections.Immutable/Directory.Build.props
+++ b/src/System.Collections.Immutable/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>1.7.0</PackageVersion>
+    <PackageVersion>1.7.1</PackageVersion>
     <AssemblyVersion>1.2.5.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IsNETCoreApp>true</IsNETCoreApp>

--- a/src/System.Collections.Immutable/ref/Configurations.props
+++ b/src/System.Collections.Immutable/ref/Configurations.props
@@ -4,10 +4,12 @@
       netstandard1.0;
       netstandard1.3;
       netstandard;
+      net461;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);
       netcoreapp;
+      netfx;
       uap-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Collections.Immutable/ref/System.Collections.Immutable.csproj
+++ b/src/System.Collections.Immutable/ref/System.Collections.Immutable.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{C7EFF4EE-70DC-453B-B817-4AF67921AB03}</ProjectGuid>
-    <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release;netstandard1.0-Debug;netstandard1.0-Release;netstandard1.3-Debug;netstandard1.3-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release;netstandard1.0-Debug;netstandard1.0-Release;netstandard1.3-Debug;netstandard1.3-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release;net461-Debug;net461-Release;netfx-Debug;netfx-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Collections.Immutable.cs" />
@@ -22,5 +22,11 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.3' or '$(TargetGroup)' == 'netstandard'">
     <Reference Include="System.Memory" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Memory" />
+    <Reference Include="netstandard" />
   </ItemGroup>
 </Project>

--- a/src/System.Collections.Immutable/src/Configurations.props
+++ b/src/System.Collections.Immutable/src/Configurations.props
@@ -4,9 +4,11 @@
       netstandard1.0;
       netstandard1.3;
       netstandard;
+      net461;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);
+      netfx;
       netcoreapp;
       uap-Windows_NT;
     </BuildConfigurations>

--- a/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
+++ b/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
@@ -6,7 +6,7 @@
     <FileAlignment>512</FileAlignment>
     <GenerateAppxPackageOnBuild>False</GenerateAppxPackageOnBuild>
     <PackageTargetFramework Condition="'$(TargetGroup)' == 'netstandard1.0'">netstandard1.0;portable-net45+win8+wp8+wpa81</PackageTargetFramework>
-    <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release;netstandard1.0-Debug;netstandard1.0-Release;netstandard1.3-Debug;netstandard1.3-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release;netstandard1.0-Debug;netstandard1.0-Release;netstandard1.3-Debug;netstandard1.3-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release;net461-Debug;net461-Release;netfx-Debug;netfx-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Properties\InternalsVisibleTo.cs" />
@@ -113,5 +113,12 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.3' or '$(TargetGroup)' == 'netstandard'">
     <Reference Include="System.Memory" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Memory" />
+    <Reference Include="netstandard" />
+    <Reference Include="System.Core" />
   </ItemGroup>
 </Project>

--- a/src/System.ComponentModel.Composition/ref/Configurations.props
+++ b/src/System.ComponentModel.Composition/ref/Configurations.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       netstandard;
-      _netfx;
+      _net461;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.ComponentModel.Composition/ref/System.ComponentModel.Composition.csproj
+++ b/src/System.ComponentModel.Composition/ref/System.ComponentModel.Composition.csproj
@@ -11,13 +11,4 @@
     <Compile Include="System.ComponentModel.Composition.cs" />
     <Compile Include="System.ComponentModel.Composition.Forwards.cs" />
   </ItemGroup>
-
-  <!-- In net461 we want to use the assembly that is part of the targetting pack, but BinPlace will replace it with
-  the live-built netstandard configuration, so we need to not binplace in those TFMs -->
-  <Target Name="RemoveNetFxBinPlacing" BeforeTargets="GetBinPlaceConfiguration">
-    <ItemGroup>
-      <BinPlaceConfiguration Remove="net461;net462;net463;net47;net471;net472;netfx" />
-    </ItemGroup>
-    <Message Importance="High" Text="@(BinPlaceConfiguration)" />
-  </Target>
 </Project>

--- a/src/System.ComponentModel.Composition/ref/System.ComponentModel.Composition.csproj
+++ b/src/System.ComponentModel.Composition/ref/System.ComponentModel.Composition.csproj
@@ -11,4 +11,13 @@
     <Compile Include="System.ComponentModel.Composition.cs" />
     <Compile Include="System.ComponentModel.Composition.Forwards.cs" />
   </ItemGroup>
+
+  <!-- In net461 we want to use the assembly that is part of the targetting pack, but BinPlace will replace it with
+  the live-built netstandard configuration, so we need to not binplace in those TFMs -->
+  <Target Name="RemoveNetFxBinPlacing" BeforeTargets="GetBinPlaceConfiguration">
+    <ItemGroup>
+      <BinPlaceConfiguration Remove="net461;net462;net463;net47;net471;net472;netfx" />
+    </ItemGroup>
+    <Message Importance="High" Text="@(BinPlaceConfiguration)" />
+  </Target>
 </Project>

--- a/src/System.Composition.AttributedModel/src/Configurations.props
+++ b/src/System.Composition.AttributedModel/src/Configurations.props
@@ -1,7 +1,12 @@
 ﻿<Project>
   <PropertyGroup>
-    <BuildConfigurations>
+    <PackageConfigurations>
       netstandard;
+      net461;
+    </PackageConfigurations>
+    <BuildConfigurations>
+      $(PackageConfigurations);
+      netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Composition.AttributedModel/src/System.Composition.AttributedModel.csproj
+++ b/src/System.Composition.AttributedModel/src/System.Composition.AttributedModel.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ProjectGuid>{C6257381-C624-494A-A9D9-5586E60856EA}</ProjectGuid>
     <AssemblyName>System.Composition.AttributedModel</AssemblyName>
-    <Configurations>netstandard-Debug;netstandard-Release</Configurations>
+    <Configurations>netstandard-Debug;netstandard-Release;net461-Debug;net461-Release;netfx-Debug;netfx-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Composition\Convention\AttributedModelProvider.cs" />
@@ -18,5 +18,8 @@
     <Compile Include="System\Composition\PartNotDiscoverableAttribute.cs" />
     <Compile Include="System\Composition\SharedAttribute.cs" />
     <Compile Include="System\Composition\SharingBoundaryAttribute.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
+    <Reference Include="mscorlib" />
   </ItemGroup>
 </Project>

--- a/src/System.Composition.Convention/src/Configurations.props
+++ b/src/System.Composition.Convention/src/Configurations.props
@@ -1,7 +1,12 @@
 ﻿<Project>
   <PropertyGroup>
-    <BuildConfigurations>
+    <PackageConfigurations>
       netstandard;
+      net461;
+    </PackageConfigurations>
+    <BuildConfigurations>
+      $(PackageConfigurations);
+      netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Composition.Convention/src/System.Composition.Convention.csproj
+++ b/src/System.Composition.Convention/src/System.Composition.Convention.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>
     </RootNamespace>
     <!-- CommonStrings needs RootNamespace to be empty -->
-    <Configurations>netstandard-Debug;netstandard-Release</Configurations>
+    <Configurations>netstandard-Debug;netstandard-Release;net461-Debug;net461-Release;netfx-Debug;netfx-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Composition\Convention\ConventionBuilder.cs" />
@@ -35,5 +35,9 @@
       <Project>{c6257381-c624-494a-a9d9-5586e60856ea}</Project>
       <Name>System.Composition.AttributedModel</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
+    <Reference Include="mscorlib" />
+    <Reference Include="System.Core" />
   </ItemGroup>
 </Project>

--- a/src/System.Composition.Hosting/src/Configurations.props
+++ b/src/System.Composition.Hosting/src/Configurations.props
@@ -1,7 +1,12 @@
 ﻿<Project>
   <PropertyGroup>
-    <BuildConfigurations>
+    <PackageConfigurations>
       netstandard;
+      net461;
+    </PackageConfigurations>
+    <BuildConfigurations>
+      $(PackageConfigurations);
+      netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Composition.Hosting/src/System.Composition.Hosting.csproj
+++ b/src/System.Composition.Hosting/src/System.Composition.Hosting.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>
     </RootNamespace>
     <!-- CommonStrings needs RootNamespace to be empty -->
-    <Configurations>netstandard-Debug;netstandard-Release</Configurations>
+    <Configurations>netstandard-Debug;netstandard-Release;net461-Debug;net461-Release;netfx-Debug;netfx-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Composition\Hosting\CompositionHost.cs" />
@@ -40,5 +40,11 @@
       <Project>{2711dfd2-8541-4628-bc53-eb784a14cdcf}</Project>
       <Name>System.Composition.Runtime</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
+    <Reference Include="mscorlib" />
+    <Reference Include="System.Core" />
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
   </ItemGroup>
 </Project>

--- a/src/System.Composition.Runtime/src/Configurations.props
+++ b/src/System.Composition.Runtime/src/Configurations.props
@@ -1,7 +1,12 @@
 ﻿<Project>
   <PropertyGroup>
-    <BuildConfigurations>
+    <PackageConfigurations>
       netstandard;
+      net461;
+    </PackageConfigurations>
+    <BuildConfigurations>
+      $(PackageConfigurations);
+      netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Composition.Runtime/src/System.Composition.Runtime.csproj
+++ b/src/System.Composition.Runtime/src/System.Composition.Runtime.csproj
@@ -3,7 +3,7 @@
     <ProjectGuid>{2711DFD2-8541-4628-BC53-EB784A14CDCF}</ProjectGuid>
     <RootNamespace>System.Composition</RootNamespace>
     <AssemblyName>System.Composition.Runtime</AssemblyName>
-    <Configurations>netstandard-Debug;netstandard-Release</Configurations>
+    <Configurations>netstandard-Debug;netstandard-Release;net461-Debug;net461-Release;netfx-Debug;netfx-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Composition\CompositionContext.cs" />
@@ -13,5 +13,10 @@
     <Compile Include="System\Composition\Hosting\CompositionFailedException.cs" />
     <Compile Include="System\Composition\Hosting\Core\CompositionContract.cs" />
     <Compile Include="System\Composition\Runtime\Util\Formatters.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
+    <Reference Include="mscorlib" />
+    <Reference Include="System.Core" />
+    <Reference Include="System" />
   </ItemGroup>
 </Project>

--- a/src/System.Composition.TypedParts/src/Configurations.props
+++ b/src/System.Composition.TypedParts/src/Configurations.props
@@ -1,7 +1,12 @@
 ﻿<Project>
   <PropertyGroup>
-    <BuildConfigurations>
+    <PackageConfigurations>
       netstandard;
+      net461;
+    </PackageConfigurations>
+    <BuildConfigurations>
+      $(PackageConfigurations);
+      netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Composition.TypedParts/src/System.Composition.TypedParts.csproj
+++ b/src/System.Composition.TypedParts/src/System.Composition.TypedParts.csproj
@@ -3,7 +3,7 @@
     <ProjectGuid>{B4B5E15C-E6B9-48EA-94C2-F067484D4D3E}</ProjectGuid>
     <RootNamespace>System.Composition</RootNamespace>
     <AssemblyName>System.Composition.TypedParts</AssemblyName>
-    <Configurations>netstandard-Debug;netstandard-Release</Configurations>
+    <Configurations>netstandard-Debug;netstandard-Release;net461-Debug;net461-Release;netfx-Debug;netfx-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Composition\CompositionContextExtensions.cs" />
@@ -44,5 +44,9 @@
       <Project>{2711dfd2-8541-4628-bc53-eb784a14cdcf}</Project>
       <Name>System.Composition.Runtime</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
+    <Reference Include="mscorlib" />
+    <Reference Include="System.Core" />
   </ItemGroup>
 </Project>

--- a/src/System.Composition/Directory.Build.props
+++ b/src/System.Composition/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <PackageVersion>1.4.0</PackageVersion>
+    <PackageVersion>1.4.1</PackageVersion>
     <AssemblyVersion>1.0.35.0</AssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/src/System.Composition/tests/Microsoft.Composition.Demos.ExtendedCollectionImports/Configurations.props
+++ b/src/System.Composition/tests/Microsoft.Composition.Demos.ExtendedCollectionImports/Configurations.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       netstandard;
+      netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Composition/tests/Microsoft.Composition.Demos.ExtendedCollectionImports/Microsoft.Composition.Demos.ExtendedCollectionImports.csproj
+++ b/src/System.Composition/tests/Microsoft.Composition.Demos.ExtendedCollectionImports/Microsoft.Composition.Demos.ExtendedCollectionImports.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ProjectGuid>{44C7E52C-3873-4C64-875C-8A23A8376D60}</ProjectGuid>
     <AssemblyName>Microsoft.Composition.Demos.ExtendedCollectionImports</AssemblyName>
-    <Configurations>netstandard-Debug;netstandard-Release</Configurations>
+    <Configurations>netstandard-Debug;netstandard-Release;netfx-Debug;netfx-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />

--- a/src/System.Composition/tests/TestLibrary/Configurations.props
+++ b/src/System.Composition/tests/TestLibrary/Configurations.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       netstandard;
+      netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Composition/tests/TestLibrary/TestLibrary.csproj
+++ b/src/System.Composition/tests/TestLibrary/TestLibrary.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{DA6841A5-0344-4CC7-98B0-89CBEE18DEE3}</ProjectGuid>
-    <Configurations>netstandard-Debug;netstandard-Release</Configurations>
+    <Configurations>netstandard-Debug;netstandard-Release;netfx-Debug;netfx-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="TestClass.cs" />

--- a/src/System.Diagnostics.DiagnosticSource/Directory.Build.props
+++ b/src/System.Diagnostics.DiagnosticSource/Directory.Build.props
@@ -2,6 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.5.0</AssemblyVersion>
+    <PackageVersion>4.7.1</PackageVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>

--- a/src/System.IO.Pipelines/Directory.Build.props
+++ b/src/System.IO.Pipelines/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.2.1</AssemblyVersion>
-    <PackageVersion>4.7.1</PackageVersion>
+    <PackageVersion>4.7.2</PackageVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.Pipelines/ref/Configurations.props
+++ b/src/System.IO.Pipelines/ref/Configurations.props
@@ -1,7 +1,12 @@
 ﻿<Project>
   <PropertyGroup>
-    <BuildConfigurations>
+    <PackageConfigurations>
       netstandard;
+      net461;
+    </PackageConfigurations>
+    <BuildConfigurations>
+      $(PackageConfigurations);
+      netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.Pipelines/ref/System.IO.Pipelines.csproj
+++ b/src/System.IO.Pipelines/ref/System.IO.Pipelines.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{9C524CA0-92FF-437B-B568-BCE8A794A69A}</ProjectGuid>
-    <Configurations>netstandard-Debug;netstandard-Release</Configurations>
+    <Configurations>netstandard-Debug;netstandard-Release;net461-Debug;net461-Release;netfx-Debug;netfx-Release</Configurations>
     <!-- We only plan to use this ref in netcoreapp. For all other netstandard compatible frameworks we should use the lib
     asset instead. -->
     <PackageTargetFramework Condition="'$(TargetGroup)' == 'netstandard'">netcoreapp2.0</PackageTargetFramework>
@@ -12,6 +12,10 @@
   <ItemGroup>
     <Reference Include="System.Memory" />
     <Reference Include="System.Threading.Tasks.Extensions" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
+    <Reference Include="mscorlib" />
+    <Reference Include="netstandard" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\System.Buffers\ref\System.Buffers.csproj" />

--- a/src/System.IO.Pipelines/src/Configurations.props
+++ b/src/System.IO.Pipelines/src/Configurations.props
@@ -3,9 +3,11 @@
     <PackageConfigurations>
       netstandard;
       netcoreapp3.0;
+      net461;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);
+      netfx;
       netcoreapp;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.IO.Pipelines/src/System.IO.Pipelines.csproj
+++ b/src/System.IO.Pipelines/src/System.IO.Pipelines.csproj
@@ -2,8 +2,6 @@
   <PropertyGroup>
     <ProjectGuid>{1032D5F6-5AE7-4002-A0E4-FEBEADFEA977}</ProjectGuid>
     <Configurations>netcoreapp-Debug;netcoreapp-Release;netcoreapp3.0-Debug;netcoreapp3.0-Release;netstandard-Debug;netstandard-Release;net461-Debug;net461-Release;netfx-Debug;netfx-Release</Configurations>
-    <!-- Some source files use #ifdefs and we need netfx to behave like netstandard -->
-    <DefineConstants Condition="'$(TargetsNetFx)' == 'true'">$(DefineConstants);netstandard</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(CommonPath)\CoreLib\System\Threading\Tasks\TaskToApm.cs">

--- a/src/System.IO.Pipelines/src/System.IO.Pipelines.csproj
+++ b/src/System.IO.Pipelines/src/System.IO.Pipelines.csproj
@@ -1,7 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{1032D5F6-5AE7-4002-A0E4-FEBEADFEA977}</ProjectGuid>
-    <Configurations>netcoreapp-Debug;netcoreapp-Release;netcoreapp3.0-Debug;netcoreapp3.0-Release;netstandard-Debug;netstandard-Release</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release;netcoreapp3.0-Debug;netcoreapp3.0-Release;netstandard-Debug;netstandard-Release;net461-Debug;net461-Release;netfx-Debug;netfx-Release</Configurations>
+    <!-- Some source files use #ifdefs and we need netfx to behave like netstandard -->
+    <DefineConstants Condition="'$(TargetsNetFx)' == 'true'">$(DefineConstants);netstandard</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(CommonPath)\CoreLib\System\Threading\Tasks\TaskToApm.cs">
@@ -40,10 +42,14 @@
   <ItemGroup Condition="'$(TargetsNetCoreApp)'=='true'">
     <Compile Include="System\IO\Pipelines\ThreadPoolScheduler.netcoreapp.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard'">
+  <ItemGroup Condition="'$(TargetGroup)'=='netstandard' Or '$(TargetsNetFx)' == 'true'">
     <Compile Include="System\IO\Pipelines\StreamExtensions.netstandard.cs" />
     <Compile Include="System\IO\Pipelines\ThreadPoolScheduler.netstandard.cs" />
     <Compile Include="System\IO\Pipelines\CancellationTokenExtensions.netstandard.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Buffers" />

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeAwaitable.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeAwaitable.cs
@@ -19,7 +19,7 @@ namespace System.IO.Pipelines
         private SynchronizationContext _synchronizationContext;
         private ExecutionContext _executionContext;
 
-#if !netstandard
+#if (!netstandard && !netfx)
         private CancellationToken CancellationToken => _cancellationTokenRegistration.Token;
 #else
         private CancellationToken _cancellationToken;
@@ -35,7 +35,7 @@ namespace System.IO.Pipelines
             _cancellationTokenRegistration = default;
             _synchronizationContext = null;
             _executionContext = null;
-#if netstandard
+#if (netstandard || netfx)
             _cancellationToken = CancellationToken.None;
 #endif
         }
@@ -54,7 +54,7 @@ namespace System.IO.Pipelines
             // Don't register if already completed, we would immediately unregistered in ObserveCancellation
             if (cancellationToken.CanBeCanceled && !IsCompleted)
             {
-#if netstandard
+#if (netstandard || netfx)
                 _cancellationToken = cancellationToken;
 #endif
                 _cancellationTokenRegistration = cancellationToken.UnsafeRegister(callback, state);
@@ -166,7 +166,7 @@ namespace System.IO.Pipelines
             cancellationToken = CancellationToken;
             CancellationTokenRegistration cancellationTokenRegistration = _cancellationTokenRegistration;
 
-#if netstandard
+#if (netstandard || netfx)
             _cancellationToken = default;
 #endif
             _cancellationTokenRegistration = default;

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeReaderStream.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeReaderStream.cs
@@ -68,7 +68,7 @@ namespace System.IO.Pipelines
             return ReadAsyncInternal(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
         }
 
-#if !netstandard
+#if (!netstandard && !netfx)
         public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
         {
             return ReadAsyncInternal(buffer, cancellationToken);

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeWriterStream.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeWriterStream.cs
@@ -69,7 +69,7 @@ namespace System.IO.Pipelines
             return GetFlushResultAsTask(valueTask);
         }
 
-#if !netstandard
+#if (!netstandard && !netfx)
         public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
         {
             ValueTask<FlushResult> valueTask = _pipeWriter.WriteAsync(buffer, cancellationToken);

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
@@ -239,7 +239,7 @@ namespace System.IO.Pipelines
 
             if (!_leaveOpen)
             {
-#if !netstandard
+#if (!netstandard && !netfx)
                 await InnerStream.DisposeAsync().ConfigureAwait(false);
 #else
                 InnerStream.Dispose();
@@ -354,7 +354,7 @@ namespace System.IO.Pipelines
 
                 if (returnSegment.Length > 0)
                 {
-#if !netstandard
+#if (!netstandard && !netfx)
                     InnerStream.Write(returnSegment.Memory.Span);
 #else
                     InnerStream.Write(returnSegment.Memory);

--- a/src/System.Json/Directory.Build.props
+++ b/src/System.Json/Directory.Build.props
@@ -2,6 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <AssemblyVersion>2.0.8.0</AssemblyVersion>
+    <PackageVersion>4.7.1</PackageVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>
 </Project>

--- a/src/System.Json/src/Configurations.props
+++ b/src/System.Json/src/Configurations.props
@@ -1,8 +1,13 @@
 ﻿<Project>
   <PropertyGroup>
-    <BuildConfigurations>
-      netstandard1.0;
+    <PackageConfigurations>
       netstandard;
+      netstandard1.0;
+      net461;
+    </PackageConfigurations>
+    <BuildConfigurations>
+      $(PackageConfigurations);
+      netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Json/src/System.Json.csproj
+++ b/src/System.Json/src/System.Json.csproj
@@ -5,7 +5,7 @@
         System.Json is a library for compat purposes so we want to keep the same identity as it originally shipped with in Silverlight
     -->
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
-    <Configurations>netstandard-Debug;netstandard-Release;netstandard1.0-Debug;netstandard1.0-Release</Configurations>
+    <Configurations>netstandard-Debug;netstandard-Release;netstandard1.0-Debug;netstandard1.0-Release;net461-Debug;net461-Release;netfx-Debug;netfx-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Json\JsonArray.cs" />
@@ -26,5 +26,10 @@
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Text.Encoding" />
     <Reference Include="System.Text.Encoding.Extensions" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
   </ItemGroup>
 </Project>

--- a/src/System.Net.Http.WinHttpHandler/Directory.Build.props
+++ b/src/System.Net.Http.WinHttpHandler/Directory.Build.props
@@ -2,6 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.5.0</AssemblyVersion>
+    <PackageVersion>4.7.1</PackageVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
   </PropertyGroup>
 </Project>

--- a/src/System.Net.WebSockets.WebSocketProtocol/Directory.Build.props
+++ b/src/System.Net.WebSockets.WebSocketProtocol/Directory.Build.props
@@ -2,6 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.2.0</AssemblyVersion>
+    <PackageVersion>4.7.1</PackageVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>
 </Project>

--- a/src/System.Net.WebSockets.WebSocketProtocol/pkg/System.Net.WebSockets.WebSocketProtocol.pkgproj
+++ b/src/System.Net.WebSockets.WebSocketProtocol/pkg/System.Net.WebSockets.WebSocketProtocol.pkgproj
@@ -6,5 +6,10 @@
     </ProjectReference>
     <ProjectReference Include="..\src\System.Net.WebSockets.WebSocketProtocol.csproj" />
   </ItemGroup>
+  <PropertyGroup>
+    <!-- Excluding the reference assets on the package so that RAR will see the run-time conflicts at build time in order to
+    generate the right binding redirects when targeting Desktop. https://github.com/dotnet/corefx/issues/32457 -->
+    <ExcludeReferenceAssets>true</ExcludeReferenceAssets>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
 </Project>

--- a/src/System.Net.WebSockets.WebSocketProtocol/ref/Configurations.props
+++ b/src/System.Net.WebSockets.WebSocketProtocol/ref/Configurations.props
@@ -1,7 +1,12 @@
 ﻿<Project>
   <PropertyGroup>
-    <BuildConfigurations>
+    <PackageConfigurations>
       netstandard;
+      net461;
+    </PackageConfigurations>
+    <BuildConfigurations>
+      $(PackageConfigurations);
+      netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Net.WebSockets.WebSocketProtocol/ref/System.Net.WebSockets.WebSocketProtocol.csproj
+++ b/src/System.Net.WebSockets.WebSocketProtocol/ref/System.Net.WebSockets.WebSocketProtocol.csproj
@@ -1,12 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{203345A4-0E3B-43C1-ADEB-FF493E578063}</ProjectGuid>
-    <Configurations>netstandard-Debug;netstandard-Release</Configurations>
+    <Configurations>netstandard-Debug;netstandard-Release;net461-Debug;net461-Release;netfx-Debug;netfx-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Net.WebSockets.WebSocketProtocol.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Memory" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
   </ItemGroup>
 </Project>

--- a/src/System.Net.WebSockets.WebSocketProtocol/src/Configurations.props
+++ b/src/System.Net.WebSockets.WebSocketProtocol/src/Configurations.props
@@ -3,9 +3,11 @@
     <PackageConfigurations>
       netstandard;
       netcoreapp2.1;
+      net461;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);
+      netfx;
       netcoreapp;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Net.WebSockets.WebSocketProtocol/src/System.Net.WebSockets.WebSocketProtocol.csproj
+++ b/src/System.Net.WebSockets.WebSocketProtocol/src/System.Net.WebSockets.WebSocketProtocol.csproj
@@ -4,7 +4,7 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <ProjectGuid>{747BE014-7C1D-4460-95AF-B41C35717165}</ProjectGuid>
     <NoWarn>$(NoWarn);CS1573</NoWarn>
-    <Configurations>netcoreapp-Debug;netcoreapp-Release;netcoreapp2.1-Debug;netcoreapp2.1-Release;netstandard-Debug;netstandard-Release</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release;netcoreapp2.1-Debug;netcoreapp2.1-Release;netstandard-Debug;netstandard-Release;net461-Debug;net461-Release;netfx-Debug;netfx-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(CommonPath)\System\Net\WebSockets\ManagedWebSocket.cs">
@@ -20,7 +20,7 @@
   <ItemGroup Condition="'$(TargetGroup)'!='netcoreapp'">
     <Compile Include="System\Numerics\BitOperations.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netstandard'">
+  <ItemGroup Condition="'$(TargetGroup)'=='netstandard' Or '$(TargetsNetFx)' == 'true'">
     <Compile Include="System\Net\WebSockets\ManagedWebSocketExtensions.netstandard.cs" />
     <Reference Include="System.Runtime.CompilerServices.Unsafe" />
   </ItemGroup>
@@ -40,5 +40,9 @@
     <Reference Include="System.Threading.Tasks" />
     <Reference Include="System.Threading.Tasks.Extensions" />
     <Reference Include="System.Threading.Timer" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
   </ItemGroup>
 </Project>

--- a/src/System.Numerics.Tensors/ref/Configurations.props
+++ b/src/System.Numerics.Tensors/ref/Configurations.props
@@ -2,9 +2,11 @@
   <PropertyGroup>
     <PackageConfigurations>
       netstandard1.1;
+      net461;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);
+      netfx;
       netstandard;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Numerics.Tensors/ref/System.Numerics.Tensors.csproj
+++ b/src/System.Numerics.Tensors/ref/System.Numerics.Tensors.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configurations>netstandard-Debug;netstandard-Release;netstandard1.1-Debug;netstandard1.1-Release</Configurations>
+    <Configurations>netstandard-Debug;netstandard-Release;netstandard1.1-Debug;netstandard1.1-Release;net461-Debug;net461-Release;netfx-Debug;netfx-Release</Configurations>
   </PropertyGroup>
   <PropertyGroup>
     <ProjectGuid>{F64208FC-83DA-4C94-973F-1DDDE4354AFF}</ProjectGuid>
@@ -16,5 +16,9 @@
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Runtime.InteropServices" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
+    <Reference Include="mscorlib" />
+    <Reference Include="netstandard" />
   </ItemGroup>
 </Project>

--- a/src/System.Numerics.Tensors/src/Configurations.props
+++ b/src/System.Numerics.Tensors/src/Configurations.props
@@ -2,9 +2,11 @@
   <PropertyGroup>
     <PackageConfigurations>
       netstandard1.1;
+      net461;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);
+      netfx;
       netstandard;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Numerics.Tensors/src/System.Numerics.Tensors.csproj
+++ b/src/System.Numerics.Tensors/src/System.Numerics.Tensors.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Configurations>netstandard-Debug;netstandard-Release;netstandard1.1-Debug;netstandard1.1-Release</Configurations>
+    <Configurations>netstandard-Debug;netstandard-Release;netstandard1.1-Debug;netstandard1.1-Release;net461-Debug;net461-Release;netfx-Debug;netfx-Release</Configurations>
     <DocumentationFile>$(OutputPath)$(MSBuildProjectName).xml</DocumentationFile>
     <RootNamespace>System.Numerics.Tensors</RootNamespace>
   </PropertyGroup>
@@ -25,5 +25,10 @@
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Runtime.InteropServices" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
   </ItemGroup>
 </Project>

--- a/src/System.Reflection.DispatchProxy/Directory.Build.props
+++ b/src/System.Reflection.DispatchProxy/Directory.Build.props
@@ -2,6 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.6.0</AssemblyVersion>
+    <PackageVersion>4.7.1</PackageVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>

--- a/src/System.Reflection.DispatchProxy/ref/Configurations.props
+++ b/src/System.Reflection.DispatchProxy/ref/Configurations.props
@@ -2,9 +2,11 @@
   <PropertyGroup>
     <PackageConfigurations>
       netstandard;
+      net461;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations)
+      netfx;
       netcoreapp;
       uap;
     </BuildConfigurations>

--- a/src/System.Reflection.DispatchProxy/ref/System.Reflection.DispatchProxy.csproj
+++ b/src/System.Reflection.DispatchProxy/ref/System.Reflection.DispatchProxy.csproj
@@ -1,12 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{7DF3C428-AAD6-41C7-98E6-6CACFD5C391E}</ProjectGuid>
-    <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release;uap-Debug;uap-Release</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release;uap-Debug;uap-Release;net461-Debug;net461-Release;netfx-Debug;netfx-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Reflection.DispatchProxy.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'uap' OR '$(TargetGroup)' == 'netcoreapp'">
     <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
+    <Reference Include="mscorlib" />
   </ItemGroup>
 </Project>

--- a/src/System.Reflection.Metadata/Directory.Build.props
+++ b/src/System.Reflection.Metadata/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>1.8.0</PackageVersion>
+    <PackageVersion>1.8.1</PackageVersion>
     <AssemblyVersion>1.4.5.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IsNETCoreApp>true</IsNETCoreApp>

--- a/src/System.Reflection.Metadata/ref/Configurations.props
+++ b/src/System.Reflection.Metadata/ref/Configurations.props
@@ -3,9 +3,11 @@
     <PackageConfigurations>
       netstandard1.1;
       netstandard;
+      net461;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);
+      netfx;
       netcoreapp;
       uap-Windows_NT;
     </BuildConfigurations>

--- a/src/System.Reflection.Metadata/ref/System.Reflection.Metadata.csproj
+++ b/src/System.Reflection.Metadata/ref/System.Reflection.Metadata.csproj
@@ -4,7 +4,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLSCompliant>false</CLSCompliant>
     <DefineConstants Condition="'$(TargetGroup)' == 'netstandard1.1'">$(DefineConstants);NETSTANDARD11</DefineConstants>
-    <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release;netstandard1.1-Debug;netstandard1.1-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release;netstandard1.1-Debug;netstandard1.1-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release;net461-Debug;net461-Release;netfx-Debug;netfx-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Reflection.Metadata.cs" />
@@ -19,7 +19,11 @@
     <Reference Include="System.Runtime" />
     <Reference Include="System.Text.Encoding" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard' Or '$(TargetGroup)' == 'netstandard1.1'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard' Or '$(TargetGroup)' == 'netstandard1.1' Or '$(TargetsNetFx)' == 'true'">
     <ProjectReference Include="..\..\System.Collections.Immutable\ref\System.Collections.Immutable.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
   </ItemGroup>
 </Project>

--- a/src/System.Reflection.Metadata/src/Configurations.props
+++ b/src/System.Reflection.Metadata/src/Configurations.props
@@ -3,9 +3,11 @@
     <PackageConfigurations>
       netstandard1.1;
       netstandard;
+      net461;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);
+      netfx;
       netcoreapp;
       uap-Windows_NT;
     </BuildConfigurations>

--- a/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
+++ b/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
@@ -9,7 +9,7 @@
     <TargetsNetCoreAppOrUap Condition="'$(TargetsNetCoreApp)'=='true' OR '$(TargetsUap)' == 'true'">true</TargetsNetCoreAppOrUap>
     <DefineConstants Condition="'$(TargetGroup)' == 'netstandard1.1'">NETSTANDARD11</DefineConstants>
     <PackageTargetFramework Condition="'$(TargetGroup)' == 'netstandard1.1'">netstandard1.1;portable-net45+win8</PackageTargetFramework>
-    <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release;netstandard1.1-Debug;netstandard1.1-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release;netstandard1.1-Debug;netstandard1.1-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release;net461-Debug;net461-Release;netfx-Debug;netfx-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Reflection\Internal\Utilities\PinnedObject.cs" />
@@ -261,5 +261,10 @@
     <Reference Include="System.Threading" />
     <Reference Include="System.IO.MemoryMappedFiles" Condition="'$(TargetGroup)' != 'netstandard1.1'" />
     <Reference Include="System.Buffers" Condition="'$(TargetsNetCoreAppOrUap)' == 'true'" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
   </ItemGroup>
 </Project>

--- a/src/System.Reflection.MetadataLoadContext/Directory.Build.props
+++ b/src/System.Reflection.MetadataLoadContext/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>4.7.1</PackageVersion>
+    <PackageVersion>4.7.2</PackageVersion>
     <AssemblyVersion>4.0.1.1</AssemblyVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/System.Reflection.MetadataLoadContext/pkg/System.Reflection.MetadataLoadContext.pkgproj
+++ b/src/System.Reflection.MetadataLoadContext/pkg/System.Reflection.MetadataLoadContext.pkgproj
@@ -6,5 +6,10 @@
     </ProjectReference>
     <ProjectReference Include="..\src\System.Reflection.MetadataLoadContext.csproj" />
   </ItemGroup>
+  <PropertyGroup>
+    <!-- Excluding the reference assets on the package so that RAR will see the run-time conflicts at build time in order to
+    generate the right binding redirects when targeting Desktop. https://github.com/dotnet/corefx/issues/32457 -->
+    <ExcludeReferenceAssets>true</ExcludeReferenceAssets>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
 </Project>

--- a/src/System.Reflection.MetadataLoadContext/ref/Configurations.props
+++ b/src/System.Reflection.MetadataLoadContext/ref/Configurations.props
@@ -1,7 +1,12 @@
 ﻿<Project>
   <PropertyGroup>
-    <BuildConfigurations>
+    <PackageConfigurations>
       netstandard;
+      net461;
+    </PackageConfigurations>
+    <BuildConfigurations>
+      $(PackageConfigurations);
+      netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Reflection.MetadataLoadContext/ref/System.Reflection.MetadataLoadContext.csproj
+++ b/src/System.Reflection.MetadataLoadContext/ref/System.Reflection.MetadataLoadContext.csproj
@@ -1,9 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{EC84D608-71BC-4FE4-86C8-CA30F3B0CC7D}</ProjectGuid>
-    <Configurations>netstandard-Debug;netstandard-Release</Configurations>
+    <Configurations>netstandard-Debug;netstandard-Release;net461-Debug;net461-Release;netfx-Debug;netfx-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Reflection.MetadataLoadContext.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
+  	<Reference Include="mscorlib" />
   </ItemGroup>
 </Project>

--- a/src/System.Reflection.MetadataLoadContext/src/Configurations.props
+++ b/src/System.Reflection.MetadataLoadContext/src/Configurations.props
@@ -2,10 +2,12 @@
   <PropertyGroup>
     <PackageConfigurations>
       netcoreapp3.0;
+      net461;
       netstandard;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);
+      netfx;
       netcoreapp;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Reflection.MetadataLoadContext/src/System.Reflection.MetadataLoadContext.csproj
+++ b/src/System.Reflection.MetadataLoadContext/src/System.Reflection.MetadataLoadContext.csproj
@@ -6,7 +6,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>$(NoWarn);CS1573</NoWarn>
     <!-- Only the netcoreapp version supports the new reflection apis (IsSZArray, etc.) -->
-    <Configurations>netcoreapp-Debug;netcoreapp-Release;netcoreapp3.0-Debug;netcoreapp3.0-Release;netstandard-Debug;netstandard-Release</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release;netcoreapp3.0-Debug;netcoreapp3.0-Release;netstandard-Debug;netstandard-Release;net461-Debug;net461-Release;netfx-Debug;netfx-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\CoreRtBridge.cs" />
@@ -79,7 +79,7 @@
     <Compile Include="System\Reflection\TypeLoading\General\HashHelpers.cs" />
     <Compile Include="System\Reflection\TypeLoading\General\Helpers.cs" />
     <Compile Include="System\Reflection\TypeLoading\General\TypeExtensions.netcoreapp.cs" Condition="'$(TargetsNetCoreApp)' == 'true'" />
-    <Compile Include="System\Reflection\TypeLoading\General\TypeExtensions.netstandard.cs" Condition="'$(TargetsNetStandard)' == 'true'" />
+    <Compile Include="System\Reflection\TypeLoading\General\TypeExtensions.netstandard.cs" Condition="'$(TargetsNetStandard)' == 'true' Or '$(TargetsNetFx)' == 'true'" />
     <Compile Include="System\Reflection\TypeLoading\General\MethodSig.cs" />
     <Compile Include="System\Reflection\TypeLoading\General\RoAssemblyName.cs" />
     <Compile Include="System\Reflection\TypeLoading\General\Sentinels.cs" />
@@ -155,5 +155,10 @@
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Runtime.InteropServices" />
     <Reference Include="System.Threading" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
   </ItemGroup>
 </Project>

--- a/src/System.Resources.Extensions/Directory.Build.props
+++ b/src/System.Resources.Extensions/Directory.Build.props
@@ -2,6 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <PackageVersion>4.7.1</PackageVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>
 </Project>

--- a/src/System.Resources.Extensions/pkg/System.Resources.Extensions.pkgproj
+++ b/src/System.Resources.Extensions/pkg/System.Resources.Extensions.pkgproj
@@ -6,5 +6,10 @@
     </ProjectReference>
     <ProjectReference Include="..\src\System.Resources.Extensions.csproj" />
   </ItemGroup>
+  <PropertyGroup>
+    <!-- Excluding the reference assets on the package so that RAR will see the run-time conflicts at build time in order to
+    generate the right binding redirects when targeting Desktop. https://github.com/dotnet/corefx/issues/32457 -->
+    <ExcludeReferenceAssets>true</ExcludeReferenceAssets>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
 </Project>

--- a/src/System.Resources.Extensions/ref/Configurations.props
+++ b/src/System.Resources.Extensions/ref/Configurations.props
@@ -1,7 +1,12 @@
 ﻿<Project>
   <PropertyGroup>
-    <BuildConfigurations>
+    <PackageConfigurations>
       netstandard;
+      net461;
+    </PackageConfigurations>
+    <BuildConfigurations>
+      $(PackageConfigurations);
+      netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Resources.Extensions/ref/System.Resources.Extensions.csproj
+++ b/src/System.Resources.Extensions/ref/System.Resources.Extensions.csproj
@@ -1,11 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configurations>netstandard-Debug;netstandard-Release</Configurations>
+    <Configurations>netstandard-Debug;netstandard-Release;net461-Debug;net461-Release;netfx-Debug;netfx-Release</Configurations>
   </PropertyGroup>
   <PropertyGroup>
     <ProjectGuid>{D8C148D2-FAB2-4D8C-ACA3-D201665F7255}</ProjectGuid>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Resources.Extensions.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
+  	<Reference Include="mscorlib" />
   </ItemGroup>
 </Project>

--- a/src/System.Resources.Extensions/src/Configurations.props
+++ b/src/System.Resources.Extensions/src/Configurations.props
@@ -1,7 +1,12 @@
 ﻿<Project>
   <PropertyGroup>
-    <BuildConfigurations>
+    <PackageConfigurations>
       netstandard;
+      net461;
+    </PackageConfigurations>
+    <BuildConfigurations>
+      $(PackageConfigurations);
+      netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Resources.Extensions/src/System.Resources.Extensions.csproj
+++ b/src/System.Resources.Extensions/src/System.Resources.Extensions.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Configurations>netstandard-Debug;netstandard-Release</Configurations>
+    <Configurations>netstandard-Debug;netstandard-Release;net461-Debug;net461-Release;netfx-Debug;netfx-Release</Configurations>
     <DefineConstants>$(DefineConstants);RESOURCES_EXTENSIONS;INTERNAL_NULLABLE_ATTRIBUTES</DefineConstants>
+    <DefineConstants Condition="'$(TargetsNetFx)' == 'true'">$(DefineConstants);netstandard;HIDE_READER</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
     <ProjectGuid>{6773D354-A573-4D9C-9A67-C7FAE579DA50}</ProjectGuid>
@@ -26,5 +27,9 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Memory" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
   </ItemGroup>
 </Project>

--- a/src/System.Resources.Extensions/src/System.Resources.Extensions.csproj
+++ b/src/System.Resources.Extensions/src/System.Resources.Extensions.csproj
@@ -3,7 +3,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Configurations>netstandard-Debug;netstandard-Release;net461-Debug;net461-Release;netfx-Debug;netfx-Release</Configurations>
     <DefineConstants>$(DefineConstants);RESOURCES_EXTENSIONS;INTERNAL_NULLABLE_ATTRIBUTES</DefineConstants>
-    <DefineConstants Condition="'$(TargetsNetFx)' == 'true'">$(DefineConstants);netstandard;HIDE_READER</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
     <ProjectGuid>{6773D354-A573-4D9C-9A67-C7FAE579DA50}</ProjectGuid>

--- a/src/System.Security.Cryptography.OpenSsl/ref/Configurations.props
+++ b/src/System.Security.Cryptography.OpenSsl/ref/Configurations.props
@@ -1,10 +1,12 @@
 ﻿<Project DefaultTargets="Build">
   <PropertyGroup>
     <PackageConfigurations>
-      netcoreapp3.0
+      netcoreapp3.0;
+      net47;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);
+      netfx;
       netcoreapp;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Security.Cryptography.OpenSsl/ref/System.Security.Cryptography.OpenSsl.cs
+++ b/src/System.Security.Cryptography.OpenSsl/ref/System.Security.Cryptography.OpenSsl.cs
@@ -20,28 +20,8 @@ namespace System.Security.Cryptography
         protected override void Dispose(bool disposing) { }
         public System.Security.Cryptography.SafeEvpPKeyHandle DuplicateKeyHandle() { throw null; }
         public override System.Security.Cryptography.DSAParameters ExportParameters(bool includePrivateParameters) { throw null; }
-        protected override byte[] HashData(byte[] data, int offset, int count, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
-        protected override byte[] HashData(System.IO.Stream data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
         public override void ImportParameters(System.Security.Cryptography.DSAParameters parameters) { }
         public override bool VerifySignature(byte[] rgbHash, byte[] rgbSignature) { throw null; }
-    }
-    public sealed partial class ECDiffieHellmanOpenSsl : System.Security.Cryptography.ECDiffieHellman
-    {
-        public ECDiffieHellmanOpenSsl() { }
-        public ECDiffieHellmanOpenSsl(int keySize) { }
-        public ECDiffieHellmanOpenSsl(System.IntPtr handle) { }
-        public ECDiffieHellmanOpenSsl(System.Security.Cryptography.ECCurve curve) { }
-        public ECDiffieHellmanOpenSsl(System.Security.Cryptography.SafeEvpPKeyHandle pkeyHandle) { }
-        public override System.Security.Cryptography.ECDiffieHellmanPublicKey PublicKey { get { throw null; } }
-        public override byte[] DeriveKeyFromHash(System.Security.Cryptography.ECDiffieHellmanPublicKey otherPartyPublicKey, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, byte[] secretPrepend, byte[] secretAppend) { throw null; }
-        public override byte[] DeriveKeyFromHmac(System.Security.Cryptography.ECDiffieHellmanPublicKey otherPartyPublicKey, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, byte[] hmacKey, byte[] secretPrepend, byte[] secretAppend) { throw null; }
-        public override byte[] DeriveKeyMaterial(System.Security.Cryptography.ECDiffieHellmanPublicKey otherPartyPublicKey) { throw null; }
-        public override byte[] DeriveKeyTls(System.Security.Cryptography.ECDiffieHellmanPublicKey otherPartyPublicKey, byte[] prfLabel, byte[] prfSeed) { throw null; }
-        public System.Security.Cryptography.SafeEvpPKeyHandle DuplicateKeyHandle() { throw null; }
-        public override System.Security.Cryptography.ECParameters ExportExplicitParameters(bool includePrivateParameters) { throw null; }
-        public override System.Security.Cryptography.ECParameters ExportParameters(bool includePrivateParameters) { throw null; }
-        public override void GenerateKey(System.Security.Cryptography.ECCurve curve) { }
-        public override void ImportParameters(System.Security.Cryptography.ECParameters parameters) { }
     }
     public sealed partial class ECDsaOpenSsl : System.Security.Cryptography.ECDsa
     {
@@ -87,7 +67,6 @@ namespace System.Security.Cryptography
     {
         public SafeEvpPKeyHandle(System.IntPtr handle, bool ownsHandle) : base (default(System.IntPtr), default(bool)) { }
         public override bool IsInvalid { get { throw null; } }
-        public static long OpenSslVersion { get { throw null; } }
         public System.Security.Cryptography.SafeEvpPKeyHandle DuplicateHandle() { throw null; }
         protected override bool ReleaseHandle() { throw null; }
     }

--- a/src/System.Security.Cryptography.OpenSsl/ref/System.Security.Cryptography.OpenSsl.csproj
+++ b/src/System.Security.Cryptography.OpenSsl/ref/System.Security.Cryptography.OpenSsl.csproj
@@ -1,10 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{8DEA82EF-2214-4295-8CC1-9FFB9B18838F}</ProjectGuid>
-    <Configurations>netcoreapp-Debug;netcoreapp-Release;netcoreapp3.0-Debug;netcoreapp3.0-Release</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release;netcoreapp3.0-Debug;netcoreapp3.0-Release;net47-Debug;net47-Release;netfx-Debug;netfx-Release</Configurations>
+    <AssemblyVersion Condition="'$(TargetsNetFx)' == 'true'">4.1.0.0</AssemblyVersion>
+    <!-- We need to build against net47 because that is where ECParameters got added inbox. We ship as net461 in order to not require
+    the facades when the package is restored. -->
+    <PackageTargetFramework Condition="'$(TargetGroup)' == 'net47'">net461</PackageTargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <SuppressPackageTargetFrameworkCompatibility Include="net461" />
     <Compile Include="System.Security.Cryptography.OpenSsl.cs" />
+    <Compile Include="System.Security.Cryptography.OpenSsl.netcoreapp.cs" Condition="'$(TargetsNetCoreApp)' == 'true'" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
     <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />
@@ -19,5 +25,9 @@
     <Reference Include="System.IO" />
     <Reference Include="System.Security.Cryptography.Algorithms" />
     <Reference Include="System.Security.Cryptography.Primitives" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
+    <Reference Include="mscorlib" />
+    <Reference Include="System.Core" />
   </ItemGroup>
 </Project>

--- a/src/System.Security.Cryptography.OpenSsl/ref/System.Security.Cryptography.OpenSsl.netcoreapp.cs
+++ b/src/System.Security.Cryptography.OpenSsl/ref/System.Security.Cryptography.OpenSsl.netcoreapp.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+namespace System.Security.Cryptography
+{
+    public sealed partial class DSAOpenSsl : System.Security.Cryptography.DSA
+    {
+        protected override byte[] HashData(byte[] data, int offset, int count, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
+        protected override byte[] HashData(System.IO.Stream data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
+    }
+    public sealed partial class ECDiffieHellmanOpenSsl : System.Security.Cryptography.ECDiffieHellman
+    {
+        public ECDiffieHellmanOpenSsl() { }
+        public ECDiffieHellmanOpenSsl(int keySize) { }
+        public ECDiffieHellmanOpenSsl(System.IntPtr handle) { }
+        public ECDiffieHellmanOpenSsl(System.Security.Cryptography.ECCurve curve) { }
+        public ECDiffieHellmanOpenSsl(System.Security.Cryptography.SafeEvpPKeyHandle pkeyHandle) { }
+        public override System.Security.Cryptography.ECDiffieHellmanPublicKey PublicKey { get { throw null; } }
+        public override byte[] DeriveKeyFromHash(System.Security.Cryptography.ECDiffieHellmanPublicKey otherPartyPublicKey, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, byte[] secretPrepend, byte[] secretAppend) { throw null; }
+        public override byte[] DeriveKeyFromHmac(System.Security.Cryptography.ECDiffieHellmanPublicKey otherPartyPublicKey, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, byte[] hmacKey, byte[] secretPrepend, byte[] secretAppend) { throw null; }
+        public override byte[] DeriveKeyMaterial(System.Security.Cryptography.ECDiffieHellmanPublicKey otherPartyPublicKey) { throw null; }
+        public override byte[] DeriveKeyTls(System.Security.Cryptography.ECDiffieHellmanPublicKey otherPartyPublicKey, byte[] prfLabel, byte[] prfSeed) { throw null; }
+        public System.Security.Cryptography.SafeEvpPKeyHandle DuplicateKeyHandle() { throw null; }
+        public override System.Security.Cryptography.ECParameters ExportExplicitParameters(bool includePrivateParameters) { throw null; }
+        public override System.Security.Cryptography.ECParameters ExportParameters(bool includePrivateParameters) { throw null; }
+        public override void GenerateKey(System.Security.Cryptography.ECCurve curve) { }
+        public override void ImportParameters(System.Security.Cryptography.ECParameters parameters) { }
+    }
+    public sealed partial class SafeEvpPKeyHandle : System.Runtime.InteropServices.SafeHandle
+    {
+        public static long OpenSslVersion { get { throw null; } }
+    }
+}

--- a/src/System.Security.Cryptography.OpenSsl/src/Configurations.props
+++ b/src/System.Security.Cryptography.OpenSsl/src/Configurations.props
@@ -4,9 +4,11 @@
       netcoreapp3.0-Unix;
       netcoreapp3.0;
       netstandard;
+      net47;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);
+      netfx;
       netcoreapp-Unix;
       netcoreapp;
     </BuildConfigurations>

--- a/src/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.csproj
+++ b/src/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.csproj
@@ -4,9 +4,12 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Security.Cryptography.OpenSsl</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <AssemblyVersion Condition="'$(TargetGroup)' == 'netstandard'">4.1.0.0</AssemblyVersion>
+    <!-- We need to build against net47 because that is where ECParameters got added inbox. We ship as net461 in order to not require
+    the facades when the package is restored. -->
+    <PackageTargetFramework Condition="'$(TargetGroup)' == 'net47'">net461</PackageTargetFramework>
+    <AssemblyVersion Condition="'$(TargetGroup)' == 'netstandard' Or '$(TargetsNetFx)' == 'true'">4.1.0.0</AssemblyVersion>
     <DefineConstants Condition="'$(TargetsNetCoreApp)' == 'true'">$(DefineConstants);netcoreapp</DefineConstants>
-    <Configurations>netcoreapp-Debug;netcoreapp-Release;netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp3.0-Debug;netcoreapp3.0-Release;netcoreapp3.0-Unix-Debug;netcoreapp3.0-Unix-Release;netstandard-Debug;netstandard-Release</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release;netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp3.0-Debug;netcoreapp3.0-Release;netcoreapp3.0-Unix-Debug;netcoreapp3.0-Unix-Release;netstandard-Debug;netstandard-Release;net47-Debug;net47-Release;netfx-Debug;netfx-Release</Configurations>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetsUnix)' != 'true'">
     <GeneratePlatformNotSupportedAssemblyMessage>SR.PlatformNotSupported_CryptographyOpenSSL</GeneratePlatformNotSupportedAssemblyMessage>
@@ -159,5 +162,10 @@
     <Reference Include="System.Security.Cryptography.Primitives" />
     <Reference Include="System.Text.Encoding.Extensions" />
     <Reference Include="System.Threading" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
+    <SuppressPackageTargetFrameworkCompatibility Include="net461" />
+    <Reference Include="mscorlib" />
+    <Reference Include="System.Core" />
   </ItemGroup>
 </Project>

--- a/src/System.Text.Encoding.CodePages/Directory.Build.props
+++ b/src/System.Text.Encoding.CodePages/Directory.Build.props
@@ -2,6 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <AssemblyVersion>4.1.3.0</AssemblyVersion>
+    <PackageVersion>4.7.1</PackageVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>

--- a/src/System.Text.Encoding.CodePages/ref/Configurations.props
+++ b/src/System.Text.Encoding.CodePages/ref/Configurations.props
@@ -1,7 +1,12 @@
-﻿<Project DefaultTargets="Build">
+﻿<Project>
   <PropertyGroup>
-    <BuildConfigurations>
+    <PackageConfigurations>
       netstandard;
+      net461;
+    </PackageConfigurations>
+    <BuildConfigurations>
+      $(PackageConfigurations);
+      netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Text.Encoding.CodePages/ref/System.Text.Encoding.CodePages.csproj
+++ b/src/System.Text.Encoding.CodePages/ref/System.Text.Encoding.CodePages.csproj
@@ -1,9 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{73FAB2B8-589D-4BEA-ADCA-E5CC02296F25}</ProjectGuid>
-    <Configurations>netstandard-Debug;netstandard-Release</Configurations>
+    <Configurations>netstandard-Debug;netstandard-Release;net461-Debug;net461-Release;netfx-Debug;netfx-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Text.Encoding.CodePages.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
+    <Reference Include="mscorlib" />
   </ItemGroup>
 </Project>

--- a/src/System.Text.Encoding.CodePages/src/Configurations.props
+++ b/src/System.Text.Encoding.CodePages/src/Configurations.props
@@ -4,9 +4,11 @@
       netstandard;
       netcoreapp2.0-Windows_NT;
       netstandard-Windows_NT;
+      net461-Windows_NT;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);
+      netfx-Windows_NT;
       netcoreapp-Windows_NT;
       uap-Windows_NT;
     </BuildConfigurations>

--- a/src/System.Text.Encoding.CodePages/src/System.Text.Encoding.CodePages.csproj
+++ b/src/System.Text.Encoding.CodePages/src/System.Text.Encoding.CodePages.csproj
@@ -5,9 +5,7 @@
     <RootNamespace>System.Text.Encoding.CodePages</RootNamespace>
     <AssemblyName>System.Text.Encoding.CodePages</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- copy the Windows-specific implementation to net461 folder so that restore without a RID works -->
-    <PackageTargetFramework Condition="'$(TargetGroup)' == 'netstandard' AND '$(TargetsWindows)' == 'true'">netstandard2.0;net461</PackageTargetFramework>
-    <Configurations>netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netcoreapp2.0-Windows_NT-Debug;netcoreapp2.0-Windows_NT-Release;netstandard-Debug;netstandard-Release;netstandard-Windows_NT-Debug;netstandard-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
+    <Configurations>netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netcoreapp2.0-Windows_NT-Debug;netcoreapp2.0-Windows_NT-Release;netstandard-Debug;netstandard-Release;netstandard-Windows_NT-Debug;netstandard-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release;net461-Windows_NT-Debug;net461-Windows_NT-Release;netfx-Windows_NT-Debug;netfx-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Microsoft\Win32\SafeHandles\SafeAllocHHandle.cs" />
@@ -69,6 +67,11 @@
     <Reference Include="System.Runtime.InteropServices" />
     <Reference Include="System.Threading" />
     <Reference Include="System.Runtime.CompilerServices.Unsafe" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
+    <Reference Include="mscorlib" />
+    <Reference Include="System.Core" />
+    <Reference Include="System" />
   </ItemGroup>
   <!-- Generator for code mapping table, target to invoke is GenerateEncodingSource -->
   <PropertyGroup>

--- a/src/System.Text.Encodings.Web/Directory.Build.props
+++ b/src/System.Text.Encodings.Web/Directory.Build.props
@@ -2,6 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.5.0</AssemblyVersion>
+    <PackageVersion>4.7.1</PackageVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>

--- a/src/System.Text.Encodings.Web/ref/Configurations.props
+++ b/src/System.Text.Encodings.Web/ref/Configurations.props
@@ -2,9 +2,11 @@
   <PropertyGroup>
     <PackageConfigurations>
       netstandard;
+      net461;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);
+      netfx;
       netcoreapp;
       uap;
     </BuildConfigurations>

--- a/src/System.Text.Encodings.Web/ref/System.Text.Encodings.Web.csproj
+++ b/src/System.Text.Encodings.Web/ref/System.Text.Encodings.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="Current">
   <PropertyGroup>
     <ProjectGuid>{41648C6D-D431-478D-8228-7EB68714541C}</ProjectGuid>
-    <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release;uap-Debug;uap-Release</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release;uap-Debug;uap-Release;net461-Debug;net461-Release;netfx-Debug;netfx-Release</Configurations>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
@@ -12,7 +12,12 @@
     <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />
     <ProjectReference Include="..\..\System.Runtime.Extensions\ref\System.Runtime.Extensions.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetsNetStandard)' == 'true'">
+  <ItemGroup Condition="'$(TargetsNetStandard)' == 'true' Or '$(TargetsNetFx)' == 'true'">
     <Reference Include="System.Memory" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
+    <Reference Include="mscorlib" />
+    <Reference Include="netstandard" />
+    <Reference Include="System" />
   </ItemGroup>
 </Project>

--- a/src/System.Text.Encodings.Web/src/Configurations.props
+++ b/src/System.Text.Encodings.Web/src/Configurations.props
@@ -1,9 +1,14 @@
 ﻿<Project DefaultTargets="Build">
   <PropertyGroup>
-    <BuildConfigurations>
+    <PackageConfigurations>
       netstandard2.1;
       netstandard;
       uap-Windows_NT;
+      net461;
+    </PackageConfigurations>
+    <BuildConfigurations>
+      $(PackageConfigurations);
+      netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Text.Encodings.Web/src/System.Text.Encodings.Web.csproj
+++ b/src/System.Text.Encodings.Web/src/System.Text.Encodings.Web.csproj
@@ -3,7 +3,7 @@
     <ProjectGuid>{B7EDBF00-765A-48E8-B593-CD668288E274}</ProjectGuid>
     <RootNamespace>System.Text.Encodings.Web</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Configurations>netstandard-Debug;netstandard-Release;netstandard2.1-Debug;netstandard2.1-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
+    <Configurations>netstandard-Debug;netstandard-Release;netstandard2.1-Debug;netstandard2.1-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release;net461-Debug;net461-Release;netfx-Debug;netfx-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Text\Encodings\Web\HexUtil.cs" />
@@ -30,6 +30,10 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Memory" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsNetCoreApp)' == 'true' OR '$(TargetsUap)' == 'true'">
     <Reference Include="System.Diagnostics.Debug" />

--- a/src/System.Threading.Channels/Directory.Build.props
+++ b/src/System.Threading.Channels/Directory.Build.props
@@ -2,6 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.2.0</AssemblyVersion>
+    <PackageVersion>4.7.1</PackageVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <IsNETCoreApp>true</IsNETCoreApp>
   </PropertyGroup>

--- a/src/System.Threading.Channels/ref/Configurations.props
+++ b/src/System.Threading.Channels/ref/Configurations.props
@@ -4,9 +4,11 @@
       netcoreapp3.0;
       netstandard1.3;
       netstandard;
+      net461;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);
+      netfx;
       netcoreapp;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Threading.Channels/ref/System.Threading.Channels.csproj
+++ b/src/System.Threading.Channels/ref/System.Threading.Channels.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{97DB4782-7AB3-4F4C-B716-CF722A0E6066}</ProjectGuid>
-    <Configurations>netcoreapp-Debug;netcoreapp-Release;netcoreapp3.0-Debug;netcoreapp3.0-Release;netstandard-Debug;netstandard-Release;netstandard1.3-Debug;netstandard1.3-Release</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release;netcoreapp3.0-Debug;netcoreapp3.0-Release;netstandard-Debug;netstandard-Release;netstandard1.3-Debug;netstandard1.3-Release;net461-Debug;net461-Release;netfx-Debug;netfx-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Threading.Channels.cs" />
@@ -22,6 +22,11 @@
   <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.3'">
     <Reference Include="System.Runtime" />
     <Reference Include="System.Threading.Tasks" />
+    <Reference Include="System.Threading.Tasks.Extensions" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
+    <Reference Include="mscorlib" />
+    <Reference Include="netstandard" />
     <Reference Include="System.Threading.Tasks.Extensions" />
   </ItemGroup>
 </Project>

--- a/src/System.Threading.Channels/src/Configurations.props
+++ b/src/System.Threading.Channels/src/Configurations.props
@@ -4,9 +4,11 @@
       netstandard1.3;
       netstandard;
       netcoreapp3.0;
+      net461;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations);
+      netfx;
       netcoreapp;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Threading.Channels/src/System.Threading.Channels.csproj
+++ b/src/System.Threading.Channels/src/System.Threading.Channels.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ProjectGuid>{AAADA5D3-CF64-4E9D-943C-EFDC006D6366}</ProjectGuid>
     <RootNamespace>System.Threading.Channels</RootNamespace>
-    <Configurations>netcoreapp-Debug;netcoreapp-Release;netcoreapp3.0-Debug;netcoreapp3.0-Release;netstandard-Debug;netstandard-Release;netstandard1.3-Debug;netstandard1.3-Release</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release;netcoreapp3.0-Debug;netcoreapp3.0-Release;netstandard-Debug;netstandard-Release;netstandard1.3-Debug;netstandard1.3-Release;net461-Debug;net461-Release;netfx-Debug;netfx-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\VoidResult.cs" />
@@ -43,5 +43,9 @@
     <Reference Include="System.Threading.ThreadPool" Condition="'$(TargetsNetCoreApp)' == 'true'" />
     <Reference Include="System.Threading.Tasks" />
     <Reference Include="System.Threading.Tasks.Extensions" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
   </ItemGroup>
 </Project>

--- a/src/System.Threading.Tasks.Dataflow/Directory.Build.props
+++ b/src/System.Threading.Tasks.Dataflow/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>4.11.0</PackageVersion>
+    <PackageVersion>4.11.1</PackageVersion>
     <AssemblyVersion>4.6.5.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IsNETCoreApp>true</IsNETCoreApp>

--- a/src/System.Threading.Tasks.Dataflow/src/Configurations.props
+++ b/src/System.Threading.Tasks.Dataflow/src/Configurations.props
@@ -1,9 +1,14 @@
 ﻿<Project DefaultTargets="Build">
   <PropertyGroup>
-    <BuildConfigurations>
+    <PackageConfigurations>
       netstandard1.0;
       netstandard1.1;
       netstandard;
+      net461;
+    </PackageConfigurations>
+    <BuildConfigurations>
+      $(PackageConfigurations);
+      netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Threading.Tasks.Dataflow/src/System.Threading.Tasks.Dataflow.csproj
+++ b/src/System.Threading.Tasks.Dataflow/src/System.Threading.Tasks.Dataflow.csproj
@@ -2,11 +2,11 @@
   <PropertyGroup>
     <ProjectGuid>{2E2F7224-7C72-4A81-9625-A5241F8D836D}</ProjectGuid>
     <RootNamespace>System.Threading.Tasks.Dataflow</RootNamespace>
-    <DefineConstants Condition="'$(TargetGroup)' == 'netstandard1.1' OR '$(TargetGroup)' == 'netstandard'">$(DefineConstants);FEATURE_TRACING</DefineConstants>
+    <DefineConstants Condition="'$(TargetGroup)' == 'netstandard1.1' OR '$(TargetGroup)' == 'netstandard' Or '$(TargetsNetFx)' == 'true'">$(DefineConstants);FEATURE_TRACING</DefineConstants>
     <DefineConstants Condition="'$(TargetGroup)' == 'netstandard1.0'">$(DefineConstants);USE_INTERNAL_CONCURRENT_COLLECTIONS</DefineConstants>
     <DefineConstants Condition="'$(TargetGroup)' == 'netstandard1.0' OR '$(TargetGroup)' == 'netstandard1.1'">$(DefineConstants);USE_INTERNAL_THREADING</DefineConstants>
     <PackageTargetFramework Condition="'$(TargetGroup)' == 'netstandard1.1'">netstandard1.1;portable-net45+win8+wpa81</PackageTargetFramework>
-    <Configurations>netstandard-Debug;netstandard-Release;netstandard1.0-Debug;netstandard1.0-Release;netstandard1.1-Debug;netstandard1.1-Release</Configurations>
+    <Configurations>netstandard-Debug;netstandard-Release;netstandard1.0-Debug;netstandard1.0-Release;netstandard1.1-Debug;netstandard1.1-Release;net461-Debug;net461-Release;netfx-Debug;netfx-Release;</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Base\DataflowBlock.cs" />
@@ -76,5 +76,10 @@
     <Reference Include="System.Runtime.Serialization.Primitives" />
     <Reference Include="System.Threading" />
     <Reference Include="System.Threading.Tasks" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
+    <Reference Include="mscorlib" />
+    <Reference Include="System.Core" />
+    <Reference Include="System" />
   </ItemGroup>
 </Project>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -35,6 +35,12 @@
     <Project Include="$(MSBuildThisFileDirectory)System.Text.Json\pkg\System.Text.Json.pkgproj">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
+    <Project Include="$(MSBuildThisFileDirectory)Microsoft.Bcl.AsyncInterfaces\pkg\Microsoft.Bcl.AsyncInterfaces.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="$(MSBuildThisFileDirectory)Microsoft.XmlSerializer.Generator\pkg\Microsoft.XmlSerializer.Generator.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
     <Project Include="$(MSBuildThisFileDirectory)System.Collections.Immutable\pkg\System.Collections.Immutable.pkgproj">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
@@ -56,10 +62,16 @@
     <Project Include="$(MSBuildThisFileDirectory)System.Composition.TypedParts\pkg\System.Composition.TypedParts.pkgproj">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
+    <Project Include="$(MSBuildThisFileDirectory)System.Diagnostics.DiagnosticSource\pkg\System.Diagnostics.DiagnosticSource.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
     <Project Include="$(MSBuildThisFileDirectory)System.IO.Pipelines\pkg\System.IO.Pipelines.pkgproj">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
     <Project Include="$(MSBuildThisFileDirectory)System.Json\pkg\System.Json.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="$(MSBuildThisFileDirectory)System.Net.Http.WinHttpHandler\pkg\System.Net.Http.WinHttpHandler.pkgproj">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
     <Project Include="$(MSBuildThisFileDirectory)System.Net.WebSockets.WebSocketProtocol\pkg\System.Net.WebSockets.WebSocketProtocol.pkgproj">

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -35,6 +35,63 @@
     <Project Include="$(MSBuildThisFileDirectory)System.Text.Json\pkg\System.Text.Json.pkgproj">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
+    <Project Include="$(MSBuildThisFileDirectory)System.Collections.Immutable\pkg\System.Collections.Immutable.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="$(MSBuildThisFileDirectory)System.Composition\pkg\System.Composition.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="$(MSBuildThisFileDirectory)System.Composition.AttributedModel\pkg\System.Composition.AttributedModel.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="$(MSBuildThisFileDirectory)System.Composition.Convention\pkg\System.Composition.Convention.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="$(MSBuildThisFileDirectory)System.Composition.Hosting\pkg\System.Composition.Hosting.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="$(MSBuildThisFileDirectory)System.Composition.Runtime\pkg\System.Composition.Runtime.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="$(MSBuildThisFileDirectory)System.Composition.TypedParts\pkg\System.Composition.TypedParts.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="$(MSBuildThisFileDirectory)System.IO.Pipelines\pkg\System.IO.Pipelines.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="$(MSBuildThisFileDirectory)System.Json\pkg\System.Json.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="$(MSBuildThisFileDirectory)System.Net.WebSockets.WebSocketProtocol\pkg\System.Net.WebSockets.WebSocketProtocol.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="$(MSBuildThisFileDirectory)System.Numerics.Tensors\pkg\System.Numerics.Tensors.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="$(MSBuildThisFileDirectory)System.Reflection.DispatchProxy\pkg\System.Reflection.DispatchProxy.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="$(MSBuildThisFileDirectory)System.Reflection.Metadata\pkg\System.Reflection.Metadata.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="$(MSBuildThisFileDirectory)System.Reflection.MetadataLoadContext\pkg\System.Reflection.MetadataLoadContext.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="$(MSBuildThisFileDirectory)System.Resources.Extensions\pkg\System.Resources.Extensions.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="$(MSBuildThisFileDirectory)System.Text.Encoding.CodePages\pkg\System.Text.Encoding.CodePages.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="$(MSBuildThisFileDirectory)System.Text.Encodings.Web\pkg\System.Text.Encodings.Web.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="$(MSBuildThisFileDirectory)System.Threading.Channels\pkg\System.Threading.Channels.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
+    <Project Include="$(MSBuildThisFileDirectory)System.Threading.Tasks.Dataflow\pkg\System.Threading.Tasks.Dataflow.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
cc: @ericstj @Anipik @safern 
Fixes https://github.com/dotnet/runtime/issues/1625

**Description**

This PR will finish the work on the release/3.1 branch that was started with PR https://github.com/dotnet/corefx/pull/42849 on release/2.1 branch. It is adding .NET Framework configurations to our OOB packages so that they won't require netsandard shims for projects ingesting them and targeting .NET Framework.

Things that need to happen before merging this PR:

- [X] Add Net461 configurations to all projects that today ship as NuGet packages and have a .NET Standard asset when consumer targets .NET Framework 4.6.1/4.6.2/4.7/4.7.1/4.7.2/4.8. (This will be done with the first commit, so that it is easier to review this commit by commit.)
- [X] Add Net461 configuration to OpenSSL OOB package which also needs it, but it will be treated specially given that it requires some special types in S.S.C.Algorithms that are not present in 461. (Done with commit 10df782)
- [x] Baseline all of the packages that have new configurations from steps 1 and 2, and now service all packages above that depend on them so that all new package versions will depend on these new packages that have the new configs. After doing this, all of our latest NuGet packages should not require the .NET Standard shims. (Done with 14b5db5)
- [x] Do some extensive testing to make sure API wasn't regressed by adding these new configurations. (I have more info on how I did this here https://github.com/dotnet/corefx/pull/42901#issuecomment-611770142).

**Customer Impact**

Customers that have hit problems caused by this issue have been trying to add manual workarounds on their projects and custom logic for deploying. Once this is fixed, customers will have to remove those workarounds from their projects and reference the new packages in order to get the benefits of not needing the extra facades or binding redirects for their application.

**Regression?**

No.

**Packaging reviewed?**

It will involve packaging changes, so it will require a review by packaging experts.

**Risk**

Low. We didn't increase Assembly Version in order to not require new binding redirects from apps. The risk here is that we are effectively causing NuGet to use a different asset from the package to pass to the compiler and a different one as well for the implementation, but we did extensive testing to ensure that we were not removing or adding API and that there was no visible difference between the assets that they used to get and the ones they will get now.
