### PR TITLE
Port graphics metafile refcount fix to avoid disposing the native image multiple times

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -1709,7 +1709,8 @@
       },
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.5.0",
-        "4.0.0.1": "4.5.1"
+        "4.0.0.1": "4.5.1",
+        "4.0.0.2": "4.5.2"
       }
     },
     "System.Drawing.Design": {

--- a/src/System.Drawing.Common/dir.props
+++ b/src/System.Drawing.Common/dir.props
@@ -2,8 +2,8 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.0.1</AssemblyVersion>
+    <AssemblyVersion>4.0.0.2</AssemblyVersion>
     <AssemblyKey>Open</AssemblyKey>
-    <PackageVersion>4.5.1</PackageVersion>
+    <PackageVersion>4.5.2</PackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -24,6 +24,9 @@
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
     <!-- add specific builds / pkgproj's here to include in servicing builds -->
+    <Project Include="$(MSBuildThisFileDirectory)System.Drawing.Common\pkg\System.Drawing.Common.pkgproj">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
   </ItemGroup>
 
   <!-- Need the PackageIndexFile file property from baseline.props -->


### PR DESCRIPTION
Ports: https://github.com/dotnet/runtime/commit/7939172ea4d0052901215e83fb59e7172dcd13d0

## Summary

Due to libgdiplus behavior we were disposing metafiles twice causing the app to crash. This adds a ref count to avoid disposing a metafile when a graphics instance still has a reference to it. 

## Customer Impact

Detected via tests.

## Regression?

No.

## Testing

Unit tests.

## Risk

Low-medium.  The fix just adds a ref count to the metafile and avoids disposing it if it is still referenced by a graphics object.

cc: @Anipik 