### PR TITLE
Port test fixes to 3.1

### DIFF
--- a/src/System.Drawing.Common/tests/FontFamilyTests.cs
+++ b/src/System.Drawing.Common/tests/FontFamilyTests.cs
@@ -100,6 +100,10 @@ namespace System.Drawing.Tests
             }
         }
 
+        // This will fail on any platform we use libgdiplus, with any
+        // installed system fonts whose name is longer than 31 chars.
+        // macOS 10.15+ ships out of the box with a problem font
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/40937", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Families_Get_ReturnsExpected()
         {

--- a/src/System.IO.Ports/tests/SerialPort/DosDevices.cs
+++ b/src/System.IO.Ports/tests/SerialPort/DosDevices.cs
@@ -4,6 +4,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Runtime.InteropServices;
 
 namespace System.IO.Ports.Tests
@@ -128,14 +129,20 @@ namespace System.IO.Ports.Tests
                     buffer = new char[buffer.Length * 2];
                     dataSize = QueryDosDevice(null, buffer, buffer.Length);
                 }
+                else if (lastError == ERROR_ACCESS_DENIED) // Access denied eg for "MSSECFLTSYS" - just skip
+                {
+                    dataSize = 0;
+                    break;
+                }
                 else
                 {
-                    throw new Exception("Unknown Win32 Error: " + lastError);
+                    throw new Exception($"Error {lastError} calling QueryDosDevice for '{name}' with buffer size {buffer.Length}. {new Win32Exception((int)lastError).Message}");
                 }
             }
             return buffer;
         }
 
+        public const int ERROR_ACCESS_DENIED = 5;
         public const int ERROR_INSUFFICIENT_BUFFER = 122;
         public const int ERROR_MORE_DATA = 234;
 


### PR DESCRIPTION
This is a port of https://github.com/dotnet/runtime/commit/100618b097f131246e1a14927189c85ffd06a4f9 which is occurring regularly due to changes to the test machines exposing a new DOS device.  The test is trying to get all devices on the machine and it can just skip the ones it cannot access.

Test only fix, does not require tactics approval.