### PR TITLE
[release/3.1] Add Fedora 34 RID

### DIFF
--- a/pkg/Microsoft.NETCore.Platforms/runtime.compatibility.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.compatibility.json
@@ -1026,6 +1026,38 @@
     "any",
     "base"
   ],
+  "fedora.34": [
+    "fedora.34",
+    "fedora",
+    "linux",
+    "unix",
+    "any",
+    "base"
+  ],
+  "fedora.34-arm64": [
+    "fedora.34-arm64",
+    "fedora.34",
+    "fedora-arm64",
+    "fedora",
+    "linux-arm64",
+    "linux",
+    "unix-arm64",
+    "unix",
+    "any",
+    "base"
+  ],
+  "fedora.34-x64": [
+    "fedora.34-x64",
+    "fedora.34",
+    "fedora-x64",
+    "fedora",
+    "linux-x64",
+    "linux",
+    "unix-x64",
+    "unix",
+    "any",
+    "base"
+  ],
   "freebsd": [
     "freebsd",
     "unix",

--- a/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -516,6 +516,23 @@
         "fedora-x64"
       ]
     },
+    "fedora.34": {
+      "#import": [
+        "fedora"
+      ]
+    },
+    "fedora.34-arm64": {
+      "#import": [
+        "fedora.34",
+        "fedora-arm64"
+      ]
+    },
+    "fedora.34-x64": {
+      "#import": [
+        "fedora.34",
+        "fedora-x64"
+      ]
+    },
     "freebsd": {
       "#import": [
         "unix"

--- a/pkg/Microsoft.NETCore.Platforms/runtimeGroups.props
+++ b/pkg/Microsoft.NETCore.Platforms/runtimeGroups.props
@@ -43,7 +43,7 @@
     <RuntimeGroup Include="fedora">
       <Parent>linux</Parent>
       <Architectures>x64;arm64</Architectures>
-      <Versions>23;24;25;26;27;28;29;30;31;32;33</Versions>
+      <Versions>23;24;25;26;27;28;29;30;31;32;33;34</Versions>
       <TreatVersionsAsCompatible>false</TreatVersionsAsCompatible>
     </RuntimeGroup>
 


### PR DESCRIPTION
Fedora 34 is currently in development. Building .NET Core 3.1 there (via source-build) fails because the runtime id `fedora.34` is unknown:

    error NETSDK1083: The specified RuntimeIdentifier 'fedora.34-x64' is not recognized.

Full log is here: https://kojipkgs.fedoraproject.org//work/tasks/7435/49647435/build.log

This is a partial backport of https://github.com/dotnet/runtime/pull/34088

