### PR TITLE
[Release/3.1] Fix race condition issues between SinglePhaseCommit and TransactionEnded events

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDelegatedTransaction.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDelegatedTransaction.cs
@@ -314,24 +314,21 @@ namespace System.Data.SqlClient
                 RuntimeHelpers.PrepareConstrainedRegions();
                 try
                 {
-                    // If the connection is doomed, we can be certain that the
-                    // transaction will eventually be rolled back, and we shouldn't
-                    // attempt to commit it.
-                    if (connection.IsConnectionDoomed)
+                    lock (connection)
                     {
-                        lock (connection)
+                        // If the connection is doomed, we can be certain that the
+                        // transaction will eventually be rolled back or is externally aborted, and we shouldn't
+                        // attempt to commit it.
+                        if (connection.IsConnectionDoomed)
                         {
                             _active = false; // set to inactive first, doesn't matter how the rest completes, this transaction is done.
                             _connection = null;
-                        }
 
-                        enlistment.Aborted(SQL.ConnectionDoomed());
-                    }
-                    else
-                    {
-                        Exception commitException;
-                        lock (connection)
+                            enlistment.Aborted(SQL.ConnectionDoomed());
+                        }
+                        else
                         {
+                            Exception commitException;
                             try
                             {
                                 // Now that we've acquired the lock, make sure we still have valid state for this operation.
@@ -357,40 +354,40 @@ namespace System.Data.SqlClient
                                 commitException = e;
                                 connection.DoomThisConnection();
                             }
-                        }
-                        if (commitException != null)
-                        {
-                            // connection.ExecuteTransaction failed with exception
-                            if (_internalTransaction.IsCommitted)
+                            if (commitException != null)
                             {
-                                // Even though we got an exception, the transaction
-                                // was committed by the server.
+                                // connection.ExecuteTransaction failed with exception
+                                if (_internalTransaction.IsCommitted)
+                                {
+                                    // Even though we got an exception, the transaction
+                                    // was committed by the server.
+                                    enlistment.Committed();
+                                }
+                                else if (_internalTransaction.IsAborted)
+                                {
+                                    // The transaction was aborted, report that to
+                                    // SysTx.
+                                    enlistment.Aborted(commitException);
+                                }
+                                else
+                                {
+                                    // The transaction is still active, we cannot
+                                    // know the state of the transaction.
+                                    enlistment.InDoubt(commitException);
+                                }
+
+                                // We eat the exception.  This is called on the SysTx
+                                // thread, not the applications thread.  If we don't 
+                                // eat the exception an UnhandledException will occur,
+                                // causing the process to FailFast.
+                            }
+
+                            connection.CleanupConnectionOnTransactionCompletion(_atomicTransaction);
+                            if (commitException == null)
+                            {
+                                // connection.ExecuteTransaction succeeded
                                 enlistment.Committed();
                             }
-                            else if (_internalTransaction.IsAborted)
-                            {
-                                // The transaction was aborted, report that to
-                                // SysTx.
-                                enlistment.Aborted(commitException);
-                            }
-                            else
-                            {
-                                // The transaction is still active, we cannot
-                                // know the state of the transaction.
-                                enlistment.InDoubt(commitException);
-                            }
-
-                            // We eat the exception.  This is called on the SysTx
-                            // thread, not the applications thread.  If we don't 
-                            // eat the exception an UnhandledException will occur,
-                            // causing the process to FailFast.
-                        }
-
-                        connection.CleanupConnectionOnTransactionCompletion(_atomicTransaction);
-                        if (commitException == null)
-                        {
-                            // connection.ExecuteTransaction succeeded
-                            enlistment.Committed();
                         }
                     }
                 }


### PR DESCRIPTION
Ports [dotnet/sqlclient#1042](https://github.com/dotnet/SqlClient/pull/1042) to fix below issue in System.Data.SqlClient:
- [dotnet/sqlclient#729](https://github.com/dotnet/SqlClient/issues/729) System.Data.SqlClient 4.8.2 throws TransactionAbortedException (the connection has been broken)
- Premier customer support: [Devdiv Ticket 1245724 ](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1245724 )

### Summary
A race condition exists between "Single Phase Commit" and "Transaction Ended" as both are triggered externally by delegated SqlTransaction. With new changes to doom connection in "Transaction Ended" Event (https://github.com/dotnet/corefx/pull/42937), "Commit" started failing intermittently leading to this issue. Dooming connection is essential to prevent connection re-use that leads to security issues, so that PR is valid and important.

But as a consequence, "Commit"'s inconsistent locking leads to this problem. Locking is essential in this part of code, but in "Single Phase Commit" implementation, late and split locking causes issues between Commit and Abort event handling, leading to intermittent "Transaction Aborted Exception".

This change in lock scope fixes the issue. It wasn't easily reproducible in Microsoft.Data.SqlClient but happens very often with System.Data.SqlClient 4.8.2 due to slow performance. Making test-case more rigorous and forcing latency while debugging aided in reproducing this issue.

### Customer Impact
❗ **Critical**: Premier customer application is impacted due to this issue _(followed via Emails)_.
### Regression?
**Yes**: Issue started occurring since System.Data.SqlClient v4.8.2 (PR #42937)

### Testing
It's not possible to add test case for this behavior since it's a race condition scenario and is greatly influenced by MS DTC that manages delegated transaction completion.

### Risk
**Low**: This PR does not introduce any critical design changes, but only makes changes in lock scope.
Issue has been verified by customers as well as with the repro apps available in issue [#729](https://github.com/dotnet/SqlClient/issues/729)


cc: @danmoseley @saurabh500 @David-Engel 
