### PR TITLE
Move some unit tests to outerloop to get clean CI

### DIFF
--- a/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -381,6 +381,7 @@ namespace System.Text.RegularExpressions.Tests
         }
 
         // On 32-bit we can't test these high inputs as they cause OutOfMemoryExceptions.
+        [OuterLoop("Can take several seconds")]
         [ConditionalTheory(typeof(Environment), nameof(Environment.Is64BitProcess))]
         [InlineData(RegexOptions.Compiled)]
         [InlineData(RegexOptions.None)]
@@ -393,6 +394,7 @@ namespace System.Text.RegularExpressions.Tests
         }
 
         // On 32-bit we can't test these high inputs as they cause OutOfMemoryExceptions.
+        [OuterLoop("Can take several seconds")]
         [ConditionalTheory(typeof(Environment), nameof(Environment.Is64BitProcess))]
         [InlineData(RegexOptions.Compiled)]
         [InlineData(RegexOptions.None)]


### PR DESCRIPTION
Just moving some tests to outerloop in the hope that it leads to clean CI and fixes https://github.com/dotnet/runtime/issues/41286. Relevant parts copied from https://github.com/dotnet/runtime/pull/2194