### PR TITLE
[release/3.1] Fix ManagedWebSocket ordering of releasing send buffer and semaphore

### DIFF
--- a/src/Common/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/Common/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -414,8 +414,8 @@ namespace System.Net.WebSockets
             {
                 if (releaseSemaphoreAndSendBuffer)
                 {
-                    _sendFrameAsyncLock.Release();
                     ReleaseSendBuffer();
+                    _sendFrameAsyncLock.Release();
                 }
             }
 
@@ -436,8 +436,8 @@ namespace System.Net.WebSockets
             }
             finally
             {
-                _sendFrameAsyncLock.Release();
                 ReleaseSendBuffer();
+                _sendFrameAsyncLock.Release();
             }
         }
 
@@ -460,8 +460,8 @@ namespace System.Net.WebSockets
             }
             finally
             {
-                _sendFrameAsyncLock.Release();
                 ReleaseSendBuffer();
+                _sendFrameAsyncLock.Release();
             }
         }
 


### PR DESCRIPTION
Port https://github.com/dotnet/runtime/pull/39199 to release/3.1.

## Summary

ManagedWebSocket is the WebSocket implementation returned from WebSocket.CreateFromStream and used by both ClientWebSocket and ASP.NET Core.  Sends on a WebSocket can't run concurrently, and there's a lock that protects access to shared resources, including a pooled buffer.  The code that ends a send operation returns the buffer to the pool and releases the lock, but it does so in the opposite (wrong) order.  As such, a second concurrent send could end up trying to use the buffer concurrently with the first send operation releasing it.

## Customer Impact

Initially reported as a sporadic ArgumentException that escapes from within the WebSocket implementation (from valid usage).  But in theory it could result in data corruption throughout the process, with a buffer being returned to the pool while it's still in use.

## Regression?

No.

## Testing

Unit tests.

## Risk

Low.  The fix just swaps two instructions (in three places) to return the buffer before releasing the lock.

cc: @danmosemsft 