### PR TITLE
Disable SetDateTimeMax test on Linux

### DIFF
--- a/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
@@ -149,6 +149,7 @@ namespace System.IO.Tests
             Assert.Equal(ticks, dateTime.Ticks);
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/43166", TestPlatforms.Linux)]
         [ConditionalFact(nameof(SupportsLongMaxDateTime))]
         public void SetDateTimeMax()
         {


### PR DESCRIPTION
The test failed on 3.1 branch https://github.com/dotnet/corefx/pull/42996
Related issue https://github.com/dotnet/runtime/issues/43166