### PR TITLE
[release/3.1] Fix writing large arrays to anonymous pipes on linux

### DIFF
--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
@@ -165,9 +165,9 @@ namespace System.IO.Pipes
             }
 
             // For anonymous pipes, write the file descriptor.
-            fixed (byte* bufPtr = &MemoryMarshal.GetReference(buffer))
+            while (buffer.Length > 0)
             {
-                while (buffer.Length > 0)
+                fixed (byte* bufPtr = &MemoryMarshal.GetReference(buffer))
                 {
                     int bytesWritten = CheckPipeCall(Interop.Sys.Write(_handle, bufPtr, buffer.Length));
                     buffer = buffer.Slice(bytesWritten);


### PR DESCRIPTION
Increment the `bufPtr` when we can't write the array in a single syscall. Should fix https://github.com/dotnet/runtime/issues/70798