### PR TITLE
Port regex timeout fix (test only change)

### DIFF
--- a/src/Common/tests/CoreFx.Private.TestUtilities/System/PlatformDetection.cs
+++ b/src/Common/tests/CoreFx.Private.TestUtilities/System/PlatformDetection.cs
@@ -35,6 +35,7 @@ namespace System
         public static bool IsArgIteratorSupported => IsMonoRuntime || (IsWindows && IsNotArmProcess);
         public static bool IsArgIteratorNotSupported => !IsArgIteratorSupported;
         public static bool Is32BitProcess => IntPtr.Size == 4;
+        public static bool Is64BitProcess => IntPtr.Size == 8;
 
         // Windows 10 Insider Preview Build 16215 introduced the necessary APIs for the UAP version of
         // ClientWebSocket.ReceiveAsync to consume partial message data as it arrives, without having to wait

--- a/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -381,8 +381,9 @@ namespace System.Text.RegularExpressions.Tests
         }
 
         // On 32-bit we can't test these high inputs as they cause OutOfMemoryExceptions.
+        // On Linux, we may get killed by the OOM Killer; on Windows, it will swap instead
         [OuterLoop("Can take several seconds")]
-        [ConditionalTheory(typeof(Environment), nameof(Environment.Is64BitProcess))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess), nameof(PlatformDetection.IsWindows))]
         [InlineData(RegexOptions.Compiled)]
         [InlineData(RegexOptions.None)]
         public void Match_Timeout_Loop_Throws(RegexOptions options)
@@ -394,8 +395,9 @@ namespace System.Text.RegularExpressions.Tests
         }
 
         // On 32-bit we can't test these high inputs as they cause OutOfMemoryExceptions.
+        // On Linux, we may get killed by the OOM Killer; on Windows, it will swap instead
         [OuterLoop("Can take several seconds")]
-        [ConditionalTheory(typeof(Environment), nameof(Environment.Is64BitProcess))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess), nameof(PlatformDetection.IsWindows))]
         [InlineData(RegexOptions.Compiled)]
         [InlineData(RegexOptions.None)]
         public void Match_Timeout_Repetition_Throws(RegexOptions options)


### PR DESCRIPTION
Port https://github.com/dotnet/runtime/pull/47209 which causes a hang on Linux.