### PR TITLE
Add RHEL 9 RID

### DIFF
--- a/pkg/Microsoft.NETCore.Platforms/runtime.compatibility.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.compatibility.json
@@ -3009,6 +3009,38 @@
     "any",
     "base"
   ],
+  "rhel.9": [
+    "rhel.9",
+    "rhel",
+    "linux",
+    "unix",
+    "any",
+    "base"
+  ],
+  "rhel.9-arm64": [
+    "rhel.9-arm64",
+    "rhel.9",
+    "rhel-arm64",
+    "rhel",
+    "linux-arm64",
+    "linux",
+    "unix-arm64",
+    "unix",
+    "any",
+    "base"
+  ],
+  "rhel.9-x64": [
+    "rhel.9-x64",
+    "rhel.9",
+    "rhel-x64",
+    "rhel",
+    "linux-x64",
+    "linux",
+    "unix-x64",
+    "unix",
+    "any",
+    "base"
+  ],
   "sles": [
     "sles",
     "linux",

--- a/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -1339,6 +1339,23 @@
         "rhel.8.0-x64"
       ]
     },
+    "rhel.9": {
+      "#import": [
+        "rhel"
+      ]
+    },
+    "rhel.9-arm64": {
+      "#import": [
+        "rhel.9",
+        "rhel-arm64"
+      ]
+    },
+    "rhel.9-x64": {
+      "#import": [
+        "rhel.9",
+        "rhel-x64"
+      ]
+    },
     "sles": {
       "#import": [
         "linux"

--- a/pkg/Microsoft.NETCore.Platforms/runtimeGroups.props
+++ b/pkg/Microsoft.NETCore.Platforms/runtimeGroups.props
@@ -119,6 +119,11 @@
       <Architectures>x64;arm64</Architectures>
       <Versions>8;8.0;8.1</Versions>
     </RuntimeGroup>
+    <RuntimeGroup Include="rhel">
+      <Parent>linux</Parent>
+      <Architectures>x64;arm64</Architectures>
+      <Versions>9</Versions>
+    </RuntimeGroup>
 
     <RuntimeGroup Include="sles">
       <Parent>linux</Parent>


### PR DESCRIPTION
Trying to build .NET Core 3.1 (via source-build) on a recent Fedora version with /etc/os-release patched to report "rhel.9" results in a build failure.

This should, hopefully, fix that error.

This is a partial backport of https://github.com/dotnet/runtime/pull/34088.