### PR TITLE
[release/3.1] Ignore 0-byte responses from AIA fetch.

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CertificateAssetDownloader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CertificateAssetDownloader.cs
@@ -20,14 +20,16 @@ namespace Internal.Cryptography.Pal
         {
             byte[] data = DownloadAsset(uri, ref remainingDownloadTime);
 
-            if (data == null)
+            if (data == null || data.Length == 0)
             {
                 return null;
             }
 
             try
             {
-                return new X509Certificate2(data);
+                X509Certificate2 certificate = new X509Certificate2(data);
+                certificate.ThrowIfInvalid();
+                return certificate;
             }
             catch (CryptographicException)
             {


### PR DESCRIPTION
Ports dotnet/runtime#38787 to release/3.1 to address dotnet/runtime#38704.

## Summary

When performing AIA fetching on Linux-based operating systems, we attempt to download the missing issuer certificate to aid in building a complete X509 chain. If the server (incorrectly) responds with a successful status code, but an empty response, we attempt to re-build the chain with an X509 certificate that is in an invalid state. This invalid state results in a null pointer being dereferenced in native code, which causes a crash of the runtime.

## Customer Impact

Initially reported by a customer in dotnet/runtime#38704. On Linux-based environments, customers that explicitly or implicitly use `X509Chain` to build a certificate that cause an AIA fetch and the server improperly responds successfully but with empty content will cause a null pointer dereference in native code, which will result in an unrecoverable hard crash of the runtime.

## Regression?

Yes. Prior to .NET Core 3.0, a managed exception was thrown instead of an access violation.

## Testing

The original fix against dotnet/runtime contains a unit test to prevent further regressions. The test is not ported here due to missing testing faculties for AIA fetching.

## Risk

**Low**. The fix is to treat empty responses or any other response that results in a certificate with an invalid handle as an invalid response.