### PR TITLE
Disable failing DNS tests on SLES

### DIFF
--- a/src/Common/tests/CoreFx.Private.TestUtilities/System/PlatformDetection.Unix.cs
+++ b/src/Common/tests/CoreFx.Private.TestUtilities/System/PlatformDetection.Unix.cs
@@ -34,6 +34,7 @@ namespace System
         public static bool IsUbuntu1710OrHigher => IsDistroAndVersionOrHigher("ubuntu", 17, 10);
         public static bool IsUbuntu1804 => IsDistroAndVersion("ubuntu", 18, 04);
         public static bool IsUbuntu1810OrHigher => IsDistroAndVersionOrHigher("ubuntu", 18, 10);
+        public static bool IsSLES => IsDistroAndVersion("sles");
         public static bool IsTizen => IsDistroAndVersion("tizen");
         public static bool IsFedora => IsDistroAndVersion("fedora");
         

--- a/src/System.Net.NameResolution/tests/FunctionalTests/GetHostByNameTest.cs
+++ b/src/System.Net.NameResolution/tests/FunctionalTests/GetHostByNameTest.cs
@@ -106,6 +106,11 @@ namespace System.Net.NameResolution.Tests
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(32797)]
         public void DnsObsoleteGetHostByName_EmptyString_ReturnsHostName()
         {
+            if (PlatformDetection.IsSLES)
+            {
+                // [ActiveIssue("https://github.com/dotnet/runtime/issues/48751")]
+                return;
+            }
             IPHostEntry entry = Dns.GetHostByName("");
 
             // DNS labels should be compared as case insensitive for ASCII characters. See RFC 4343.
@@ -116,6 +121,12 @@ namespace System.Net.NameResolution.Tests
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(32797)]
         public void DnsObsoleteBeginEndGetHostByName_EmptyString_ReturnsHostName()
         {
+            if (PlatformDetection.IsSLES)
+            {
+                // [ActiveIssue("https://github.com/dotnet/runtime/issues/48751")]
+                return;
+            }
+
             IPHostEntry entry = Dns.EndGetHostByName(Dns.BeginGetHostByName("", null, null));
 
             // DNS labels should be compared as case insensitive for ASCII characters. See RFC 4343.

--- a/src/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
+++ b/src/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
@@ -27,6 +27,12 @@ namespace System.Net.NameResolution.Tests
         [InlineData(TestSettings.LocalHost)]
         public async Task Dns_GetHostEntry_HostString_Ok(string hostName)
         {
+            if (PlatformDetection.IsSLES)
+            {
+                // [ActiveIssue("https://github.com/dotnet/runtime/issues/48751")]
+                return;
+            }
+
             try
             {
                 await TestGetHostEntryAsync(() => Task.FromResult(Dns.GetHostEntry(hostName)));
@@ -71,10 +77,20 @@ namespace System.Net.NameResolution.Tests
         }
 
         [ActiveIssue(37362, TestPlatforms.OSX)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/48751", TestPlatforms.Linux)]
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(32797)]
         [InlineData("")]
         [InlineData(TestSettings.LocalHost)]
-        public async Task Dns_GetHostEntryAsync_HostString_Ok(string hostName) => await TestGetHostEntryAsync(() => Dns.GetHostEntryAsync(hostName));
+        public async Task Dns_GetHostEntryAsync_HostString_Ok(string hostName)
+        {
+            if (PlatformDetection.IsSLES)
+            {
+                // [ActiveIssue("https://github.com/dotnet/runtime/issues/48751")]
+                return;
+            }
+
+            await TestGetHostEntryAsync(() => Dns.GetHostEntryAsync(hostName));
+        }
 
         [Fact]
         public async Task Dns_GetHostEntryAsync_IPString_Ok() => await TestGetHostEntryAsync(() => Dns.GetHostEntryAsync(TestSettings.LocalIPString));


### PR DESCRIPTION
port of https://github.com/dotnet/runtime/pull/48759

As there's currently no infrastructure to disable just for SLES,
disabling for its parent, which is Linux.

Related to https://github.com/dotnet/runtime/issues/48751

cc @dotnet/ncl @ViktorHofer 