### PR TITLE
Disable build of System.Net.Http.WinHttpHandler to avoid problem on net461

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/Directory.Build.props
+++ b/src/System.Net.Http.WinHttpHandler/Directory.Build.props
@@ -2,7 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.5.0</AssemblyVersion>
-    <PackageVersion>4.7.1</PackageVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
   </PropertyGroup>
 </Project>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -71,9 +71,6 @@
     <Project Include="$(MSBuildThisFileDirectory)System.Json\pkg\System.Json.pkgproj">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
-    <Project Include="$(MSBuildThisFileDirectory)System.Net.Http.WinHttpHandler\pkg\System.Net.Http.WinHttpHandler.pkgproj">
-      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
-    </Project>
     <Project Include="$(MSBuildThisFileDirectory)System.Net.WebSockets.WebSocketProtocol\pkg\System.Net.WebSockets.WebSocketProtocol.pkgproj">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>


### PR DESCRIPTION
cc: @wtgodbe @Anipik @mmitche @ericstj 

This will undo the build of System.Net.Http.WinHttpHandler

FYI: @karelz @alnikola as this affects #42888 fix.
