### PR TITLE
[release/3.1] Fix linux pipeline

### DIFF
--- a/eng/pipelines/linux.yml
+++ b/eng/pipelines/linux.yml
@@ -102,7 +102,7 @@ stages:
                 _publishTests: true
 
         pool:
-          name: Hosted Ubuntu 1604
+          vmImage: ubuntu-20.04
 
         container: $[ variables['_dockerContainer'] ]
         buildScriptPrefix: $(_buildScriptPrefix)
@@ -158,7 +158,7 @@ stages:
                   _buildExtraArguments: --warnAsError false
 
           pool:
-            name: Hosted Ubuntu 1604
+            vmImage: ubuntu-20.04
 
           container: $[ variables['_dockerContainer'] ]
           buildExtraArguments: $(_buildExtraArguments)


### PR DESCRIPTION
Getting this error when building the internal pipeline:
```
[warning]An image label with the label Ubuntu16 does not exist.
```

This is an attempt to fix this, based on @safern suggestion.