### PR TITLE
[release/3.1] Fix Path.EndsInDirectorySeparator recursive call

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -157,13 +157,15 @@
     "Microsoft.IO.Redist": {
       "StableVersions": [
         "4.6.0",
-        "4.7.0"
+        "4.7.0",
+        "4.7.1"
       ],
       "BaselineVersion": "4.7.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.6.0",
-        "4.0.1.0": "4.7.0"
+        "4.0.1.0": "4.7.0",
+        "4.0.1.1": "4.7.1"
       }
     },
     "Microsoft.JScript": {

--- a/src/Common/src/CoreLib/System/IO/Path.cs
+++ b/src/Common/src/CoreLib/System/IO/Path.cs
@@ -922,7 +922,7 @@ namespace System.IO
         /// <summary>
         /// Trims one trailing directory separator beyond the root of the path.
         /// </summary>
-        public static ReadOnlySpan<char> TrimEndingDirectorySeparator(ReadOnlySpan<char> path) => TrimEndingDirectorySeparator(path);
+        public static ReadOnlySpan<char> TrimEndingDirectorySeparator(ReadOnlySpan<char> path) => PathInternal.TrimEndingDirectorySeparator(path);
 
         /// <summary>
         /// Returns true if the path ends in a directory separator.

--- a/src/Microsoft.IO.Redist/Directory.Build.props
+++ b/src/Microsoft.IO.Redist/Directory.Build.props
@@ -1,7 +1,8 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.1</AssemblyVersion>
+    <PackageVersion>4.7.1</PackageVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <IsNETCoreApp>false</IsNETCoreApp>
     <IsUAP>false</IsUAP>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -26,6 +26,9 @@
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
     <!-- add specific builds / pkgproj's here to include in servicing builds -->
+    <Project Include="$(MSBuildThisFileDirectory)Microsoft.IO.Redist\pkg\Microsoft.IO.Redist.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/37538

### Summary

[This 3.1 code fix](https://github.com/dotnet/corefx/pull/42501/files), which addressed a .NET Standard issue in System.IO.FileSystem.AccessControl introduced a recursive call in Path.cs that affects the `Microsoft.IO` version of `Path`.

### Customer Impact

Currently impacts Visual Studio who is consuming Microsoft.IO (see issue).
System.IO is not affected by this recursive call because the `Path` code consumed by that namespace lives in the mirrored file in coreclr.

### Regression?

Yes.

### Testing

I built corefx in both netcoreapp3.1 and netfx.
I ran the tests in System.Runtime.Extensions, which is where the Path unit tests live, for both frameworks.
There are no Microsoft.IO unit tests, so I copied the dll into a NetFX console app, made a call to `TrimEndingDirectorySeparator(ReadOnlySpan<char> path)` and confirmed that the issue is resolved for Microsft.IO.

### Risk

Low: Accepting this change will get rid of the recursive call affecting Microsoft.IO.

cc @danmosemsft @ericstj