### PR TITLE
Remove RedHat 6 from CI

### DIFF
--- a/eng/pipelines/linux.yml
+++ b/eng/pipelines/linux.yml
@@ -28,16 +28,16 @@ stages:
         displayName: Build
         strategy:
           matrix:
-              # Run RedHat7 in release mode on CI to cover Release configuration differences
-              x64_Release:
-                _BuildConfig: Release
-                _architecture: x64
-                _framework: netcoreapp
-                _helixQueues: $(linuxDefaultQueues)
-                _dockerContainer: rhel7_container
-                _buildScriptPrefix: ''
-                _buildExtraArguments: ''
-                _publishTests: true
+            # Run RedHat7 in release mode on CI to cover Release configuration differences
+            x64_Release:
+              _BuildConfig: Release
+              _architecture: x64
+              _framework: netcoreapp
+              _helixQueues: $(linuxDefaultQueues)
+              _dockerContainer: rhel7_container
+              _buildScriptPrefix: ''
+              _buildExtraArguments: ''
+              _publishTests: true
 
             ${{ if eq(parameters.fullMatrix, 'false') }}:
 

--- a/eng/pipelines/linux.yml
+++ b/eng/pipelines/linux.yml
@@ -28,7 +28,7 @@ stages:
         displayName: Build
         strategy:
           matrix:
-
+              # Run RedHat7 in release mode on CI to cover Release configuration differences
               x64_Release:
                 _BuildConfig: Release
                 _architecture: x64

--- a/eng/pipelines/linux.yml
+++ b/eng/pipelines/linux.yml
@@ -28,16 +28,6 @@ stages:
         displayName: Build
         strategy:
           matrix:
-            # Run RedHat6 in release mode on CI to cover Release configuration differences
-            RedHat6_x64_Release:
-              _BuildConfig: Release
-              _architecture: x64
-              _framework: netcoreapp
-              _buildScriptPrefix: ''
-              _buildExtraArguments: /p:RuntimeOS=rhel.6 /p:PortableBuild=false
-              _dockerContainer: rhel6_container
-              _helixQueues: $(redhatHelixQueue)
-              _publishTests: ${{ parameters.fullMatrix }}
 
             ${{ if eq(parameters.fullMatrix, 'false') }}:
               x64_Debug:
@@ -121,7 +111,6 @@ stages:
         timeoutInMinutes: 240
 
         variables:
-          - redhatHelixQueue: RedHat.6.Amd64.Open
 
           - ${{ if eq(parameters.fullMatrix, 'false') }}:
             - linuxDefaultQueues: Centos.7.Amd64.Open+RedHat.7.Amd64.Open+Debian.9.Amd64.Open+Ubuntu.1604.Amd64.Open+Ubuntu.1804.Amd64.Open+SLES.15.Amd64.Open+\(Fedora.29.Amd64.Open\)ubuntu.1604.amd64.open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-29-helix-a12566d-20191210224553

--- a/eng/pipelines/linux.yml
+++ b/eng/pipelines/linux.yml
@@ -37,7 +37,7 @@ stages:
               _dockerContainer: rhel7_container
               _buildScriptPrefix: ''
               _buildExtraArguments: ''
-              _publishTests: true
+              _publishTests: ${{ parameters.fullMatrix }}
 
             ${{ if eq(parameters.fullMatrix, 'false') }}:
 

--- a/eng/pipelines/linux.yml
+++ b/eng/pipelines/linux.yml
@@ -29,7 +29,18 @@ stages:
         strategy:
           matrix:
 
+              x64_Release:
+                _BuildConfig: Release
+                _architecture: x64
+                _framework: netcoreapp
+                _helixQueues: $(linuxDefaultQueues)
+                _dockerContainer: rhel7_container
+                _buildScriptPrefix: ''
+                _buildExtraArguments: ''
+                _publishTests: true
+
             ${{ if eq(parameters.fullMatrix, 'false') }}:
+
               x64_Debug:
                 _BuildConfig: Debug
                 _architecture: x64
@@ -49,15 +60,6 @@ stages:
                 _buildExtraArguments: /p:RuntimeOS=linux-musl
 
             ${{ if eq(parameters.fullMatrix, 'true') }}:
-              x64_Release:
-                _BuildConfig: Release
-                _architecture: x64
-                _framework: netcoreapp
-                _helixQueues: $(linuxDefaultQueues)
-                _dockerContainer: rhel7_container
-                _buildScriptPrefix: ''
-                _buildExtraArguments: ''
-                _publishTests: true
 
               musl_x64_Release:
                 _BuildConfig: Release


### PR DESCRIPTION
As mentioned in https://github.com/dotnet/corefx/pull/43037#issuecomment-782912425

I moved the RHEL7 configuration up so it runs with both values of fullmatrix so that the Release configuration is protected.

Is this right?