### PR TITLE
Update public pool names

### DIFF
--- a/eng/pipelines/windows.yml
+++ b/eng/pipelines/windows.yml
@@ -111,7 +111,7 @@ stages:
             name: NetCore1ESPool-Svc-Internal
             demands: ImageOverride -equals Build.Windows.10.Amd64.VS2017
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            name: NetCore1ESPool-Svc-Public
+            name: NetCore-Svc-Public
             demands: ImageOverride -equals Build.Windows.10.Amd64.VS2017.Open
 
         submitToHelix: true
@@ -168,7 +168,7 @@ stages:
               name: NetCore1ESPool-Svc-Internal
               demands: ImageOverride -equals Build.Windows.10.Amd64.VS2017
             ${{ if eq(variables['System.TeamProject'], 'public') }}:
-              name: NetCore1ESPool-Svc-Public
+              name: NetCore-Svc-Public
               demands: ImageOverride -equals Build.Windows.10.Amd64.VS2017.Open
 
           submitToHelix: true
@@ -218,7 +218,7 @@ stages:
                 name: NetCore1ESPool-Svc-Internal
                 demands: ImageOverride -equals Build.Windows.10.Amd64.VS2017
               ${{ if eq(variables['System.TeamProject'], 'public') }}:
-                name: NetCore1ESPool-Svc-Public
+                name: NetCore-Svc-Public
                 demands: ImageOverride -equals Build.Windows.10.Amd64.VS2017.Open
 
             submitToHelix: false


### PR DESCRIPTION
This change is required to continue building PRs in the dotnet public repo.  The agents and images used in the new project / organization are identical and build regressions are not expected.

For questions / concerns, please stop by the .NET Core Engineering Services [First Responders Teams Channel](https://teams.microsoft.com/l/channel/19%3aafba3d1545dd45d7b79f34c1821f6055%40thread.skype/First%2520Responders?groupId=4d73664c-9f2f-450d-82a5-c2f02756606d&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47).
