### PR TITLE
Bring back rhel6 build without testing

### DIFF
--- a/eng/pipelines/linux.yml
+++ b/eng/pipelines/linux.yml
@@ -100,6 +100,16 @@ stages:
                 _buildScriptPrefix: 'ROOTFS_DIR=/crossrootfs/arm64 '
                 _buildExtraArguments: -warnAsError false
                 _publishTests: true
+            
+            ${{ if eq(parameters.isOfficialBuild, 'true') }}:
+              RedHat6_x64_Release:
+                _BuildConfig: Release
+                _architecture: x64
+                _framework: netcoreapp
+                _buildScriptPrefix: ''
+                _buildExtraArguments: /p:RuntimeOS=rhel.6 /p:PortableBuild=false
+                _dockerContainer: rhel6_container
+                _publishTests: false
 
         pool:
           name: Hosted Ubuntu 1604
@@ -132,6 +142,14 @@ stages:
           displayName: Build
           strategy:
             matrix:
+              RedHat6_x64_Release:
+                _BuildConfig: Release
+                _architecture: x64
+                _framework: netcoreapp
+                _buildScriptPrefix: ''
+                _buildExtraArguments: /p:RuntimeOS=rhel.6 /p:PortableBuild=false
+                _dockerContainer: rhel6_container
+
               arm_Debug:
                 _BuildConfig: Debug
                 _architecture: arm

--- a/eng/pipelines/linux.yml
+++ b/eng/pipelines/linux.yml
@@ -137,7 +137,7 @@ stages:
 
       # Legs without helix testing
       # Only run this leg in PRs.
-      - ${{ if and(eq(parameters.fullMatrix, 'false'), and(ne(parameters.testScope, 'outerloop'), ne(parameters.testScope, 'all'))) }}:
+      - ${{ if and(eq(parameters.isOfficialBuild, 'false'), and(ne(parameters.testScope, 'outerloop'), ne(parameters.testScope, 'all'))) }}:
         - job: LinuxNoTest
           displayName: Build
           strategy:
@@ -150,29 +150,30 @@ stages:
                 _buildExtraArguments: /p:RuntimeOS=rhel.6 /p:PortableBuild=false
                 _dockerContainer: rhel6_container
 
-              arm_Debug:
-                _BuildConfig: Debug
-                _architecture: arm
-                _framework: netcoreapp
-                _buildExtraArguments: /p:RuntimeOS=ubuntu.16.04 -warnAsError false
-                _buildScriptPrefix: 'ROOTFS_DIR=/crossrootfs/arm '
-                _dockerContainer: ubuntu_1604_arm_cross_container
+              ${{ if eq(parameters.isFullMatrix, 'false') }}:
+                arm_Debug:
+                  _BuildConfig: Debug
+                  _architecture: arm
+                  _framework: netcoreapp
+                  _buildExtraArguments: /p:RuntimeOS=ubuntu.16.04 -warnAsError false
+                  _buildScriptPrefix: 'ROOTFS_DIR=/crossrootfs/arm '
+                  _dockerContainer: ubuntu_1604_arm_cross_container
 
-              musl_arm64_Debug:
-                _BuildConfig: Debug
-                _architecture: arm64
-                _framework: netcoreapp
-                _dockerContainer: alpine_37_arm64_container
-                _buildScriptPrefix: 'ROOTFS_DIR=/crossrootfs/arm64 '
-                _buildExtraArguments: -warnAsError false /p:BuildNativeCompiler=--clang5.0 /p:RuntimeOS=linux-musl
+                musl_arm64_Debug:
+                  _BuildConfig: Debug
+                  _architecture: arm64
+                  _framework: netcoreapp
+                  _dockerContainer: alpine_37_arm64_container
+                  _buildScriptPrefix: 'ROOTFS_DIR=/crossrootfs/arm64 '
+                  _buildExtraArguments: -warnAsError false /p:BuildNativeCompiler=--clang5.0 /p:RuntimeOS=linux-musl
 
-              arm64_Debug:
-                _BuildConfig: Debug
-                _architecture: arm64
-                _framework: netcoreapp
-                _dockerContainer: ubuntu_1604_arm64_cross_container
-                _buildScriptPrefix: 'ROOTFS_DIR=/crossrootfs/arm64 '
-                _buildExtraArguments: --warnAsError false
+                arm64_Debug:
+                  _BuildConfig: Debug
+                  _architecture: arm64
+                  _framework: netcoreapp
+                  _dockerContainer: ubuntu_1604_arm64_cross_container
+                  _buildScriptPrefix: 'ROOTFS_DIR=/crossrootfs/arm64 '
+                  _buildExtraArguments: --warnAsError false
 
           pool:
             name: Hosted Ubuntu 1604


### PR DESCRIPTION
In: https://github.com/dotnet/corefx/pull/43039 we removed rhel6 from the builds because the test pool doesn't exist anymore. However core-setup builds are failing because we dropped support from rhel6 RID by not producing the runtime package for rhel6 for the private corefx package. Bring them back until we decide if we will support the RID or not in the upcoming servicing releases.
