### PR TITLE
Microsoft.Bcl.HashCode: AllowPartiallyTrustedCallers for the net461 target

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -36,7 +36,8 @@
     "Microsoft.Bcl.HashCode": {
       "StableVersions": [
         "1.0.0",
-        "1.1.0"
+        "1.1.0",
+        "1.1.1"
       ],
       "BaselineVersion": "1.1.0",
       "InboxOn": {},
@@ -645,10 +646,6 @@
       ],
       "InboxOn": {}
     },
-    "runtime.win-x64.Microsoft.Private.CoreFx.NETCoreApp": {
-      "BaselineVersion": "4.7.0",
-      "InboxOn": {}
-    },
     "runtime.win7-x64.runtime.native.System.Data.SqlClient.sni": {
       "StableVersions": [
         "4.0.1",
@@ -663,6 +660,10 @@
         "4.3.0"
       ],
       "BaselineVersion": "4.3.0",
+      "InboxOn": {}
+    },
+    "runtime.win-x64.Microsoft.Private.CoreFx.NETCoreApp": {
+      "BaselineVersion": "4.7.0",
       "InboxOn": {}
     },
     "SMDiagnostics": {

--- a/src/Common/src/CoreLib/System/HashCode.cs
+++ b/src/Common/src/CoreLib/System/HashCode.cs
@@ -64,7 +64,9 @@ namespace System
         private uint _v1, _v2, _v3, _v4;
         private uint _queue1, _queue2, _queue3;
         private uint _length;
-
+#if ALLOW_PARTIALLY_TRUSTED_CALLERS        
+        [System.Security.SecuritySafeCritical]
+#endif        
         private static unsafe uint GenerateGlobalSeed()
         {
             uint result;

--- a/src/Microsoft.Bcl.HashCode/src/AssemblyInfo.netfx.cs
+++ b/src/Microsoft.Bcl.HashCode/src/AssemblyInfo.netfx.cs
@@ -1,0 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Security;
+
+[assembly: AllowPartiallyTrustedCallers]

--- a/src/Microsoft.Bcl.HashCode/src/Interop.GetRandomBytes.cs
+++ b/src/Microsoft.Bcl.HashCode/src/Interop.GetRandomBytes.cs
@@ -8,6 +8,9 @@ using System.Security.Cryptography;
 
 internal partial class Interop
 {
+#if ALLOW_PARTIALLY_TRUSTED_CALLERS
+    [System.Security.SecuritySafeCritical]
+#endif
     internal static unsafe void GetRandomBytes(byte* buffer, int length)
     {
         if (!LocalAppContextSwitches.UseNonRandomizedHashSeed)

--- a/src/Microsoft.Bcl.HashCode/src/Microsoft.Bcl.HashCode.csproj
+++ b/src/Microsoft.Bcl.HashCode/src/Microsoft.Bcl.HashCode.csproj
@@ -7,6 +7,9 @@
     <Configurations>netstandard-Debug;netstandard-Release;net461-Debug;net461-Release;netcoreapp-Debug;netcoreapp-Release;netcoreapp2.1-Debug;netcoreapp2.1-Release;netfx-Debug;netfx-Release;netstandard2.1-Debug;netstandard2.1-Release</Configurations>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetsNetFx)' == 'true'">
+    <DefineConstants>$(DefineConstants);ALLOW_PARTIALLY_TRUSTED_CALLERS</DefineConstants>
+  </PropertyGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
     <Compile Include="$(CommonPath)\CoreLib\System\HashCode.cs">
       <Link>ProductionCode\Common\CoreLib\System\HashCode.cs</Link>
@@ -23,5 +26,8 @@
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' == 'true' AND '$(TargetGroup)' != 'netstandard2.1'">
     <Reference Include="System.Runtime" />
     <Reference Include="System.Resources.ResourceManager" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
+    <Compile Include="AssemblyInfo.netfx.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/46782. It seems the package version was already incremented. I'm hoping the test failure is unrelated :)