### PR TITLE
[Release/3.1] Fix infinite loop when end of stream is reached

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SslOverTdsStream.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SslOverTdsStream.cs
@@ -103,9 +103,16 @@ namespace System.Data.SqlClient.SNI
                     // Account for split packets
                     while (readBytes < TdsEnums.HEADER_LEN)
                     {
-                        readBytes += async ?
+                        var readBytesForHeader = async ?
                             await _stream.ReadAsync(packetData, readBytes, TdsEnums.HEADER_LEN - readBytes, token).ConfigureAwait(false) :
                             _stream.Read(packetData, readBytes, TdsEnums.HEADER_LEN - readBytes);
+
+                        if (readBytesForHeader == 0)
+                        {
+                            throw new EndOfStreamException("End of stream reached");
+                        }
+
+                        readBytes += readBytesForHeader;
                     }
 
                     _packetBytes = (packetData[TdsEnums.HEADER_LEN_FIELD_OFFSET] << 8) | packetData[TdsEnums.HEADER_LEN_FIELD_OFFSET + 1];


### PR DESCRIPTION
Ports https://github.com/dotnet/SqlClient/pull/577 to fix issue https://github.com/dotnet/SqlClient/issues/165 in System.Data.SqlClient

### Summary
The issue has been occurring for many customer applications where Client and Server cannot find a common security protocol to continue SSL handshake as the server does not send any further information while the client continues to loop. This started happening recently when client OS and docker containers disabled TLS v1.0 and v1.1, while target servers were not upgraded to TLS v1.2. 

### Customer Impact
**Medium:** The issue impacts Linux and Mac applications where servers are not ready to transition to TLS v1.2.

### Regression?
No, this issue is reproducible with all previous versions of .NET Core SqlClient drivers (impacts Managed SNI use-cases).

### Testing
In order to test this issue, a special setup is required on server side, to disable TLS v1.2 while the client only supports with TLSv1.2+. Local testing has been done to confirm the fix is applicable and the driver can now come out of infinite loop and throw exception.

### Risk
**Low:** The fix is not a major functional change, and it applies only to Linux/Mac customers if their servers are not updated to support TLS 1.2. This has also been released in Microsoft.Data.SqlClient v1.1.3 and v2.0.0.

cc: @danmosemsft @saurabh500 @David-Engel 