### PR TITLE
Removing reference assets from Microsoft.Bcl.AsyncInterfaces and Microsoft.Bcl.HashCode packages

### DIFF
--- a/src/Microsoft.Bcl.AsyncInterfaces/Directory.Build.props
+++ b/src/Microsoft.Bcl.AsyncInterfaces/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <PackageVersion>1.1.1</PackageVersion>
+    <PackageVersion>1.1.2</PackageVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <!-- This assembly should never be placed inbox as it is only for downlevel compatibility. -->
   </PropertyGroup>

--- a/src/Microsoft.Bcl.AsyncInterfaces/pkg/Microsoft.Bcl.AsyncInterfaces.pkgproj
+++ b/src/Microsoft.Bcl.AsyncInterfaces/pkg/Microsoft.Bcl.AsyncInterfaces.pkgproj
@@ -6,5 +6,10 @@
     </ProjectReference>
     <ProjectReference Include="..\src\Microsoft.Bcl.AsyncInterfaces.csproj" />
   </ItemGroup>
+  <PropertyGroup>
+    <!-- Excluding reference assets so as to not expose reference assemblies for Desktop projects that use the
+         workflow compiler. See https://github.com/dotnet/runtime/issues/37496 for more details  -->
+    <ExcludeReferenceAssets>true</ExcludeReferenceAssets>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
 </Project>

--- a/src/Microsoft.Bcl.AsyncInterfaces/pkg/Microsoft.Bcl.AsyncInterfaces.pkgproj
+++ b/src/Microsoft.Bcl.AsyncInterfaces/pkg/Microsoft.Bcl.AsyncInterfaces.pkgproj
@@ -1,15 +1,9 @@
 <Project DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
   <ItemGroup>
-    <ProjectReference Include="..\ref\Microsoft.Bcl.AsyncInterfaces.csproj">
+    <ProjectReference Include="..\src\Microsoft.Bcl.AsyncInterfaces.csproj">
       <SupportedFramework>net461;netcoreapp2.0;uap10.0.16299;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
-    <ProjectReference Include="..\src\Microsoft.Bcl.AsyncInterfaces.csproj" />
   </ItemGroup>
-  <PropertyGroup>
-    <!-- Excluding reference assets so as to not expose reference assemblies for Desktop projects that use the
-         workflow compiler. See https://github.com/dotnet/runtime/issues/37496 for more details  -->
-    <ExcludeReferenceAssets>true</ExcludeReferenceAssets>
-  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
 </Project>

--- a/src/Microsoft.Bcl.HashCode/Directory.Build.props
+++ b/src/Microsoft.Bcl.HashCode/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <PackageVersion>1.1.0</PackageVersion>
+    <PackageVersion>1.1.1</PackageVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <!-- This assembly should never be placed inbox as it is only for downlevel compatibility. -->
   </PropertyGroup>

--- a/src/Microsoft.Bcl.HashCode/pkg/Microsoft.Bcl.HashCode.pkgproj
+++ b/src/Microsoft.Bcl.HashCode/pkg/Microsoft.Bcl.HashCode.pkgproj
@@ -6,5 +6,10 @@
     </ProjectReference>
     <ProjectReference Include="..\src\Microsoft.Bcl.HashCode.csproj" />
   </ItemGroup>
+  <PropertyGroup>
+    <!-- Excluding reference assets so as to not expose reference assemblies for Desktop projects that use the
+         workflow compiler. See https://github.com/dotnet/runtime/issues/37496 for more details  -->
+    <ExcludeReferenceAssets>true</ExcludeReferenceAssets>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
 </Project>

--- a/src/Microsoft.Bcl.HashCode/pkg/Microsoft.Bcl.HashCode.pkgproj
+++ b/src/Microsoft.Bcl.HashCode/pkg/Microsoft.Bcl.HashCode.pkgproj
@@ -1,15 +1,9 @@
 <Project DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
   <ItemGroup>
-    <ProjectReference Include="..\ref\Microsoft.Bcl.HashCode.csproj">
+    <ProjectReference Include="..\src\Microsoft.Bcl.HashCode.csproj">
       <SupportedFramework>net461;netcoreapp2.0;uap10.0.16299;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
-    <ProjectReference Include="..\src\Microsoft.Bcl.HashCode.csproj" />
   </ItemGroup>
-  <PropertyGroup>
-    <!-- Excluding reference assets so as to not expose reference assemblies for Desktop projects that use the
-         workflow compiler. See https://github.com/dotnet/runtime/issues/37496 for more details  -->
-    <ExcludeReferenceAssets>true</ExcludeReferenceAssets>
-  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/37496

cc: @ericstj @StephenBonikowsky @Anipik @andreyns

Applications that rely on the workflow compiler task require all of the consuming packages to not expose reference assets when restored for .NET Framework. For this reason, we want to remove the reference assets from these two compat packs which are part of the closure of Microsoft.Extensions.Hosting.