### PR TITLE
Fix RSA OAEP decryption in OpenSSL with non-power-of-two keys lengths

### DIFF
--- a/src/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
+++ b/src/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
@@ -226,7 +226,7 @@ namespace System.Security.Cryptography
 
                 if (rsaPaddingProcessor != null)
                 {
-                    return rsaPaddingProcessor.DepadOaep(paddingBuf, destination, out bytesWritten);
+                    return rsaPaddingProcessor.DepadOaep(paddingBuf.AsSpan(0, returnValue), destination, out bytesWritten);
                 }
                 else
                 {

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Test.Cryptography;
 using Xunit;
 
@@ -664,6 +665,23 @@ namespace System.Security.Cryptography.Rsa.Tests
             Assert.Equal(TestData.HelloBytes, output);
         }
 
+        [Theory]
+        [MemberData(nameof(OaepPaddingModes))]
+        public void NonPowerOfTwoKeySizeOaepRoundtrip(RSAEncryptionPadding oaepPaddingMode)
+        {
+            byte[] crypt;
+            byte[] output;
+
+            using (RSA rsa = RSAFactory.Create(3072))
+            {
+                crypt = Encrypt(rsa, TestData.HelloBytes, oaepPaddingMode);
+                output = Decrypt(rsa, crypt, oaepPaddingMode);
+            }
+
+            Assert.NotEqual(crypt, output);
+            Assert.Equal(TestData.HelloBytes, output);
+        }
+
         [Fact]
         public void NotSupportedValueMethods()
         {
@@ -671,6 +689,21 @@ namespace System.Security.Cryptography.Rsa.Tests
             {
                 Assert.Throws<NotSupportedException>(() => rsa.DecryptValue(null));
                 Assert.Throws<NotSupportedException>(() => rsa.EncryptValue(null));
+            }
+        }
+
+        public static IEnumerable<object[]> OaepPaddingModes
+        {
+            get
+            {
+                yield return new object[] { RSAEncryptionPadding.OaepSHA1 };
+
+                if (RSAFactory.SupportsSha2Oaep)
+                {
+                    yield return new object[] { RSAEncryptionPadding.OaepSHA256 };
+                    yield return new object[] { RSAEncryptionPadding.OaepSHA384 };
+                    yield return new object[] { RSAEncryptionPadding.OaepSHA512 };
+                }
             }
         }
     }


### PR DESCRIPTION
## Customer Impact

A customer reported in dotnet/runtime#71607 that decrypting RSA OAEP with SHA2 and a 3072-bit key on Linux resulted in a OAEP de-padding error, while other platforms were able to perform these operations successfully.

Investigation in to the issue led to uncover that RSA OAEP decryption that uses the managed implementation does not work with non-power-of-two keys because we do not slice a rented buffer accordingly. The current implementation only works because `CryptoPool.Rent` happens to give back power-of-two arrays which are exactly the same size as the key.

The fix is to slice the data to the correct size.

This does not affect dotnet/runtime because the managed implementation of RSA OAEP is no longer used for OpenSSL RSA decryption. This change was introduced in dotnet/runtime#50063.

## Testing

Unit tests were introduced to test RSA OAEP encryption with a 3072-bit RSA key. These tests will be forward-ported to dotnet/runtime.

## Risk

Minimal. The change is localized and understood that a `Slice` was missing.