### PR TITLE
[release/3.1] Port SafeProcessHandle.Unix: fix missing DangerousRelease

### DIFF
--- a/src/System.Diagnostics.Process/src/Microsoft/Win32/SafeHandles/SafeProcessHandle.Unix.cs
+++ b/src/System.Diagnostics.Process/src/Microsoft/Win32/SafeHandles/SafeProcessHandle.Unix.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Win32.SafeHandles
         private readonly bool _releaseRef;
 
         internal SafeProcessHandle(int processId, SafeWaitHandle handle) : 
-            this(handle.DangerousGetHandle(), ownsHandle: false)
+            this(handle.DangerousGetHandle(), ownsHandle: true)
         {
             ProcessId = processId;
             _handle = handle;


### PR DESCRIPTION
Port https://github.com/dotnet/runtime/pull/37412

###  Description

Ports #37412. Original issue https://github.com/dotnet/runtime/issues/36661
Fixes regression introduced in [this PR](https://github.com/dotnet/corefx/pull/36199) between 2.2 and 3.0 

###  Description from original PR 

Because the SafeProcessHandle was not owned, ReleaseHandle was not called, causing the wrapped SafeWaitHandle to never release its resources.

###  Customer Impact

From customer:
> This is very impactful for our embedded clients. If left out would mean skipping .Net core 3. The clients cycle a process exactly once per second which amounts to ~ 10-20 mb leak every 24 hrs. I should imagine any long running processes like asp.net core servers that spawn any child processes are also affected.

We are asked to port this to enable the customer to migrate to 3.1.

###  Risk

Low. 
* We already shipped this in Preview 6 and the customer (@myrup) validated the change there
* The change is limited to Unix
* The change is very localized and relatively straightforward to understand. 
