### PR TITLE
correct system.numerics.tensors package version in package index and directoty.build.props

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -3535,14 +3535,12 @@
     },
     "System.Numerics.Tensors": {
       "StableVersions": [
-        "0.1.0",
-        "0.3.0"
+        "0.1.0"
       ],
-      "BaselineVersion": "0.3.0",
+      "BaselineVersion": "0.1.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
-        "0.1.0.0": "0.1.0",
-        "0.2.0.0": "0.2.0"
+        "0.1.0.0": "0.1.0"
       }
     },
     "System.Numerics.Vectors": {

--- a/src/System.Numerics.Tensors/Directory.Build.props
+++ b/src/System.Numerics.Tensors/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <AssemblyVersion>0.2.1.0</AssemblyVersion>
-    <PackageVersion>0.3.0</PackageVersion>
+    <PackageVersion>0.2.0</PackageVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <!-- This is a preview package. Do not mark as stable. -->
     <BlockStable>true</BlockStable>


### PR DESCRIPTION
The last released version for SNT is 0.1.0 during that era 

so correcting baseline version and stable version list
tested change locally by building the package. the package should be in non-shipping with a version suffix