### PR TITLE
Fix serialization of read-only IEnumerable's for DCS

### DIFF
--- a/src/System.Private.DataContractSerialization/src/Resources/Strings.resx
+++ b/src/System.Private.DataContractSerialization/src/Resources/Strings.resx
@@ -1,4 +1,5 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
   <!-- 
     Microsoft ResX Schema 
     
@@ -1156,5 +1157,8 @@
   </data>
   <data name="FailedToCreateMethodDelegate" xml:space="preserve">
     <value>Failed to create Delegate for method '{0}' of type '{1}'.</value>
+  </data>
+  <data name="ReadOnlyCollectionDeserialization" xml:space="preserve">
+    <value>Collection type '{0}' cannot be deserialized since it</value>
   </data>
 </root>

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -795,6 +795,33 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
+    public static void DCS_EnumerableMemberConcreteTypeWithoutDefaultContructor()
+    {
+        TypeWithEnumerableMembers x = new TypeWithEnumerableMembers
+        {
+            F1 = new MyEnumerable('a', 45),
+            F2 = new List<string> { "a", "b", "c" }.OrderBy(x => x),
+            P1 = new MyEnumerable("x", "y"),
+            P2 = new List<int> { 1, 2, 3 }.OrderBy(x => x)
+        };
+
+        var dcs = new DataContractSerializer(typeof(TypeWithEnumerableMembers));
+
+        string baseline = @"<TypeWithEnumerableMembers xmlns=""http://schemas.datacontract.org/2004/07/SerializationTypes"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance""><F1 xmlns:a=""http://schemas.microsoft.com/2003/10/Serialization/Arrays""><a:anyType i:type=""b:char"" xmlns:b=""http://schemas.microsoft.com/2003/10/Serialization/"">97</a:anyType><a:anyType i:type=""b:int"" xmlns:b=""http://www.w3.org/2001/XMLSchema"">45</a:anyType></F1><F2 xmlns:a=""http://schemas.microsoft.com/2003/10/Serialization/Arrays""><a:anyType i:type=""b:string"" xmlns:b=""http://www.w3.org/2001/XMLSchema"">a</a:anyType><a:anyType i:type=""b:string"" xmlns:b=""http://www.w3.org/2001/XMLSchema"">b</a:anyType><a:anyType i:type=""b:string"" xmlns:b=""http://www.w3.org/2001/XMLSchema"">c</a:anyType></F2><P1 xmlns:a=""http://schemas.microsoft.com/2003/10/Serialization/Arrays""><a:anyType i:type=""b:string"" xmlns:b=""http://www.w3.org/2001/XMLSchema"">x</a:anyType><a:anyType i:type=""b:string"" xmlns:b=""http://www.w3.org/2001/XMLSchema"">y</a:anyType></P1><P2 xmlns:a=""http://schemas.microsoft.com/2003/10/Serialization/Arrays""><a:anyType i:type=""b:int"" xmlns:b=""http://www.w3.org/2001/XMLSchema"">1</a:anyType><a:anyType i:type=""b:int"" xmlns:b=""http://www.w3.org/2001/XMLSchema"">2</a:anyType><a:anyType i:type=""b:int"" xmlns:b=""http://www.w3.org/2001/XMLSchema"">3</a:anyType></P2><RO1 xmlns:a=""http://schemas.microsoft.com/2003/10/Serialization/Arrays""/></TypeWithEnumerableMembers>";
+        using (MemoryStream ms = new MemoryStream())
+        {
+            dcs.WriteObject(ms, x);
+            ms.Position = 0;
+
+            string actualOutput = new StreamReader(ms).ReadToEnd();
+
+            Utils.CompareResult result = Utils.Compare(baseline, actualOutput);
+            Assert.True(result.Equal, string.Format("{1}{0}Test failed for input: {2}{0}Expected: {3}{0}Actual: {4}",
+                Environment.NewLine, result.ErrorMessage, x, baseline, actualOutput));
+        }
+    }
+
+    [Fact]
     public static void DCS_CustomType()
     {
         MyTypeA x = new MyTypeA


### PR DESCRIPTION
Servicing change for dotnet/runtime#34151

## Description

When a DataContractSerializer is created for an IEnumerable type without a default constructor, we should still be able to serialize the contents even though we can't instantiate an instance when deserializing. The silverlight implementation of DCS was originally ported which lacks this capability.  This breaks serialization of the results from many LINQ queries.  
The fix is to port the late throwing capability from .NET Framework.

## Customer Impact

Internal customer is unable to port an existing .NET Framework WCF based service to CoreWCF.

## Regression

This is a regression from .NET Framework. This is not a regression from earlier versions of .NET Core.

## Testing

This includes a unit test which serializes a LINQ query result which returns a type without a default constructor.

## Risk

**Low**. This is porting the existing implementation from .NET Framework. It's not introducing any new failure code paths as it turns a throw into a potential deferred throw. Existing happy code path is unaltered. Includes tests for the specific customer scenario.