### PR TITLE
Fixing System.Net.Http.Json so that it won't require facades when restored in net461

### DIFF
--- a/src/System.Net.Http.Json/Directory.Build.props
+++ b/src/System.Net.Http.Json/Directory.Build.props
@@ -3,6 +3,6 @@
   <PropertyGroup>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <AssemblyVersion>3.2.0.0</AssemblyVersion>
-    <PackageVersion>3.2.0</PackageVersion>
+    <PackageVersion>3.2.1</PackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -26,6 +26,9 @@
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
     <!-- add specific builds / pkgproj's here to include in servicing builds -->
+    <Project Include="$(MSBuildThisFileDirectory)System.Net.Http.Json\pkg\System.Net.Http.Json.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
     <Project Include="$(MSBuildThisFileDirectory)System.Net.Http.WinHttpHandler\pkg\System.Net.Http.WinHttpHandler.pkgproj">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/1625

This is a new package comming in from the blazor branch, which for it's release would have still required the netstandard shims. By re-spinning a build it will automatically get fixed so that is what this PR is doing.