### PR TITLE
[release/3.1] [corefx] Fix FileStream.Dispose silently fails on Dispose when disk has run out of space

### DIFF
--- a/src/System.IO.FileSystem/System.IO.FileSystem.sln
+++ b/src/System.IO.FileSystem/System.IO.FileSystem.sln
@@ -20,6 +20,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E89
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.IO.FileSystem.Manual.Tests", "tests\ManualTests\System.IO.FileSystem.Manual.Tests.csproj", "{70FA2031-8D6E-4127-901E-2B0D90420E08}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -38,6 +40,10 @@ Global
 		{4B15C12E-B6AB-4B05-8ECA-C2E2AEA67482}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
 		{4B15C12E-B6AB-4B05-8ECA-C2E2AEA67482}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
 		{4B15C12E-B6AB-4B05-8ECA-C2E2AEA67482}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
+		{70FA2031-8D6E-4127-901E-2B0D90420E08}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
+		{70FA2031-8D6E-4127-901E-2B0D90420E08}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
+		{70FA2031-8D6E-4127-901E-2B0D90420E08}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
+		{70FA2031-8D6E-4127-901E-2B0D90420E08}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -46,6 +52,7 @@ Global
 		{F0D49126-6A1C-42D5-9428-4374C868BAF8} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{1B528B61-14F9-4BFC-A79A-F0BDB3339150} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{4B15C12E-B6AB-4B05-8ECA-C2E2AEA67482} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
+		{70FA2031-8D6E-4127-901E-2B0D90420E08} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9BEAA279-BD7B-42E8-91C5-519267FEB4BB}

--- a/src/System.IO.FileSystem/tests/ManualTests/ManualTests.cs
+++ b/src/System.IO.FileSystem/tests/ManualTests/ManualTests.cs
@@ -1,0 +1,77 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using Microsoft.DotNet.XUnitExtensions;
+using Xunit;
+
+namespace System.IO.ManualTests
+{
+    public class FileSystemManualTests
+    {
+        public static bool ManualTestsEnabled => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MANUAL_TESTS"));
+
+        [ConditionalFact(nameof(ManualTestsEnabled))]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        public static void Throw_FileStreamDispose_WhenRemoteMountRunsOutOfSpace()
+        {
+            /*
+            Example of mounting a remote folder using sshfs and two Linux machines:
+            In remote machine:
+                - Install openssh-server.
+                - Create an ext4 partition of 1 MB size.
+                
+            In local machine:
+                - Install sshfs and openssh-client.
+                - Create a local folder inside the current user's home, named "mountedremote":
+                    $ mkdir ~/mountedremote
+                - Mount the remote folder into "mountedremote":
+                    $ sudo sshfs -o allow_other,default_permissions remoteuser@xxx.xxx.xxx.xxx:/home/remoteuser/share /home/localuser/mountedremote
+                - Set the environment variable MANUAL_TESTS=1
+                - Run this manual test.
+                - Expect the exception.
+                - Unmount the folder:
+                    $ fusermount -u ~/mountedremote
+            */
+
+            string mountedPath = $"{Environment.GetEnvironmentVariable("HOME")}/mountedremote";
+            string largefile = $"{mountedPath}/largefile.txt";
+            string origin = $"{mountedPath}/copyme.txt";
+            string destination = $"{mountedPath}/destination.txt";
+
+            // Ensure the remote folder exists
+            Assert.True(Directory.Exists(mountedPath));
+
+            // Delete copied file if exists
+            if (File.Exists(destination))
+            {
+                File.Delete(destination);
+            }
+
+            // Create huge file if not exists
+            if (!File.Exists(largefile))
+            {
+                File.WriteAllBytes(largefile, new byte[925696]);
+            }
+
+            // Create original file if not exists
+            if (!File.Exists(origin))
+            {
+                File.WriteAllBytes(origin, new byte[8192]);
+            }
+
+            Assert.True(File.Exists(largefile));
+            Assert.True(File.Exists(origin));
+
+            using FileStream originStream = new FileStream(origin, FileMode.Open, FileAccess.Read);
+            Stream destinationStream = new FileStream(destination, FileMode.Create, FileAccess.Write);
+            originStream.CopyTo(destinationStream, 1);
+
+            Assert.Throws<IOException>(() =>
+            {
+                destinationStream.Dispose();
+            });
+        }
+    }
+}

--- a/src/System.IO.FileSystem/tests/ManualTests/System.IO.FileSystem.Manual.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/ManualTests/System.IO.FileSystem.Manual.Tests.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <ProjectGuid>{70FA2031-8D6E-4127-901E-2B0D90420E08}</ProjectGuid>
+    <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ManualTests.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Backporting PR https://github.com/dotnet/runtime/pull/38742

The main fix goes into coreclr: https://github.com/dotnet/coreclr/pull/28099

Fixes: https://github.com/dotnet/runtime/issues/42360

This fix only introduced a **manual** test, which won't be executed with the CI, and only runs if the user manually sets an environment variable. 

## Customer Impact

A customer hit this issue in 3.1 when trying to deploy to AzureStorage: https://github.com/dotnet/runtime/issues/42360

On Unix, when the disk runs out of space before a `FileStream` is disposed and the buffer is flushed to disk, `Dispose` silently succeeds, causing files to be corrupted and preventing the user from taking corrective action.

On Windows, we throw at the expected moment, allowing the user to react appropriately.

The suggested fix is to save any error thrown when the `SafeFileHandle.ReleaseHandle` method is called when the handle is disposed, then check that saved error in `FileStream.Dispose`, and throw an exception if there was an error.

## Testing

Manually verified using the provided manual test introduced in this change.

## Risk

Low.

The code is doing an additional check that will ensure an exception is thrown so the user can be notified of failure. The modified code was identical to the code in 5.0.

The customer that reported the issue for 3.1 verified this code fix with a private DLL sent to them, and verified the exception is now being thrown as expected:

https://github.com/dotnet/runtime/issues/42360#issuecomment-694545520

The customer also verified the behavior in 5.0 and confirmed that their issue is gone in that version, which justifies the backport: https://github.com/dotnet/runtime/issues/42360#issuecomment-693791617
