### PR TITLE
SocketsHttpHandler: Add a switch to allow non-ascii headers

### DIFF
--- a/src/Common/tests/System/Net/Http/GenericLoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/GenericLoopbackServer.cs
@@ -83,6 +83,8 @@ namespace System.Net.Test.Common
 
     public struct HttpHeaderData
     {
+        public static readonly Encoding Latin1Encoding = Encoding.GetEncoding("ISO-8859-1");
+
         public string Name { get; }
         public string Value { get; }
         public bool HuffmanEncoded { get; }

--- a/src/Common/tests/System/Net/Http/GenericLoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/GenericLoopbackServer.cs
@@ -87,13 +87,15 @@ namespace System.Net.Test.Common
         public string Value { get; }
         public bool HuffmanEncoded { get; }
         public byte[] Raw { get; }
+        public bool Latin1 { get; }
 
-        public HttpHeaderData(string name, string value, bool huffmanEncoded = false, byte[] raw = null)
+        public HttpHeaderData(string name, string value, bool huffmanEncoded = false, byte[] raw = null, bool latin1 = false)
         {
             Name = name;
             Value = value;
             HuffmanEncoded = huffmanEncoded;
             Raw = raw;
+            Latin1 = latin1;
         }
 
         public override string ToString() => Name == null ? "<empty>" : (Name + ": " + (Value ?? string.Empty));

--- a/src/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -17,6 +17,8 @@ namespace System.Net.Test.Common
 {
     public class Http2LoopbackConnection : GenericLoopbackConnection
     {
+        private static readonly Encoding s_latin1Encoding = Encoding.GetEncoding("ISO-8859-1");
+
         private Socket _connectionSocket;
         private Stream _connectionStream;
         private TaskCompletionSource<bool> _ignoredSettingsAckPromise;
@@ -381,9 +383,9 @@ namespace System.Net.Test.Common
             }
         }
 
-        private static int EncodeString(string value, Span<byte> headerBlock, bool huffmanEncode)
+        private static int EncodeString(string value, Span<byte> headerBlock, bool huffmanEncode, bool latin1 = false)
         {
-            byte[] data = Encoding.ASCII.GetBytes(value);
+            byte[] data = (latin1 ? s_latin1Encoding : Encoding.ASCII).GetBytes(value);
             byte prefix;
 
             if (!huffmanEncode)
@@ -536,12 +538,12 @@ namespace System.Net.Test.Common
             }
         }
 
-        public static int EncodeHeader(HttpHeaderData headerData, Span<byte> headerBlock)
+        public static int EncodeHeader(HttpHeaderData headerData, Span<byte> headerBlock, bool latin1 = false)
         {
             // Always encode as literal, no indexing.
             int bytesGenerated = EncodeInteger(0, 0, 0b11110000, headerBlock);
             bytesGenerated += EncodeString(headerData.Name, headerBlock.Slice(bytesGenerated), headerData.HuffmanEncoded);
-            bytesGenerated += EncodeString(headerData.Value, headerBlock.Slice(bytesGenerated), headerData.HuffmanEncoded);
+            bytesGenerated += EncodeString(headerData.Value, headerBlock.Slice(bytesGenerated), headerData.HuffmanEncoded, latin1);
             return bytesGenerated;
         }
 
@@ -680,7 +682,7 @@ namespace System.Net.Test.Common
             {
                 foreach (HttpHeaderData headerData in headers)
                 {
-                    bytesGenerated += EncodeHeader(headerData, headerBlock.AsSpan().Slice(bytesGenerated));
+                    bytesGenerated += EncodeHeader(headerData, headerBlock.AsSpan().Slice(bytesGenerated), headerData.Latin1);
                 }
             }
 

--- a/src/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -17,8 +17,6 @@ namespace System.Net.Test.Common
 {
     public class Http2LoopbackConnection : GenericLoopbackConnection
     {
-        private static readonly Encoding s_latin1Encoding = Encoding.GetEncoding("ISO-8859-1");
-
         private Socket _connectionSocket;
         private Stream _connectionStream;
         private TaskCompletionSource<bool> _ignoredSettingsAckPromise;
@@ -385,7 +383,7 @@ namespace System.Net.Test.Common
 
         private static int EncodeString(string value, Span<byte> headerBlock, bool huffmanEncode, bool latin1 = false)
         {
-            byte[] data = (latin1 ? s_latin1Encoding : Encoding.ASCII).GetBytes(value);
+            byte[] data = (latin1 ? HttpHeaderData.Latin1Encoding : Encoding.ASCII).GetBytes(value);
             byte prefix;
 
             if (!huffmanEncode)

--- a/src/Common/tests/System/Net/Http/LoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/LoopbackServer.cs
@@ -16,6 +16,9 @@ namespace System.Net.Test.Common
 {
     public sealed partial class LoopbackServer : GenericLoopbackServer, IDisposable
     {
+        private static readonly byte[] s_newLineBytes = new byte[] { (byte)'\r', (byte)'\n' };
+        private static readonly byte[] s_colonSpaceBytes = new byte[] { (byte)':', (byte)' ' };
+
         private Socket _listenSocket;
         private Options _options;
         private Uri _uri;
@@ -515,6 +518,16 @@ namespace System.Net.Test.Common
 
             public async Task<string> ReadLineAsync()
             {
+                byte[] lineBytes = await ReadLineBytesAsync().ConfigureAwait(false);
+
+                if (lineBytes is null)
+                    return null;
+
+                return Encoding.ASCII.GetString(lineBytes);
+            }
+
+            private async Task<byte[]> ReadLineBytesAsync()
+            {
                 int index = 0;
                 int startSearch = _readStart;
 
@@ -560,12 +573,38 @@ namespace System.Net.Test.Common
                     if (_readBuffer[_readStart + stringLength] == '\n') { stringLength--; }
                     if (_readBuffer[_readStart + stringLength] == '\r') { stringLength--; }
 
-                    string line = System.Text.Encoding.ASCII.GetString(_readBuffer, _readStart, stringLength + 1);
+                    byte[] line = _readBuffer.AsSpan(_readStart, stringLength + 1).ToArray();
                     _readStart = index + 1;
                     return line;
                 }
 
                 return null;
+            }
+
+            private async Task<List<byte[]>> ReadRequestHeaderBytesAsync()
+            {
+                var lines = new List<byte[]>();
+
+                byte[] line;
+
+                while (true)
+                {
+                    line = await ReadLineBytesAsync().ConfigureAwait(false);
+
+                    if (line is null || line.Length == 0)
+                    {
+                        break;
+                    }
+
+                    lines.Add(line);
+                }
+
+                if (line == null)
+                {
+                    throw new IOException("Unexpected EOF trying to read request header");
+                }
+
+                return lines;
             }
 
             public override void Dispose()
@@ -640,24 +679,24 @@ namespace System.Net.Test.Common
 
             public override async Task<HttpRequestData> ReadRequestDataAsync(bool readBody = true)
             {
-                List<string> headerLines = null;
                 HttpRequestData requestData = new HttpRequestData();
 
-                headerLines = await ReadRequestHeaderAsync().ConfigureAwait(false);
+                List<byte[]> headerLines = await ReadRequestHeaderBytesAsync().ConfigureAwait(false);
 
                 // Parse method and path
-                string[] splits = headerLines[0].Split(' ');
+                string[] splits = Encoding.ASCII.GetString(headerLines[0]).Split(' ');
                 requestData.Method = splits[0];
                 requestData.Path = splits[1];
 
                 // Convert header lines to key/value pairs
                 // Skip first line since it's the status line
-                foreach (var line in headerLines.Skip(1))
+                foreach (byte[] lineBytes in headerLines.Skip(1))
                 {
+                    string line = Encoding.ASCII.GetString(lineBytes);
                     int offset = line.IndexOf(':');
                     string name = line.Substring(0, offset);
                     string value = line.Substring(offset + 1).TrimStart();
-                    requestData.Headers.Add(new HttpHeaderData(name, value));
+                    requestData.Headers.Add(new HttpHeaderData(name, value, raw: lineBytes));
                 }
 
                 if (requestData.Method != "GET")
@@ -737,7 +776,7 @@ namespace System.Net.Test.Common
 
             public override async Task SendResponseAsync(HttpStatusCode? statusCode = HttpStatusCode.OK, IList<HttpHeaderData> headers = null, string content = null, bool isFinal = true, int requestId = 0)
             {
-                string headerString = null;
+                MemoryStream headerBytes = new MemoryStream();
                 int contentLength = -1;
                 bool isChunked = false;
                 bool hasContentLength  = false;
@@ -762,22 +801,36 @@ namespace System.Net.Test.Common
                             isChunked = true;
                         }
 
-                        headerString = headerString + $"{headerData.Name}: {headerData.Value}\r\n";
+                        byte[] nameBytes = Encoding.ASCII.GetBytes(headerData.Name);
+                        headerBytes.Write(nameBytes, 0, nameBytes.Length);
+                        headerBytes.Write(s_colonSpaceBytes, 0, s_colonSpaceBytes.Length);
+
+                        byte[] valueBytes = (headerData.Latin1 ? Encoding.GetEncoding("ISO-8859-1") : Encoding.ASCII).GetBytes(headerData.Value);
+                        headerBytes.Write(valueBytes, 0, valueBytes.Length);
+                        headerBytes.Write(s_newLineBytes, 0, s_newLineBytes.Length);
                     }
                 }
 
                 bool endHeaders = content != null || isFinal;
                 if (statusCode != null)
                 {
-                    // If we need to send status line, prepped it to headers and possibly add missing headers to the end.
-                    headerString =
+                    byte[] temp = headerBytes.ToArray();
+                    headerBytes.SetLength(0);
+                    byte[] headerStartBytes = Encoding.ASCII.GetBytes(
                         $"HTTP/1.1 {(int)statusCode} {GetStatusDescription((HttpStatusCode)statusCode)}\r\n" +
-                        (!hasContentLength && !isChunked && content != null ? $"Content-length: {content.Length}\r\n" : "") +
-                        headerString +
-                        (endHeaders ? "\r\n" : "");
+                        (!hasContentLength && !isChunked && content != null ? $"Content-length: {content.Length}\r\n" : ""));
+                    headerBytes.Write(headerStartBytes, 0, headerStartBytes.Length);
+                    headerBytes.Write(temp, 0, temp.Length);
+
+                    if (endHeaders)
+                    {
+                        headerBytes.Write(s_newLineBytes, 0, s_newLineBytes.Length);
+                    }
                 }
 
-                await SendResponseAsync(headerString).ConfigureAwait(false);
+                headerBytes.Position = 0;
+                await headerBytes.CopyToAsync(_stream).ConfigureAwait(false);
+
                 if (content != null)
                 {
                     await SendResponseBodyAsync(content, isFinal: isFinal, requestId: requestId).ConfigureAwait(false);

--- a/src/Common/tests/System/Net/Http/LoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/LoopbackServer.cs
@@ -18,7 +18,6 @@ namespace System.Net.Test.Common
     {
         private static readonly byte[] s_newLineBytes = new byte[] { (byte)'\r', (byte)'\n' };
         private static readonly byte[] s_colonSpaceBytes = new byte[] { (byte)':', (byte)' ' };
-        private static readonly Encoding s_latin1Encoding = Encoding.GetEncoding("ISO-8859-1");
 
         private Socket _listenSocket;
         private Options _options;
@@ -806,7 +805,7 @@ namespace System.Net.Test.Common
                         headerBytes.Write(nameBytes, 0, nameBytes.Length);
                         headerBytes.Write(s_colonSpaceBytes, 0, s_colonSpaceBytes.Length);
 
-                        byte[] valueBytes = (headerData.Latin1 ? s_latin1Encoding : Encoding.ASCII).GetBytes(headerData.Value);
+                        byte[] valueBytes = (headerData.Latin1 ? HttpHeaderData.Latin1Encoding : Encoding.ASCII).GetBytes(headerData.Value);
                         headerBytes.Write(valueBytes, 0, valueBytes.Length);
                         headerBytes.Write(s_newLineBytes, 0, s_newLineBytes.Length);
                     }

--- a/src/Common/tests/System/Net/Http/LoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/LoopbackServer.cs
@@ -18,6 +18,7 @@ namespace System.Net.Test.Common
     {
         private static readonly byte[] s_newLineBytes = new byte[] { (byte)'\r', (byte)'\n' };
         private static readonly byte[] s_colonSpaceBytes = new byte[] { (byte)':', (byte)' ' };
+        private static readonly Encoding s_latin1Encoding = Encoding.GetEncoding("ISO-8859-1");
 
         private Socket _listenSocket;
         private Options _options;
@@ -805,7 +806,7 @@ namespace System.Net.Test.Common
                         headerBytes.Write(nameBytes, 0, nameBytes.Length);
                         headerBytes.Write(s_colonSpaceBytes, 0, s_colonSpaceBytes.Length);
 
-                        byte[] valueBytes = (headerData.Latin1 ? Encoding.GetEncoding("ISO-8859-1") : Encoding.ASCII).GetBytes(headerData.Value);
+                        byte[] valueBytes = (headerData.Latin1 ? s_latin1Encoding : Encoding.ASCII).GetBytes(headerData.Value);
                         headerBytes.Write(valueBytes, 0, valueBytes.Length);
                         headerBytes.Write(s_newLineBytes, 0, s_newLineBytes.Length);
                     }

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -93,6 +93,7 @@
     <Compile Include="System\Net\Http\SocketsHttpHandler\HPack\HPackEncoder.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HPack\IntegerEncoder.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HPack\StaticTable.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\StaticHttpSettings.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\SystemProxyInfo.cs" />
     <Compile Include="$(CommonPath)\CoreLib\System\IO\StreamHelpers.CopyValidation.cs">
       <Link>Common\CoreLib\System\IO\StreamHelpers.CopyValidation.cs</Link>
@@ -161,7 +162,6 @@
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpContentWriteStream.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\IHttpTrace.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\SocketsHttpHandler.cs" />
-    <Compile Include="System\Net\Http\SocketsHttpHandler\StaticHttpSettings.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\RawConnectionStream.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\RedirectHandler.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\TaskCompletionSourceWithCancellation.cs" />

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -161,6 +161,7 @@
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpContentWriteStream.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\IHttpTrace.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\SocketsHttpHandler.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\StaticHttpSettings.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\RawConnectionStream.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\RedirectHandler.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\TaskCompletionSourceWithCancellation.cs" />

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackEncoder.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackEncoder.cs
@@ -217,28 +217,18 @@ namespace System.Net.Http.HPack
         {
             if (value.Length <= destination.Length)
             {
-                if (StaticHttpSettings.AllowNonAsciiHeaders)
+                int mask = StaticHttpSettings.EncodingValidationMask;
+                for (int i = 0; i < value.Length; i++)
                 {
-                    for (int i = 0; i < value.Length; i++)
+                    int c = value[i];
+                    if ((c & mask) != 0)
                     {
-                        char c = value[i];
-                        destination[i] = (byte)c;
+                        throw new HttpRequestException(SR.net_http_request_invalid_char_encoding);
                     }
-                }
-                else
-                {
-                    for (int i = 0; i < value.Length; i++)
-                    {
-                        char c = value[i];
-                        if ((c & 0xFF80) != 0)
-                        {
-                            throw new HttpRequestException(SR.net_http_request_invalid_char_encoding);
-                        }
 
-                        destination[i] = (byte)c;
-                    }
+                    destination[i] = (byte)c;
                 }
-                
+
 
                 bytesWritten = value.Length;
                 return true;

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackEncoder.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackEncoder.cs
@@ -229,7 +229,6 @@ namespace System.Net.Http.HPack
                     destination[i] = (byte)c;
                 }
 
-
                 bytesWritten = value.Length;
                 return true;
             }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackEncoder.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackEncoder.cs
@@ -217,7 +217,7 @@ namespace System.Net.Http.HPack
         {
             if (value.Length <= destination.Length)
             {
-                if (HttpConnectionSettings.AllowNonAsciiHeaders)
+                if (StaticHttpSettings.AllowNonAsciiHeaders)
                 {
                     for (int i = 0; i < value.Length; i++)
                     {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackEncoder.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackEncoder.cs
@@ -217,16 +217,28 @@ namespace System.Net.Http.HPack
         {
             if (value.Length <= destination.Length)
             {
-                for (int i = 0; i < value.Length; i++)
+                if (HttpConnectionSettings.AllowNonAsciiHeaders)
                 {
-                    char c = value[i];
-                    if ((c & 0xFF80) != 0)
+                    for (int i = 0; i < value.Length; i++)
                     {
-                        throw new HttpRequestException(SR.net_http_request_invalid_char_encoding);
+                        char c = value[i];
+                        destination[i] = (byte)c;
                     }
-
-                    destination[i] = (byte)c;
                 }
+                else
+                {
+                    for (int i = 0; i < value.Length; i++)
+                    {
+                        char c = value[i];
+                        if ((c & 0xFF80) != 0)
+                        {
+                            throw new HttpRequestException(SR.net_http_request_invalid_char_encoding);
+                        }
+
+                        destination[i] = (byte)c;
+                    }
+                }
+                
 
                 bytesWritten = value.Length;
                 return true;

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -1147,7 +1147,7 @@ namespace System.Net.Http
             if (s.Length <= _writeBuffer.Length - offset)
             {
                 byte[] writeBuffer = _writeBuffer;
-                if (HttpConnectionSettings.AllowNonAsciiHeaders)
+                if (StaticHttpSettings.AllowNonAsciiHeaders)
                 {
                     foreach (char c in s)
                     {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -1147,14 +1147,25 @@ namespace System.Net.Http
             if (s.Length <= _writeBuffer.Length - offset)
             {
                 byte[] writeBuffer = _writeBuffer;
-                foreach (char c in s)
+                if (HttpConnectionSettings.AllowNonAsciiHeaders)
                 {
-                    if ((c & 0xFF80) != 0)
+                    foreach (char c in s)
                     {
-                        throw new HttpRequestException(SR.net_http_request_invalid_char_encoding);
+                        writeBuffer[offset++] = (byte)c;
                     }
-                    writeBuffer[offset++] = (byte)c;
                 }
+                else
+                {
+                    foreach (char c in s)
+                    {
+                        if ((c & 0xFF80) != 0)
+                        {
+                            throw new HttpRequestException(SR.net_http_request_invalid_char_encoding);
+                        }
+                        writeBuffer[offset++] = (byte)c;
+                    }
+                }
+                
                 _writeOffset = offset;
                 return Task.CompletedTask;
             }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -1200,10 +1200,12 @@ namespace System.Net.Http
             for (int i = 0; i < s.Length; i++)
             {
                 char c = s[i];
-                if ((c & 0xFF80) != 0)
+
+                if (!StaticHttpSettings.AllowNonAsciiHeaders && (c & 0xFF80) != 0)
                 {
                     throw new HttpRequestException(SR.net_http_request_invalid_char_encoding);
                 }
+
                 await WriteByteAsync((byte)c).ConfigureAwait(false);
             }
         }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -1148,7 +1148,7 @@ namespace System.Net.Http
             {
                 byte[] writeBuffer = _writeBuffer;
                 int mask = StaticHttpSettings.EncodingValidationMask;
-                foreach (char c in s)
+                foreach (int c in s)
                 {
                     if ((c & mask) != 0)
                     {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
@@ -21,6 +21,11 @@ namespace System.Net.Http
 
         private static readonly Lazy<bool> s_allowNonAsciiHeaders = new Lazy<bool>(GetAllowNonAsciiCharactersSetting);
 
+        // Disables a validation that checks whether Http headers contain a non-ASCII character.
+        // This is a workaround that has been introduced as a patch specific to the 3.1 branch.
+        // Unlike other options in HttpConnectionSettings, this one has a global scope.
+        // Lazy initialization is being used to make sure clients can also use AppContext.SetSwitch() or Environment.SetEnvironmentVariable()
+        // before the first calls to HttpClient API-s.
         internal static bool AllowNonAsciiHeaders => s_allowNonAsciiHeaders.Value;
 
         internal DecompressionMethods _automaticDecompression = HttpHandlerDefaults.DefaultAutomaticDecompression;
@@ -153,6 +158,7 @@ namespace System.Net.Http
 
         private static bool GetAllowNonAsciiCharactersSetting()
         {
+            // First check for the AppContext switch, giving it priority over the environment variable.
             if (AppContext.TryGetSwitch(AllowNonAsciiCharactersAppCtxSettingName, out bool value))
             {
                 return value;

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
@@ -12,21 +12,8 @@ namespace System.Net.Http
     {
         private const string Http2SupportEnvironmentVariableSettingName = "DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_HTTP2SUPPORT";
         private const string Http2SupportAppCtxSettingName = "System.Net.Http.SocketsHttpHandler.Http2Support";
-        
         private const string Http2UnencryptedSupportEnvironmentVariableSettingName = "DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_HTTP2UNENCRYPTEDSUPPORT";
         private const string Http2UnencryptedSupportAppCtxSettingName = "System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport";
-
-        private const string AllowNonAsciiCharactersEnvironmentVariableSettingName = "DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_ALLOWNONASCIIHEADERS";
-        private const string AllowNonAsciiCharactersAppCtxSettingName = "System.Net.Http.SocketsHttpHandler.AllowNonAsciiHeaders";
-
-        private static readonly Lazy<bool> s_allowNonAsciiHeaders = new Lazy<bool>(GetAllowNonAsciiCharactersSetting);
-
-        // Disables a validation that checks whether Http headers contain a non-ASCII character.
-        // This is a workaround that has been introduced as a patch specific to the 3.1 branch.
-        // Unlike other options in HttpConnectionSettings, this one has a global scope.
-        // Lazy initialization is being used to make sure clients can also use AppContext.SetSwitch() or Environment.SetEnvironmentVariable()
-        // before the first calls to HttpClient API-s.
-        internal static bool AllowNonAsciiHeaders => s_allowNonAsciiHeaders.Value;
 
         internal DecompressionMethods _automaticDecompression = HttpHandlerDefaults.DefaultAutomaticDecompression;
 
@@ -154,24 +141,6 @@ namespace System.Net.Http
                 // Default to a maximum of HTTP/1.1.
                 return false;
             }
-        }
-
-        private static bool GetAllowNonAsciiCharactersSetting()
-        {
-            // First check for the AppContext switch, giving it priority over the environment variable.
-            if (AppContext.TryGetSwitch(AllowNonAsciiCharactersAppCtxSettingName, out bool value))
-            {
-                return value;
-            }
-
-            // AppContext switch wasn't used. Check the environment variable.
-            string envVar = Environment.GetEnvironmentVariable(AllowNonAsciiCharactersEnvironmentVariableSettingName);
-            if (envVar != null && (envVar.Equals("true", StringComparison.OrdinalIgnoreCase) || envVar.Equals("1")))
-            {
-                return true;
-            }
-
-            return false;
         }
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
@@ -12,8 +12,16 @@ namespace System.Net.Http
     {
         private const string Http2SupportEnvironmentVariableSettingName = "DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_HTTP2SUPPORT";
         private const string Http2SupportAppCtxSettingName = "System.Net.Http.SocketsHttpHandler.Http2Support";
+        
         private const string Http2UnencryptedSupportEnvironmentVariableSettingName = "DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_HTTP2UNENCRYPTEDSUPPORT";
         private const string Http2UnencryptedSupportAppCtxSettingName = "System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport";
+
+        private const string AllowNonAsciiCharactersEnvironmentVariableSettingName = "DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_ALLOWNONASCIIHEADERS";
+        private const string AllowNonAsciiCharactersAppCtxSettingName = "System.Net.Http.SocketsHttpHandler.AllowNonAsciiHeaders";
+
+        private static readonly Lazy<bool> s_allowNonAsciiHeaders = new Lazy<bool>(GetAllowNonAsciiCharactersSetting);
+
+        internal static bool AllowNonAsciiHeaders => s_allowNonAsciiHeaders.Value;
 
         internal DecompressionMethods _automaticDecompression = HttpHandlerDefaults.DefaultAutomaticDecompression;
 
@@ -141,6 +149,23 @@ namespace System.Net.Http
                 // Default to a maximum of HTTP/1.1.
                 return false;
             }
+        }
+
+        private static bool GetAllowNonAsciiCharactersSetting()
+        {
+            if (AppContext.TryGetSwitch(AllowNonAsciiCharactersAppCtxSettingName, out bool value))
+            {
+                return value;
+            }
+
+            // AppContext switch wasn't used. Check the environment variable.
+            string envVar = Environment.GetEnvironmentVariable(AllowNonAsciiCharactersEnvironmentVariableSettingName);
+            if (envVar != null && (envVar.Equals("true", StringComparison.OrdinalIgnoreCase) || envVar.Equals("1")))
+            {
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/StaticHttpSettings.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/StaticHttpSettings.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Net.Http
+{
+    internal static class StaticHttpSettings
+    {
+        private const string AllowNonAsciiCharactersEnvironmentVariableSettingName = "DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_ALLOWNONASCIIHEADERS";
+        private const string AllowNonAsciiCharactersAppCtxSettingName = "System.Net.Http.SocketsHttpHandler.AllowNonAsciiHeaders";
+
+        private static readonly Lazy<bool> s_allowNonAsciiHeaders = new Lazy<bool>(GetAllowNonAsciiCharactersSetting);
+
+        // Disables a validation that checks whether Http headers contain a non-ASCII character.
+        // This is a workaround that has been introduced as a patch specific to the 3.1 branch.
+        // Unlike options in HttpConnectionSettings, this one has a global scope.
+        // Lazy initialization is being used to make sure clients can also use AppContext.SetSwitch() or Environment.SetEnvironmentVariable()
+        // before the first calls to HttpClient API-s.
+        internal static bool AllowNonAsciiHeaders => s_allowNonAsciiHeaders.Value;
+
+        private static bool GetAllowNonAsciiCharactersSetting()
+        {
+            // First check for the AppContext switch, giving it priority over the environment variable.
+            if (AppContext.TryGetSwitch(AllowNonAsciiCharactersAppCtxSettingName, out bool value))
+            {
+                return value;
+            }
+
+            // AppContext switch wasn't used. Check the environment variable.
+            string envVar = Environment.GetEnvironmentVariable(AllowNonAsciiCharactersEnvironmentVariableSettingName);
+            if (envVar != null && (envVar.Equals("true", StringComparison.OrdinalIgnoreCase) || envVar.Equals("1")))
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/StaticHttpSettings.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/StaticHttpSettings.cs
@@ -9,14 +9,12 @@ namespace System.Net.Http
         private const string AllowLatin1CharactersEnvironmentVariableSettingName = "DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_ALLOWLATIN1HEADERS";
         private const string AllowLatin1CharactersAppCtxSettingName = "System.Net.Http.SocketsHttpHandler.AllowLatin1Headers";
 
-        private static readonly Lazy<bool> s_allowLatin1Headers = new Lazy<bool>(GetAllowLatin1HeadersSetting);
-
         // Disables a validation that checks whether Http headers contain a non-ASCII character.
         // This is a workaround that has been introduced as a patch specific to the 3.1 branch.
         // Unlike options in HttpConnectionSettings, this one has a global scope.
         // Lazy initialization is being used to make sure clients can also use AppContext.SetSwitch() or Environment.SetEnvironmentVariable()
         // before the first calls to HttpClient API-s.
-        internal static bool AllowLatin1Headers => s_allowLatin1Headers.Value;
+        internal static bool AllowLatin1Headers { get; } = GetAllowLatin1HeadersSetting();
 
         internal static int EncodingValidationMask => AllowLatin1Headers ? 0xFF00 : 0xFF80;
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/StaticHttpSettings.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/StaticHttpSettings.cs
@@ -6,21 +6,21 @@ namespace System.Net.Http
 {
     internal static class StaticHttpSettings
     {
-        private const string AllowNonAsciiCharactersEnvironmentVariableSettingName = "DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_ALLOWNONASCIIHEADERS";
-        private const string AllowNonAsciiCharactersAppCtxSettingName = "System.Net.Http.SocketsHttpHandler.AllowNonAsciiHeaders";
+        private const string AllowNonAsciiCharactersEnvironmentVariableSettingName = "DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_ALLOWLATIN1HEADERS";
+        private const string AllowNonAsciiCharactersAppCtxSettingName = "System.Net.Http.SocketsHttpHandler.AllowLatin1Headers";
 
-        private static readonly Lazy<bool> s_allowNonAsciiHeaders = new Lazy<bool>(GetAllowNonAsciiCharactersSetting);
+        private static readonly Lazy<bool> s_allowLatin1Headers = new Lazy<bool>(GetAllowLatin1HeadersSetting);
 
         // Disables a validation that checks whether Http headers contain a non-ASCII character.
         // This is a workaround that has been introduced as a patch specific to the 3.1 branch.
         // Unlike options in HttpConnectionSettings, this one has a global scope.
         // Lazy initialization is being used to make sure clients can also use AppContext.SetSwitch() or Environment.SetEnvironmentVariable()
         // before the first calls to HttpClient API-s.
-        internal static bool AllowNonAsciiHeaders => s_allowNonAsciiHeaders.Value;
+        internal static bool AllowLatin1Headers => s_allowLatin1Headers.Value;
 
-        internal static int EncodingValidationMask => AllowNonAsciiHeaders ? 0xFF00 : 0xFF80;
+        internal static int EncodingValidationMask => AllowLatin1Headers ? 0xFF00 : 0xFF80;
 
-        private static bool GetAllowNonAsciiCharactersSetting()
+        private static bool GetAllowLatin1HeadersSetting()
         {
             // First check for the AppContext switch, giving it priority over the environment variable.
             if (AppContext.TryGetSwitch(AllowNonAsciiCharactersAppCtxSettingName, out bool value))

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/StaticHttpSettings.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/StaticHttpSettings.cs
@@ -6,8 +6,8 @@ namespace System.Net.Http
 {
     internal static class StaticHttpSettings
     {
-        private const string AllowNonAsciiCharactersEnvironmentVariableSettingName = "DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_ALLOWLATIN1HEADERS";
-        private const string AllowNonAsciiCharactersAppCtxSettingName = "System.Net.Http.SocketsHttpHandler.AllowLatin1Headers";
+        private const string AllowLatin1CharactersEnvironmentVariableSettingName = "DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_ALLOWLATIN1HEADERS";
+        private const string AllowLatin1CharactersAppCtxSettingName = "System.Net.Http.SocketsHttpHandler.AllowLatin1Headers";
 
         private static readonly Lazy<bool> s_allowLatin1Headers = new Lazy<bool>(GetAllowLatin1HeadersSetting);
 
@@ -23,13 +23,13 @@ namespace System.Net.Http
         private static bool GetAllowLatin1HeadersSetting()
         {
             // First check for the AppContext switch, giving it priority over the environment variable.
-            if (AppContext.TryGetSwitch(AllowNonAsciiCharactersAppCtxSettingName, out bool value))
+            if (AppContext.TryGetSwitch(AllowLatin1CharactersAppCtxSettingName, out bool value))
             {
                 return value;
             }
 
             // AppContext switch wasn't used. Check the environment variable.
-            string envVar = Environment.GetEnvironmentVariable(AllowNonAsciiCharactersEnvironmentVariableSettingName);
+            string envVar = Environment.GetEnvironmentVariable(AllowLatin1CharactersEnvironmentVariableSettingName);
             if (envVar != null && (envVar.Equals("true", StringComparison.OrdinalIgnoreCase) || envVar.Equals("1")))
             {
                 return true;

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/StaticHttpSettings.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/StaticHttpSettings.cs
@@ -18,6 +18,8 @@ namespace System.Net.Http
         // before the first calls to HttpClient API-s.
         internal static bool AllowNonAsciiHeaders => s_allowNonAsciiHeaders.Value;
 
+        internal static int EncodingValidationMask => AllowNonAsciiHeaders ? 0xFF00 : 0xFF80;
+
         private static bool GetAllowNonAsciiCharactersSetting()
         {
             // First check for the AppContext switch, giving it priority over the environment variable.

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Headers.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Headers.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http.Headers;
 using System.Net.Test.Common;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.DotNet.RemoteExecutor;
@@ -134,7 +135,7 @@ namespace System.Net.Http.Functional.Tests
             {
                 using (HttpClient client = CreateHttpClient())
                 {
-                    HttpResponseMessage response = await  client.GetAsync(uri).ConfigureAwait(false);
+                    HttpResponseMessage response = await client.GetAsync(uri).ConfigureAwait(false);
                     Assert.Equal(headers.Count, response.Headers.Count());
                     Assert.NotNull(response.Headers.GetValues("x-empty"));
                 }
@@ -152,18 +153,18 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public async Task GetAsync_MissingExpires_ReturnNull()
         {
-             await LoopbackServerFactory.CreateClientAndServerAsync(async uri =>
-             {
+            await LoopbackServerFactory.CreateClientAndServerAsync(async uri =>
+            {
                 using (HttpClient client = CreateHttpClient())
                 {
                     HttpResponseMessage response = await client.GetAsync(uri);
                     Assert.Null(response.Content.Headers.Expires);
                 }
             },
-            async server =>
-            {
-                await server.HandleRequestAsync(HttpStatusCode.OK);
-            });
+           async server =>
+           {
+               await server.HandleRequestAsync(HttpStatusCode.OK);
+           });
         }
 
         [Theory]
@@ -287,94 +288,137 @@ namespace System.Net.Http.Functional.Tests
                     });
                 });
         }
+    }
 
-        private static readonly (string Name, string[] Values)[] s_nonAsciiHeaders = new[]
-        {   
-            ("Some-Header1", new[] { "\uD83D\uDE03", "UTF8-best-fit-to-latin1" }),
-            ("Some-Header2", new[] { "\u00FF", "\u00C4nd", "Ascii\u00A9" }),
+    public abstract class HttpClientHandlerTest_Headers_NonAscii : HttpClientHandlerTestBase
+    {
+        public HttpClientHandlerTest_Headers_NonAscii() : base(null)
+        {
+        }
+
+        private static readonly (string Name, string[] Values)[] s_validLatin1Characters = new[]
+        {
+            ("a", new[] { "aa"})
+            //("a", new[] { "\x0081"})
+            //("Header1", new[] { "\x0081\x00FF\x00FE", "ascii-only" }),
+            //("Set-Cookie", new[] { "\u00FF", "\x00B0\x00B1\x00B2", "Ascii\x00B8" }),
         };
 
-        private static void AllowNonAsciiHeaders(string useAppCtxSwitchInner)
+        private static readonly (string Name, string[] Values)[] s_invalidUnicodeCharacters = new[]
         {
+            ("header-0", new[] { "\uD83D\uDE03", "\uD83D\uDE48\uD83D\uDE49\uD83D\uDE4A" }),
+            ("Set-Cookie", new[] { "\uD83C\uDDF8\uD83C\uDDEE" }),
+        };
+
+        private static (string Name, string[] Values)[] GetNonAsciiTestHeaders(bool unicode) => unicode ? s_invalidUnicodeCharacters : s_validLatin1Characters;
+
+        private static bool AllowNonAsciiHeaders(string useAppCtxSwitchInner, string switchValueInner)
+        {
+            bool switchValue = bool.Parse(switchValueInner);
             if (bool.Parse(useAppCtxSwitchInner))
             {
-                AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.AllowNonAsciiHeaders", true);
+                AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.AllowNonAsciiHeaders", switchValue);
             }
             else
             {
-                Environment.SetEnvironmentVariable("DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_ALLOWNONASCIIHEADERS", "True");
+                Environment.SetEnvironmentVariable("DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_ALLOWNONASCIIHEADERS", switchValueInner);
             }
+            return switchValue;
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void SendAsync_CustomRequestEncodingSelector_CanSendLatin1HeaderValues(bool useAppCtxSwitchOuter)
+        // bool useAppCtxSwitch, bool switchValue, bool utf8
+        public static readonly TheoryData<bool, bool, bool> NonAsciiTestConfigurations = new TheoryData<bool, bool, bool>()
         {
-            RemoteExecutor.Invoke((useAppCtxSwitchInner) =>
-            {
-                AllowNonAsciiHeaders(useAppCtxSwitchInner);
+            { true, false, false },
+            { true, false, true },
+            { true, true, false },
+            { true, true, true },
+            { false, true, false },
+        };
 
-                LoopbackServerFactory.CreateClientAndServerAsync(
-                    async uri =>
-                    {
-                        var requestMessage = new HttpRequestMessage(HttpMethod.Get, uri);
-
-                        foreach ((string name, string[] values) in s_nonAsciiHeaders)
-                        {
-                            requestMessage.Headers.Add(name, values);
-                        }
-
-                        using HttpClientHandler handler = CreateHttpClientHandler();
-                        var underlyingHandler = (SocketsHttpHandler)GetUnderlyingSocketsHttpHandler(handler);
-
-                        using HttpClient client = CreateHttpClient(handler);
-
-                        await client.SendAsync(requestMessage);
-                    },
-                    async server =>
-                    {
-                        HttpRequestData requestData = await server.HandleRequestAsync();
-
-                        Assert.All(requestData.Headers,
-                            h => Assert.False(h.HuffmanEncoded, "Expose raw decoded bytes once HuffmanEncoding is supported"));
-
-                        Encoding valueEncoding = Encoding.GetEncoding("ISO-8859-1");
-
-                        foreach ((string name, string[] values) in s_nonAsciiHeaders)
-                        {
-                            byte[] valueBytes = valueEncoding.GetBytes(string.Join(", ", values));
-                            Assert.Single(requestData.Headers,
-                                h => h.Name.Equals(name, StringComparison.OrdinalIgnoreCase) && h.Raw.AsSpan().IndexOf(valueBytes) != -1);
-                        }
-                    })
-                .GetAwaiter().GetResult();
-            }, useAppCtxSwitchOuter.ToString());
-        }
-
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void SendAsync_CustomResponseEncodingSelector_CanReceiveNonAsciiHeaderValues(bool useAppCtxSwitchOuter)
+        // Since RemoteExecutor cannot invoke delegates defined in abstract types, we should define the actual test cases in derived classes.
+        protected int SendAsync_SendNonAsciiCharacters_Impl(string useAppCtxSwitchInner, string switchValueInner, string unicodeInner)
         {
-            RemoteExecutor.Invoke((useAppCtxSwitchInner) =>
-            {
-                AllowNonAsciiHeaders(useAppCtxSwitchInner);
+            bool allowNonAscii = AllowNonAsciiHeaders(useAppCtxSwitchInner, switchValueInner);
+            bool unicode = bool.Parse(unicodeInner);
+            bool expectSuccess = allowNonAscii && !unicode;
 
-                LoopbackServerFactory.CreateClientAndServerAsync(
+            (string name, string[] values)[] headers = GetNonAsciiTestHeaders(unicode);
+
+            LoopbackServerFactory.CreateClientAndServerAsync(
                 async uri =>
                 {
-                    var requestMessage = new HttpRequestMessage(HttpMethod.Get, uri);
+                    using var requestMessage = new HttpRequestMessage(HttpMethod.Get, uri) { Version = VersionFromUseHttp2 };
 
-                    using HttpClientHandler handler = CreateHttpClientHandler();
-                    var underlyingHandler = (SocketsHttpHandler)GetUnderlyingSocketsHttpHandler(handler);
+                    foreach ((string name, string[] values) in headers)
+                    {
+                        requestMessage.Headers.Add(name, values);
+                    }
 
-                    using HttpClient client = CreateHttpClient(handler);
+                    using HttpClient client = CreateHttpClient();
 
-                    using HttpResponseMessage response = await client.SendAsync(requestMessage);
+                    if (expectSuccess)
+                    {
+                        await client.SendAsync(requestMessage);
+                    }
+                    else
+                    {
+                        await Assert.ThrowsAsync<HttpRequestException>(() => client.SendAsync(requestMessage));
+                    }
+                },
+                async server =>
+                {
+                    HttpRequestData requestData = null;
+                    try
+                    {
+                        requestData = await server.HandleRequestAsync();
+                    }
+                    catch (Exception)
+                    {
+                        if (expectSuccess)
+                            throw;
+                    }
+
+                    if (!expectSuccess)
+                        return;
+
+                    Assert.All(requestData.Headers,
+                        h => Assert.False(h.HuffmanEncoded, "Expose raw decoded bytes once HuffmanEncoding is supported"));
+
                     Encoding valueEncoding = Encoding.GetEncoding("ISO-8859-1");
 
-                    foreach ((string name, string[] values) in s_nonAsciiHeaders)
+                    foreach ((string name, string[] values) in headers)
+                    {
+                        byte[] valueBytes = valueEncoding.GetBytes(string.Join(", ", values));
+
+                        Assert.Single(requestData.Headers,
+                            h => h.Name.Equals(name, StringComparison.OrdinalIgnoreCase) && h.Raw.AsSpan().IndexOf(valueBytes) != -1);
+                    }
+                })
+                .GetAwaiter().GetResult();
+
+            return RemoteExecutor.SuccessExitCode;
+        }
+
+        protected int SendAsync_ReceiveNonAsciiCharacters_Inner(string useAppCtxSwitchInner, string switchValueInner, string unicodeInner)
+        {
+            bool allowNonAscii = AllowNonAsciiHeaders(useAppCtxSwitchInner, switchValueInner);
+            bool unicode = bool.Parse(unicodeInner);
+            bool expectSuccess = allowNonAscii && !unicode;
+
+            LoopbackServerFactory.CreateClientAndServerAsync(
+                async uri =>
+                {
+                    using var requestMessage = new HttpRequestMessage(HttpMethod.Get, uri) { Version = VersionFromUseHttp2 };
+                    using HttpClient client = CreateHttpClient();
+
+                    using HttpResponseMessage response = await client.SendAsync(requestMessage);
+
+                    if (!expectSuccess)
+                        return;
+
+                    Encoding valueEncoding = Encoding.GetEncoding("ISO-8859-1");
+                    foreach ((string name, string[] values) in GetNonAsciiTestHeaders(unicode))
                     {
                         IEnumerable<string> receivedValues = Assert.Single(response.Headers, h => h.Key.Equals(name, StringComparison.OrdinalIgnoreCase)).Value;
                         string value = Assert.Single(receivedValues);
@@ -385,14 +429,14 @@ namespace System.Net.Http.Functional.Tests
                 },
                 async server =>
                 {
-                    List<HttpHeaderData> headerData = s_nonAsciiHeaders
-                        .Select(h => new HttpHeaderData(h.Name, string.Join(", ", h.Values)))
+                    List<HttpHeaderData> headerData = GetNonAsciiTestHeaders(unicode)
+                        .Select(h => new HttpHeaderData(h.Name, string.Join(", ", h.Values), latin1: true))
                         .ToList();
 
                     await server.HandleRequestAsync(headers: headerData);
                 })
                 .GetAwaiter().GetResult();
-            }, useAppCtxSwitchOuter.ToString());
+            return RemoteExecutor.SuccessExitCode;
         }
     }
 }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Headers.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Headers.cs
@@ -382,7 +382,7 @@ namespace System.Net.Http.Functional.Tests
                     Assert.All(requestData.Headers,
                         h => Assert.False(h.HuffmanEncoded, "Expose raw decoded bytes once HuffmanEncoding is supported"));
 
-                    Encoding valueEncoding = Encoding.GetEncoding("ISO-8859-1");
+                    Encoding valueEncoding = HttpHeaderData.Latin1Encoding;
 
                     foreach ((string name, string[] values) in headers)
                     {
@@ -413,7 +413,7 @@ namespace System.Net.Http.Functional.Tests
                     if (!expectSuccess)
                         return;
 
-                    Encoding valueEncoding = Encoding.GetEncoding("ISO-8859-1");
+                    Encoding valueEncoding = HttpHeaderData.Latin1Encoding;
                     foreach ((string name, string[] values) in GetNonAsciiTestHeaders(unicode))
                     {
                         IEnumerable<string> receivedValues = Assert.Single(response.Headers, h => h.Key.Equals(name, StringComparison.OrdinalIgnoreCase)).Value;

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Headers.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Headers.cs
@@ -315,11 +315,11 @@ namespace System.Net.Http.Functional.Tests
             bool switchValue = bool.Parse(switchValueInner);
             if (bool.Parse(useAppCtxSwitchInner))
             {
-                AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.AllowNonAsciiHeaders", switchValue);
+                AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.AllowLatin1Headers", switchValue);
             }
             else
             {
-                Environment.SetEnvironmentVariable("DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_ALLOWNONASCIIHEADERS", switchValueInner);
+                Environment.SetEnvironmentVariable("DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_ALLOWLATIN1HEADERS", switchValueInner);
             }
             return switchValue;
         }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Headers.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Headers.cs
@@ -335,7 +335,7 @@ namespace System.Net.Http.Functional.Tests
         };
 
         // Since RemoteExecutor cannot invoke delegates defined in abstract types, we should define the actual test cases in derived classes.
-        protected int SendAsync_SendNonAsciiCharacters_Impl(string useAppCtxSwitchInner, string switchValueInner, string unicodeInner)
+        protected int SendAsync_SendNonAsciiCharacters_Inner(string useAppCtxSwitchInner, string switchValueInner, string unicodeInner)
         {
             bool allowLatin1 = AllowLatin1Headers(useAppCtxSwitchInner, switchValueInner);
             bool unicode = bool.Parse(unicodeInner);

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Headers.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Headers.cs
@@ -310,7 +310,7 @@ namespace System.Net.Http.Functional.Tests
 
         private static (string Name, string[] Values)[] GetNonAsciiTestHeaders(bool unicode) => unicode ? s_invalidUnicodeCharacters : s_validLatin1Characters;
 
-        private static bool AllowNonAsciiHeaders(string useAppCtxSwitchInner, string switchValueInner)
+        private static bool AllowLatin1Headers(string useAppCtxSwitchInner, string switchValueInner)
         {
             bool switchValue = bool.Parse(switchValueInner);
             if (bool.Parse(useAppCtxSwitchInner))
@@ -337,9 +337,9 @@ namespace System.Net.Http.Functional.Tests
         // Since RemoteExecutor cannot invoke delegates defined in abstract types, we should define the actual test cases in derived classes.
         protected int SendAsync_SendNonAsciiCharacters_Impl(string useAppCtxSwitchInner, string switchValueInner, string unicodeInner)
         {
-            bool allowNonAscii = AllowNonAsciiHeaders(useAppCtxSwitchInner, switchValueInner);
+            bool allowLatin1 = AllowLatin1Headers(useAppCtxSwitchInner, switchValueInner);
             bool unicode = bool.Parse(unicodeInner);
-            bool expectSuccess = allowNonAscii && !unicode;
+            bool expectSuccess = allowLatin1 && !unicode;
 
             (string name, string[] values)[] headers = GetNonAsciiTestHeaders(unicode);
 
@@ -400,9 +400,9 @@ namespace System.Net.Http.Functional.Tests
 
         protected int SendAsync_ReceiveNonAsciiCharacters_Inner(string useAppCtxSwitchInner, string switchValueInner, string unicodeInner)
         {
-            bool allowNonAscii = AllowNonAsciiHeaders(useAppCtxSwitchInner, switchValueInner);
+            bool allowLatin1 = AllowLatin1Headers(useAppCtxSwitchInner, switchValueInner);
             bool unicode = bool.Parse(unicodeInner);
-            bool expectSuccess = allowNonAscii && !unicode;
+            bool expectSuccess = allowLatin1 && !unicode;
 
             LoopbackServerFactory.CreateClientAndServerAsync(
                 async uri =>
@@ -428,7 +428,7 @@ namespace System.Net.Http.Functional.Tests
                 async server =>
                 {
                     List<HttpHeaderData> headerData = GetNonAsciiTestHeaders(unicode)
-                        .Select(h => new HttpHeaderData(h.Name, string.Join(", ", h.Values), latin1: true))
+                        .Select(h => new HttpHeaderData(h.Name, string.Join(", ", h.Values), latin1: allowLatin1))
                         .ToList();
 
                     await server.HandleRequestAsync(headers: headerData);

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Headers.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Headers.cs
@@ -298,10 +298,8 @@ namespace System.Net.Http.Functional.Tests
 
         private static readonly (string Name, string[] Values)[] s_validLatin1Characters = new[]
         {
-            ("a", new[] { "aa"})
-            //("a", new[] { "\x0081"})
-            //("Header1", new[] { "\x0081\x00FF\x00FE", "ascii-only" }),
-            //("Set-Cookie", new[] { "\u00FF", "\x00B0\x00B1\x00B2", "Ascii\x00B8" }),
+            ("Header1", new[] { "\x0081\x00FF\x00FE", "ascii-only" }),
+            ("Set-Cookie", new[] { "\u00FF", "\x00B0\x00B1\x00B2", "Ascii\x00B8" }),
         };
 
         private static readonly (string Name, string[] Values)[] s_invalidUnicodeCharacters = new[]

--- a/src/System.Net.Http/tests/FunctionalTests/MultipartContentTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/MultipartContentTest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -359,6 +360,44 @@ namespace System.Net.Http.Functional.Tests
             mc.Add(new MockContent());
             Task t = mc.ReadAsStreamAsync();
             await Assert.ThrowsAsync<NotImplementedException>(() => t);
+        }
+
+        [Fact]
+        public async Task ReadAsStreamAsync_CanEncodeLatin1()
+        {
+            var mc = new MultipartContent("subtype", "fooBoundary");
+
+            var stringContent = new StringContent("bar1");
+            stringContent.Headers.Add("latin1", "\uD83D\uDE00");
+            mc.Add(stringContent);
+
+            var byteArrayContent = new ByteArrayContent(Encoding.ASCII.GetBytes("bar4"));
+            byteArrayContent.Headers.Add("default", "\uD83D\uDE00");
+            mc.Add(byteArrayContent);
+
+            var ms = new MemoryStream();
+            await (await mc.ReadAsStreamAsync()).CopyToAsync(ms);
+
+            Encoding latin1 = Encoding.GetEncoding("ISO-8859-1");
+
+            byte[] expected = Concat(
+                latin1.GetBytes("--fooBoundary\r\n"),
+                latin1.GetBytes("Content-Type: text/plain; charset=utf-8\r\n"),
+                latin1.GetBytes("latin1: "),
+                latin1.GetBytes("\uD83D\uDE00"),
+                latin1.GetBytes("\r\n\r\n"),
+                latin1.GetBytes("bar1"),
+                latin1.GetBytes("\r\n--fooBoundary\r\n"),
+                latin1.GetBytes("default: "),
+                latin1.GetBytes("\uD83D\uDE00"),
+                latin1.GetBytes("\r\n\r\n"),
+                latin1.GetBytes("bar4"),
+                latin1.GetBytes("\r\n--fooBoundary--\r\n"));
+
+            byte[] actual = ms.ToArray();
+            Assert.Equal(expected, actual);
+
+            static byte[] Concat(params byte[][] arrays) => arrays.SelectMany(b => b).ToArray();
         }
 
         #region Helpers

--- a/src/System.Net.Http/tests/FunctionalTests/MultipartContentTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/MultipartContentTest.cs
@@ -378,7 +378,7 @@ namespace System.Net.Http.Functional.Tests
             var ms = new MemoryStream();
             await (await mc.ReadAsStreamAsync()).CopyToAsync(ms);
 
-            Encoding latin1 = Encoding.GetEncoding("ISO-8859-1");
+            Encoding latin1 = Test.Common.HttpHeaderData.Latin1Encoding;
 
             byte[] expected = Concat(
                 latin1.GetBytes("--fooBoundary\r\n"),

--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -2255,12 +2255,74 @@ namespace System.Net.Http.Functional.Tests
         protected override bool UseSocketsHttpHandler => true;
     }
 
+    public sealed class SocketsHttpHandlerTest_HttpClientHandlerTest_Headers_Http11_NonAscii : HttpClientHandlerTest_Headers_NonAscii
+    {
+        [Theory]
+        [MemberData(nameof(NonAsciiTestConfigurations))]
+        public void SendAsync_SendNonAsciiCharacters(bool useAppCtxSwitch, bool switchValue, bool unicode)
+        {
+            //SendAsync_SendNonAsciiCharacters_Impl(useAppCtxSwitch.ToString(), switchValue.ToString(), unicode.ToString());
+
+            RemoteExecutor.Invoke(
+                (useAppCtxSwitchInner, switchValueInner, utf8Inner) => SendAsync_SendNonAsciiCharacters_Impl(useAppCtxSwitchInner, switchValueInner, utf8Inner),
+                useAppCtxSwitch.ToString(),
+                switchValue.ToString(),
+                unicode.ToString())
+                .Dispose();
+        }
+
+        [Theory]
+        [MemberData(nameof(NonAsciiTestConfigurations))]
+        public void SendAsync_ReceiveNonAsciiCharacters(bool useAppCtxSwitch, bool switchValue, bool unicode)
+        {
+            RemoteExecutor.Invoke(
+               (useAppCtxSwitchInner, switchValueInner, utf8Inner) => SendAsync_ReceiveNonAsciiCharacters_Inner(useAppCtxSwitchInner, switchValueInner, utf8Inner),
+               useAppCtxSwitch.ToString(),
+               switchValue.ToString(),
+               unicode.ToString())
+               .Dispose();
+        }
+    }
+
     [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.SupportsAlpn))]
     public sealed class SocketsHttpHandlerTest_HttpClientHandlerTest_Headers_Http2 : HttpClientHandlerTest_Headers
     {
         public SocketsHttpHandlerTest_HttpClientHandlerTest_Headers_Http2(ITestOutputHelper output) : base(output) { }
         protected override bool UseSocketsHttpHandler => true;
         protected override bool UseHttp2 => true;
+    }
+
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.SupportsAlpn))]
+    public sealed class SocketsHttpHandlerTest_HttpClientHandlerTest_Headers_Http2_NonAscii : HttpClientHandlerTest_Headers_NonAscii
+    {
+        protected override bool UseSocketsHttpHandler => true;
+        protected override bool UseHttp2 => true;
+
+        [Theory]
+        [MemberData(nameof(NonAsciiTestConfigurations))]
+        public void SendAsync_SendNonAsciiCharacters(bool useAppCtxSwitch, bool switchValue, bool unicode)
+        {
+            //SendAsync_SendNonAsciiCharacters_Impl(useAppCtxSwitch.ToString(), switchValue.ToString(), unicode.ToString());
+
+            RemoteExecutor.Invoke(
+                (useAppCtxSwitchInner, switchValueInner, utf8Inner) => SendAsync_SendNonAsciiCharacters_Impl(useAppCtxSwitchInner, switchValueInner, utf8Inner),
+                useAppCtxSwitch.ToString(),
+                switchValue.ToString(),
+                unicode.ToString())
+                .Dispose();
+        }
+
+        [Theory]
+        [MemberData(nameof(NonAsciiTestConfigurations))]
+        public void SendAsync_ReceiveNonAsciiCharacters(bool useAppCtxSwitch, bool switchValue, bool unicode)
+        {
+            RemoteExecutor.Invoke(
+               (useAppCtxSwitchInner, switchValueInner, utf8Inner) => SendAsync_ReceiveNonAsciiCharacters_Inner(useAppCtxSwitchInner, switchValueInner, utf8Inner),
+               useAppCtxSwitch.ToString(),
+               switchValue.ToString(),
+               unicode.ToString())
+               .Dispose();
+        }
     }
 
     [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.SupportsAlpn))]

--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -2262,7 +2262,7 @@ namespace System.Net.Http.Functional.Tests
         public void SendAsync_SendNonAsciiCharacters(bool useAppCtxSwitch, bool switchValue, bool unicode)
         {
             RemoteExecutor.Invoke(
-                (useAppCtxSwitchInner, switchValueInner, utf8Inner) => SendAsync_SendNonAsciiCharacters_Impl(useAppCtxSwitchInner, switchValueInner, utf8Inner),
+                (useAppCtxSwitchInner, switchValueInner, unicodeInner) => SendAsync_SendNonAsciiCharacters_Inner(useAppCtxSwitchInner, switchValueInner, unicodeInner),
                 useAppCtxSwitch.ToString(),
                 switchValue.ToString(),
                 unicode.ToString())
@@ -2274,7 +2274,7 @@ namespace System.Net.Http.Functional.Tests
         public void SendAsync_ReceiveNonAsciiCharacters(bool useAppCtxSwitch, bool switchValue, bool unicode)
         {
             RemoteExecutor.Invoke(
-               (useAppCtxSwitchInner, switchValueInner, utf8Inner) => SendAsync_ReceiveNonAsciiCharacters_Inner(useAppCtxSwitchInner, switchValueInner, utf8Inner),
+               (useAppCtxSwitchInner, switchValueInner, unicodeInner) => SendAsync_ReceiveNonAsciiCharacters_Inner(useAppCtxSwitchInner, switchValueInner, unicodeInner),
                useAppCtxSwitch.ToString(),
                switchValue.ToString(),
                unicode.ToString())
@@ -2301,7 +2301,7 @@ namespace System.Net.Http.Functional.Tests
         public void SendAsync_SendNonAsciiCharacters(bool useAppCtxSwitch, bool switchValue, bool unicode)
         {
             RemoteExecutor.Invoke(
-                (useAppCtxSwitchInner, switchValueInner, utf8Inner) => SendAsync_SendNonAsciiCharacters_Impl(useAppCtxSwitchInner, switchValueInner, utf8Inner),
+                (useAppCtxSwitchInner, switchValueInner, unicodeInner) => SendAsync_SendNonAsciiCharacters_Inner(useAppCtxSwitchInner, switchValueInner, unicodeInner),
                 useAppCtxSwitch.ToString(),
                 switchValue.ToString(),
                 unicode.ToString())
@@ -2313,7 +2313,7 @@ namespace System.Net.Http.Functional.Tests
         public void SendAsync_ReceiveNonAsciiCharacters(bool useAppCtxSwitch, bool switchValue, bool unicode)
         {
             RemoteExecutor.Invoke(
-               (useAppCtxSwitchInner, switchValueInner, utf8Inner) => SendAsync_ReceiveNonAsciiCharacters_Inner(useAppCtxSwitchInner, switchValueInner, utf8Inner),
+               (useAppCtxSwitchInner, switchValueInner, unicodeInner) => SendAsync_ReceiveNonAsciiCharacters_Inner(useAppCtxSwitchInner, switchValueInner, unicodeInner),
                useAppCtxSwitch.ToString(),
                switchValue.ToString(),
                unicode.ToString())

--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -2261,8 +2261,6 @@ namespace System.Net.Http.Functional.Tests
         [MemberData(nameof(NonAsciiTestConfigurations))]
         public void SendAsync_SendNonAsciiCharacters(bool useAppCtxSwitch, bool switchValue, bool unicode)
         {
-            //SendAsync_SendNonAsciiCharacters_Impl(useAppCtxSwitch.ToString(), switchValue.ToString(), unicode.ToString());
-
             RemoteExecutor.Invoke(
                 (useAppCtxSwitchInner, switchValueInner, utf8Inner) => SendAsync_SendNonAsciiCharacters_Impl(useAppCtxSwitchInner, switchValueInner, utf8Inner),
                 useAppCtxSwitch.ToString(),
@@ -2302,8 +2300,6 @@ namespace System.Net.Http.Functional.Tests
         [MemberData(nameof(NonAsciiTestConfigurations))]
         public void SendAsync_SendNonAsciiCharacters(bool useAppCtxSwitch, bool switchValue, bool unicode)
         {
-            //SendAsync_SendNonAsciiCharacters_Impl(useAppCtxSwitch.ToString(), switchValue.ToString(), unicode.ToString());
-
             RemoteExecutor.Invoke(
                 (useAppCtxSwitchInner, switchValueInner, utf8Inner) => SendAsync_SendNonAsciiCharacters_Impl(useAppCtxSwitchInner, switchValueInner, utf8Inner),
                 useAppCtxSwitch.ToString(),

--- a/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -300,6 +300,9 @@
     <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\ArrayBuffer.cs">
       <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\ArrayBuffer.cs</Link>
     </Compile>
+    <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\HttpConnectionSettings.cs">
+      <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\HttpConnectionSettings.cs</Link>
+    </Compile>
     <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\HttpEnvironmentProxy.cs">
       <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\HttpEnvironmentProxy.cs</Link>
     </Compile>

--- a/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -300,9 +300,6 @@
     <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\ArrayBuffer.cs">
       <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\ArrayBuffer.cs</Link>
     </Compile>
-    <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\HttpConnectionSettings.cs">
-      <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\HttpConnectionSettings.cs</Link>
-    </Compile>
     <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\HttpEnvironmentProxy.cs">
       <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\HttpEnvironmentProxy.cs</Link>
     </Compile>
@@ -341,6 +338,9 @@
     </Compile>
     <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\HPack\DynamicTable.cs">
       <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\HPack\DynamicTable.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\StaticHttpSettings.cs">
+      <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\StaticHttpSettings.cs</Link>
     </Compile>
     <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.cs">
       <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.cs</Link>


### PR DESCRIPTION
.NET Core's `SocketHttpHandler` does not allow sending non-ASCII characters in HTTP headers according to RFC, however in reality services accept/require other characters/encodings.

In dotnet/runtime#38711 we are introducing a generic solution for .NET 5. This is a 3.1-only workaround exposing two switches to relax header validation globally before the first usage of `HttpClient`, enabling advanced users to send Latin-1 encoded headers:
- AppContext switch: `System.Net.Http.SocketsHttpHandler.AllowLatin1Headers`
- Environment variable: `DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_ALLOWLATIN1HEADERS`

###  Customer Impact

Unblock migration to .NET Core 3.1 for customers who need to send Latin-1 headers.

### Testing

The PR adds tests (and minimal necessary test infrastructure changes) based on the ones in dotnet/runtime#39468 and dotnet/runtime#39169 to make sure these scenarios do not regress.

Validation: we sent private builds to the partner asking for this feature, and they confirmed that the change fixes their issue.

###  Risk

Low. The workaround is hidden behind a switch, our default behavior remains unchanged.
