### PR TITLE
Switch to 1ES servicing pools on release/3.1

### DIFF
--- a/eng/pipelines/pre-publish.yml
+++ b/eng/pipelines/pre-publish.yml
@@ -19,8 +19,8 @@ stages:
           timeoutInMinutes: 160
 
           pool:
-            name: NetCoreInternal-Pool
-            queue: buildpool.windows.10.amd64.vs2017
+            name: NetCore1ESPool-Svc-Internal
+            demands: ImageOverride -equals Build.windows.10.amd64.vs2017
 
           workspace:
             clean: all

--- a/eng/pipelines/windows.yml
+++ b/eng/pipelines/windows.yml
@@ -148,11 +148,11 @@ stages:
 
           pool:
             ${{ if ne(variables['System.TeamProject'], 'public') }}:
-              name: NetCoreInternal-Pool
-              queue: BuildPool.Windows.10.Amd64.VS2017
+              name: NetCore1ESPool-Svc-Internal
+              demands: ImageOverride -equals Build.Windows.10.Amd64.VS2017
             ${{ if eq(variables['System.TeamProject'], 'public') }}:
-              name: NetCorePublic-Pool
-              queue: BuildPool.Windows.10.Amd64.VS2017.Open
+              name: NetCore1ESPool-Svc-Public
+              demands: ImageOverride -equals Build.Windows.10.Amd64.VS2017.Open
 
           submitToHelix: true
           buildExtraArguments: /p:RuntimeOS=win10


### PR DESCRIPTION
Tracking issue: https://github.com/dotnet/core-eng/issues/14276