### PR TITLE
[release/2.1] Backport missing SslStream API to 2.1

### DIFF
--- a/src/System.Net.Security/ref/System.Net.Security.cs
+++ b/src/System.Net.Security/ref/System.Net.Security.cs
@@ -213,8 +213,8 @@ namespace System.Net.Security
         public virtual System.Threading.Tasks.Task ShutdownAsync() { throw null; }
         public void Write(byte[] buffer) { }
         public override void Write(byte[] buffer, int offset, int count) { }
-        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) { throw null; }
-        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken) { throw null; }
+        public override System.Threading.Tasks.Task WriteAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public override System.Threading.Tasks.ValueTask WriteAsync(System.ReadOnlyMemory<byte> buffer, System.Threading.CancellationToken cancellationToken = default) { throw null; }
     }
 }
 namespace System.Security.Authentication

--- a/src/System.Net.Security/ref/System.Net.Security.cs
+++ b/src/System.Net.Security/ref/System.Net.Security.cs
@@ -213,6 +213,8 @@ namespace System.Net.Security
         public virtual System.Threading.Tasks.Task ShutdownAsync() { throw null; }
         public void Write(byte[] buffer) { }
         public override void Write(byte[] buffer, int offset, int count) { }
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) { throw null; }
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken) { throw null; }
     }
 }
 namespace System.Security.Authentication

--- a/src/System.Net.Security/ref/System.Net.Security.cs
+++ b/src/System.Net.Security/ref/System.Net.Security.cs
@@ -206,6 +206,8 @@ namespace System.Net.Security
         public override void Flush() { }
         public override System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
         public override int Read(byte[] buffer, int offset, int count) { throw null; }
+        public override System.Threading.Tasks.Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) { throw null; }
+        public override System.Threading.Tasks.ValueTask<int> ReadAsync(System.Memory<byte> buffer, CancellationToken cancellationToken = default) { throw null; }
         public override long Seek(long offset, System.IO.SeekOrigin origin) { throw null; }
         public override void SetLength(long value) { }
         public virtual System.Threading.Tasks.Task ShutdownAsync() { throw null; }


### PR DESCRIPTION
Add missing ReadAsync and WriteAsync API to SslStream. This is a backport of #29658 to 2.1 (only SslStream part)

Fix dotnet/runtime#38185

## Summary
For non-sealed types, not specifying an override in a ref can lead to a derived type skipping the method in the hierarchy when calling to base.Method(). This was fixed for 3.1 in #29658 but not ported to 2.1. Implementation of ReadAsync and WriteAsync exists in SslStream, only explicit API is missing.

## Customer Impact
SqlClient team reported Stack Overflow exception when trying to use a class derived from SslStream in a mix of dotnetcore 2.1 and 3.x dotnet/runtime#38185 The team is working on the SqlClient driver and this is a potential issue for the end-users.

## Regression?
No

## Testing
Verified by SqlClient team, see comment below.

## Risk
Low. Only explicitly specifying the override in the ref, the implementation already exists.