### PR TITLE
Disable parallel xunit tests and enable logs

### DIFF
--- a/src/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
+++ b/src/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
@@ -78,4 +78,8 @@
     <Reference Include="System.Reflection.Emit.Lightweight" />
     <Reference Include="System.Reflection.Primitives" />
   </ItemGroup>
+  <PropertyGroup>
+    <XUnitShowProgress>true</XUnitShowProgress>
+    <TestDisableParallelization>true</TestDisableParallelization>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Hopefully this gives us more info on the failing legs in CI for RegEx. 