### PR TITLE
Fixing Debuggable attribute getting set on S.R.CS.Unsafe Release builds

### DIFF
--- a/src/System.Runtime.CompilerServices.Unsafe/Directory.Build.props
+++ b/src/System.Runtime.CompilerServices.Unsafe/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>4.7.1</PackageVersion>
+    <PackageVersion>4.7.2</PackageVersion>
     <AssemblyVersion>4.0.6.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IsNETCoreApp>true</IsNETCoreApp>

--- a/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.ilproj
+++ b/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.ilproj
@@ -7,6 +7,10 @@
     <IncludePath Condition="'$(TargetGroup)' == 'netfx'">include\net461</IncludePath>
     <IlasmFlags>$(IlasmFlags) -INCLUDE=$(IncludePath)</IlasmFlags>
     <Configurations>netcoreapp-Debug;netcoreapp-Release;netcoreapp2.0-Debug;netcoreapp2.0-Release;netstandard-Debug;netstandard-Release;netstandard1.0-Debug;netstandard1.0-Release</Configurations>
+    <!-- Switching DebugType to portable on netfx builds so that we don't pass attribute -DEBUG=OPT to illink which
+    is causing attribute [assembly: Debuggable(DebuggableAttribute.DebuggingModes.Default | DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+    to get set on Release builds. See https://github.com/dotnet/runtime/issues/36664 for more info -->
+    <DebugType Condition="'$(TargetsNetFx)' == 'true' And '$(ConfigurationGroup)' == 'Release'">portable</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -32,6 +32,9 @@
     <Project Include="$(MSBuildThisFileDirectory)System.Net.Http.WinHttpHandler\pkg\System.Net.Http.WinHttpHandler.pkgproj">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
+    <Project Include="$(MSBuildThisFileDirectory)System.Runtime.CompilerServices.Unsafe\pkg\System.Runtime.CompilerServices.Unsafe.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/36664

cc: @ericstj @Anipik @jkotas @tannergooding 

Full issue description is on the linked issue above, but generally we recently serviced Unsafe package and added a net461 asset in there which broke some customers since this new asset had attribute `[assembly: Debuggable(DebuggableAttribute.DebuggingModes.Default | DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]` set. This fix will change DebugType so that the linker SDK won't send an option to the linker causing this attribute to get set.