### PR TITLE
Fixing HashCode Seed Initialization on BCL package

### DIFF
--- a/src/Common/src/CoreLib/System/HashCode.cs
+++ b/src/Common/src/CoreLib/System/HashCode.cs
@@ -45,7 +45,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Numerics;
 using System.Runtime.CompilerServices;
-using System.Security.Cryptography;
 
 namespace System
 {
@@ -55,9 +54,6 @@ namespace System
     public struct HashCode
     {
         private static readonly uint s_seed = GenerateGlobalSeed();
-#if BUILDING_COMPAT_HASHCODE // Will only be defined when building Microsoft.Bcl.HashCode project
-        private static bool UseNonRandomizedGlobalSeed => LocalAppContextSwitches.UseNonRandomizedHashSeed;
-#endif
 
         private const uint Prime1 = 2654435761U;
         private const uint Prime2 = 2246822519U;
@@ -69,38 +65,12 @@ namespace System
         private uint _queue1, _queue2, _queue3;
         private uint _length;
 
-#if BUILDING_COMPAT_HASHCODE // Will only be defined when building Microsoft.Bcl.HashCode project
-        private static unsafe uint GenerateGlobalSeed()
-        {
-            if (UseNonRandomizedGlobalSeed)
-            {
-                uint result;
-                Interop.GetRandomBytes((byte*)&result, sizeof(uint));
-                return result;
-            }
-            else
-            {
-                byte[] tmp = new byte[sizeof(uint)];
-
-                using (RandomNumberGenerator rng = RandomNumberGenerator.Create())
-                {
-                    rng.GetBytes(tmp);
-                }
-
-                fixed (byte* pTmp = tmp)
-                {
-                    return *((uint*)pTmp);
-                }
-            }
-        }
-#else
         private static unsafe uint GenerateGlobalSeed()
         {
             uint result;
             Interop.GetRandomBytes((byte*)&result, sizeof(uint));
             return result;
         }
-#endif
 
         public static int Combine<T1>(T1 value1)
         {

--- a/src/Common/src/CoreLib/System/HashCode.cs
+++ b/src/Common/src/CoreLib/System/HashCode.cs
@@ -45,6 +45,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
 
 namespace System
 {
@@ -54,6 +55,9 @@ namespace System
     public struct HashCode
     {
         private static readonly uint s_seed = GenerateGlobalSeed();
+#if BUILDING_COMPAT_HASHCODE // Will only be defined when building Microsoft.Bcl.HashCode project
+        private static bool UseNonRandomizedGlobalSeed => LocalAppContextSwitches.UseNonRandomizedHashSeed;
+#endif
 
         private const uint Prime1 = 2654435761U;
         private const uint Prime2 = 2246822519U;
@@ -65,12 +69,38 @@ namespace System
         private uint _queue1, _queue2, _queue3;
         private uint _length;
 
+#if BUILDING_COMPAT_HASHCODE // Will only be defined when building Microsoft.Bcl.HashCode project
+        private static unsafe uint GenerateGlobalSeed()
+        {
+            if (UseNonRandomizedGlobalSeed)
+            {
+                uint result;
+                Interop.GetRandomBytes((byte*)&result, sizeof(uint));
+                return result;
+            }
+            else
+            {
+                byte[] tmp = new byte[sizeof(uint)];
+
+                using (RandomNumberGenerator rng = RandomNumberGenerator.Create())
+                {
+                    rng.GetBytes(tmp);
+                }
+
+                fixed (byte* pTmp = tmp)
+                {
+                    return *((uint*)pTmp);
+                }
+            }
+        }
+#else
         private static unsafe uint GenerateGlobalSeed()
         {
             uint result;
             Interop.GetRandomBytes((byte*)&result, sizeof(uint));
             return result;
         }
+#endif
 
         public static int Combine<T1>(T1 value1)
         {

--- a/src/Microsoft.Bcl.HashCode/Directory.Build.props
+++ b/src/Microsoft.Bcl.HashCode/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <PackageVersion>1.1.0</PackageVersion>
+    <PackageVersion>1.1.1</PackageVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <!-- This assembly should never be placed inbox as it is only for downlevel compatibility. -->
   </PropertyGroup>

--- a/src/Microsoft.Bcl.HashCode/src/Interop.GetRandomBytes.cs
+++ b/src/Microsoft.Bcl.HashCode/src/Interop.GetRandomBytes.cs
@@ -3,12 +3,21 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 
 internal partial class Interop
 {
     internal static unsafe void GetRandomBytes(byte* buffer, int length)
     {
-        byte[] bytes = Guid.NewGuid().ToByteArray();
-        buffer = (byte*)BitConverter.ToUInt32(bytes, 0);
+        if (!LocalAppContextSwitches.UseNonRandomizedHashSeed)
+        {
+            using (RandomNumberGenerator rng = RandomNumberGenerator.Create())
+            {
+                byte[] tmp = new byte[length];
+                rng.GetBytes(tmp);
+                Marshal.Copy(tmp, 0, (IntPtr)buffer, length);
+            }
+        }
     }
 }

--- a/src/Microsoft.Bcl.HashCode/src/LocalAppContextSwitches.cs
+++ b/src/Microsoft.Bcl.HashCode/src/LocalAppContextSwitches.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+namespace System
+{
+    internal static partial class LocalAppContextSwitches
+    {
+        private static int s_useNonRandomizedHashSeed;
+        public static bool UseNonRandomizedHashSeed
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => GetCachedSwitchValue("Switch.System.Data.UseNonRandomizedHashSeed", ref s_useNonRandomizedHashSeed);
+        }
+    }
+}

--- a/src/Microsoft.Bcl.HashCode/src/Microsoft.Bcl.HashCode.csproj
+++ b/src/Microsoft.Bcl.HashCode/src/Microsoft.Bcl.HashCode.csproj
@@ -3,7 +3,6 @@
     <ProjectGuid>{B77D0212-D53C-4F7F-8CEC-2E067AC6FCAB}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly Condition="'$(TargetFramework)' != 'netstandard2.0' AND '$(TargetsNetFx)' != 'true'">true</IsPartialFacadeAssembly>
-    <DefineConstants>$(DefineConstants);BUILDING_COMPAT_HASHCODE</DefineConstants>
     <OmitResources>$(IsPartialFacadeAssembly)</OmitResources>
     <Configurations>netstandard-Debug;netstandard-Release;net461-Debug;net461-Release;netcoreapp-Debug;netcoreapp-Release;netcoreapp2.1-Debug;netcoreapp2.1-Release;netfx-Debug;netfx-Release;netstandard2.1-Debug;netstandard2.1-Release</Configurations>
     <Nullable>enable</Nullable>

--- a/src/Microsoft.Bcl.HashCode/src/Microsoft.Bcl.HashCode.csproj
+++ b/src/Microsoft.Bcl.HashCode/src/Microsoft.Bcl.HashCode.csproj
@@ -3,8 +3,9 @@
     <ProjectGuid>{B77D0212-D53C-4F7F-8CEC-2E067AC6FCAB}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly Condition="'$(TargetFramework)' != 'netstandard2.0' AND '$(TargetsNetFx)' != 'true'">true</IsPartialFacadeAssembly>
+    <DefineConstants>$(DefineConstants);BUILDING_COMPAT_HASHCODE</DefineConstants>
     <OmitResources>$(IsPartialFacadeAssembly)</OmitResources>
-    <Configurations>net461-Debug;net461-Release;netcoreapp-Debug;netcoreapp-Release;netcoreapp2.1-Debug;netcoreapp2.1-Release;netfx-Debug;netfx-Release;netstandard-Debug;netstandard-Release;netstandard2.1-Debug;netstandard2.1-Release</Configurations>
+    <Configurations>netstandard-Debug;netstandard-Release;net461-Debug;net461-Release;netcoreapp-Debug;netcoreapp-Release;netcoreapp2.1-Debug;netcoreapp2.1-Release;netfx-Debug;netfx-Release;netstandard2.1-Debug;netstandard2.1-Release</Configurations>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
@@ -13,6 +14,10 @@
     </Compile>
     <Compile Include="BitOperations.cs" />
     <Compile Include="Interop.GetRandomBytes.cs" />
+    <Compile Include="LocalAppContextSwitches.cs" />
+    <Compile Include="$(CommonPath)\CoreLib\System\LocalAppContextSwitches.Common.cs">
+      <Link>Common\CoreLib\System\LocalAppContextSwitches.Common.cs</Link>
+    </Compile>
     <Reference Include="mscorlib" />
     <Reference Include="System" />
   </ItemGroup>

--- a/src/Microsoft.Bcl.HashCode/tests/Configurations.props
+++ b/src/Microsoft.Bcl.HashCode/tests/Configurations.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       netfx;
+      netcoreapp;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.Bcl.HashCode/tests/Configurations.props
+++ b/src/Microsoft.Bcl.HashCode/tests/Configurations.props
@@ -1,0 +1,7 @@
+<Project DefaultTargets="Build">
+  <PropertyGroup>
+    <BuildConfigurations>
+      netfx;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/src/Microsoft.Bcl.HashCode/tests/HashCodeSeedInitializerTests.cs
+++ b/src/Microsoft.Bcl.HashCode/tests/HashCodeSeedInitializerTests.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.RemoteExecutor;
+using System;
+using System.Reflection;
+using Xunit;
+
+namespace Microsoft.Bcl.HashCode.Tests
+{
+    public class HashCodeSeedInitializerTests
+    {
+        [Fact]
+        public void EnsureSeedReturnsDifferentValuesTest()
+        {
+            var executor1 = RemoteExecutor.Invoke(GetHashCodeSeed, new RemoteInvokeOptions() { CheckExitCode = false });
+
+            int FirstSeed = executor1.ExitCode;
+            executor1.Dispose();
+
+            var executor2 = RemoteExecutor.Invoke(GetHashCodeSeed, new RemoteInvokeOptions() { CheckExitCode = false });
+
+            int SecondSeed = executor2.ExitCode;
+            executor2.Dispose();
+
+            Assert.NotEqual(FirstSeed, SecondSeed);
+
+            int GetHashCodeSeed()
+            {
+                var seed1Field = typeof(System.HashCode).GetField("s_seed", BindingFlags.NonPublic | BindingFlags.Static);
+                int returnCode = (int)((uint)seed1Field.GetValue(null));
+                return returnCode;
+            };
+        }
+
+    }
+
+}

--- a/src/Microsoft.Bcl.HashCode/tests/HashCodeSeedInitializerTests.cs
+++ b/src/Microsoft.Bcl.HashCode/tests/HashCodeSeedInitializerTests.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Bcl.HashCode.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp, "AppContextSwitch is not supported on .NETCore")]
         public void EnsureSeedReturnsEqualValuesWhenAppContextSwitchIsSet()
         {
             int FirstSeed = CalculateHashCodeInRemoteProcess(setAppContextSwitch: true);

--- a/src/Microsoft.Bcl.HashCode/tests/HashCodeSeedInitializerTests.cs
+++ b/src/Microsoft.Bcl.HashCode/tests/HashCodeSeedInitializerTests.cs
@@ -14,10 +14,16 @@ namespace Microsoft.Bcl.HashCode.Tests
         [Fact]
         public void EnsureSeedReturnsDifferentValuesTest()
         {
-            int FirstSeed = CalculateHashCodeInRemoteProcess(setAppContextSwitch: false);
-            int SecondSeed = CalculateHashCodeInRemoteProcess(setAppContextSwitch: false);
+            // Adding 5 retries since in Netcoreapp-Linux the seed that is generated is time-dependant so
+            // this test might fail there. This will ensure we reduce flakiness while still providing
+            // regression coverage.
+            RetryHelper.Execute(() =>
+            {
+                int FirstSeed = CalculateHashCodeInRemoteProcess(setAppContextSwitch: false);
+                int SecondSeed = CalculateHashCodeInRemoteProcess(setAppContextSwitch: false);
 
-            Assert.NotEqual(FirstSeed, SecondSeed);
+                Assert.NotEqual(FirstSeed, SecondSeed);
+            });
         }
 
         [Fact]

--- a/src/Microsoft.Bcl.HashCode/tests/HashCodeSeedInitializerTests.cs
+++ b/src/Microsoft.Bcl.HashCode/tests/HashCodeSeedInitializerTests.cs
@@ -14,23 +14,26 @@ namespace Microsoft.Bcl.HashCode.Tests
         [Fact]
         public void EnsureSeedReturnsDifferentValuesTest()
         {
-            var executor1 = RemoteExecutor.Invoke(GetHashCodeSeed, new RemoteInvokeOptions() { CheckExitCode = false });
-
-            int FirstSeed = executor1.ExitCode;
-            executor1.Dispose();
-
-            var executor2 = RemoteExecutor.Invoke(GetHashCodeSeed, new RemoteInvokeOptions() { CheckExitCode = false });
-
-            int SecondSeed = executor2.ExitCode;
-            executor2.Dispose();
+            int FirstSeed = CalculateHashCodeInRemoteProcess();
+            int SecondSeed = CalculateHashCodeInRemoteProcess();
 
             Assert.NotEqual(FirstSeed, SecondSeed);
+        }
+
+        private int CalculateHashCodeInRemoteProcess()
+        {
+            var executor = RemoteExecutor.Invoke(GetHashCodeSeed, new RemoteInvokeOptions() { CheckExitCode = false });
+
+            int hashedResult = executor.ExitCode;
+            executor.Dispose();
+
+            return hashedResult;
 
             int GetHashCodeSeed()
             {
-                var seed1Field = typeof(System.HashCode).GetField("s_seed", BindingFlags.NonPublic | BindingFlags.Static);
-                int returnCode = (int)((uint)seed1Field.GetValue(null));
-                return returnCode;
+                System.HashCode hc = new System.HashCode();
+                hc.Add(5);
+                return hc.ToHashCode();
             };
         }
 

--- a/src/Microsoft.Bcl.HashCode/tests/Microsoft.Bcl.HashCode.Tests.csproj
+++ b/src/Microsoft.Bcl.HashCode/tests/Microsoft.Bcl.HashCode.Tests.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Configurations>netfx-Debug;netfx-Release</Configurations>
+    <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="HashCodeSeedInitializerTests.cs" />
+  </ItemGroup>
+</Project>

--- a/src/Microsoft.Bcl.HashCode/tests/Microsoft.Bcl.HashCode.Tests.csproj
+++ b/src/Microsoft.Bcl.HashCode/tests/Microsoft.Bcl.HashCode.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configurations>netfx-Debug;netfx-Release</Configurations>
+    <Configurations>netfx-Debug;netfx-Release;netcoreapp-Debug;netcoreapp-Release</Configurations>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
   </PropertyGroup>
   <ItemGroup>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -26,6 +26,9 @@
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
     <!-- add specific builds / pkgproj's here to include in servicing builds -->
+    <Project Include="$(MSBuildThisFileDirectory)Microsoft.Bcl.HashCode\pkg\Microsoft.Bcl.HashCode.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
fixes https://github.com/dotnet/runtime/issues/42808

Fixing seed initialization on Microsoft.Bcl.Hashcode to match netcoreapp behavior. Also provided a quirk in case people consuming the BCL package want to fall back to the non-randomized version.

cc: @stephentoub @bartonjs @ericstj @fabricefou @Anipik 

## Customer Impact

NetStandard implementation of GetRandomBytes has a bug which causes it to always return 0. This is used by HashCode when generating its internal seed used for generating hashes, which causes the user to get non-random hashes when consuming the Microsoft.Bcl.HashCode package in netstandard.

## Testing

We added test coverage as part of this PR to ensure that a) Customers behavior will now be the same in netcoreapp and netfx and b) we added an AppContext switch so that folks can fall back to wrong behavior if they depended on non-randomized hashes.

## Regression?

No. This package has had the incorrect behavior since we initially shipped it.

## Risk

Low. It may break customers that depended on the wrong behavior, but for such cases we provided an AppContext switch that they can decide to turn on if necessary.