### PR TITLE
Ensuring WinHttpHandler will reference TargetingPack assembly versions for netfx builds

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/Directory.Build.props
+++ b/src/System.Net.Http.WinHttpHandler/Directory.Build.props
@@ -1,6 +1,7 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
+    <PackageVersion>4.7.1</PackageVersion>
     <AssemblyVersion>4.0.5.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
   </PropertyGroup>

--- a/src/System.Net.Http.WinHttpHandler/ref/Configurations.props
+++ b/src/System.Net.Http.WinHttpHandler/ref/Configurations.props
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <BuildConfigurations>
       netstandard;
+      net461;
+      netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Net.Http.WinHttpHandler/ref/System.Net.Http.WinHttpHandler.csproj
+++ b/src/System.Net.Http.WinHttpHandler/ref/System.Net.Http.WinHttpHandler.csproj
@@ -3,7 +3,7 @@
     <ProjectGuid>{8C9AABA7-A8F0-4A5A-8A5F-65A0EFC03483}</ProjectGuid>
     <Configurations>netstandard-Debug;netstandard-Release;net461-Debug;net461-Release;netfx-Debug;netfx-Release</Configurations>
     <!-- Ensure Assemblies are first resolved via targeting pack, and then using refpath -->
-    <AssemblySearchPaths>$(NuGetPackageRoot)\microsoft.targetingpack.netframework.v4.6.1\1.0.1\lib\net461\;$(AssemblySearchPaths)</AssemblySearchPaths>
+    <AssemblySearchPaths Condition="'$(TargetGroup)' == 'net461'">$(NuGetPackageRoot)\microsoft.targetingpack.netframework.v4.6.1\1.0.1\lib\net461\;$(AssemblySearchPaths)</AssemblySearchPaths>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Net.Http.WinHttpHandler.cs" />

--- a/src/System.Net.Http.WinHttpHandler/ref/System.Net.Http.WinHttpHandler.csproj
+++ b/src/System.Net.Http.WinHttpHandler/ref/System.Net.Http.WinHttpHandler.csproj
@@ -1,9 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{8C9AABA7-A8F0-4A5A-8A5F-65A0EFC03483}</ProjectGuid>
-    <Configurations>netstandard-Debug;netstandard-Release</Configurations>
+    <Configurations>netstandard-Debug;netstandard-Release;net461-Debug;net461-Release;netfx-Debug;netfx-Release</Configurations>
+    <!-- Ensure Assemblies are first resolved via targeting pack, and then using refpath -->
+    <AssemblySearchPaths>$(NuGetPackageRoot)\microsoft.targetingpack.netframework.v4.6.1\1.0.1\lib\net461\;$(AssemblySearchPaths)</AssemblySearchPaths>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Net.Http.WinHttpHandler.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
 </Project>

--- a/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.csproj
+++ b/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.csproj
@@ -12,6 +12,8 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetGroup)' == 'net461'">
     <DefineConstants>$(DefineConstants);netfx</DefineConstants>
+    <!-- Ensure Assemblies are first resolved via targeting pack, and then using refpath -->
+    <AssemblySearchPaths>$(NuGetPackageRoot)\microsoft.targetingpack.netframework.v4.6.1\1.0.1\lib\net461\;$(AssemblySearchPaths)</AssemblySearchPaths>
   </PropertyGroup>
   <Import Project="System.Net.Http.WinHttpHandler.msbuild" Condition="'$(TargetsWindows)' == 'true'" />
   <ItemGroup Condition="'$(TargetGroup)' == 'net46' OR '$(TargetGroup)' == 'net461'">
@@ -42,6 +44,7 @@
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="netstandard" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.3'">
     <Reference Include="Microsoft.Win32.Primitives" />

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -26,6 +26,9 @@
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
     <!-- add specific builds / pkgproj's here to include in servicing builds -->
+    <Project Include="$(MSBuildThisFileDirectory)System.Net.Http.WinHttpHandler\pkg\System.Net.Http.WinHttpHandler.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
cc: @ericstj @Anipik @wtgodbe 

These changes will fix WinHttpHandler to make it build against the net461 targeting pack first to avoid regression when the netstandard facades are not injected by the package automatically. This should unblock us from shipping WinHttpHandler package again now without the need of the netstandard facades.

FYI: @karelz after this is in, we will be able to ship the pending change on WinHttpHandler package.

I will add the No Merge label since this is not supposed to ship until next release and branches are locked right now.

FYI: @Jozkee we will most likely need to do the same changes to the package we are shipping for Blazor.