### PR TITLE
[H/2] Split lock to prevent deadlock in WindowUpdate processing

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -133,7 +133,7 @@ namespace System.Net.Http
                 if (NetEventSource.IsEnabled) Trace($"{request}, {nameof(initialWindowSize)}={initialWindowSize}");
             }
 
-            private object SyncObject => _streamWindow;
+            private object SyncObject => this;
 
             public int StreamId => _streamId;
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/48220 also in 3.1

### Description

Deadlock in HTTP/2 - when a window update (WINDOW_UPDATE frame) is received at the same time as the HTTP/2 request is being completed.
We saw the very same problem in 5.0 in https://github.com/dotnet/runtime/issues/48220 (reported by customer) and fixed it in https://github.com/dotnet/runtime/pull/47769 for .NET 5.0.

The problem lies in firstly locking connection sync object and then stream's (window update) while request completions attempts to lock stream and than connection.

In 5.0 (https://github.com/dotnet/runtime/pull/47769), we've split `Http2Stream` lock into 2 objects, one for the stream itself (used for completion etc.) and other for credit handling (window updates and sent bytes counting).
In 3.1, `Http2Stream` looks slightly different and uses credit manager's sync object as stream's sync object. So redefining stream's sync object to lock over `this` achieves the same thing as the fix in 5.0 since operations over `Http2Stream` are guarded with stream's lock and operations with credit lock credit manager itself (separate sync object for window updates and sent bytes counting).

### Customer Impact

Reliability problem.
Reported by customer using YARP. They are hitting it for specific backend server (likely due to timing). Temporary workaround is to disable HTTP/2 for the endpoint - such solution does not scale for larger number of backends and might not be acceptable for other backends.

### Regression

No

### Risk

Low.

Local test run for 3.1.
When we fixed the issue in 5.0, we got a confirmation from the reporting customer that the fix helped and that it didn't break anything.
YARP customer needing the 3.1 fix is unable to verify the fix on unsigned binaries.

### Link to PR / issue in main

Issue: https://github.com/dotnet/runtime/issues/48220
6.0 (main) PR: https://github.com/dotnet/runtime/pull/47769
5.0.5 servicing PR: https://github.com/dotnet/runtime/pull/47921

### Is there a packaging impact?

No