### PR TITLE
[release/3.1] release `existingTrust` to avoid native memory leak in ssl handshake on macOS

### DIFF
--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.c
@@ -388,6 +388,7 @@ int32_t AppleCryptoNative_SslIsHostnameMatch(SSLContextRef sslContext, CFStringR
     if (anchors == NULL)
     {
         CFRelease(certs);
+        CFRelease(existingTrust);
         return -6;
     }
 
@@ -456,6 +457,9 @@ int32_t AppleCryptoNative_SslIsHostnameMatch(SSLContextRef sslContext, CFStringR
 
     if (anchors != NULL)
         CFRelease(anchors);
+
+    if (existingTrust != NULL)
+        CFRelease(existingTrust);
 
     CFRelease(sslPolicy);
     return ret;


### PR DESCRIPTION
This is port of https://github.com/dotnet/runtime/pull/41657 to fix https://github.com/dotnet/runtime/issues/34080

## Summary
There is memory leak inside of AppleCryptoNative_SslIsHostnameMatch() function which is used to verify peer's name in every client TLS handshake on macOS. There is no workaround and if running long enough, .NET will consume all available memory and crash. The `SecTrustRef` is internal structure and holds additional objects - like URL of OCSP or CRL responder so leaked memory is bigger than small. 

## Customer  Impact 
We have worked with a major customer who has been hitting this leak in an app that they intend to widely deploy within their organization (10K”s of deployments). They are encountering this leak and it is blocking their deployment. They have attempted to work around it by restarting the app when their memory consumption reaches a threshold but this workaround is not sustainable for them at scale so they are seeking a fix backported to 3.1 LTS.

## Regression?
no.

## Testing
the fix was verified with Apple's development tools e.g. `leaks` utility

## Risk
low. This releases structure we obtained via `SSLCopyPeerTrust` and it does not change any flow.

cc: @danmosemsft 


