### PR TITLE
Disable failing unit tests

### DIFF
--- a/src/System.Globalization.Extensions/tests/IdnMapping/Data/Unicode_6_0/IdnaTest_6.txt
+++ b/src/System.Globalization.Extensions/tests/IdnMapping/Data/Unicode_6_0/IdnaTest_6.txt
@@ -165,7 +165,7 @@ B;	ΒΌΛΟΣ.COM;	βόλοσ.com;	xn--nxasmq6b.com
 B;	βόλοσ.com;	;	xn--nxasmq6b.com
 B;	Βόλοσ.com;	βόλοσ.com;	xn--nxasmq6b.com
 B;	xn--nxasmq6b.com;	βόλοσ.com;	xn--nxasmq6b.com
-B;	XN--NXASMQ6B.COM;	βόλοσ.com;	xn--nxasmq6b.com
+# B;	XN--NXASMQ6B.COM;	βόλοσ.com;	xn--nxasmq6b.com
 B;	Xn--Nxasmq6b.com;	βόλοσ.com;	xn--nxasmq6b.com
 T;	Βόλος.com;	βόλος.com;	xn--nxasmq6b.com
 N;	Βόλος.com;	βόλος.com;	xn--nxasmm1c.com
@@ -794,7 +794,7 @@ B;	XN--0PB6875K;	\u0770\uD803\uDE78;	xn--0pb6875k
 B;	Xn--0Pb6875k;	\u0770\uD803\uDE78;	xn--0pb6875k
 B;	\u0770\uD803\uDE78;	;	xn--0pb6875k
 B;	\u0717\uD802\uDE0C.\uD803\uDE7D\u067C\u0311\uA9B8．\uDB42\uDEDD\u06C5\uD803\uDED7;	[P1 V6 B1];	[P1 V6 B1]
-B;	\uD803\uDE78。\uD803\uDEA9\u094D;	[P1 V6 B1];	[P1 V6 B1]
+# B;	\uD803\uDE78。\uD803\uDEA9\u094D;	[P1 V6 B1];	[P1 V6 B1]
 T;	\uDBF5\uDEF5\uA806\uD90E\uDC87ς\u200D\uDB40\uDDA7;	[P1 V6 C2];	[P1 V6]
 N;	\uDBF5\uDEF5\uA806\uD90E\uDC87ς\u200D\uDB40\uDDA7;	[P1 V6 C2];	[P1 V6 C2]
 T;	\uDBF5\uDEF5\uA806\uD90E\uDC87Σ\u200D\uDB40\uDDA7;	[P1 V6 C2];	[P1 V6]

--- a/src/System.Globalization.Extensions/tests/IdnMapping/IdnMappingIdnaConformanceTests.cs
+++ b/src/System.Globalization.Extensions/tests/IdnMapping/IdnMappingIdnaConformanceTests.cs
@@ -81,6 +81,7 @@ namespace System.Globalization.Tests
         /// Same applies to Windows 10 >= 10.0.15063 in the IdnaTest_9.txt file
         /// </remarks>
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // https://github.com/dotnet/corefx/issues/21332
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/76651", TestPlatforms.Linux | TestPlatforms.OSX)]
         public void GetAscii_Invalid()
         {
             Assert.All(Factory.GetDataset().Where(entry => !entry.ASCIIResult.Success), entry =>

--- a/src/System.Globalization.Extensions/tests/IdnMapping/IdnMappingIdnaConformanceTests.cs
+++ b/src/System.Globalization.Extensions/tests/IdnMapping/IdnMappingIdnaConformanceTests.cs
@@ -81,7 +81,6 @@ namespace System.Globalization.Tests
         /// Same applies to Windows 10 >= 10.0.15063 in the IdnaTest_9.txt file
         /// </remarks>
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // https://github.com/dotnet/corefx/issues/21332
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/76651", TestPlatforms.Linux | TestPlatforms.OSX)]
         public void GetAscii_Invalid()
         {
             Assert.All(Factory.GetDataset().Where(entry => !entry.ASCIIResult.Success), entry =>
@@ -108,7 +107,6 @@ namespace System.Globalization.Tests
         /// Same applies to Windows 10 >= 10.0.15063 in the IdnaTest_9.txt file
         /// </remarks>
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/76651", TestPlatforms.Linux | TestPlatforms.OSX)]
         public void GetUnicode_Invalid()
         {
             Assert.All(Factory.GetDataset().Where(entry => !entry.UnicodeResult.Success), entry =>

--- a/src/System.Globalization.Extensions/tests/IdnMapping/IdnMappingIdnaConformanceTests.cs
+++ b/src/System.Globalization.Extensions/tests/IdnMapping/IdnMappingIdnaConformanceTests.cs
@@ -18,7 +18,7 @@ namespace System.Globalization.Tests
         /// <summary>
         /// Tests positive cases for GetAscii.  Windows fails by design on some entries that should pass.  The recommendation is to take the source input
         /// for this if needed.
-        /// 
+        ///
         /// There are some others that failed which have been commented out and marked in the dataset as "GETASCII DOES FAILS ON WINDOWS 8.1"
         /// Same applies to Windows 10 >= 10.0.15063 in the IdnaTest_9.txt file
         [Fact]
@@ -44,7 +44,7 @@ namespace System.Globalization.Tests
         /// <summary>
         /// Tests positive cases for GetUnicode.  Windows fails by design on some entries that should pass.  The recommendation is to take the source input
         /// for this if needed.
-        /// 
+        ///
         /// There are some others that failed which have been commented out and marked in the dataset as "GETUNICODE DOES FAILS ON WINDOWS 8.1"
         /// Same applies to Windows 10 >= 10.0.15063 in the IdnaTest_9.txt file
         /// </summary>
@@ -76,7 +76,7 @@ namespace System.Globalization.Tests
         /// Tests negative cases for GetAscii.
         /// </summary>
         /// <remarks>
-        /// There are some failures on Windows 8.1 that have been commented out 
+        /// There are some failures on Windows 8.1 that have been commented out
         /// from the 6.0\IdnaTest.txt.  To find them, search for "GETASCII DOES NOT FAIL ON WINDOWS 8.1"
         /// Same applies to Windows 10 >= 10.0.15063 in the IdnaTest_9.txt file
         /// </remarks>
@@ -102,11 +102,12 @@ namespace System.Globalization.Tests
         /// Tests negative cases for GetUnicode.
         /// </summary>
         /// <remarks>
-        /// There are some failures on Windows 8.1 that have been commented out 
+        /// There are some failures on Windows 8.1 that have been commented out
         /// from the 6.0\IdnaTest.txt.  To find them, search for "GETUNICODE DOES NOT FAIL ON WINDOWS 8.1"
         /// Same applies to Windows 10 >= 10.0.15063 in the IdnaTest_9.txt file
         /// </remarks>
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/76651", TestPlatforms.Linux | TestPlatforms.OSX)]
         public void GetUnicode_Invalid()
         {
             Assert.All(Factory.GetDataset().Where(entry => !entry.UnicodeResult.Success), entry =>

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -1624,6 +1624,7 @@ namespace System.Net.Http.Functional.Tests
         [Theory]
         [InlineData(99)]
         [InlineData(1000)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/76654", TestPlatforms.Linux)]
         public async Task GetAsync_StatusCodeOutOfRange_ExpectedException(int statusCode)
         {
             if (PlatformDetection.IsUap && statusCode == 99)

--- a/src/System.Net.Http/tests/FunctionalTests/HttpProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpProtocolTests.cs
@@ -455,6 +455,7 @@ namespace System.Net.Http.Functional.Tests
 
         [Theory]
         [MemberData(nameof(InvalidStatusLine))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/76654", TestPlatforms.Linux)]
         public async Task GetAsync_InvalidStatusLine_ThrowsException(string responseString)
         {
             await GetAsyncThrowsExceptionHelper(responseString);

--- a/src/System.Net.Http/tests/FunctionalTests/HttpProtocolTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpProtocolTests.cs
@@ -163,6 +163,7 @@ namespace System.Net.Http.Functional.Tests
             }, new LoopbackServer.Options { StreamWrapper = GetStream });
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/76654", TestPlatforms.Linux | TestPlatforms.OSX)]
         [Theory]
         [InlineData(2)]
         [InlineData(7)]
@@ -207,6 +208,7 @@ namespace System.Net.Http.Functional.Tests
             }, new LoopbackServer.Options { StreamWrapper = GetStream });
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/76654", TestPlatforms.Linux | TestPlatforms.OSX)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Uap ignores response version if not 1.0 or 1.1")]
         [Theory]
         [InlineData(0)]
@@ -246,6 +248,7 @@ namespace System.Net.Http.Functional.Tests
             }, new LoopbackServer.Options { StreamWrapper = GetStream_ClientDisconnectOk });
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/76654", TestPlatforms.Linux | TestPlatforms.OSX)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Uap ignores response version if not 1.0 or 1.1")]
         [Theory]
         [InlineData(2, 0)]
@@ -362,7 +365,7 @@ namespace System.Net.Http.Functional.Tests
                 await GetAsyncSuccessHelper(statusLine, expectedStatusCode, reasonNoSpace);
             }
         }
-        
+
         [Theory]
         [InlineData("HTTP/1.1 200", 200, "")] // This test data requires the fix in .NET Framework 4.7.3
         [InlineData("HTTP/1.1 200 O\tK", 200, "O\tK")]
@@ -403,7 +406,7 @@ namespace System.Net.Http.Functional.Tests
             yield return "HTTP/1.1 2345";
             yield return "HTTP/A.1 200 OK";
             yield return "HTTP/X.Y.Z 200 OK";
-            
+
             // Only pass on .NET Core Windows & SocketsHttpHandler.
             if (PlatformDetection.IsNetCore && !PlatformDetection.IsUap && PlatformDetection.IsWindows)
             {
@@ -426,7 +429,7 @@ namespace System.Net.Http.Functional.Tests
                 yield return "HTTP/1.1\t";
                 yield return "HTTP/1.1  ";
             }
-            
+
             // Skip these test cases on UAP since the behavior is different.
             if (!PlatformDetection.IsUap)
             {
@@ -447,7 +450,7 @@ namespace System.Net.Http.Functional.Tests
                 yield return "NOTHTTP/1.1 200 OK";
             }
         }
-        
+
         public static TheoryData InvalidStatusLine = GetInvalidStatusLine().ToTheoryData();
 
         [Theory]
@@ -456,7 +459,7 @@ namespace System.Net.Http.Functional.Tests
         {
             await GetAsyncThrowsExceptionHelper(responseString);
         }
-        
+
         [Fact]
         public async Task GetAsync_ReasonPhraseHasLF_BehaviorDifference()
         {

--- a/src/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/CertificateRequestUsageTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/CertificateRequestUsageTests.cs
@@ -332,6 +332,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/76653", TestPlatforms.OSX)]
         public static void AlwaysVersion3()
         {
             using (ECDsa ecdsa = ECDsa.Create(EccTestData.Secp384r1Data.KeyParameters))


### PR DESCRIPTION
- https://github.com/dotnet/runtime/issues/76651 System.Globalization.Tests.IdnMappingIdnaConformanceTests.GetUnicode_Invalid
- https://github.com/dotnet/runtime/issues/76653 System.Security.Cryptography.X509Certificates.Tests.CertificateCreation.CertificateRequestUsageTests.AlwaysVersion3
- https://github.com/dotnet/runtime/issues/76654 System.Net.Http.Functional.Tests.PlatformHandler_HttpProtocolTests*