### PR TITLE
[release/3.1] Fix Windows AccessViolationException in FileSystemWatcher when monitoring network share for changes

### DIFF
--- a/src/Common/src/Interop/Windows/Kernel32/Interop.ReadDirectoryChangesW.cs
+++ b/src/Common/src/Interop/Windows/Kernel32/Interop.ReadDirectoryChangesW.cs
@@ -29,13 +29,8 @@ internal partial class Interop
             internal FileAction Action;
 
             // Note that the file name is not null terminated
-            internal uint FileNameLength;
-            internal char _FileName;
-
-            internal unsafe ReadOnlySpan<char> FileName
-            {
-                get { fixed (char* c = &_FileName) { return new ReadOnlySpan<char>(c, (int)FileNameLength / sizeof(char)); } }
-            }
+            internal readonly uint FileNameLength;
+            internal readonly char FileName;
         }
 
         internal enum FileAction : uint

--- a/src/Common/src/Interop/Windows/Kernel32/Interop.ReadDirectoryChangesW.cs
+++ b/src/Common/src/Interop/Windows/Kernel32/Interop.ReadDirectoryChangesW.cs
@@ -29,8 +29,8 @@ internal partial class Interop
             internal FileAction Action;
 
             // Note that the file name is not null terminated
-            private uint FileNameLength;
-            private char _FileName;
+            internal uint FileNameLength;
+            internal char _FileName;
 
             internal unsafe ReadOnlySpan<char> FileName
             {


### PR DESCRIPTION
## Customer impact

This issue was reported for 3.1 twice:
- https://github.com/dotnet/runtime/issues/40412 - w3wp.exe crash in FileSystemWatcher after 2.2 -> 3.1 migration (c0000005 Access Violation)
- https://github.com/dotnet/runtime/issues/42108 - FileSystemWatcher crash UNALIGNED_STACK_POINTER

When monitoring a network share with `FileSystemWatcher`, if there are network issues that could cause the data to arrive malformed, then after casting the byte array to a `FILE_NOTIFY_INFORMATION`, attempts to access the struct fields can throw an AV.

The 6.0 (master) PR: https://github.com/dotnet/runtime/pull/42419
The 5.0 backport PR: https://github.com/dotnet/runtime/pull/42420

## Testing

The issue was also reported internally by one of the customers. Our CSS partner was able to reproduce it locally.

I provided him a private binary of System.IO.FileSystem.Watcher.dll with the changes in this fix, and he confirmed the AV no longer happens.

## Risk

Low. We are introducing boundary checks after casting data data coming from a P/Invoke, with the explicit purpose of removing an unexpected AV exception.