### PR TITLE
[release/3.1] Fix ReadOnlySequence created out of sliced Memory owned by MemoryManager

### DIFF
--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
@@ -153,7 +153,7 @@ namespace System.Buffers
                 _startObject = manager;
                 _endObject = manager;
                 _startInteger = ReadOnlySequence.MemoryManagerToSequenceStart(index);
-                _endInteger = ReadOnlySequence.MemoryManagerToSequenceEnd(length);
+                _endInteger = ReadOnlySequence.MemoryManagerToSequenceEnd(index + length);
             }
             else if (MemoryMarshal.TryGetArray(memory, out ArraySegment<T> segment))
             {

--- a/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.byte.cs
+++ b/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.byte.cs
@@ -21,6 +21,11 @@ namespace System.Memory.Tests
             public Memory() : base(ReadOnlySequenceFactory<byte>.MemoryFactory) { }
         }
 
+        public class MemoryManager : ReadOnlySequenceTestsByte
+        {
+            public MemoryManager() : base(ReadOnlySequenceFactory<byte>.MemoryManagerFactory) { }
+        }
+
         public class SingleSegment : ReadOnlySequenceTestsByte
         {
             public SingleSegment() : base(ReadOnlySequenceFactory<byte>.SingleSegmentFactory) { }


### PR DESCRIPTION
Port https://github.com/dotnet/runtime/pull/57479 to release/3.1

The following description is a copy of the port to 5.0 description (https://github.com/dotnet/runtime/pull/57562)

<details>

## Customer Impact

Customers who create `ReadOnlySequence<T>` out of sliced `Memory` owned by any `MemoryManager` are seeing invalid end position and length. This issue was reported by a customer and the fix was provided by them as well.

Depending on the input (how many elements of the original `Memory` were sliced) iteration over `ReadOnlySequence<T>` can result in returning incomplete data or throwing `ArgumentOutOfRangeException`. These conditions can lead to data loss or data corruption that would be difficult to diagnose in a production application.

```cs
using System;
using System.Buffers;
using System.Runtime.CompilerServices;
using System.Runtime.InteropServices;

public class Program
{
    public static void Main()
    {
        MemoryManager<byte> memoryManager = new CustomMemoryManager<byte>(4);
        ReadOnlySequence<byte> ros = new ReadOnlySequence<byte>(memoryManager.Memory.Slice(1));
        Console.WriteLine(ros.Length); // prints 2 instead of 3

        foreach (var item in ros)
        {
            Console.WriteLine(item.Length); // prints 2 instead of 3
        }

        memoryManager = new CustomMemoryManager<byte>(3);
        ros = new ReadOnlySequence<byte>(memoryManager.Memory.Slice(2));
        Console.WriteLine(ros.Length); // prints -1 instead of 1

        foreach (var item in ros) // throws System.ArgumentOutOfRangeException
        {
            Console.WriteLine(item.Length); // never gets printed
        }
    }
}

public unsafe class CustomMemoryManager<T> : MemoryManager<T>
{
    private readonly T[] _buffer;

    public CustomMemoryManager(int size) => _buffer = new T[size];

    public unsafe override Span<T> GetSpan() => _buffer;

    public override unsafe MemoryHandle Pin(int elementIndex = 0)
    {
        if ((uint)elementIndex > (uint)_buffer.Length)
        {
            throw new ArgumentOutOfRangeException(nameof(elementIndex));
        }

        var handle = GCHandle.Alloc(_buffer, GCHandleType.Pinned);
        return new MemoryHandle(Unsafe.Add<T>((void*)handle.AddrOfPinnedObject(), elementIndex), handle, this);
    }

    public override void Unpin() { }

    protected override void Dispose(bool disposing) { }
}
```

## Testing

Failing test has been added in this PR.

![image](https://user-images.githubusercontent.com/6011991/130180884-ca0b35a0-ee09-4c23-933c-b189d67c771f.png)

## Risk

Low, as the change is very simple and obvious when you look at `ReadOnlySequence<T>` ctor that accepts `ReadOnlyMemory<T>` :

https://github.com/dotnet/corefx/blob/646a2190f7685ece82b7cbb7ccf7d44ba4cfbefa/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs#L165
https://github.com/dotnet/corefx/blob/646a2190f7685ece82b7cbb7ccf7d44ba4cfbefa/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs#L175

## Regression

This is not a regression.

</details>