### PR TITLE
[release/3.1] Disable failing 3.1 tests

### DIFF
--- a/src/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/EventLogRecordTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/EventLogRecordTests.cs
@@ -86,6 +86,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/77234")]
         [ConditionalFact(typeof(Helpers), nameof(Helpers.SupportsEventLogs))]
         public void ExceptionOnce()
         {

--- a/src/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/ProviderMetadataTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/ProviderMetadataTests.cs
@@ -18,6 +18,7 @@ namespace System.Diagnostics.Tests
             Assert.Throws<EventLogNotFoundException>(() => new ProviderMetadata("Source_Does_Not_Exist"));
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/77234")]
         [ConditionalTheory(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         [InlineData(true)]
         [InlineData(false)]

--- a/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -412,6 +412,7 @@ namespace System.IO.Tests
             }
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/77233")]
         [Theory,
             MemberData(nameof(PathsWithReservedDeviceNames))]
         [PlatformSpecific(TestPlatforms.Windows)] // device name prefixes


### PR DESCRIPTION
Disables tests mentioned in:

- https://github.com/dotnet/runtime/issues/77233
- https://github.com/dotnet/runtime/issues/77234