### PR TITLE
[Release/3.1] Fix wrong data blended with transactions in .NET Core

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/Common/AdapterUtil.SqlClient.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Common/AdapterUtil.SqlClient.cs
@@ -574,6 +574,8 @@ namespace System.Data.Common
         }
 
         // global constant strings
+        internal const string Connection = "Connection";
+        internal const string Command = "Command";
         internal const string Parameter = "Parameter";
         internal const string ParameterName = "ParameterName";
         internal const string ParameterSetPosition = "set_Position";

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDataReader.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDataReader.cs
@@ -3347,9 +3347,6 @@ namespace System.Data.SqlClient
                 }
                 throw;
             }
-            /* Even though ThreadAbortException exists in .NET Core, 
-             * since Abort is not supported, the common language runtime won't ever throw ThreadAbortException.
-             * just to keep a common codebase!*/
             catch (ThreadAbortException e)
             {
                 _isClosed = true;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -975,9 +975,9 @@ namespace System.Data.SqlClient
                         stateObj = _parser.GetSession(this);
                         mustPutSession = true;
                     }
-                    else if (internalTransaction.OpenResultsCount != 0)
+                    if (internalTransaction.OpenResultsCount != 0)
                     {
-                        //throw SQL.CannotCompleteDelegatedTransactionWithOpenResults(this);
+                        throw SQL.CannotCompleteDelegatedTransactionWithOpenResults(this, _parser.MARSOn);
                     }
                 }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlUtil.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlUtil.cs
@@ -605,6 +605,13 @@ namespace System.Data.SqlClient
         //
         // SQL.SqlDelegatedTransaction
         //
+        internal static Exception CannotCompleteDelegatedTransactionWithOpenResults(SqlInternalConnectionTds internalConnection, bool marsOn)
+        {
+            SqlErrorCollection errors = new SqlErrorCollection();
+            errors.Add(new SqlError(TdsEnums.TIMEOUT_EXPIRED, (byte)0x00, TdsEnums.MIN_ERROR_CLASS, null, (SR.GetString(SR.ADP_OpenReaderExists, marsOn ? ADP.Command : ADP.Connection)), "", 0, TdsEnums.SNI_WAIT_TIMEOUT));
+            return SqlException.CreateException(errors, null, internalConnection);
+        }
+
         internal static TransactionPromotionException PromotionFailed(Exception inner)
         {
             TransactionPromotionException e = new TransactionPromotionException(SR.GetString(SR.SqlDelegatedTransaction_PromotionFailed), inner);


### PR DESCRIPTION
Ports dotnet/sqlclient#1023 to fix a critical issue that also exists in System.Data.SqlClient:
- Fixes [#980](https://github.com/dotnet/SqlClient/issues/980) SqlDataReader returns stale data

### Summary
When working with delegated transactions, completing a transaction with open resultset leads to data corruption in the connection instance that's sent back to connection pool. Because connection pooling is enabled by default, it results in the pooled connection to contain stale data from old transaction.

This issue was identified in Microsoft.Data.SqlClient but was also traced back to System.Data.SqlClient oldest version in .NET Core.

### Customer Impact
❗ **Critical**: This issue causes data corruption and leads to customers reading data from old query.

### Regression?
**No**: The issue exists since [System.Data.SqlClient v4.5.0-preview1](https://www.nuget.org/packages/System.Data.SqlClient/4.5.0-preview1-26216-02).
It was an error that occurred during port activity of System.Data.SqlClient Transaction support from .NET Framework.

### Testing
Test has been added to cover the wrong data flow.

### Risk
**Low**: Fix matches the implementation with System.Data.SqlClient (in .NET Framework) and has been verified by various members of the community. It has also been released in [Microsoft.Data.SqlClient v3.0.0-preview2](https://www.nuget.org/packages/Microsoft.Data.SqlClient/3.0.0-preview2.21106.5).

cc: @danmoseley @saurabh500 @David-Engel 
