### PR TITLE
Making System.Net.Http.Json to depend on inbox version of System.Net.Http for net461

### DIFF
--- a/src/System.Net.Http.Json/ref/System.Net.Http.Json.csproj
+++ b/src/System.Net.Http.Json/ref/System.Net.Http.Json.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <Configurations>netstandard-Debug;netstandard-Release;net461-Debug;net461-Release;netfx-Debug;netfx-Release</Configurations>
     <Nullable>enable</Nullable>
+    <!-- Ensure Assemblies are first resolved via targeting pack when targeting netfx -->
+    <AssemblySearchPaths Condition="'$(TargetsNetFx)' == 'true'">$(NuGetPackageRoot)\microsoft.targetingpack.netframework.v4.6.1\1.0.1\lib\net461\;$(AssemblySearchPaths)</AssemblySearchPaths>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Net.Http.Json.cs" />

--- a/src/System.Net.Http.Json/src/System.Net.Http.Json.csproj
+++ b/src/System.Net.Http.Json/src/System.Net.Http.Json.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <Configurations>netstandard-Debug;netstandard-Release;net461-Debug;net461-Release;netfx-Debug;netfx-Release</Configurations>
     <Nullable>enable</Nullable>
+    <!-- Ensure Assemblies are first resolved via targeting pack when targeting netfx -->
+    <AssemblySearchPaths Condition="'$(TargetsNetFx)' == 'true'">$(NuGetPackageRoot)\microsoft.targetingpack.netframework.v4.6.1\1.0.1\lib\net461\;$(AssemblySearchPaths)</AssemblySearchPaths>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\ArraySegmentExtensions.netstandard.cs" />


### PR DESCRIPTION
cc: @ericstj 

As expected, System.Net.Http.Json net461 configuration incorrectly depends on System.Net.Http.dll version 4.2.0.0. This is fine for now since HttpJson package depends on the netstandard facades, but this will change once this branch is merged to release/3.1 so it is important to make sure that we address this now. I have verified that after this change the package reflects the change only on the lib/net461 asset by downgrading its System.Net.Http dependency from 4.2.0.0 down to 4.0.0.0. Apart from that, the package remains unchanged.

FYI: @Jozkee 